### PR TITLE
refactor: move selected items to sidebar for SpellsStep and AdeptPowe…

### DIFF
--- a/app/characters/create/components/ValidationPanel.tsx
+++ b/app/characters/create/components/ValidationPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CreationState, GearItem, CyberwareItem, BiowareItem, Lifestyle } from "@/lib/types";
+import type { CreationState, GearItem, CyberwareItem, BiowareItem, Lifestyle, AdeptPower } from "@/lib/types";
 import { ShoppingCartSection } from "./ShoppingCartSection";
 
 interface ValidationPanelProps {
@@ -21,6 +21,19 @@ interface ValidationPanelProps {
   essenceLoss?: number;
   onRemoveCyberware?: (index: number) => void;
   onRemoveBioware?: (index: number) => void;
+  
+  // Spells cart props
+  spells?: string[];
+  spellsKarmaSpent?: number;
+  freeSpellsCount?: number;
+  onRemoveSpell?: (spellId: string) => void;
+  getSpellName?: (spellId: string) => string;
+  
+  // Adept powers cart props
+  adeptPowers?: AdeptPower[];
+  powerPointsSpent?: number;
+  powerPointsBudget?: number;
+  onRemoveAdeptPower?: (powerId: string) => void;
 }
 
 function formatCurrency(value: number): string {
@@ -49,6 +62,15 @@ export function ValidationPanel({
   essenceLoss,
   onRemoveCyberware,
   onRemoveBioware,
+  spells,
+  spellsKarmaSpent,
+  freeSpellsCount,
+  onRemoveSpell,
+  getSpellName,
+  adeptPowers,
+  powerPointsSpent,
+  powerPointsBudget,
+  onRemoveAdeptPower,
 }: ValidationPanelProps) {
   // Determine cart type based on current step
   const cartType =
@@ -56,6 +78,10 @@ export function ValidationPanel({
       ? ("gear" as const)
       : currentStepId === "augmentations"
       ? ("augmentations" as const)
+      : currentStepId === "spells"
+      ? ("spells" as const)
+      : currentStepId === "adept-powers"
+      ? ("adept-powers" as const)
       : null;
 
   const isCartVisible = cartType !== null;
@@ -214,6 +240,15 @@ export function ValidationPanel({
         essenceLoss={essenceLoss}
         onRemoveCyberware={onRemoveCyberware}
         onRemoveBioware={onRemoveBioware}
+        spells={spells}
+        spellsKarmaSpent={spellsKarmaSpent}
+        freeSpellsCount={freeSpellsCount}
+        onRemoveSpell={onRemoveSpell}
+        getSpellName={getSpellName}
+        adeptPowers={adeptPowers}
+        powerPointsSpent={powerPointsSpent}
+        powerPointsBudget={powerPointsBudget}
+        onRemoveAdeptPower={onRemoveAdeptPower}
       />
 
       {/* Validation Messages */}

--- a/app/characters/create/components/steps/AdeptPowersStep.tsx
+++ b/app/characters/create/components/steps/AdeptPowersStep.tsx
@@ -504,49 +504,6 @@ export function AdeptPowersStep({ state, updateState, budgetValues }: StepProps)
                         </div>
                     )}
 
-                    {/* Current Powers */}
-                    <div className="rounded-lg border border-zinc-200 bg-zinc-50/50 p-4 dark:border-zinc-700 dark:bg-zinc-800/30">
-                        <h3 className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                            Selected Powers ({selectedPowers.length})
-                        </h3>
-
-                        {selectedPowers.length === 0 ? (
-                            <p className="py-4 text-center text-xs text-zinc-500 italic">
-                                No powers selected yet.
-                            </p>
-                        ) : (
-                            <div className="space-y-2">
-                                {selectedPowers.map((power) => (
-                                    <div
-                                        key={power.id}
-                                        className="flex items-center justify-between rounded bg-white p-2 shadow-sm dark:bg-zinc-800"
-                                    >
-                                        <div className="min-w-0 flex-1">
-                                            <div className="flex items-center gap-2">
-                                                <span className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                                                    {power.name}
-                                                    {power.rating && ` ${power.rating}`}
-                                                    {power.specification && ` (${power.specification})`}
-                                                </span>
-                                                <span className="flex-shrink-0 rounded bg-violet-100 px-1.5 py-0.5 text-[10px] font-bold text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
-                                                    {power.powerPointCost} PP
-                                                </span>
-                                            </div>
-                                        </div>
-                                        <button
-                                            onClick={() => handleRemovePower(power.id)}
-                                            className="ml-2 rounded p-1 text-zinc-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20"
-                                            title="Remove power"
-                                        >
-                                            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-                    </div>
                 </div>
             </div>
         </div>

--- a/app/characters/create/components/steps/SpellsStep.tsx
+++ b/app/characters/create/components/steps/SpellsStep.tsx
@@ -138,8 +138,6 @@ export function SpellsStep({ state, updateState, budgetValues }: StepProps) {
         return spells;
     }, [allSpells, spellFilter, searchQuery]);
 
-    const getSpellById = useCallback((id: string) => allSpells.find(s => s.id === id), [allSpells]);
-
     const toggleSpell = useCallback(
         (spellId: string) => {
             const isSelected = selectedSpells.includes(spellId);
@@ -245,9 +243,7 @@ export function SpellsStep({ state, updateState, budgetValues }: StepProps) {
                 )}
             </div>
 
-            <div className="grid gap-6 lg:grid-cols-3">
-                {/* Left Column: Search & List */}
-                <div className="lg:col-span-2 space-y-4">
+            <div className="space-y-4">
                     <div className="sticky top-0 z-10 space-y-2 bg-white pb-2 dark:bg-zinc-900">
                         <input
                             type="text"
@@ -361,80 +357,6 @@ export function SpellsStep({ state, updateState, budgetValues }: StepProps) {
                             </div>
                         )}
                     </div>
-                </div>
-
-                {/* Right Column: Selected Spells */}
-                <div className="space-y-4">
-                    <div className="sticky top-4 rounded-lg border border-zinc-200 bg-zinc-50/50 p-4 dark:border-zinc-700 dark:bg-zinc-800/30">
-                        <h3 className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                            Selected Spells ({selectedSpells.length})
-                        </h3>
-
-                        {selectedSpells.length === 0 ? (
-                            <p className="py-4 text-center text-xs text-zinc-500 italic">
-                                No spells selected yet.
-                            </p>
-                        ) : (
-                            <div className="space-y-2">
-                                {selectedSpells.map((id, index) => {
-                                    const spell = getSpellById(id);
-                                    const isFree = index < freeSpells;
-
-                                    return (
-                                        <div key={id} className="flex items-center justify-between rounded bg-white p-2 shadow-sm dark:bg-zinc-800">
-                                            <div className="min-w-0 flex-1">
-                                                <div className="flex items-center gap-2">
-                                                    <span className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                                                        {spell?.name || id}
-                                                    </span>
-                                                    {!isFree && (
-                                                        <span className="flex-shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-bold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
-                                                            {SPELL_KARMA_COST}K
-                                                        </span>
-                                                    )}
-                                                    {isFree && (
-                                                        <span className="flex-shrink-0 rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-bold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
-                                                            FREE
-                                                        </span>
-                                                    )}
-                                                </div>
-                                            </div>
-                                            <button
-                                                onClick={() => toggleSpell(id)}
-                                                className="ml-2 rounded p-1 text-zinc-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20"
-                                                title="Remove spell"
-                                            >
-                                                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                                </svg>
-                                            </button>
-                                        </div>
-                                    );
-                                })}
-                            </div>
-                        )}
-
-                        {/* Validation Messages */}
-                        {selectedSpells.length > maxTotalSpells && (
-                            <div className="mt-4 rounded bg-red-50 p-2 text-xs text-red-600 dark:bg-red-900/20 dark:text-red-400">
-                                You have exceeded the maximum of {maxTotalSpells} spells (Magic × 2).
-                            </div>
-                        )}
-
-                        {categoriesAtLimit.length > 0 && (
-                            <div className="mt-4 rounded bg-amber-50 p-2 text-xs text-amber-700 dark:bg-amber-900/20 dark:text-amber-400">
-                                <div className="font-medium mb-1">Category limits reached:</div>
-                                <ul className="list-disc list-inside space-y-0.5">
-                                    {categoriesAtLimit.map((cat) => (
-                                        <li key={cat.id}>
-                                            {cat.name}: {spellsPerCategory[cat.id]}/{maxPerCategory} (Magic × 2)
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
-                    </div>
-                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
…rsStep

- Extend ShoppingCartSection to support 'spells' and 'adept-powers' cart types
- Display selected spells with free/karma indicators in sidebar
- Display selected adept powers with PP costs in sidebar
- Update ValidationPanel to handle new cart types based on currentStepId
- Extract spells and adept powers state in CreationWizard
- Add handleRemoveSpell and handleRemoveAdeptPower handlers
- Refactor SpellsStep: remove right column, make catalog full width
- Refactor AdeptPowersStep: remove selected powers list, keep config form
- Follows same pattern as GearStep and AugmentationsStep for consistency

This frees up space in the main content area for better catalog browsing while keeping selected items always visible in the sidebar.