### PR TITLE
B5.1.4: Implement mystic adept power point purchase with karma

### DIFF
--- a/app/characters/create/components/CreationWizard.tsx
+++ b/app/characters/create/components/CreationWizard.tsx
@@ -364,7 +364,8 @@ export function CreationWizard({ onCancel, onComplete }: CreationWizardProps) {
         const karmaSpentGear = (state.budgets["karma-spent-gear"] as number) || 0;
         const karmaSpentSpells = (state.budgets["karma-spent-spells"] as number) || 0;
         const karmaSpentForms = (state.budgets["karma-spent-complex-forms"] as number) || 0;
-        const karmaRemaining = karmaBase + karmaGained - karmaSpentPos - karmaSpentGear - karmaSpentSpells - karmaSpentForms;
+        const karmaSpentPowerPoints = (state.budgets["karma-spent-power-points"] as number) || 0;
+        const karmaRemaining = karmaBase + karmaGained - karmaSpentPos - karmaSpentGear - karmaSpentSpells - karmaSpentForms - karmaSpentPowerPoints;
         if (karmaRemaining > 7) {
           errors.push({
             constraintId: "karma-carryover",
@@ -439,7 +440,8 @@ export function CreationWizard({ onCancel, onComplete }: CreationWizardProps) {
           ((state.budgets["karma-spent-positive"] as number) || 0) +
           ((state.budgets["karma-spent-gear"] as number) || 0) +
           ((state.budgets["karma-spent-spells"] as number) || 0) +
-          ((state.budgets["karma-spent-complex-forms"] as number) || 0);
+          ((state.budgets["karma-spent-complex-forms"] as number) || 0) +
+          ((state.budgets["karma-spent-power-points"] as number) || 0);
         const finalKarmaRemaining = finalKarmaBase + finalKarmaGained - finalKarmaSpent;
         if (finalKarmaRemaining > 7) {
           errors.push({
@@ -785,7 +787,8 @@ export function CreationWizard({ onCancel, onComplete }: CreationWizardProps) {
         ((state.budgets["karma-spent-positive"] as number) || 0) +
         ((state.budgets["karma-spent-gear"] as number) || 0) +
         ((state.budgets["karma-spent-spells"] as number) || 0) +
-        ((state.budgets["karma-spent-complex-forms"] as number) || 0);
+        ((state.budgets["karma-spent-complex-forms"] as number) || 0) +
+        ((state.budgets["karma-spent-power-points"] as number) || 0);
 
       // Calculate remaining Karma (carryover into gameplay)
       const karmaRemaining =

--- a/app/characters/create/components/steps/ReviewStep.tsx
+++ b/app/characters/create/components/steps/ReviewStep.tsx
@@ -117,9 +117,10 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
   const karmaSpentGear = (state.budgets["karma-spent-gear"] as number) || 0;
   const karmaSpentSpells = (state.budgets["karma-spent-spells"] as number) || 0;
   const karmaSpentComplexForms = (state.budgets["karma-spent-complex-forms"] as number) || 0;
+  const karmaSpentPowerPoints = (state.budgets["karma-spent-power-points"] as number) || 0;
 
   const karmaTotal = (budgetValues["karma"] || 25) + karmaGainedNegative;
-  const karmaSpent = karmaSpentPositive + karmaSpentGear + karmaSpentSpells + karmaSpentComplexForms;
+  const karmaSpent = karmaSpentPositive + karmaSpentGear + karmaSpentSpells + karmaSpentComplexForms + karmaSpentPowerPoints;
   const karmaRemaining = karmaTotal - karmaSpent;
 
   const nuyenTotal = budgetValues["nuyen"] || 0;
@@ -701,6 +702,11 @@ export function ReviewStep({ state, updateState, budgetValues }: StepProps) {
             <span className="ml-2 text-xs font-normal text-violet-600 dark:text-violet-400">
               ({((state.selections.adeptPowers as Array<{ id: string; name: string; rating?: number; powerPointCost: number; specification?: string }>) || []).reduce((sum, p) => sum + p.powerPointCost, 0).toFixed(2)} PP)
             </span>
+            {karmaSpentPowerPoints > 0 && (
+              <span className="ml-2 text-xs font-normal text-amber-600 dark:text-amber-400">
+                ({Math.floor(karmaSpentPowerPoints / 5)} PP purchased with Karma)
+              </span>
+            )}
           </h3>
           <div className="mt-3 flex flex-wrap gap-2">
             {((state.selections.adeptPowers as Array<{ id: string; name: string; rating?: number; powerPointCost: number; specification?: string }>) || []).map((power) => (


### PR DESCRIPTION
- Add karma purchase functionality for mystic adepts (5 Karma = 1 PP)
- Update AdeptPowersStep with purchase/remove handlers and UI
- Include karma-spent-power-points in all karma calculations
- Add validation for max power points (Magic rating limit)
- Update ReviewStep to display karma spent on power points
- Follow distributed karma spending pattern from M0.6