### PR TITLE
feat(ruleset): implement ruleset integrity capability

### DIFF
--- a/app/api/campaigns/[id]/route.ts
+++ b/app/api/campaigns/[id]/route.ts
@@ -117,6 +117,35 @@ export async function PUT(
             }
         }
 
+        // Edition Transition Guard
+        // Satisfies Ruleset Integrity: "A campaign MUST NOT transition between
+        // different game editions once initialized."
+        // @see docs/capabilities/ruleset.integrity.md
+        if (
+            (body as Record<string, unknown>).editionCode !== undefined &&
+            (body as Record<string, unknown>).editionCode !== campaign!.editionCode
+        ) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "Edition cannot be changed after campaign initialization. Create a new campaign for a different edition."
+                },
+                { status: 400 }
+            );
+        }
+        if (
+            (body as Record<string, unknown>).editionId !== undefined &&
+            (body as Record<string, unknown>).editionId !== campaign!.editionId
+        ) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: "Edition cannot be changed after campaign initialization. Create a new campaign for a different edition."
+                },
+                { status: 400 }
+            );
+        }
+
         // Merge advancement settings if present
         const { advancementSettings, ...restBody } = body;
         const updateData: Partial<Campaign> = { ...restBody };

--- a/data/violations/_index.json
+++ b/data/violations/_index.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": "f9e7e7f2-06c8-4de4-9a0a-0a2a16fed02c",
+    "characterId": "char-789",
+    "violationType": "content_access",
+    "severity": "error",
+    "timestamp": "2025-12-24T21:20:14.330Z"
+  },
+  {
+    "id": "1a2b401f-8c79-489d-8cb1-f55168d57547",
+    "characterId": "test-char-1766611214336",
+    "violationType": "creation",
+    "severity": "error",
+    "timestamp": "2025-12-24T21:20:14.336Z"
+  },
+  {
+    "id": "fedfee34-32c3-4769-a11d-5bbfd8dc8b2d",
+    "characterId": "test-char-1766611214336",
+    "violationType": "advancement",
+    "severity": "error",
+    "timestamp": "2025-12-24T21:20:14.338Z"
+  },
+  {
+    "id": "c159b35f-e9a2-4568-852a-0d1f3c284a6e",
+    "characterId": "test-char-1766611214340",
+    "violationType": "creation",
+    "severity": "error",
+    "timestamp": "2025-12-24T21:20:14.340Z"
+  },
+  {
+    "id": "606683cb-059c-4c7e-8245-7fdc04a6ad5c",
+    "characterId": "test-char-1766611214340",
+    "violationType": "advancement",
+    "severity": "error",
+    "timestamp": "2025-12-24T21:20:14.341Z"
+  },
+  {
+    "id": "ea10bc62-33a5-4464-b28b-d4d57bccea34",
+    "characterId": "char-val-test",
+    "campaignId": "campaign-123",
+    "violationType": "edition_mismatch",
+    "severity": "error",
+    "timestamp": "2025-12-24T21:20:14.343Z"
+  },
+  {
+    "id": "f7210b53-cddf-4169-a6ff-c2e49e6e04e5",
+    "characterId": "char-val-test",
+    "campaignId": "campaign-123",
+    "violationType": "edition_mismatch",
+    "severity": "error",
+    "timestamp": "2025-12-24T21:20:14.347Z"
+  }
+]

--- a/docs/architecture/merge-precedence.md
+++ b/docs/architecture/merge-precedence.md
@@ -1,0 +1,98 @@
+# Merge Precedence Model
+
+This document describes the deterministic precedence model used to resolve conflicts when multiple ruleset bundles (Core Rulebook + Sourcebooks) modify the same data.
+
+> [!IMPORTANT]
+> This documentation satisfies the Ruleset Integrity Capability requirement:
+> _"Data conflicts across multiple active bundles MUST be resolved using a predefined precedence model, ensuring a predictable and verifiable ruleset state."_
+
+## Overview
+
+Shadow Master uses a **layered merge approach** where later layers overlay earlier ones. The system applies merge strategies (`merge`, `replace`, `append`, `remove`) as defined in [ADR-003: Rule Merging Strategies](../decisions/003-ruleset.rule-merging-strategies.md).
+
+## Precedence Order (Lowest to Highest)
+
+| Priority | Layer                             | Description                                              |
+| -------- | --------------------------------- | -------------------------------------------------------- |
+| 1 (Base) | **Core Rulebook**                 | The edition's primary rulebook (e.g., SR5 Core)          |
+| 2        | **Standard Sourcebooks**          | Additional rulebooks in alphabetical order by `bookCode` |
+| 3        | **Explicit Priority Sourcebooks** | Books with a `priority` field, sorted ascending          |
+| 4 (Top)  | **Campaign Overrides**            | GM-specific house rules (future enhancement)             |
+
+### Resolution Rules
+
+1. **Higher priority wins**: When the same property is modified by multiple books, the highest priority book's value is used.
+
+2. **Alphabetical fallback**: Books without explicit priority are processed alphabetically by `bookCode`. Example: `chrome-flesh` < `rigger-5` < `run-faster`.
+
+3. **Explicit removal always wins**: If any book uses the `remove` strategy, the removal is applied regardless of priority.
+
+4. **Strategy-specific merging**:
+   - `merge`: Deep recursive merge (objects combine, arrays merge by ID)
+   - `replace`: Complete overwrite of the target
+   - `append`: Items added to array without removing existing
+   - `remove`: Specific keys or items are deleted
+
+## Examples
+
+### Example 1: Cost Override
+
+```
+Core Rulebook (priority 1):
+  Ares Predator V: { cost: 725 }
+
+Run & Gun (priority 2):
+  Ares Predator V: { cost: 700, strategy: "merge" }
+
+Result:
+  Ares Predator V: { cost: 700 }  ← Run & Gun wins
+```
+
+### Example 2: Attribute Addition
+
+```
+Core Rulebook:
+  Weapon: { damage: "8P", ap: -1 }
+
+Chrome Flesh:
+  Weapon: { smartgunIntegrated: true, strategy: "merge" }
+
+Result:
+  Weapon: { damage: "8P", ap: -1, smartgunIntegrated: true }
+```
+
+### Example 3: Removal
+
+```
+Core Rulebook:
+  Skills: ["etiquette", "con", "intimidation"]
+
+Errata 2.0:
+  Skills: ["con"], strategy: "remove"
+
+Result:
+  Skills: ["etiquette", "intimidation"]  ← "con" removed
+```
+
+## Implementation Reference
+
+The merge logic is implemented in [`lib/rules/merge.ts`](file:///Users/jrags/Code/Jasrags/shadow-master/lib/rules/merge.ts).
+
+Key functions:
+
+- `produceMergedRuleset()` — Main merge orchestrator
+- `mergeRules()` — Applies strategy-based merge
+- `deepMerge()` — Recursive object/array merging
+
+## Silent Resolution
+
+Per design decision, merge conflicts are resolved silently without UI notification. GMs who need to inspect merge behavior can:
+
+1. Review the source data files in `data/editions/{edition}/books/`
+2. Examine the `snapshotId` on the merged ruleset
+3. (Future) Access an audit log of applied merges
+
+## Related Documents
+
+- [ADR-003: Rule Merging Strategies](../decisions/003-ruleset.rule-merging-strategies.md)
+- [Ruleset Integrity Capability](../capabilities/ruleset.integrity.md)

--- a/lib/rules/__tests__/optional-rules.test.ts
+++ b/lib/rules/__tests__/optional-rules.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  extractOptionalRules,
+  resolveOptionalRules,
+  getActiveOptionalRules,
+  isOptionalRuleActive,
+  validateOptionalRuleAccess,
+  createEmptyOptionalRulesState,
+  createDefaultOptionalRulesState,
+  enableOptionalRule,
+  disableOptionalRule,
+  resetOptionalRule,
+  type OptionalRule,
+  type OptionalRulesState,
+} from "../optional-rules";
+import type { LoadedRuleset } from "../loader-types";
+
+describe("optional-rules", () => {
+  // Test data
+  const mockOptionalRules: OptionalRule[] = [
+    {
+      id: "wireless-bonuses",
+      name: "Wireless Bonuses",
+      description: "Enable wireless bonuses for gear",
+      sourceBookId: "core",
+      defaultEnabled: true,
+      affectedModules: ["gear", "cyberware"],
+    },
+    {
+      id: "called-shots",
+      name: "Called Shots",
+      description: "Enable called shot rules",
+      sourceBookId: "run-and-gun",
+      defaultEnabled: true,
+      affectedModules: ["combat"],
+    },
+    {
+      id: "martial-arts",
+      name: "Martial Arts",
+      description: "Enable martial arts subsystem",
+      sourceBookId: "run-and-gun",
+      defaultEnabled: false,
+      affectedModules: ["combat"],
+    },
+  ];
+
+  describe("resolveOptionalRules", () => {
+    it("should use defaults when no state provided", () => {
+      const result = resolveOptionalRules(mockOptionalRules, undefined);
+
+      expect(result.allRules).toHaveLength(3);
+      expect(result.activeRules).toHaveLength(2); // wireless-bonuses and called-shots
+      expect(result.inactiveRules).toHaveLength(1); // martial-arts
+    });
+
+    it("should use defaults with empty state", () => {
+      const state = createEmptyOptionalRulesState();
+      const result = resolveOptionalRules(mockOptionalRules, state);
+
+      expect(result.activeRules).toHaveLength(2);
+      expect(result.inactiveRules).toHaveLength(1);
+    });
+
+    it("should enable a disabled rule when in enabledRuleIds", () => {
+      const state: OptionalRulesState = {
+        enabledRuleIds: ["martial-arts"],
+        disabledRuleIds: [],
+      };
+      const result = resolveOptionalRules(mockOptionalRules, state);
+
+      expect(result.activeRules).toHaveLength(3);
+      expect(result.activeRules.map((r) => r.id)).toContain("martial-arts");
+    });
+
+    it("should disable an enabled rule when in disabledRuleIds", () => {
+      const state: OptionalRulesState = {
+        enabledRuleIds: [],
+        disabledRuleIds: ["wireless-bonuses"],
+      };
+      const result = resolveOptionalRules(mockOptionalRules, state);
+
+      expect(result.activeRules).toHaveLength(1);
+      expect(result.inactiveRules).toHaveLength(2);
+      expect(result.inactiveRules.map((r) => r.id)).toContain("wireless-bonuses");
+    });
+
+    it("should give disabledRuleIds precedence over enabledRuleIds", () => {
+      const state: OptionalRulesState = {
+        enabledRuleIds: ["martial-arts"],
+        disabledRuleIds: ["martial-arts"], // Both! Disabled wins
+      };
+      const result = resolveOptionalRules(mockOptionalRules, state);
+
+      expect(result.activeRules.map((r) => r.id)).not.toContain("martial-arts");
+      expect(result.inactiveRules.map((r) => r.id)).toContain("martial-arts");
+    });
+  });
+
+  describe("isOptionalRuleActive", () => {
+    it("should return true for active rule", () => {
+      const state = createEmptyOptionalRulesState();
+      expect(isOptionalRuleActive("wireless-bonuses", mockOptionalRules, state)).toBe(true);
+    });
+
+    it("should return false for inactive rule", () => {
+      const state = createEmptyOptionalRulesState();
+      expect(isOptionalRuleActive("martial-arts", mockOptionalRules, state)).toBe(false);
+    });
+
+    it("should return false for non-existent rule", () => {
+      const state = createEmptyOptionalRulesState();
+      expect(isOptionalRuleActive("fake-rule", mockOptionalRules, state)).toBe(false);
+    });
+  });
+
+  describe("validateOptionalRuleAccess", () => {
+    it("should return null for active rule", () => {
+      const state = createEmptyOptionalRulesState();
+      const error = validateOptionalRuleAccess("wireless-bonuses", mockOptionalRules, state);
+      expect(error).toBeNull();
+    });
+
+    it("should return error for inactive rule", () => {
+      const state = createEmptyOptionalRulesState();
+      const error = validateOptionalRuleAccess("martial-arts", mockOptionalRules, state);
+      expect(error).toContain("disabled");
+    });
+
+    it("should return error for non-existent rule", () => {
+      const state = createEmptyOptionalRulesState();
+      const error = validateOptionalRuleAccess("fake-rule", mockOptionalRules, state);
+      expect(error).toContain("not found");
+    });
+  });
+
+  describe("mutation helpers", () => {
+    let state: OptionalRulesState;
+
+    beforeEach(() => {
+      state = createEmptyOptionalRulesState();
+    });
+
+    describe("enableOptionalRule", () => {
+      it("should add rule to enabledRuleIds", () => {
+        const newState = enableOptionalRule(state, "martial-arts");
+        expect(newState.enabledRuleIds).toContain("martial-arts");
+      });
+
+      it("should remove rule from disabledRuleIds if present", () => {
+        state = { enabledRuleIds: [], disabledRuleIds: ["martial-arts"] };
+        const newState = enableOptionalRule(state, "martial-arts");
+        expect(newState.disabledRuleIds).not.toContain("martial-arts");
+        expect(newState.enabledRuleIds).toContain("martial-arts");
+      });
+
+      it("should not duplicate if already enabled", () => {
+        state = { enabledRuleIds: ["martial-arts"], disabledRuleIds: [] };
+        const newState = enableOptionalRule(state, "martial-arts");
+        expect(newState.enabledRuleIds.filter((id) => id === "martial-arts")).toHaveLength(1);
+      });
+    });
+
+    describe("disableOptionalRule", () => {
+      it("should add rule to disabledRuleIds", () => {
+        const newState = disableOptionalRule(state, "wireless-bonuses");
+        expect(newState.disabledRuleIds).toContain("wireless-bonuses");
+      });
+
+      it("should remove rule from enabledRuleIds if present", () => {
+        state = { enabledRuleIds: ["wireless-bonuses"], disabledRuleIds: [] };
+        const newState = disableOptionalRule(state, "wireless-bonuses");
+        expect(newState.enabledRuleIds).not.toContain("wireless-bonuses");
+        expect(newState.disabledRuleIds).toContain("wireless-bonuses");
+      });
+    });
+
+    describe("resetOptionalRule", () => {
+      it("should remove rule from both lists", () => {
+        state = { enabledRuleIds: ["rule-a"], disabledRuleIds: ["rule-b"] };
+        
+        let newState = resetOptionalRule(state, "rule-a");
+        expect(newState.enabledRuleIds).not.toContain("rule-a");
+        
+        newState = resetOptionalRule(state, "rule-b");
+        expect(newState.disabledRuleIds).not.toContain("rule-b");
+      });
+    });
+  });
+
+  describe("createDefaultOptionalRulesState", () => {
+    it("should return empty state", () => {
+      const state = createDefaultOptionalRulesState(mockOptionalRules);
+      expect(state.enabledRuleIds).toHaveLength(0);
+      expect(state.disabledRuleIds).toHaveLength(0);
+    });
+  });
+});

--- a/lib/rules/campaign-validation.ts
+++ b/lib/rules/campaign-validation.ts
@@ -97,6 +97,37 @@ export function validateCharacterCampaignCompliance(
         }
     }
 
+    // 5. Optional Rules Compliance
+    // Satisfies: "Any attempt to use content or mechanics from a disabled
+    // or incompatible bundle MUST be rejected."
+    // @see docs/capabilities/ruleset.integrity.md
+    if (campaign.optionalRules) {
+        const { disabledRuleIds } = campaign.optionalRules;
+        
+        // Check if character uses content that requires disabled optional rules
+        // This is a foundational check - specific content validation would be
+        // implemented by the content modules (qualities, gear, etc.) checking
+        // their requiredOptionalRuleId against the campaign's active rules.
+        
+        // For now, we validate that character metadata doesn't reference
+        // any explicitly disabled rules
+        const characterOptionalRules = (character as { optionalRuleIds?: string[] }).optionalRuleIds;
+        if (characterOptionalRules && characterOptionalRules.length > 0) {
+            const violatingRules = characterOptionalRules.filter(
+                (ruleId) => disabledRuleIds.includes(ruleId)
+            );
+            
+            if (violatingRules.length > 0) {
+                errors.push({
+                    constraintId: "campaign-optional-rule-violation",
+                    field: "optionalRuleIds",
+                    message: `Character uses optional rules disabled in this campaign: ${violatingRules.join(", ")}`,
+                    severity: "error",
+                });
+            }
+        }
+    }
+
     return {
         valid: errors.length === 0,
         errors,

--- a/lib/rules/optional-rules.ts
+++ b/lib/rules/optional-rules.ts
@@ -1,0 +1,329 @@
+/**
+ * Optional Rules System
+ *
+ * Provides governance for optional rules that can be activated or
+ * deactivated at the campaign level by the GM.
+ *
+ * Satisfies Ruleset Integrity Capability:
+ * - "The system MUST support 'optional rules' defined within bundles
+ *    that can be activated or deactivated by a campaign authority."
+ *
+ * @see docs/capabilities/ruleset.integrity.md
+ * @see docs/decisions/003-ruleset.rule-merging-strategies.md
+ */
+
+import type { ID, RuleModuleType } from "../types";
+import type { LoadedRuleset } from "./loader-types";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * An optional rule that can be toggled on/off at campaign level.
+ */
+export interface OptionalRule {
+  /** Unique identifier for this optional rule */
+  id: string;
+
+  /** Display name */
+  name: string;
+
+  /** Description of what this rule changes */
+  description: string;
+
+  /** The source book that defines this rule */
+  sourceBookId: ID;
+
+  /** Whether this rule is enabled by default when the book is active */
+  defaultEnabled: boolean;
+
+  /** Which ruleset modules this rule affects */
+  affectedModules: RuleModuleType[];
+
+  /** Tags for categorization (e.g., "combat", "magic", "matrix") */
+  tags?: string[];
+}
+
+/**
+ * Campaign-level configuration for optional rules.
+ * GM-controlled; players cannot override.
+ */
+export interface OptionalRulesState {
+  /** IDs of rules explicitly enabled (overrides defaultEnabled: false) */
+  enabledRuleIds: string[];
+
+  /** IDs of rules explicitly disabled (overrides defaultEnabled: true) */
+  disabledRuleIds: string[];
+}
+
+/**
+ * Result of extracting optional rules from a ruleset.
+ */
+export interface OptionalRulesExtraction {
+  /** All optional rules found in the loaded books */
+  allRules: OptionalRule[];
+
+  /** Rules that are active given the current state */
+  activeRules: OptionalRule[];
+
+  /** Rules that are inactive given the current state */
+  inactiveRules: OptionalRule[];
+}
+
+/**
+ * Structure for optional rules module payload in book data.
+ * This may be defined in a book's payload.modules under a custom key.
+ */
+interface OptionalRulesPayload {
+  rules?: Array<Partial<OptionalRule>>;
+}
+
+// =============================================================================
+// EXTRACTION
+// =============================================================================
+
+/**
+ * Extract all optional rules from a loaded ruleset.
+ *
+ * Scans each book's payload for optional rules data.
+ * Note: Optional rules are typically stored in a book's custom metadata
+ * or in a dedicated "optionalRules" payload structure.
+ *
+ * @param ruleset - The loaded ruleset containing book payloads
+ * @returns Array of all optional rules found
+ */
+export function extractOptionalRules(ruleset: LoadedRuleset): OptionalRule[] {
+  const rules: OptionalRule[] = [];
+
+  for (const book of ruleset.books) {
+    // Access the modules object - check for a custom optionalRules key
+    // Since optionalRules isn't a standard RuleModuleType, we check the raw payload
+    const modulesPayload = book.payload.modules as Record<string, { payload?: unknown } | undefined>;
+    
+    // Try to find optional rules in a custom module or in the book's metadata
+    const optionalRulesEntry = modulesPayload["optionalRules"] as { payload?: OptionalRulesPayload } | undefined;
+    
+    if (optionalRulesEntry?.payload?.rules && Array.isArray(optionalRulesEntry.payload.rules)) {
+      const bookRules = optionalRulesEntry.payload.rules
+        .filter((r): r is OptionalRule =>
+          typeof r.id === "string" &&
+          typeof r.name === "string" &&
+          typeof r.description === "string"
+        )
+        .map((r) => ({
+          ...r,
+          sourceBookId: book.id,
+          defaultEnabled: r.defaultEnabled ?? true,
+          affectedModules: r.affectedModules ?? [],
+        }));
+
+      rules.push(...bookRules);
+    }
+  }
+
+  return rules;
+}
+
+// =============================================================================
+// RESOLUTION
+// =============================================================================
+
+/**
+ * Determine which optional rules are active given the campaign's configuration.
+ *
+ * Resolution logic:
+ * 1. Start with each rule's defaultEnabled value
+ * 2. If rule ID is in enabledRuleIds, it's active
+ * 3. If rule ID is in disabledRuleIds, it's inactive
+ * 4. disabledRuleIds takes precedence over enabledRuleIds if both contain the same ID
+ *
+ * @param allRules - All optional rules extracted from the ruleset
+ * @param state - Campaign-level optional rules configuration
+ * @returns Extraction result with active and inactive rules
+ */
+export function resolveOptionalRules(
+  allRules: OptionalRule[],
+  state: OptionalRulesState | undefined
+): OptionalRulesExtraction {
+  if (!state) {
+    // No campaign configuration - use defaults
+    const activeRules = allRules.filter((r) => r.defaultEnabled);
+    const inactiveRules = allRules.filter((r) => !r.defaultEnabled);
+    return { allRules, activeRules, inactiveRules };
+  }
+
+  const { enabledRuleIds, disabledRuleIds } = state;
+  const activeRules: OptionalRule[] = [];
+  const inactiveRules: OptionalRule[] = [];
+
+  for (const rule of allRules) {
+    // Disabled takes precedence
+    if (disabledRuleIds.includes(rule.id)) {
+      inactiveRules.push(rule);
+    } else if (enabledRuleIds.includes(rule.id)) {
+      activeRules.push(rule);
+    } else if (rule.defaultEnabled) {
+      activeRules.push(rule);
+    } else {
+      inactiveRules.push(rule);
+    }
+  }
+
+  return { allRules, activeRules, inactiveRules };
+}
+
+/**
+ * Get active optional rules from a loaded ruleset and campaign state.
+ *
+ * Convenience function combining extraction and resolution.
+ *
+ * @param ruleset - The loaded ruleset
+ * @param campaignOptionalState - Campaign's optional rules configuration
+ * @returns Array of currently active optional rules
+ */
+export function getActiveOptionalRules(
+  ruleset: LoadedRuleset,
+  campaignOptionalState: OptionalRulesState | undefined
+): OptionalRule[] {
+  const allRules = extractOptionalRules(ruleset);
+  const { activeRules } = resolveOptionalRules(allRules, campaignOptionalState);
+  return activeRules;
+}
+
+// =============================================================================
+// VALIDATION
+// =============================================================================
+
+/**
+ * Check if a specific optional rule is active.
+ *
+ * @param ruleId - The ID of the optional rule to check
+ * @param allRules - All optional rules from the ruleset
+ * @param state - Campaign's optional rules configuration
+ * @returns true if the rule is active, false otherwise
+ */
+export function isOptionalRuleActive(
+  ruleId: string,
+  allRules: OptionalRule[],
+  state: OptionalRulesState | undefined
+): boolean {
+  const { activeRules } = resolveOptionalRules(allRules, state);
+  return activeRules.some((r) => r.id === ruleId);
+}
+
+/**
+ * Validate that content requiring a specific optional rule is accessible.
+ *
+ * @param requiredRuleId - The optional rule ID that must be active
+ * @param allRules - All optional rules from the ruleset
+ * @param state - Campaign's optional rules configuration
+ * @returns Error message if rule is inactive, null if accessible
+ */
+export function validateOptionalRuleAccess(
+  requiredRuleId: string,
+  allRules: OptionalRule[],
+  state: OptionalRulesState | undefined
+): string | null {
+  const rule = allRules.find((r) => r.id === requiredRuleId);
+
+  if (!rule) {
+    return `Optional rule '${requiredRuleId}' not found in ruleset`;
+  }
+
+  if (!isOptionalRuleActive(requiredRuleId, allRules, state)) {
+    return `Optional rule '${rule.name}' is disabled in this campaign`;
+  }
+
+  return null;
+}
+
+// =============================================================================
+// DEFAULTS
+// =============================================================================
+
+/**
+ * Create an empty optional rules state.
+ */
+export function createEmptyOptionalRulesState(): OptionalRulesState {
+  return {
+    enabledRuleIds: [],
+    disabledRuleIds: [],
+  };
+}
+
+/**
+ * Create an optional rules state with all defaults.
+ *
+ * @param allRules - All optional rules to base defaults on
+ * @returns State that matches the default enabled state of all rules
+ */
+export function createDefaultOptionalRulesState(
+  // Parameter kept for API consistency - allows future enhancement
+  // to pre-populate state based on rule defaults
+  allRules: OptionalRule[]
+): OptionalRulesState {
+  // Empty state means "use defaults" - no explicit overrides needed
+  // The allRules parameter is available for future customization
+  void allRules;
+  return createEmptyOptionalRulesState();
+}
+
+// =============================================================================
+// MUTATION HELPERS
+// =============================================================================
+
+/**
+ * Enable an optional rule in the state.
+ *
+ * @param state - Current state
+ * @param ruleId - ID of rule to enable
+ * @returns New state with rule enabled
+ */
+export function enableOptionalRule(
+  state: OptionalRulesState,
+  ruleId: string
+): OptionalRulesState {
+  return {
+    enabledRuleIds: state.enabledRuleIds.includes(ruleId)
+      ? state.enabledRuleIds
+      : [...state.enabledRuleIds, ruleId],
+    disabledRuleIds: state.disabledRuleIds.filter((id) => id !== ruleId),
+  };
+}
+
+/**
+ * Disable an optional rule in the state.
+ *
+ * @param state - Current state
+ * @param ruleId - ID of rule to disable
+ * @returns New state with rule disabled
+ */
+export function disableOptionalRule(
+  state: OptionalRulesState,
+  ruleId: string
+): OptionalRulesState {
+  return {
+    enabledRuleIds: state.enabledRuleIds.filter((id) => id !== ruleId),
+    disabledRuleIds: state.disabledRuleIds.includes(ruleId)
+      ? state.disabledRuleIds
+      : [...state.disabledRuleIds, ruleId],
+  };
+}
+
+/**
+ * Reset an optional rule to its default state.
+ *
+ * @param state - Current state
+ * @param ruleId - ID of rule to reset
+ * @returns New state with rule reset to default
+ */
+export function resetOptionalRule(
+  state: OptionalRulesState,
+  ruleId: string
+): OptionalRulesState {
+  return {
+    enabledRuleIds: state.enabledRuleIds.filter((id) => id !== ruleId),
+    disabledRuleIds: state.disabledRuleIds.filter((id) => id !== ruleId),
+  };
+}

--- a/lib/storage/__tests__/violation-record.test.ts
+++ b/lib/storage/__tests__/violation-record.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "fs";
+import path from "path";
+import {
+  recordViolation,
+  getViolationById,
+  getViolationsByCharacter,
+  getViolationsByCampaign,
+  queryViolations,
+  getViolationCountsByType,
+  createViolationFromValidation,
+  type ViolationRecordInput,
+} from "../violation-record";
+
+describe("violation-record", () => {
+  const DATA_DIR = path.join(process.cwd(), "data", "violations");
+
+  // Track created violation IDs for cleanup
+  let createdIds: string[] = [];
+
+  beforeEach(async () => {
+    createdIds = [];
+  });
+
+  afterEach(async () => {
+    // Cleanup created violations
+    for (const id of createdIds) {
+      try {
+        await fs.unlink(path.join(DATA_DIR, `${id}.json`));
+      } catch {
+        // Ignore if file doesn't exist
+      }
+    }
+
+    // Reset index to empty array if it exists
+    try {
+      const indexPath = path.join(DATA_DIR, "_index.json");
+      const index = JSON.parse(await fs.readFile(indexPath, "utf-8"));
+      const filteredIndex = index.filter(
+        (entry: { id: string }) => !createdIds.includes(entry.id)
+      );
+      await fs.writeFile(indexPath, JSON.stringify(filteredIndex, null, 2));
+    } catch {
+      // Ignore if index doesn't exist
+    }
+  });
+
+  describe("recordViolation", () => {
+    it("should create a violation record with generated id and timestamp", async () => {
+      const input: ViolationRecordInput = {
+        characterId: "char-123",
+        violationType: "creation",
+        severity: "error",
+        constraintId: "test-constraint",
+        details: {
+          attemptedAction: "Add forbidden quality",
+          rejectReason: "Quality not available in edition",
+        },
+      };
+
+      const record = await recordViolation(input);
+      createdIds.push(record.id);
+
+      expect(record.id).toBeDefined();
+      expect(record.timestamp).toBeDefined();
+      expect(record.characterId).toBe("char-123");
+      expect(record.violationType).toBe("creation");
+      expect(record.constraintId).toBe("test-constraint");
+    });
+
+    it("should save the record to disk", async () => {
+      const input: ViolationRecordInput = {
+        characterId: "char-456",
+        violationType: "advancement",
+        severity: "error",
+        constraintId: "max-rating",
+        details: {
+          attemptedAction: "Increase skill to 14",
+          rejectReason: "Exceeds maximum rating of 13",
+        },
+      };
+
+      const record = await recordViolation(input);
+      createdIds.push(record.id);
+
+      // Verify file exists
+      const filePath = path.join(DATA_DIR, `${record.id}.json`);
+      const fileContent = await fs.readFile(filePath, "utf-8");
+      const savedRecord = JSON.parse(fileContent);
+
+      expect(savedRecord.id).toBe(record.id);
+      expect(savedRecord.characterId).toBe("char-456");
+    });
+  });
+
+  describe("getViolationById", () => {
+    it("should retrieve a violation by ID", async () => {
+      const input: ViolationRecordInput = {
+        characterId: "char-789",
+        violationType: "content_access",
+        severity: "error",
+        constraintId: "book-restriction",
+        details: {
+          attemptedAction: "Access Run & Gun content",
+          rejectReason: "Book not enabled in campaign",
+        },
+      };
+
+      const created = await recordViolation(input);
+      createdIds.push(created.id);
+
+      const retrieved = await getViolationById(created.id);
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.id).toBe(created.id);
+      expect(retrieved!.characterId).toBe("char-789");
+    });
+
+    it("should return null for non-existent ID", async () => {
+      const result = await getViolationById("non-existent-id");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getViolationsByCharacter", () => {
+    it("should return violations for a specific character", async () => {
+      const characterId = `test-char-${Date.now()}`;
+
+      // Create two violations for the same character
+      const v1 = await recordViolation({
+        characterId,
+        violationType: "creation",
+        severity: "error",
+        constraintId: "test-1",
+        details: { attemptedAction: "Action 1", rejectReason: "Reason 1" },
+      });
+      createdIds.push(v1.id);
+
+      const v2 = await recordViolation({
+        characterId,
+        violationType: "advancement",
+        severity: "error",
+        constraintId: "test-2",
+        details: { attemptedAction: "Action 2", rejectReason: "Reason 2" },
+      });
+      createdIds.push(v2.id);
+
+      const violations = await getViolationsByCharacter(characterId);
+
+      expect(violations.length).toBeGreaterThanOrEqual(2);
+      expect(violations.every((v) => v.characterId === characterId)).toBe(true);
+    });
+
+    it("should return empty array for character with no violations", async () => {
+      const violations = await getViolationsByCharacter("no-violations-char");
+      expect(violations).toEqual([]);
+    });
+  });
+
+  describe("createViolationFromValidation", () => {
+    it("should create a violation with validation context", async () => {
+      const record = await createViolationFromValidation({
+        characterId: "char-val-test",
+        campaignId: "campaign-123",
+        violationType: "edition_mismatch",
+        constraintId: "edition-check",
+        attemptedAction: "Join SR6 campaign with SR5 character",
+        rejectReason: "Edition mismatch",
+        rulesetSnapshotId: "snapshot-abc",
+        enabledBookIds: ["core", "run-faster"],
+      });
+      createdIds.push(record.id);
+
+      expect(record.campaignId).toBe("campaign-123");
+      expect(record.details.rulesetSnapshotId).toBe("snapshot-abc");
+      expect(record.details.enabledBookIds).toContain("core");
+    });
+  });
+
+  describe("getViolationCountsByType", () => {
+    it("should return counts by violation type", async () => {
+      const charId = `count-test-${Date.now()}`;
+
+      const v1 = await recordViolation({
+        characterId: charId,
+        violationType: "creation",
+        severity: "error",
+        constraintId: "c1",
+        details: { attemptedAction: "a", rejectReason: "r" },
+      });
+      createdIds.push(v1.id);
+
+      const v2 = await recordViolation({
+        characterId: charId,
+        violationType: "creation",
+        severity: "error",
+        constraintId: "c2",
+        details: { attemptedAction: "a", rejectReason: "r" },
+      });
+      createdIds.push(v2.id);
+
+      const v3 = await recordViolation({
+        characterId: charId,
+        violationType: "advancement",
+        severity: "error",
+        constraintId: "c3",
+        details: { attemptedAction: "a", rejectReason: "r" },
+      });
+      createdIds.push(v3.id);
+
+      const counts = await getViolationCountsByType(charId);
+
+      expect(counts.creation).toBeGreaterThanOrEqual(2);
+      expect(counts.advancement).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/lib/storage/violation-record.ts
+++ b/lib/storage/violation-record.ts
@@ -1,0 +1,441 @@
+/**
+ * Violation Record Storage
+ *
+ * Provides persistent storage for validation rejection audit trail.
+ *
+ * Satisfies Ruleset Integrity Capability:
+ * - "Any attempt to use content or mechanics from a disabled or
+ *    incompatible bundle MUST be rejected with a clear violation record."
+ *
+ * Design Decision: Violations are stored indefinitely for full audit trail.
+ *
+ * @see docs/capabilities/ruleset.integrity.md
+ */
+
+import { promises as fs } from "fs";
+import path from "path";
+import { randomUUID } from "crypto";
+import type { ID } from "../types";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Type of violation that occurred.
+ */
+export type ViolationType =
+  | "creation" // During character creation
+  | "advancement" // During character advancement
+  | "content_access" // Attempting to access disabled content
+  | "edition_mismatch" // Edition compatibility violation
+  | "book_restriction" // Book not enabled in campaign
+  | "optional_rule"; // Optional rule violation
+
+/**
+ * Severity of the violation.
+ */
+export type ViolationSeverity = "error" | "warning";
+
+/**
+ * A record of a validation rejection for audit purposes.
+ */
+export interface ViolationRecord {
+  /** Unique ID for this violation record */
+  id: ID;
+
+  /** Character that triggered the violation */
+  characterId: ID;
+
+  /** Campaign context (if applicable) */
+  campaignId?: ID;
+
+  /** User who triggered the violation */
+  userId?: ID;
+
+  /** When the violation occurred */
+  timestamp: string;
+
+  /** Type of violation */
+  violationType: ViolationType;
+
+  /** Severity level */
+  severity: ViolationSeverity;
+
+  /** The specific constraint that was violated */
+  constraintId: string;
+
+  /** Detailed information about the violation */
+  details: {
+    /** What action was attempted */
+    attemptedAction: string;
+
+    /** Why it was rejected */
+    rejectReason: string;
+
+    /** Ruleset snapshot ID at time of violation */
+    rulesetSnapshotId?: string;
+
+    /** Book IDs that were active */
+    enabledBookIds?: string[];
+
+    /** Additional context */
+    context?: Record<string, unknown>;
+  };
+}
+
+/**
+ * Input for creating a new violation record.
+ */
+export type ViolationRecordInput = Omit<ViolationRecord, "id" | "timestamp">;
+
+/**
+ * Query options for retrieving violations.
+ */
+export interface ViolationQueryOptions {
+  /** Filter by character ID */
+  characterId?: ID;
+
+  /** Filter by campaign ID */
+  campaignId?: ID;
+
+  /** Filter by user ID */
+  userId?: ID;
+
+  /** Filter by violation type */
+  violationType?: ViolationType;
+
+  /** Filter by severity */
+  severity?: ViolationSeverity;
+
+  /** Only violations after this date */
+  after?: string;
+
+  /** Only violations before this date */
+  before?: string;
+
+  /** Maximum number of records to return */
+  limit?: number;
+
+  /** Offset for pagination */
+  offset?: number;
+}
+
+// =============================================================================
+// DATA DIRECTORY
+// =============================================================================
+
+const DATA_DIR = path.join(process.cwd(), "data", "violations");
+
+/**
+ * Ensure the violations directory exists.
+ */
+async function ensureDataDir(): Promise<void> {
+  try {
+    await fs.access(DATA_DIR);
+  } catch {
+    await fs.mkdir(DATA_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Get the file path for a violation record.
+ */
+function getViolationFilePath(id: ID): string {
+  return path.join(DATA_DIR, `${id}.json`);
+}
+
+/**
+ * Get the index file path.
+ */
+function getIndexFilePath(): string {
+  return path.join(DATA_DIR, "_index.json");
+}
+
+// =============================================================================
+// INDEX MANAGEMENT
+// =============================================================================
+
+/**
+ * Index entry for quick lookups.
+ */
+interface ViolationIndexEntry {
+  id: ID;
+  characterId: ID;
+  campaignId?: ID;
+  userId?: ID;
+  violationType: ViolationType;
+  severity: ViolationSeverity;
+  timestamp: string;
+}
+
+/**
+ * Read the violations index.
+ */
+async function readIndex(): Promise<ViolationIndexEntry[]> {
+  try {
+    const content = await fs.readFile(getIndexFilePath(), "utf-8");
+    return JSON.parse(content) as ViolationIndexEntry[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write the violations index.
+ */
+async function writeIndex(entries: ViolationIndexEntry[]): Promise<void> {
+  await fs.writeFile(getIndexFilePath(), JSON.stringify(entries, null, 2));
+}
+
+/**
+ * Add an entry to the index.
+ */
+async function addToIndex(record: ViolationRecord): Promise<void> {
+  const index = await readIndex();
+  index.push({
+    id: record.id,
+    characterId: record.characterId,
+    campaignId: record.campaignId,
+    userId: record.userId,
+    violationType: record.violationType,
+    severity: record.severity,
+    timestamp: record.timestamp,
+  });
+  await writeIndex(index);
+}
+
+// =============================================================================
+// CRUD OPERATIONS
+// =============================================================================
+
+/**
+ * Record a new violation.
+ *
+ * @param input - Violation data (without id and timestamp)
+ * @returns The created violation record
+ */
+export async function recordViolation(
+  input: ViolationRecordInput
+): Promise<ViolationRecord> {
+  await ensureDataDir();
+
+  const record: ViolationRecord = {
+    ...input,
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+  };
+
+  // Write the full record
+  await fs.writeFile(
+    getViolationFilePath(record.id),
+    JSON.stringify(record, null, 2)
+  );
+
+  // Update index for efficient queries
+  await addToIndex(record);
+
+  return record;
+}
+
+/**
+ * Get a violation record by ID.
+ *
+ * @param id - Violation ID
+ * @returns The violation record or null if not found
+ */
+export async function getViolationById(id: ID): Promise<ViolationRecord | null> {
+  try {
+    const content = await fs.readFile(getViolationFilePath(id), "utf-8");
+    return JSON.parse(content) as ViolationRecord;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get all violations for a character.
+ *
+ * @param characterId - Character ID
+ * @returns Array of violation records
+ */
+export async function getViolationsByCharacter(
+  characterId: ID
+): Promise<ViolationRecord[]> {
+  const index = await readIndex();
+  const matchingIds = index
+    .filter((e) => e.characterId === characterId)
+    .map((e) => e.id);
+
+  const records: ViolationRecord[] = [];
+  for (const id of matchingIds) {
+    const record = await getViolationById(id);
+    if (record) {
+      records.push(record);
+    }
+  }
+
+  return records.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+}
+
+/**
+ * Get all violations for a campaign.
+ *
+ * @param campaignId - Campaign ID
+ * @returns Array of violation records
+ */
+export async function getViolationsByCampaign(
+  campaignId: ID
+): Promise<ViolationRecord[]> {
+  const index = await readIndex();
+  const matchingIds = index
+    .filter((e) => e.campaignId === campaignId)
+    .map((e) => e.id);
+
+  const records: ViolationRecord[] = [];
+  for (const id of matchingIds) {
+    const record = await getViolationById(id);
+    if (record) {
+      records.push(record);
+    }
+  }
+
+  return records.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+}
+
+/**
+ * Query violations with filters.
+ *
+ * @param options - Query options
+ * @returns Array of matching violation records
+ */
+export async function queryViolations(
+  options: ViolationQueryOptions = {}
+): Promise<ViolationRecord[]> {
+  const index = await readIndex();
+
+  // Apply filters to index
+  let filtered = index;
+
+  if (options.characterId) {
+    filtered = filtered.filter((e) => e.characterId === options.characterId);
+  }
+
+  if (options.campaignId) {
+    filtered = filtered.filter((e) => e.campaignId === options.campaignId);
+  }
+
+  if (options.userId) {
+    filtered = filtered.filter((e) => e.userId === options.userId);
+  }
+
+  if (options.violationType) {
+    filtered = filtered.filter((e) => e.violationType === options.violationType);
+  }
+
+  if (options.severity) {
+    filtered = filtered.filter((e) => e.severity === options.severity);
+  }
+
+  if (options.after) {
+    const afterDate = new Date(options.after);
+    filtered = filtered.filter((e) => new Date(e.timestamp) > afterDate);
+  }
+
+  if (options.before) {
+    const beforeDate = new Date(options.before);
+    filtered = filtered.filter((e) => new Date(e.timestamp) < beforeDate);
+  }
+
+  // Sort by timestamp descending (newest first)
+  filtered.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+
+  // Apply pagination
+  const offset = options.offset ?? 0;
+  const limit = options.limit ?? 100;
+  filtered = filtered.slice(offset, offset + limit);
+
+  // Load full records
+  const records: ViolationRecord[] = [];
+  for (const entry of filtered) {
+    const record = await getViolationById(entry.id);
+    if (record) {
+      records.push(record);
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Get violation count by type for a character.
+ *
+ * @param characterId - Character ID
+ * @returns Map of violation type to count
+ */
+export async function getViolationCountsByType(
+  characterId: ID
+): Promise<Record<ViolationType, number>> {
+  const index = await readIndex();
+  const characterViolations = index.filter((e) => e.characterId === characterId);
+
+  const counts: Record<ViolationType, number> = {
+    creation: 0,
+    advancement: 0,
+    content_access: 0,
+    edition_mismatch: 0,
+    book_restriction: 0,
+    optional_rule: 0,
+  };
+
+  for (const entry of characterViolations) {
+    counts[entry.violationType]++;
+  }
+
+  return counts;
+}
+
+// =============================================================================
+// HELPER FOR VALIDATION INTEGRATION
+// =============================================================================
+
+/**
+ * Create and record a violation from validation context.
+ *
+ * Convenience function for use in validation code.
+ *
+ * @param params - Violation parameters
+ * @returns The recorded violation
+ */
+export async function createViolationFromValidation(params: {
+  characterId: ID;
+  campaignId?: ID;
+  userId?: ID;
+  violationType: ViolationType;
+  constraintId: string;
+  attemptedAction: string;
+  rejectReason: string;
+  rulesetSnapshotId?: string;
+  enabledBookIds?: string[];
+}): Promise<ViolationRecord> {
+  return recordViolation({
+    characterId: params.characterId,
+    campaignId: params.campaignId,
+    userId: params.userId,
+    violationType: params.violationType,
+    severity: "error",
+    constraintId: params.constraintId,
+    details: {
+      attemptedAction: params.attemptedAction,
+      rejectReason: params.rejectReason,
+      rulesetSnapshotId: params.rulesetSnapshotId,
+      enabledBookIds: params.enabledBookIds,
+    },
+  });
+}

--- a/lib/types/campaign.ts
+++ b/lib/types/campaign.ts
@@ -102,6 +102,19 @@ export interface Campaign {
     /** Optional rules enabled (e.g., "wireless bonuses", "alternate init") */
     enabledOptionalRules?: string[];
 
+    /**
+     * Structured optional rules configuration (GM-controlled).
+     * Takes precedence over enabledOptionalRules when present.
+     *
+     * @see docs/capabilities/ruleset.integrity.md
+     */
+    optionalRules?: {
+        /** IDs of rules explicitly enabled (overrides defaultEnabled: false) */
+        enabledRuleIds: string[];
+        /** IDs of rules explicitly disabled (overrides defaultEnabled: true) */
+        disabledRuleIds: string[];
+    };
+
     /** House rules (freeform text or structured JSON) */
     houseRules?: string | Record<string, unknown>;
 


### PR DESCRIPTION
- Add optional-rules.ts for campaign-level rule toggling
- Add violation-record.ts for persistent audit storage
- Add merge-precedence.md documenting conflict resolution
- Add edition transition guard to campaigns API
- Add optional rules validation to campaign-validation.ts
- Update Campaign type with optionalRules field
- Add unit tests for optional-rules and violation-record

Satisfies: docs/capabilities/ruleset.integrity.md
Refs: ADR-002, ADR-003, ADR-004