### PR TITLE
feat(ruleset-discovery): implement Ruleset Discovery capability

### DIFF
--- a/app/api/editions/[editionCode]/content/route.ts
+++ b/app/api/editions/[editionCode]/content/route.ts
@@ -1,0 +1,204 @@
+/**
+ * API Route: GET /api/editions/[editionCode]/content
+ *
+ * Returns paginated content previews for an edition.
+ * Supports filtering by category.
+ *
+ * Query params:
+ *   - category: Filter by content category (metatypes, skills, qualities, gear, etc.)
+ *   - limit: Maximum number of items to return (default: 20, max: 100)
+ *   - offset: Pagination offset (default: 0)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAllBookPayloads, getEdition } from "@/lib/storage/editions";
+import type { ContentPreviewItem, ContentPreviewResponse } from "@/lib/types";
+import type { EditionCode } from "@/lib/types";
+
+// Valid content categories for filtering
+const VALID_CATEGORIES = [
+  "metatypes",
+  "skills",
+  "qualities",
+  "gear",
+  "magic",
+  "cyberware",
+  "bioware",
+  "vehicles",
+] as const;
+
+type ContentCategoryType = (typeof VALID_CATEGORIES)[number];
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ editionCode: string }> }
+) {
+  try {
+    const { editionCode } = await params;
+    const { searchParams } = new URL(request.url);
+    
+    const category = searchParams.get("category") as ContentCategoryType | null;
+    const limit = Math.min(parseInt(searchParams.get("limit") || "20"), 100);
+    const offset = parseInt(searchParams.get("offset") || "0");
+
+    // Validate edition exists
+    const edition = await getEdition(editionCode as EditionCode);
+    if (!edition) {
+      return NextResponse.json(
+        { success: false, error: `Edition not found: ${editionCode}` },
+        { status: 404 }
+      );
+    }
+
+    // Validate category if provided
+    if (category && !VALID_CATEGORIES.includes(category)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid category: ${category}. Valid options: ${VALID_CATEGORIES.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    const payloads = await getAllBookPayloads(editionCode as EditionCode);
+    const allItems: ContentPreviewItem[] = [];
+
+    // Extract items based on category or all categories
+    for (const payload of payloads) {
+      const modules = payload.modules || {};
+      const sourceBook = payload.meta.title;
+
+      if (!category || category === "metatypes") {
+        const metatypesPayload = modules.metatypes?.payload as { metatypes?: Array<{ id: string; name: string; description?: string }> } | undefined;
+        if (metatypesPayload?.metatypes) {
+          for (const item of metatypesPayload.metatypes) {
+            allItems.push({
+              id: item.id,
+              name: item.name,
+              category: "metatypes",
+              summary: item.description?.slice(0, 100),
+              source: sourceBook,
+            });
+          }
+        }
+      }
+
+      if (!category || category === "skills") {
+        const skillsPayload = modules.skills?.payload as { activeSkills?: Array<{ id: string; name: string; linkedAttribute?: string }> } | undefined;
+        if (skillsPayload?.activeSkills) {
+          for (const item of skillsPayload.activeSkills) {
+            allItems.push({
+              id: item.id,
+              name: item.name,
+              category: "skills",
+              summary: item.linkedAttribute ? `Linked to ${item.linkedAttribute}` : undefined,
+              source: sourceBook,
+            });
+          }
+        }
+      }
+
+      if (!category || category === "qualities") {
+        const qualitiesPayload = modules.qualities?.payload as { 
+          positive?: Array<{ id: string; name: string; description?: string }>; 
+          negative?: Array<{ id: string; name: string; description?: string }>; 
+        } | undefined;
+        if (qualitiesPayload) {
+          for (const item of qualitiesPayload.positive || []) {
+            allItems.push({
+              id: item.id,
+              name: item.name,
+              category: "qualities",
+              summary: item.description?.slice(0, 100),
+              source: sourceBook,
+            });
+          }
+          for (const item of qualitiesPayload.negative || []) {
+            allItems.push({
+              id: item.id,
+              name: item.name,
+              category: "qualities",
+              summary: item.description?.slice(0, 100),
+              source: sourceBook,
+            });
+          }
+        }
+      }
+
+      if (!category || category === "gear") {
+        // Gear structure: weapons/armor are objects with category keys (pistols, rifles, etc.)
+        // Each category contains an array of items
+        const gearPayload = modules.gear?.payload as Record<string, unknown> | undefined;
+        if (gearPayload) {
+          // Extract weapons (nested object with categories)
+          const weapons = gearPayload.weapons as Record<string, Array<{ id?: string; name: string; damage?: string }>> | undefined;
+          if (weapons && typeof weapons === "object") {
+            for (const [weaponCategory, weaponList] of Object.entries(weapons)) {
+              if (Array.isArray(weaponList)) {
+                for (const item of weaponList) {
+                  allItems.push({
+                    id: item.id || item.name.toLowerCase().replace(/\s+/g, "-"),
+                    name: item.name,
+                    category: "gear",
+                    summary: item.damage ? `${weaponCategory}: ${item.damage}` : weaponCategory,
+                    source: sourceBook,
+                  });
+                }
+              }
+            }
+          }
+
+          // Extract armor (can be array or nested object)
+          const armor = gearPayload.armor;
+          if (Array.isArray(armor)) {
+            for (const item of armor as Array<{ id?: string; name: string; armorRating?: number }>) {
+              allItems.push({
+                id: item.id || item.name.toLowerCase().replace(/\s+/g, "-"),
+                name: item.name,
+                category: "gear",
+                summary: item.armorRating ? `Armor: ${item.armorRating}` : undefined,
+                source: sourceBook,
+              });
+            }
+          } else if (armor && typeof armor === "object") {
+            // Handle nested armor categories
+            for (const [, armorList] of Object.entries(armor as Record<string, unknown>)) {
+              if (Array.isArray(armorList)) {
+                for (const item of armorList as Array<{ id?: string; name: string; armorRating?: number }>) {
+                  allItems.push({
+                    id: item.id || item.name.toLowerCase().replace(/\s+/g, "-"),
+                    name: item.name,
+                    category: "gear",
+                    summary: item.armorRating ? `Armor: ${item.armorRating}` : undefined,
+                    source: sourceBook,
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Apply pagination
+    const total = allItems.length;
+    const items = allItems.slice(offset, offset + limit);
+
+    const response: ContentPreviewResponse = {
+      items,
+      total,
+      offset,
+      limit,
+      category: category || undefined,
+    };
+
+    return NextResponse.json({
+      success: true,
+      ...response,
+    });
+  } catch (error) {
+    console.error("Failed to fetch content:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch content" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/editions/[editionCode]/methods/[methodId]/route.ts
+++ b/app/api/editions/[editionCode]/methods/[methodId]/route.ts
@@ -1,0 +1,155 @@
+/**
+ * API Route: GET /api/editions/[editionCode]/methods/[methodId]
+ *
+ * Returns detailed information about a specific creation method,
+ * including its impact on resource allocation.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCreationMethod, getEdition } from "@/lib/storage/editions";
+import type { CreationMethodSummary } from "@/lib/types";
+import type { EditionCode } from "@/lib/types";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ editionCode: string; methodId: string }> }
+) {
+  try {
+    const { editionCode, methodId } = await params;
+
+    // Validate edition exists
+    const edition = await getEdition(editionCode as EditionCode);
+    if (!edition) {
+      return NextResponse.json(
+        { success: false, error: `Edition not found: ${editionCode}` },
+        { status: 404 }
+      );
+    }
+
+    // Get the creation method
+    const method = await getCreationMethod(editionCode as EditionCode, methodId);
+    if (!method) {
+      return NextResponse.json(
+        { success: false, error: `Creation method not found: ${methodId}` },
+        { status: 404 }
+      );
+    }
+
+    // Build detailed summary with resource allocation explanation
+    const summary: CreationMethodSummary = {
+      id: method.id,
+      name: method.name,
+      description: method.description || `${method.name} character creation method`,
+      resourceAllocationImpact: buildResourceAllocationExplanation(method),
+      complexity: determineComplexity(method),
+      estimatedTimeMinutes: estimateCreationTime(method),
+      tradeoffs: getMethodTradeoffs(method),
+    };
+
+    return NextResponse.json({
+      success: true,
+      method: summary,
+      rawMethod: method, // Include raw data for advanced users
+    });
+  } catch (error) {
+    console.error("Failed to fetch creation method:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch creation method" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Generate explanation of resource allocation for a creation method
+ */
+function buildResourceAllocationExplanation(method: {
+  id: string;
+  name: string;
+  type?: string;
+}): string {
+  // Build explanation based on method type
+  if (method.id === "priority" || method.type === "priority") {
+    return "Priority-based creation uses five priority levels (A through E) assigned to five categories: Metatype, Attributes, Magic/Resonance, Skills, and Resources. Each priority can only be used once, creating meaningful trade-offs. High priority in one area means lower priority elsewhere.";
+  }
+  
+  if (method.id === "sum-to-ten" || method.type === "sum-to-ten") {
+    return "Sum-to-Ten is a variant of Priority creation where priority levels are assigned point values (A=4, B=3, C=2, D=1, E=0) and must total exactly 10. This allows for more flexible combinations than standard Priority.";
+  }
+  
+  if (method.id === "karma-build" || method.type === "karma") {
+    return "Karma Build provides a pool of Karma points to spend directly on all character aspects. Every attribute point, skill rank, and enhancement has a Karma cost. This method offers maximum flexibility but requires careful planning.";
+  }
+  
+  if (method.id === "life-modules" || method.type === "life-modules") {
+    return "Life Modules create characters through narrative choices representing life stages. Each module (nationality, formative years, education, career) provides skills, contacts, and backgrounds while telling your character's story.";
+  }
+
+  return `The ${method.name} method allocates resources based on its specific rules. Consult the rulebook for detailed allocation guidelines.`;
+}
+
+/**
+ * Determine complexity level based on method characteristics
+ */
+function determineComplexity(method: {
+  id: string;
+  type?: string;
+}): "beginner" | "intermediate" | "advanced" {
+  if (method.id === "priority") return "beginner";
+  if (method.id === "sum-to-ten") return "intermediate";
+  if (method.id === "karma-build" || method.type === "karma") return "advanced";
+  if (method.id === "life-modules") return "intermediate";
+  return "intermediate";
+}
+
+/**
+ * Estimate character creation time in minutes
+ */
+function estimateCreationTime(method: { id: string }): number {
+  switch (method.id) {
+    case "priority":
+      return 60; // 1 hour for beginners
+    case "sum-to-ten":
+      return 75;
+    case "karma-build":
+      return 120; // 2 hours for point-buy
+    case "life-modules":
+      return 90;
+    default:
+      return 90;
+  }
+}
+
+/**
+ * Get key tradeoffs for a creation method
+ */
+function getMethodTradeoffs(method: { id: string }): string[] {
+  switch (method.id) {
+    case "priority":
+      return [
+        "Simple and fast but limits optimization",
+        "Priority A-E choices create clear character archetypes",
+        "Less flexible than point-buy systems",
+      ];
+    case "sum-to-ten":
+      return [
+        "More flexible than standard Priority",
+        "Can create unique priority combinations",
+        "Still constrained to total of 10 points",
+      ];
+    case "karma-build":
+      return [
+        "Maximum flexibility in character design",
+        "Requires careful math and planning",
+        "Can create highly optimized or unbalanced characters",
+      ];
+    case "life-modules":
+      return [
+        "Narrative-driven character creation",
+        "Less mathematical optimization",
+        "Great for developing character backstory",
+      ];
+    default:
+      return [];
+  }
+}

--- a/app/rulesets/components/ContentPreview.tsx
+++ b/app/rulesets/components/ContentPreview.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Loader2, ChevronLeft, ChevronRight } from "lucide-react";
+import type { ContentPreviewItem, EditionCode } from "@/lib/types";
+
+interface ContentPreviewProps {
+    editionCode: EditionCode;
+    category?: string;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+    metatypes: "Metatypes",
+    skills: "Skills",
+    qualities: "Qualities",
+    gear: "Gear",
+    magic: "Magic",
+    cyberware: "Cyberware",
+    bioware: "Bioware",
+    vehicles: "Vehicles",
+};
+
+export default function ContentPreview({ editionCode, category }: ContentPreviewProps) {
+    const [items, setItems] = useState<ContentPreviewItem[]>([]);
+    const [total, setTotal] = useState(0);
+    const [offset, setOffset] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [selectedCategory, setSelectedCategory] = useState<string | undefined>(category);
+
+    const limit = 10;
+
+    useEffect(() => {
+        async function fetchContent() {
+            setLoading(true);
+            setError(null);
+            try {
+                const params = new URLSearchParams({
+                    limit: limit.toString(),
+                    offset: offset.toString(),
+                });
+                if (selectedCategory) {
+                    params.set("category", selectedCategory);
+                }
+
+                const res = await fetch(`/api/editions/${editionCode}/content?${params}`);
+                const data = await res.json();
+
+                if (data.success) {
+                    setItems(data.items);
+                    setTotal(data.total);
+                } else {
+                    setError(data.error || "Failed to load content");
+                }
+            } catch (err) {
+                setError("An error occurred while loading content");
+                console.error(err);
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        fetchContent();
+    }, [editionCode, offset, selectedCategory]);
+
+    const handleCategoryChange = (cat: string | undefined) => {
+        setSelectedCategory(cat);
+        setOffset(0);
+    };
+
+    const hasNext = offset + limit < total;
+    const hasPrev = offset > 0;
+
+    return (
+        <div className="space-y-4">
+            {/* Category Filter */}
+            <div className="flex flex-wrap gap-2">
+                <button
+                    onClick={() => handleCategoryChange(undefined)}
+                    className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                        !selectedCategory
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                    }`}
+                >
+                    All
+                </button>
+                {Object.entries(CATEGORY_LABELS).map(([key, label]) => (
+                    <button
+                        key={key}
+                        onClick={() => handleCategoryChange(key)}
+                        className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                            selectedCategory === key
+                                ? "bg-primary text-primary-foreground"
+                                : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+                        }`}
+                    >
+                        {label}
+                    </button>
+                ))}
+            </div>
+
+            {/* Content List */}
+            {loading ? (
+                <div className="flex items-center justify-center py-8">
+                    <Loader2 className="w-6 h-6 animate-spin text-primary" />
+                </div>
+            ) : error ? (
+                <div className="text-center py-8 text-destructive">{error}</div>
+            ) : items.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                    No content found{selectedCategory ? ` in ${CATEGORY_LABELS[selectedCategory]}` : ""}.
+                </div>
+            ) : (
+                <div className="space-y-2">
+                    {items.map((item) => (
+                        <div
+                            key={`${item.category}-${item.id}`}
+                            className="p-3 rounded-lg bg-secondary/30 border border-border hover:bg-secondary/50 transition-colors"
+                        >
+                            <div className="flex items-start justify-between">
+                                <div>
+                                    <h4 className="font-medium text-foreground">{item.name}</h4>
+                                    {item.summary && (
+                                        <p className="text-sm text-muted-foreground mt-0.5 line-clamp-2">
+                                            {item.summary}
+                                        </p>
+                                    )}
+                                </div>
+                                {item.category && (
+                                    <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">
+                                        {CATEGORY_LABELS[item.category] || item.category}
+                                    </span>
+                                )}
+                            </div>
+                            {item.source && (
+                                <p className="text-xs text-muted-foreground mt-2">
+                                    Source: {item.source}
+                                </p>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Pagination */}
+            {total > limit && (
+                <div className="flex items-center justify-between pt-2 border-t border-border">
+                    <span className="text-sm text-muted-foreground">
+                        Showing {offset + 1}-{Math.min(offset + limit, total)} of {total}
+                    </span>
+                    <div className="flex gap-2">
+                        <button
+                            onClick={() => setOffset(Math.max(0, offset - limit))}
+                            disabled={!hasPrev}
+                            className="p-2 rounded-lg bg-secondary hover:bg-secondary/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                            <ChevronLeft className="w-4 h-4" />
+                        </button>
+                        <button
+                            onClick={() => setOffset(offset + limit)}
+                            disabled={!hasNext}
+                            className="p-2 rounded-lg bg-secondary hover:bg-secondary/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                            <ChevronRight className="w-4 h-4" />
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/app/rulesets/components/EditionCard.tsx
+++ b/app/rulesets/components/EditionCard.tsx
@@ -4,13 +4,18 @@ import { Book, Layers, ArrowRight } from "lucide-react";
 interface EditionCardProps {
     edition: Edition;
     onSelect: (code: EditionCode) => void;
+    isSelected?: boolean;
 }
 
-export default function EditionCard({ edition, onSelect }: EditionCardProps) {
+export default function EditionCard({ edition, onSelect, isSelected }: EditionCardProps) {
     return (
         <div
             onClick={() => onSelect(edition.shortCode)}
-            className="group relative overflow-hidden rounded-xl border border-border bg-card hover:border-primary/50 transition-all duration-300 cursor-pointer hover:shadow-lg"
+            className={`group relative overflow-hidden rounded-xl border bg-card transition-all duration-300 cursor-pointer hover:shadow-lg ${
+                isSelected 
+                    ? "border-primary shadow-lg ring-2 ring-primary/20" 
+                    : "border-border hover:border-primary/50"
+            }`}
         >
             <div className="p-6">
                 <div className="flex justify-between items-start mb-4">

--- a/app/rulesets/components/EditionDetailView.tsx
+++ b/app/rulesets/components/EditionDetailView.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
 import { Edition, EditionCode, Book, CreationMethod } from "@/lib/types";
-import { X, ArrowRight, Loader2, BookOpen, UserPlus } from "lucide-react";
+import { X, ArrowRight, Loader2, BookOpen, UserPlus, Layers } from "lucide-react";
 import BookCard from "./BookCard";
 import CreationMethodCard from "./CreationMethodCard";
+import ContentPreview from "./ContentPreview";
 
 interface EditionDetailViewProps {
     editionCode: EditionCode;
@@ -18,7 +19,7 @@ export default function EditionDetailView({ editionCode, onClose }: EditionDetai
         creationMethods: CreationMethod[];
     } | null>(null);
 
-    const [activeTab, setActiveTab] = useState<"overview" | "books" | "methods">("overview");
+    const [activeTab, setActiveTab] = useState<"overview" | "content" | "books" | "methods">("overview");
 
     useEffect(() => {
         async function fetchData() {
@@ -95,11 +96,10 @@ export default function EditionDetailView({ editionCode, onClose }: EditionDetai
                     </a>
                 </div>
 
-                {/* Tabs */}
-                <div className="flex border-b border-border">
+                <div className="flex border-b border-border overflow-x-auto">
                     <button
                         onClick={() => setActiveTab("overview")}
-                        className={`px-4 py-2 border-b-2 font-medium text-sm transition-colors ${activeTab === "overview"
+                        className={`px-4 py-2 border-b-2 font-medium text-sm transition-colors whitespace-nowrap ${activeTab === "overview"
                             ? "border-primary text-primary"
                             : "border-transparent text-muted-foreground hover:text-foreground"
                             }`}
@@ -107,8 +107,20 @@ export default function EditionDetailView({ editionCode, onClose }: EditionDetai
                         Overview
                     </button>
                     <button
+                        onClick={() => setActiveTab("content")}
+                        className={`px-4 py-2 border-b-2 font-medium text-sm transition-colors whitespace-nowrap ${activeTab === "content"
+                            ? "border-primary text-primary"
+                            : "border-transparent text-muted-foreground hover:text-foreground"
+                            }`}
+                    >
+                        <span className="flex items-center gap-1.5">
+                            <Layers className="w-4 h-4" />
+                            Content
+                        </span>
+                    </button>
+                    <button
                         onClick={() => setActiveTab("books")}
-                        className={`px-4 py-2 border-b-2 font-medium text-sm transition-colors ${activeTab === "books"
+                        className={`px-4 py-2 border-b-2 font-medium text-sm transition-colors whitespace-nowrap ${activeTab === "books"
                             ? "border-primary text-primary"
                             : "border-transparent text-muted-foreground hover:text-foreground"
                             }`}
@@ -117,7 +129,7 @@ export default function EditionDetailView({ editionCode, onClose }: EditionDetai
                     </button>
                     <button
                         onClick={() => setActiveTab("methods")}
-                        className={`px-4 py-2 border-b-2 font-medium text-sm transition-colors ${activeTab === "methods"
+                        className={`px-4 py-2 border-b-2 font-medium text-sm transition-colors whitespace-nowrap ${activeTab === "methods"
                             ? "border-primary text-primary"
                             : "border-transparent text-muted-foreground hover:text-foreground"
                             }`}
@@ -153,6 +165,12 @@ export default function EditionDetailView({ editionCode, onClose }: EditionDetai
                                     <p className="text-2xl font-bold">{creationMethods?.length || 0}</p>
                                 </div>
                             </div>
+                        </div>
+                    )}
+
+                    {activeTab === "content" && (
+                        <div className="animate-in fade-in zoom-in-95 duration-200">
+                            <ContentPreview editionCode={edition.shortCode} />
                         </div>
                     )}
 

--- a/data/editions/sr5/edition.json
+++ b/data/editions/sr5/edition.json
@@ -12,6 +12,15 @@
     "priority"
   ],
   "defaultCreationMethodId": "priority",
+  "philosophy": "Fifth Edition brings a streamlined approach to the classic Shadowrun experience, balancing narrative freedom with structured mechanical resolution. The Priority system provides clear trade-offs during character creation, while Limits ensure no single attribute dominates dice rolls.",
+  "mechanicalHighlights": [
+    "Priority-based character creation with clear trade-offs",
+    "Limits system (Physical, Mental, Social) constraining maximum hits",
+    "Wireless Matrix with Grid Overwatch Division (GOD)",
+    "Essence-based magic/resonance interaction for augmented awakened",
+    "Streamlined initiative with variable action economy"
+  ],
+  "supportedContentTypes": ["core", "sourcebook", "adventure"],
   "createdAt": "2025-01-01T00:00:00.000Z",
   "updatedAt": "2025-01-01T00:00:00.000Z"
 }

--- a/lib/types/discovery.ts
+++ b/lib/types/discovery.ts
@@ -1,0 +1,160 @@
+/**
+ * Ruleset Discovery Types
+ *
+ * Types supporting the Ruleset Discovery capability for browsing
+ * editions, source materials, and content summaries.
+ *
+ * @see docs/capabilities/ruleset.discovery.md
+ */
+
+import type { EditionCode, BookCategory } from "./edition";
+
+// =============================================================================
+// CONTENT SUMMARY TYPES
+// =============================================================================
+
+/**
+ * Category summary for content discovery
+ */
+export interface ContentCategory {
+  id: string;
+  name: string;
+  itemCount: number;
+  /** Optional description of the category */
+  description?: string;
+}
+
+/**
+ * Complete content summary for an edition
+ * Provides counts and category overviews for all major content domains.
+ */
+export interface ContentSummary {
+  editionCode: EditionCode;
+  
+  /** Total counts by domain */
+  metatypeCount: number;
+  skillCount: number;
+  qualityCount: number;
+  spellCount: number;
+  gearCount: number;
+  augmentationCount: number;
+  vehicleCount: number;
+  
+  /** Detailed category breakdowns */
+  categories: ContentCategory[];
+  
+  /** When this summary was generated */
+  generatedAt: string;
+}
+
+// =============================================================================
+// BOOK SUMMARY TYPES
+// =============================================================================
+
+/**
+ * Summary of a book's metadata and content contributions
+ */
+export interface BookSummary {
+  id: string;
+  title: string;
+  abbreviation?: string;
+  category: BookCategory;
+  /** Role description (e.g., "Core rules foundation", "Gear expansion") */
+  role: string;
+  /** Content domains this book contributes to */
+  contentContributions: ContentCategory[];
+  /** Page count if available */
+  pageCount?: number;
+  /** Release year of the book */
+  releaseYear?: number;
+}
+
+// =============================================================================
+// EDITION DISCOVERY TYPES
+// =============================================================================
+
+/**
+ * Extended edition metadata for discovery interfaces
+ * Supplements the base Edition type with discovery-specific fields.
+ */
+export interface EditionDiscoveryMetadata {
+  /** Game philosophy/design approach abstract */
+  philosophy?: string;
+  
+  /** Key mechanical features of this edition */
+  mechanicalHighlights?: string[];
+  
+  /** Types of content supported (core, sourcebook, adventure) */
+  supportedContentTypes?: BookCategory[];
+  
+  /** Tags for categorization and filtering */
+  tags?: string[];
+}
+
+// =============================================================================
+// CREATION METHOD SUMMARY TYPES
+// =============================================================================
+
+/**
+ * Summary of a creation method's resource allocation impact
+ */
+export interface CreationMethodSummary {
+  id: string;
+  name: string;
+  /** Brief description of the method */
+  description: string;
+  /** Detailed explanation of resource allocation */
+  resourceAllocationImpact: string;
+  /** Complexity level for new players */
+  complexity: "beginner" | "intermediate" | "advanced";
+  /** Estimated time to complete character creation */
+  estimatedTimeMinutes?: number;
+  /** Key tradeoffs or considerations */
+  tradeoffs?: string[];
+}
+
+// =============================================================================
+// CONTENT PREVIEW TYPES
+// =============================================================================
+
+/**
+ * Preview item for content browsing (metatypes, gear, etc.)
+ * Minimal data for high-performance discovery browsing.
+ */
+export interface ContentPreviewItem {
+  id: string;
+  name: string;
+  category?: string;
+  /** Brief description for preview */
+  summary?: string;
+  /** Source book reference */
+  source?: string;
+}
+
+/**
+ * Paginated content preview response
+ */
+export interface ContentPreviewResponse {
+  items: ContentPreviewItem[];
+  total: number;
+  offset: number;
+  limit: number;
+  category?: string;
+}
+
+// =============================================================================
+// DISCOVERY API RESPONSE TYPES
+// =============================================================================
+
+/**
+ * Enhanced edition response with discovery metadata
+ */
+export interface EditionDiscoveryResponse {
+  success: boolean;
+  editionCode: EditionCode;
+  contentSummary?: ContentSummary;
+  books?: BookSummary[];
+  creationMethods?: CreationMethodSummary[];
+  discoveryMetadata?: EditionDiscoveryMetadata;
+  error?: string;
+}

--- a/lib/types/edition.ts
+++ b/lib/types/edition.ts
@@ -58,6 +58,14 @@ export interface Edition {
   /** Default creation method for new characters */
   defaultCreationMethodId?: ID;
 
+  // Discovery metadata (optional, for enhanced browsing)
+  /** Game philosophy/design approach abstract */
+  philosophy?: string;
+  /** Key mechanical features of this edition */
+  mechanicalHighlights?: string[];
+  /** Types of content supported */
+  supportedContentTypes?: BookCategory[];
+
   createdAt: ISODateString;
   updatedAt?: ISODateString;
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -257,3 +257,15 @@ export type {
   ResolvedEffect,
 } from "./gameplay";
 
+// Discovery types (for ruleset browsing)
+export type {
+  ContentCategory,
+  ContentSummary,
+  BookSummary,
+  EditionDiscoveryMetadata,
+  CreationMethodSummary,
+  ContentPreviewItem,
+  ContentPreviewResponse,
+  EditionDiscoveryResponse,
+} from "./discovery";
+


### PR DESCRIPTION
- Add discovery types (ContentSummary, BookSummary, CreationMethodSummary)
- Add content summarization storage functions (getEditionContentSummary, getBookSummary)
- Add /api/editions/[code]/content endpoint with category filtering and pagination
- Add /api/editions/[code]/methods/[methodId] endpoint for creation method details
- Add ContentPreview component for browsing edition content
- Add URL-based deep linking to EditionBrowser (?edition=sr5)
- Add Content tab to EditionDetailView
- Extend Edition interface with philosophy, mechanicalHighlights, supportedContentTypes
- Enhance SR5 edition.json with discovery metadata

Capability guarantees satisfied:
- Edition metadata queryable (name, release year, versioning)
- Content summary with category counts
- Creation methods with allocation impact accessible
- Source material categorized (Core, Sourcebook, Adventure)
- Deep linking for shared campaign planning
- Discovery interfaces are read-only