### PR TITLE
feat(B5): Implement Adept Powers System

### DIFF
--- a/app/api/rulesets/[editionCode]/route.ts
+++ b/app/api/rulesets/[editionCode]/route.ts
@@ -6,7 +6,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { loadAndMergeRuleset } from "@/lib/rules/merge";
-import { loadRuleset, extractMetatypes, extractSkills, extractQualities, extractPriorityTable, extractMagicPaths, extractLifestyles, extractLifestyleModifiers, extractGear, extractSpells, extractComplexForms, extractCyberware, extractBioware, extractAugmentationRules, extractContactTemplates } from "@/lib/rules/loader";
+import { loadRuleset, extractMetatypes, extractSkills, extractQualities, extractPriorityTable, extractMagicPaths, extractLifestyles, extractLifestyleModifiers, extractGear, extractSpells, extractComplexForms, extractCyberware, extractBioware, extractAugmentationRules, extractContactTemplates, extractAdeptPowers } from "@/lib/rules/loader";
 
 export async function GET(
   request: NextRequest,
@@ -52,6 +52,7 @@ export async function GET(
         bioware: extractBioware(loadedRuleset),
         augmentationRules: extractAugmentationRules(loadedRuleset),
         contactTemplates: extractContactTemplates(loadedRuleset),
+        adeptPowers: extractAdeptPowers(loadedRuleset),
       }
       : null;
 

--- a/app/characters/create/components/CreationWizard.tsx
+++ b/app/characters/create/components/CreationWizard.tsx
@@ -35,6 +35,7 @@ import { ContactsStep } from "./steps/ContactsStep";
 import { GearStep } from "./steps/GearStep";
 import { KarmaStep } from "./steps/KarmaStep";
 import { SpellsStep } from "./steps/SpellsStep";
+import { AdeptPowersStep } from "./steps/AdeptPowersStep";
 import { ReviewStep } from "./steps/ReviewStep";
 
 interface CreationWizardProps {
@@ -140,10 +141,17 @@ export function CreationWizard({ onCancel, onComplete }: CreationWizardProps) {
     // Check if character is magical (Magician, Mystic Adept, or Aspected Mage)
     const isMagical = ["magician", "mystic-adept", "aspected-mage"].includes(magicPath);
 
+    // Check if character can use adept powers
+    const isAdept = ["adept", "mystic-adept"].includes(magicPath);
+
     return rawSteps.filter((step) => {
       // Hide Spells step for mundane characters and technomancers
       // (Technomancers use Complex Forms which are currently in KarmaStep)
       if (step.id === "spells" && !isMagical) {
+        return false;
+      }
+      // Hide Adept Powers step for non-adepts
+      if (step.id === "adept-powers" && !isAdept) {
         return false;
       }
       return true;
@@ -905,6 +913,8 @@ export function CreationWizard({ onCancel, onComplete }: CreationWizardProps) {
         return <GearStep {...stepProps} />;
       case "spells":
         return <SpellsStep {...stepProps} />;
+      case "adept-powers":
+        return <AdeptPowersStep {...stepProps} />;
       case "karma":
         return <KarmaStep {...stepProps} />;
       case "review":

--- a/app/characters/create/components/steps/AdeptPowersStep.tsx
+++ b/app/characters/create/components/steps/AdeptPowersStep.tsx
@@ -1,0 +1,426 @@
+"use client";
+
+import { useMemo, useState, useCallback } from "react";
+import { useAdeptPowers, usePriorityTable } from "@/lib/rules";
+import type { CreationState, AdeptPower } from "@/lib/types";
+import type { AdeptPowerCatalogItem } from "@/lib/rules/loader";
+
+interface StepProps {
+    state: CreationState;
+    updateState: (updates: Partial<CreationState>) => void;
+    budgetValues: Record<string, number>;
+}
+
+export function AdeptPowersStep({ state, updateState, budgetValues }: StepProps) {
+    const adeptPowersCatalog = useAdeptPowers();
+    const priorityTable = usePriorityTable();
+
+    const [searchQuery, setSearchQuery] = useState("");
+    const [selectedPowerId, setSelectedPowerId] = useState<string | null>(null);
+    const [selectedLevel, setSelectedLevel] = useState(1);
+    const [selectedSpec, setSelectedSpec] = useState<string>("");
+
+    // Get magic rating for PP budget
+    const magicRating = useMemo(() => {
+        const magicPriority = state.priorities?.magic;
+        const magicalPath = (state.selections["magical-path"] as string) || "mundane";
+
+        if (!magicPriority || !priorityTable?.table[magicPriority]) {
+            return 0;
+        }
+
+        const magicData = priorityTable.table[magicPriority].magic as {
+            options?: Array<{
+                path: string;
+                magicRating?: number;
+            }>;
+        };
+
+        const option = magicData?.options?.find((o) => o.path === magicalPath);
+        return option?.magicRating || 0;
+    }, [state.priorities?.magic, priorityTable, state.selections]);
+
+    // Mystic Adepts allocate a portion of their Magic to PP
+    // For now, assume full Magic = PP for adepts
+    const isMysticAdept = (state.selections["magical-path"] as string) === "mystic-adept";
+    const powerPointBudget = isMysticAdept
+        ? ((state.selections["power-points-allocation"] as number) || 0)
+        : magicRating;
+
+    // Get current adept powers from state
+    const selectedPowers = useMemo(() => {
+        return (state.selections.adeptPowers || []) as AdeptPower[];
+    }, [state.selections.adeptPowers]);
+
+    // Calculate total PP spent
+    const ppSpent = useMemo(() => {
+        return selectedPowers.reduce((sum, p) => sum + p.powerPointCost, 0);
+    }, [selectedPowers]);
+
+    const ppRemaining = Math.round((powerPointBudget - ppSpent) * 100) / 100;
+
+    // Filter powers
+    const filteredPowers = useMemo(() => {
+        if (!searchQuery.trim()) return adeptPowersCatalog;
+        const search = searchQuery.toLowerCase();
+        return adeptPowersCatalog.filter(
+            (p) =>
+                p.name.toLowerCase().includes(search) ||
+                p.description.toLowerCase().includes(search)
+        );
+    }, [adeptPowersCatalog, searchQuery]);
+
+    // Get power by ID
+    const getPowerById = useCallback(
+        (id: string) => adeptPowersCatalog.find((p) => p.id === id),
+        [adeptPowersCatalog]
+    );
+
+    // Calculate cost for a power at a given level
+    const calculateCost = useCallback((power: AdeptPowerCatalogItem, level: number): number => {
+        if (power.costType === "table" && power.levels) {
+            const levelData = power.levels.find((l) => l.level === level);
+            return levelData?.cost || 0;
+        }
+        if (power.costType === "perLevel") {
+            return (power.cost || 0) * level;
+        }
+        return power.cost || 0;
+    }, []);
+
+    // Check if power is already selected
+    const isPowerSelected = useCallback(
+        (powerId: string, spec?: string) => {
+            return selectedPowers.some(
+                (p) => p.catalogId === powerId && (spec ? p.specification === spec : true)
+            );
+        },
+        [selectedPowers]
+    );
+
+    // Add power
+    const handleAddPower = useCallback(() => {
+        if (!selectedPowerId) return;
+
+        const power = getPowerById(selectedPowerId);
+        if (!power) return;
+
+        const cost = calculateCost(power, selectedLevel);
+        if (cost > ppRemaining) return;
+
+        // Check if already selected (for non-multiple powers)
+        if (isPowerSelected(selectedPowerId, selectedSpec) && !power.requiresSkill && !power.requiresAttribute) {
+            return;
+        }
+
+        const newPower: AdeptPower = {
+            id: `${selectedPowerId}-${Date.now()}`,
+            catalogId: selectedPowerId,
+            name: power.name,
+            rating: power.costType === "perLevel" || power.costType === "table" ? selectedLevel : undefined,
+            powerPointCost: cost,
+            specification: selectedSpec || undefined,
+        };
+
+        const updatedPowers = [...selectedPowers, newPower];
+
+        updateState({
+            selections: {
+                ...state.selections,
+                adeptPowers: updatedPowers,
+            },
+            budgets: {
+                ...state.budgets,
+                "power-points-spent": ppSpent + cost,
+            },
+        });
+
+        // Reset form
+        setSelectedPowerId(null);
+        setSelectedLevel(1);
+        setSelectedSpec("");
+    }, [selectedPowerId, selectedLevel, selectedSpec, getPowerById, calculateCost, ppRemaining, isPowerSelected, selectedPowers, ppSpent, state.selections, state.budgets, updateState]);
+
+    // Remove power
+    const handleRemovePower = useCallback((powerId: string) => {
+        const power = selectedPowers.find((p) => p.id === powerId);
+        if (!power) return;
+
+        const updatedPowers = selectedPowers.filter((p) => p.id !== powerId);
+
+        updateState({
+            selections: {
+                ...state.selections,
+                adeptPowers: updatedPowers,
+            },
+            budgets: {
+                ...state.budgets,
+                "power-points-spent": ppSpent - power.powerPointCost,
+            },
+        });
+    }, [selectedPowers, ppSpent, state.selections, state.budgets, updateState]);
+
+    // Get selected power for detail view
+    const selectedPowerData = selectedPowerId ? getPowerById(selectedPowerId) : null;
+    const selectedCost = selectedPowerData ? calculateCost(selectedPowerData, selectedLevel) : 0;
+
+    return (
+        <div className="space-y-6">
+            {/* Power Point Budget */}
+            <div className="rounded-lg bg-violet-50 p-4 dark:bg-violet-900/20">
+                <div className="flex items-center justify-between">
+                    <div>
+                        <div className="text-sm font-medium text-violet-800 dark:text-violet-200">Power Points</div>
+                        <div className="text-xs text-violet-600 dark:text-violet-400">
+                            {isMysticAdept ? "Allocated from Magic rating" : `Magic Rating ${magicRating}`}
+                        </div>
+                    </div>
+                    <div className="text-right">
+                        <div className="text-2xl font-bold text-violet-700 dark:text-violet-300">{ppRemaining}</div>
+                        <div className="text-xs text-violet-600 dark:text-violet-400">/ {powerPointBudget} PP</div>
+                    </div>
+                </div>
+                <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-violet-200 dark:bg-violet-800">
+                    <div
+                        className="h-full rounded-full bg-violet-500 transition-all duration-300"
+                        style={{ width: `${powerPointBudget > 0 ? (ppSpent / powerPointBudget) * 100 : 0}%` }}
+                    />
+                </div>
+            </div>
+
+            {/* Mystic Adept PP Allocation */}
+            {isMysticAdept && (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
+                    <label className="block text-sm font-medium text-amber-800 dark:text-amber-200 mb-2">
+                        Power Points Allocation (Magic Rating: {magicRating})
+                    </label>
+                    <input
+                        type="range"
+                        min={0}
+                        max={magicRating}
+                        step={1}
+                        value={powerPointBudget}
+                        onChange={(e) =>
+                            updateState({
+                                selections: {
+                                    ...state.selections,
+                                    "power-points-allocation": parseInt(e.target.value),
+                                },
+                            })
+                        }
+                        className="w-full"
+                    />
+                    <div className="flex justify-between text-xs text-amber-600 dark:text-amber-400 mt-1">
+                        <span>0 PP (Full Spellcasting)</span>
+                        <span className="font-bold">{powerPointBudget} PP</span>
+                        <span>{magicRating} PP (Full Adept)</span>
+                    </div>
+                </div>
+            )}
+
+            <div className="grid gap-6 lg:grid-cols-3">
+                {/* Left: Power Catalog */}
+                <div className="lg:col-span-2 space-y-4">
+                    <input
+                        type="text"
+                        placeholder="Search powers..."
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                    />
+
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        {filteredPowers.map((power) => {
+                            const isSelected = selectedPowerId === power.id;
+                            const alreadyHas = isPowerSelected(power.id);
+                            const baseCost = power.costType === "table"
+                                ? (power.levels?.[0]?.cost || 0)
+                                : power.cost || 0;
+
+                            return (
+                                <button
+                                    key={power.id}
+                                    onClick={() => {
+                                        setSelectedPowerId(isSelected ? null : power.id);
+                                        setSelectedLevel(1);
+                                        setSelectedSpec("");
+                                    }}
+                                    className={`relative flex flex-col items-start gap-2 rounded-lg border p-3 text-left transition-all ${isSelected
+                                            ? "border-violet-500 bg-violet-50 ring-1 ring-violet-500 dark:border-violet-400 dark:bg-violet-900/30"
+                                            : alreadyHas && !power.requiresSkill && !power.requiresAttribute
+                                                ? "border-emerald-300 bg-emerald-50/50 dark:border-emerald-700 dark:bg-emerald-900/20"
+                                                : "border-zinc-200 bg-white hover:border-violet-300 hover:shadow-sm dark:border-zinc-700 dark:bg-zinc-800/50 dark:hover:border-violet-700"
+                                        }`}
+                                >
+                                    <div className="flex w-full items-start justify-between gap-2">
+                                        <div className="font-medium text-zinc-900 dark:text-zinc-100">
+                                            {power.name}
+                                        </div>
+                                        <div className="flex-shrink-0 rounded bg-violet-100 px-1.5 py-0.5 text-xs font-bold text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
+                                            {power.costType === "perLevel" ? `${baseCost}/lvl` : `${baseCost} PP`}
+                                        </div>
+                                    </div>
+
+                                    <p className="text-xs text-zinc-500 dark:text-zinc-400 line-clamp-2">
+                                        {power.description}
+                                    </p>
+
+                                    {power.activation && (
+                                        <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] uppercase text-zinc-600 dark:bg-zinc-700 dark:text-zinc-400">
+                                            {power.activation} action
+                                        </span>
+                                    )}
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* Right: Selected Power Config + Current Powers */}
+                <div className="space-y-4">
+                    {/* Power Configuration */}
+                    {selectedPowerData && (
+                        <div className="rounded-lg border border-violet-200 bg-violet-50 p-4 dark:border-violet-800 dark:bg-violet-900/20">
+                            <h3 className="font-medium text-violet-900 dark:text-violet-100 mb-3">
+                                {selectedPowerData.name}
+                            </h3>
+
+                            {/* Level Selector */}
+                            {(selectedPowerData.costType === "perLevel" || selectedPowerData.costType === "table") && (
+                                <div className="mb-3">
+                                    <label className="block text-sm text-violet-700 dark:text-violet-300 mb-1">
+                                        Level
+                                    </label>
+                                    <div className="flex gap-1">
+                                        {Array.from(
+                                            { length: selectedPowerData.maxLevel || 1 },
+                                            (_, i) => i + 1
+                                        ).map((lvl) => (
+                                            <button
+                                                key={lvl}
+                                                onClick={() => setSelectedLevel(lvl)}
+                                                className={`flex h-8 w-8 items-center justify-center rounded text-sm font-medium transition-colors ${selectedLevel >= lvl
+                                                        ? "bg-violet-500 text-white"
+                                                        : "bg-white text-zinc-600 hover:bg-violet-100 dark:bg-zinc-700 dark:text-zinc-300"
+                                                    }`}
+                                            >
+                                                {lvl}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* Attribute Selector */}
+                            {selectedPowerData.requiresAttribute && selectedPowerData.validAttributes && (
+                                <div className="mb-3">
+                                    <label className="block text-sm text-violet-700 dark:text-violet-300 mb-1">
+                                        Attribute
+                                    </label>
+                                    <select
+                                        value={selectedSpec}
+                                        onChange={(e) => setSelectedSpec(e.target.value)}
+                                        className="w-full rounded border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+                                    >
+                                        <option value="">Select attribute...</option>
+                                        {selectedPowerData.validAttributes.map((attr) => (
+                                            <option key={attr} value={attr}>
+                                                {attr.charAt(0).toUpperCase() + attr.slice(1)}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            )}
+
+                            {/* Skill Selector */}
+                            {selectedPowerData.requiresSkill && selectedPowerData.validSkills && (
+                                <div className="mb-3">
+                                    <label className="block text-sm text-violet-700 dark:text-violet-300 mb-1">
+                                        Skill
+                                    </label>
+                                    <select
+                                        value={selectedSpec}
+                                        onChange={(e) => setSelectedSpec(e.target.value)}
+                                        className="w-full rounded border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+                                    >
+                                        <option value="">Select skill...</option>
+                                        {selectedPowerData.validSkills.map((skill) => (
+                                            <option key={skill} value={skill}>
+                                                {skill.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ")}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            )}
+
+                            {/* Cost Preview */}
+                            <div className="flex items-center justify-between rounded bg-white p-2 dark:bg-zinc-800 mb-3">
+                                <span className="text-sm text-zinc-600 dark:text-zinc-400">Cost:</span>
+                                <span className={`font-bold ${selectedCost > ppRemaining ? "text-red-600" : "text-violet-600 dark:text-violet-400"}`}>
+                                    {selectedCost} PP
+                                </span>
+                            </div>
+
+                            {/* Add Button */}
+                            <button
+                                onClick={handleAddPower}
+                                disabled={
+                                    selectedCost > ppRemaining ||
+                                    (selectedPowerData.requiresAttribute && !selectedSpec) ||
+                                    (selectedPowerData.requiresSkill && !selectedSpec)
+                                }
+                                className="w-full rounded-lg bg-violet-500 py-2 text-sm font-medium text-white transition-colors hover:bg-violet-600 disabled:cursor-not-allowed disabled:bg-zinc-300 disabled:text-zinc-500"
+                            >
+                                Add Power
+                            </button>
+                        </div>
+                    )}
+
+                    {/* Current Powers */}
+                    <div className="rounded-lg border border-zinc-200 bg-zinc-50/50 p-4 dark:border-zinc-700 dark:bg-zinc-800/30">
+                        <h3 className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                            Selected Powers ({selectedPowers.length})
+                        </h3>
+
+                        {selectedPowers.length === 0 ? (
+                            <p className="py-4 text-center text-xs text-zinc-500 italic">
+                                No powers selected yet.
+                            </p>
+                        ) : (
+                            <div className="space-y-2">
+                                {selectedPowers.map((power) => (
+                                    <div
+                                        key={power.id}
+                                        className="flex items-center justify-between rounded bg-white p-2 shadow-sm dark:bg-zinc-800"
+                                    >
+                                        <div className="min-w-0 flex-1">
+                                            <div className="flex items-center gap-2">
+                                                <span className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                                                    {power.name}
+                                                    {power.rating && ` ${power.rating}`}
+                                                    {power.specification && ` (${power.specification})`}
+                                                </span>
+                                                <span className="flex-shrink-0 rounded bg-violet-100 px-1.5 py-0.5 text-[10px] font-bold text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
+                                                    {power.powerPointCost} PP
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <button
+                                            onClick={() => handleRemovePower(power.id)}
+                                            className="ml-2 rounded p-1 text-zinc-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20"
+                                            title="Remove power"
+                                        >
+                                            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/characters/create/components/steps/ReviewStep.tsx
+++ b/app/characters/create/components/steps/ReviewStep.tsx
@@ -365,23 +365,20 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
               return (
                 <div
                   key={attr}
-                  className={`rounded p-2 text-center ${
-                    hasAugBonus
+                  className={`rounded p-2 text-center ${hasAugBonus
                       ? "bg-cyan-100 ring-1 ring-cyan-300 dark:bg-cyan-900/30 dark:ring-cyan-700"
                       : "bg-zinc-100 dark:bg-zinc-700"
-                  }`}
+                    }`}
                 >
                   <div
-                    className={`text-[10px] font-medium uppercase ${
-                      hasAugBonus ? "text-cyan-600 dark:text-cyan-400" : "text-zinc-500 dark:text-zinc-400"
-                    }`}
+                    className={`text-[10px] font-medium uppercase ${hasAugBonus ? "text-cyan-600 dark:text-cyan-400" : "text-zinc-500 dark:text-zinc-400"
+                      }`}
                   >
                     {attr.slice(0, 3)}
                   </div>
                   <div
-                    className={`text-lg font-bold ${
-                      hasAugBonus ? "text-cyan-700 dark:text-cyan-300" : "text-zinc-900 dark:text-zinc-100"
-                    }`}
+                    className={`text-lg font-bold ${hasAugBonus ? "text-cyan-700 dark:text-cyan-300" : "text-zinc-900 dark:text-zinc-100"
+                      }`}
                   >
                     {totalValue}
                     {hasAugBonus && (
@@ -423,11 +420,10 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
               </div>
             )}
             <div
-              className={`rounded px-3 py-2 text-center ${
-                augmentationEffects.totalEssenceLoss > 0
+              className={`rounded px-3 py-2 text-center ${augmentationEffects.totalEssenceLoss > 0
                   ? "bg-rose-100 ring-1 ring-rose-300 dark:bg-rose-900/30 dark:ring-rose-700"
                   : "bg-rose-100 dark:bg-rose-900/30"
-              }`}
+                }`}
             >
               <div className="text-[10px] font-medium uppercase text-rose-600 dark:text-rose-400">Essence</div>
               <div className="text-lg font-bold text-rose-700 dark:text-rose-300">
@@ -446,11 +442,10 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
         <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Derived Stats</h3>
         <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-5">
           <div
-            className={`rounded p-2 text-center ${
-              augmentationEffects.initiativeDiceBonus > 0
+            className={`rounded p-2 text-center ${augmentationEffects.initiativeDiceBonus > 0
                 ? "bg-blue-100 ring-1 ring-blue-300 dark:bg-blue-900/30 dark:ring-blue-700"
                 : "bg-blue-50 dark:bg-blue-900/20"
-            }`}
+              }`}
           >
             <div className="text-[10px] font-medium text-blue-600 dark:text-blue-400">Initiative</div>
             <div className="font-bold text-blue-700 dark:text-blue-300">
@@ -469,11 +464,10 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
             <div className="font-bold text-zinc-900 dark:text-zinc-100">{derivedStats.mentalLimit}</div>
           </div>
           <div
-            className={`rounded p-2 text-center ${
-              augmentationEffects.totalEssenceLoss > 0
+            className={`rounded p-2 text-center ${augmentationEffects.totalEssenceLoss > 0
                 ? "bg-zinc-100 ring-1 ring-amber-300 dark:bg-zinc-700 dark:ring-amber-700"
                 : "bg-zinc-100 dark:bg-zinc-700"
-            }`}
+              }`}
           >
             <div className="text-[10px] font-medium text-zinc-500 dark:text-zinc-400">Social Limit</div>
             <div className="font-bold text-zinc-900 dark:text-zinc-100">
@@ -687,13 +681,41 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
             {selectedSpells.map((spellId, index) => (
               <span
                 key={spellId}
-                className={`rounded-full px-3 py-1 text-sm font-medium ${
-                  index < freeSpells
+                className={`rounded-full px-3 py-1 text-sm font-medium ${index < freeSpells
                     ? "bg-purple-100 text-purple-800 dark:bg-purple-900/50 dark:text-purple-200"
                     : "bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200"
-                }`}
+                  }`}
               >
                 {getSpellName(spellId)}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Adept Powers */}
+      {((state.selections.adeptPowers as Array<{ id: string; name: string; rating?: number; powerPointCost: number; specification?: string }>) || []).length > 0 && (
+        <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+          <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            Adept Powers ({((state.selections.adeptPowers as Array<{ id: string; name: string; rating?: number; powerPointCost: number; specification?: string }>) || []).length})
+            <span className="ml-2 text-xs font-normal text-violet-600 dark:text-violet-400">
+              ({((state.selections.adeptPowers as Array<{ id: string; name: string; rating?: number; powerPointCost: number; specification?: string }>) || []).reduce((sum, p) => sum + p.powerPointCost, 0).toFixed(2)} PP)
+            </span>
+          </h3>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {((state.selections.adeptPowers as Array<{ id: string; name: string; rating?: number; powerPointCost: number; specification?: string }>) || []).map((power) => (
+              <span
+                key={power.id}
+                className="inline-flex items-center gap-1 rounded-full bg-violet-100 px-3 py-1 text-sm dark:bg-violet-900/50"
+              >
+                <span className="font-medium text-violet-800 dark:text-violet-200">
+                  {power.name}
+                  {power.rating && ` ${power.rating}`}
+                  {power.specification && ` (${power.specification})`}
+                </span>
+                <span className="text-xs text-violet-600 dark:text-violet-400">
+                  {power.powerPointCost} PP
+                </span>
               </span>
             ))}
           </div>
@@ -715,11 +737,10 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
             {selectedComplexForms.map((formId, index) => (
               <span
                 key={formId}
-                className={`rounded-full px-3 py-1 text-sm font-medium ${
-                  index < freeComplexForms
+                className={`rounded-full px-3 py-1 text-sm font-medium ${index < freeComplexForms
                     ? "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/50 dark:text-cyan-200"
                     : "bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200"
-                }`}
+                  }`}
               >
                 {getComplexFormName(formId)}
               </span>
@@ -849,22 +870,20 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
 
       {/* Validation Status */}
       <div
-        className={`rounded-lg p-4 ${
-          hasErrors
+        className={`rounded-lg p-4 ${hasErrors
             ? "border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20"
             : validationIssues.length > 0
-            ? "border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20"
-            : "border border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-900/20"
-        }`}
+              ? "border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20"
+              : "border border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-900/20"
+          }`}
       >
         <h3
-          className={`text-sm font-semibold ${
-            hasErrors
+          className={`text-sm font-semibold ${hasErrors
               ? "text-red-800 dark:text-red-200"
               : validationIssues.length > 0
-              ? "text-amber-800 dark:text-amber-200"
-              : "text-emerald-800 dark:text-emerald-200"
-          }`}
+                ? "text-amber-800 dark:text-amber-200"
+                : "text-emerald-800 dark:text-emerald-200"
+            }`}
         >
           {hasErrors ? "Issues to Resolve" : validationIssues.length > 0 ? "Warnings" : "Ready to Create"}
         </h3>
@@ -873,11 +892,10 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
             {validationIssues.map((issue, i) => (
               <li
                 key={i}
-                className={`flex items-center gap-2 text-sm ${
-                  issue.type === "error"
+                className={`flex items-center gap-2 text-sm ${issue.type === "error"
                     ? "text-red-700 dark:text-red-300"
                     : "text-amber-700 dark:text-amber-300"
-                }`}
+                  }`}
               >
                 {issue.type === "error" ? (
                   <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/data/editions/sr5/core-rulebook.json
+++ b/data/editions/sr5/core-rulebook.json
@@ -135,6 +135,288 @@
         ]
       }
     },
+    "adeptPowers": {
+      "mergeStrategy": "replace",
+      "payload": {
+        "powers": [
+          {
+            "id": "adrenaline-boost",
+            "name": "Adrenaline Boost",
+            "cost": 0.25,
+            "costType": "perLevel",
+            "maxLevel": 4,
+            "activation": "free",
+            "description": "+2 Initiative Score per level for the current Combat Turn. Take Drain equal to levels at beginning of next turn."
+          },
+          {
+            "id": "astral-perception",
+            "name": "Astral Perception",
+            "cost": 1,
+            "costType": "fixed",
+            "activation": "simple",
+            "description": "See into the astral plane. Dual-natured while active, can attack astral forms."
+          },
+          {
+            "id": "attribute-boost",
+            "name": "Attribute Boost",
+            "cost": 0.25,
+            "costType": "perLevel",
+            "maxLevel": 4,
+            "activation": "simple",
+            "requiresAttribute": true,
+            "validAttributes": [
+              "body",
+              "agility",
+              "reaction",
+              "strength"
+            ],
+            "description": "Boost a Physical Attribute. Make Magic + Rating Test; each hit boosts attribute by 1. Lasts 2x hits Combat Turns. Drain equal to level afterward."
+          },
+          {
+            "id": "combat-sense",
+            "name": "Combat Sense",
+            "cost": 0.5,
+            "costType": "perLevel",
+            "maxLevel": 6,
+            "description": "+1 defense pool per level against ranged/melee attacks. Always get Perception Test before surprise."
+          },
+          {
+            "id": "critical-strike",
+            "name": "Critical Strike",
+            "cost": 0.5,
+            "costType": "fixed",
+            "requiresSkill": true,
+            "validSkills": [
+              "unarmed-combat",
+              "clubs",
+              "blades",
+              "astral-combat"
+            ],
+            "description": "+1 DV with the selected melee skill. May purchase multiple times for different skills."
+          },
+          {
+            "id": "danger-sense",
+            "name": "Danger Sense",
+            "cost": 0.25,
+            "costType": "perLevel",
+            "maxLevel": 6,
+            "description": "+1 die per level on Surprise Tests."
+          },
+          {
+            "id": "enhanced-perception",
+            "name": "Enhanced Perception",
+            "cost": 0.5,
+            "costType": "perLevel",
+            "maxLevel": 6,
+            "description": "+1 die per level to all Perception and Assensing Tests."
+          },
+          {
+            "id": "enhanced-accuracy",
+            "name": "Enhanced Accuracy",
+            "cost": 0.25,
+            "costType": "fixed",
+            "requiresSkill": true,
+            "validSkills": [
+              "pistols",
+              "automatics",
+              "longarms",
+              "heavy-weapons",
+              "clubs",
+              "blades",
+              "throwing-weapons",
+              "archery"
+            ],
+            "description": "+1 Accuracy with the selected Combat Skill. Cannot use with Unarmed Combat."
+          },
+          {
+            "id": "improved-ability",
+            "name": "Improved Ability",
+            "cost": 0.5,
+            "costType": "perLevel",
+            "maxLevel": 6,
+            "requiresSkill": true,
+            "description": "+1 skill rating per level. Max improvement = current skill × 1.5 (round up). Must know the skill."
+          },
+          {
+            "id": "improved-physical-attribute",
+            "name": "Improved Physical Attribute",
+            "cost": 1,
+            "costType": "perLevel",
+            "maxLevel": 4,
+            "requiresAttribute": true,
+            "validAttributes": [
+              "body",
+              "agility",
+              "reaction",
+              "strength"
+            ],
+            "description": "Permanently increase a Physical Attribute by 1 per level, up to augmented maximum."
+          },
+          {
+            "id": "improved-potential",
+            "name": "Improved Potential",
+            "cost": 0.5,
+            "costType": "perLevel",
+            "maxLevel": 2,
+            "requiresLimit": true,
+            "validLimits": [
+              "physical",
+              "mental",
+              "social"
+            ],
+            "description": "Raise one inherent limit by 1 per level. May purchase once per limit."
+          },
+          {
+            "id": "improved-reflexes",
+            "name": "Improved Reflexes",
+            "cost": null,
+            "costType": "table",
+            "maxLevel": 3,
+            "levels": [
+              {
+                "level": 1,
+                "cost": 1.5,
+                "bonus": "+1 REA, +1D6 Initiative"
+              },
+              {
+                "level": 2,
+                "cost": 2.5,
+                "bonus": "+2 REA, +2D6 Initiative"
+              },
+              {
+                "level": 3,
+                "cost": 3.5,
+                "bonus": "+3 REA, +3D6 Initiative"
+              }
+            ],
+            "description": "Increase Reaction and Initiative Dice. Cannot combine with other Initiative enhancements."
+          },
+          {
+            "id": "improved-sense",
+            "name": "Improved Sense",
+            "cost": 0.25,
+            "costType": "fixed",
+            "variants": [
+              {
+                "id": "low-light-vision",
+                "name": "Low-Light Vision"
+              },
+              {
+                "id": "thermographic-vision",
+                "name": "Thermographic Vision"
+              },
+              {
+                "id": "direction-sense",
+                "name": "Direction Sense",
+                "bonus": "+2 Navigation"
+              },
+              {
+                "id": "improved-tactile",
+                "name": "Improved Tactile",
+                "bonus": "+2 tactile Perception"
+              },
+              {
+                "id": "perfect-pitch",
+                "name": "Perfect Pitch"
+              },
+              {
+                "id": "human-scale",
+                "name": "Human Scale"
+              }
+            ],
+            "description": "Gain a sensory enhancement not normal for your metatype."
+          },
+          {
+            "id": "killing-hands",
+            "name": "Killing Hands",
+            "cost": 0.5,
+            "costType": "fixed",
+            "activation": "free",
+            "description": "Unarmed attacks may cause Physical damage. Attacks are magical and bypass Immunity to Normal Weapons."
+          },
+          {
+            "id": "kinesics",
+            "name": "Kinesics",
+            "cost": 0.25,
+            "costType": "perLevel",
+            "maxLevel": 4,
+            "description": "+1 per level to resist Social Tests and tests to read emotions (Judge Intentions, assensing, etc.)."
+          },
+          {
+            "id": "light-body",
+            "name": "Light Body",
+            "cost": 0.25,
+            "costType": "perLevel",
+            "maxLevel": 4,
+            "description": "Add level to Agility for jump distance. +1 die per level to Gymnastics for jumps. Reduce fall damage by level meters."
+          },
+          {
+            "id": "missile-parry",
+            "name": "Missile Parry",
+            "cost": 0.25,
+            "costType": "perLevel",
+            "maxLevel": 4,
+            "activation": "interrupt",
+            "description": "+1 defense die per level vs slow projectiles (arrows, knives, grenades). Net hits = catch missile."
+          },
+          {
+            "id": "mystic-armor",
+            "name": "Mystic Armor",
+            "cost": 0.5,
+            "costType": "perLevel",
+            "maxLevel": 6,
+            "description": "+1 Armor per level. Stacks with other armor, no encumbrance. Protects in astral combat."
+          },
+          {
+            "id": "natural-immunity",
+            "name": "Natural Immunity",
+            "cost": 0.25,
+            "costType": "perLevel",
+            "maxLevel": 4,
+            "description": "+1 die per level to resist toxins and disease."
+          },
+          {
+            "id": "pain-resistance",
+            "name": "Pain Resistance",
+            "cost": 0.5,
+            "costType": "perLevel",
+            "maxLevel": 4,
+            "description": "Wound modifiers start 1 box later per level. +2 dice per level to resist torture/pain."
+          },
+          {
+            "id": "spell-resistance",
+            "name": "Spell Resistance",
+            "cost": 0.5,
+            "costType": "perLevel",
+            "maxLevel": 6,
+            "description": "+1 die per level to resist spells, rituals, preparations, and Innate Spell critter powers."
+          },
+          {
+            "id": "traceless-walk",
+            "name": "Traceless Walk",
+            "cost": 1,
+            "costType": "fixed",
+            "description": "Leave no visible traces. -4 hearing Perception to detect. Don't trip pressure/vibration sensors. -2 to Track Tests."
+          },
+          {
+            "id": "voice-control",
+            "name": "Voice Control",
+            "cost": 0.5,
+            "costType": "perLevel",
+            "maxLevel": 3,
+            "description": "Control voice pitch, tone, volume. +level to Impersonation. +level to Social limit."
+          },
+          {
+            "id": "wall-running",
+            "name": "Wall Running",
+            "cost": 0.5,
+            "costType": "fixed",
+            "activation": "simple",
+            "description": "Run up vertical surfaces. Running + Strength [Magic] Test = meters climbed per action."
+          }
+        ]
+      }
+    },
     "metatypes": {
       "mergeStrategy": "replace",
       "payload": {
@@ -7950,6 +8232,16 @@
                 "payload": {
                   "type": "custom",
                   "target": "spells"
+                }
+              },
+              {
+                "id": "adept-powers",
+                "title": "Adept Powers",
+                "type": "custom",
+                "description": "Select adept powers using your Power Points (equal to Magic for Adepts).",
+                "payload": {
+                  "type": "custom",
+                  "target": "adeptPowers"
                 }
               },
               {

--- a/lib/rules/RulesetContext.tsx
+++ b/lib/rules/RulesetContext.tsx
@@ -22,7 +22,7 @@ import type {
   ID,
   ContactTemplateData,
 } from "../types";
-import { QualityData } from "./loader";
+import { QualityData, AdeptPowerCatalogItem } from "./loader";
 export type { QualityData };
 
 // =============================================================================
@@ -356,6 +356,7 @@ export interface RulesetData {
   bioware: BiowareCatalogData | null;
   augmentationRules: AugmentationRulesData;
   contactTemplates: ContactTemplateData[];
+  adeptPowers: AdeptPowerCatalogItem[];
 }
 
 /**
@@ -405,6 +406,7 @@ const defaultData: RulesetData = {
   bioware: null,
   augmentationRules: defaultAugmentationRules,
   contactTemplates: [],
+  adeptPowers: [],
 };
 
 const defaultState: RulesetContextState = {
@@ -484,6 +486,7 @@ export function RulesetProvider({
             bioware: extractedData.bioware || null,
             augmentationRules: extractedData.augmentationRules || defaultAugmentationRules,
             contactTemplates: extractedData.contactTemplates || [],
+            adeptPowers: extractedData.adeptPowers || [],
           }
           : defaultData;
 
@@ -1017,4 +1020,12 @@ export function checkAttributeBonusLimit(
 export function useContactTemplates(): ContactTemplateData[] {
   const { data } = useRuleset();
   return data.contactTemplates;
+}
+
+/**
+ * Hook to get adept powers catalog
+ */
+export function useAdeptPowers(): AdeptPowerCatalogItem[] {
+  const { data } = useRuleset();
+  return data.adeptPowers;
 }

--- a/lib/rules/index.ts
+++ b/lib/rules/index.ts
@@ -24,6 +24,7 @@ export {
   useSpells,
   useComplexForms,
   useContactTemplates,
+  useAdeptPowers,
 } from "./RulesetContext";
 
 export type {

--- a/lib/rules/loader.ts
+++ b/lib/rules/loader.ts
@@ -817,3 +817,36 @@ export function extractContactTemplates(ruleset: LoadedRuleset): ContactTemplate
   const module = extractModule<{ templates: ContactTemplateData[] }>(ruleset, "contactTemplates");
   return module?.templates || [];
 }
+
+// =============================================================================
+// ADEPT POWER DATA TYPES AND LOADERS
+// =============================================================================
+
+/**
+ * Adept power catalog item from ruleset data
+ */
+export interface AdeptPowerCatalogItem {
+  id: string;
+  name: string;
+  cost: number | null;
+  costType: "fixed" | "perLevel" | "table";
+  maxLevel?: number;
+  activation?: "free" | "simple" | "complex" | "interrupt";
+  description: string;
+  requiresSkill?: boolean;
+  validSkills?: string[];
+  requiresAttribute?: boolean;
+  validAttributes?: string[];
+  requiresLimit?: boolean;
+  validLimits?: string[];
+  levels?: Array<{ level: number; cost: number; bonus: string }>;
+  variants?: Array<{ id: string; name: string; bonus?: string }>;
+}
+
+/**
+ * Load adept powers from a ruleset
+ */
+export function extractAdeptPowers(ruleset: LoadedRuleset): AdeptPowerCatalogItem[] {
+  const module = extractModule<{ powers: AdeptPowerCatalogItem[] }>(ruleset, "adeptPowers");
+  return module?.powers || [];
+}

--- a/lib/types/character.ts
+++ b/lib/types/character.ts
@@ -302,9 +302,11 @@ export interface LanguageSkill {
 
 export interface AdeptPower {
   id: string;
+  catalogId: string;      // Reference to catalog power ID
   name: string;
-  rating?: number;
-  powerPointCost: number;
+  rating?: number;        // For leveled powers
+  powerPointCost: number; // Actual PP spent
+  specification?: string; // For skill/attribute-specific powers (e.g., "Agility" or "Pistols")
 }
 
 export interface BoundSpirit {

--- a/lib/types/edition.ts
+++ b/lib/types/edition.ts
@@ -121,6 +121,7 @@ export type RuleModuleType =
   | "lifestyle" // Lifestyle costs and features
   | "contacts" // Contact rules and costs
   | "contactTemplates" // Pre-defined contact templates
+  | "adeptPowers" // Adept magical abilities
   | "priorities" // Priority table for creation (SR5)
   | "creationMethods" // Available character creation methods
   | "advancement" // Karma advancement rules


### PR DESCRIPTION
- Add 24 adept powers to core-rulebook.json with full schema (cost, costType, maxLevel, skill/attribute requirements)
- Create AdeptPowersStep.tsx with Power Point tracking
  - Searchable power catalog with cost badges
  - Level/rating selector for variable-cost powers
  - Skill/attribute pickers for specific powers
  - Mystic Adept PP allocation slider
- Extend AdeptPower interface with catalogId and specification fields
- Add extractAdeptPowers() loader and useAdeptPowers() hook
- Wire step into CreationWizard (visible for Adept/Mystic Adept paths)
- Add adept powers display section to ReviewStep