### PR TITLE
feat(weapon-customization): implement core validation engine and API …

### DIFF
--- a/app/api/characters/[characterId]/weapons/[weaponId]/mods/[modId]/route.ts
+++ b/app/api/characters/[characterId]/weapons/[weaponId]/mods/[modId]/route.ts
@@ -1,0 +1,160 @@
+/**
+ * API Route: /api/characters/[characterId]/weapons/[weaponId]/mods/[modId]
+ *
+ * DELETE - Remove a modification from a weapon
+ *
+ * Satisfies:
+ * - Guarantee: "Modifications flagged as 'built-in' MUST NOT be removable"
+ * - Guarantee: "Any manual modification MUST be reversible, resulting in the
+ *   immediate restoration of the occupied mount point"
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { getUserById } from "@/lib/storage/users";
+import { getCharacter, updateCharacterWithAudit } from "@/lib/storage/characters";
+import { getCampaignById } from "@/lib/storage/campaigns";
+import type { Weapon, InstalledWeaponMod } from "@/lib/types/character";
+import { removeModification } from "@/lib/rules/gear/weapon-customization";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+interface ModRemovalResponse {
+  success: boolean;
+  weapon?: {
+    id: string;
+    name: string;
+    modifications: InstalledWeaponMod[];
+    occupiedMounts: string[];
+  };
+  restoredMounts?: string[];
+  nuyenRefunded?: number;
+  error?: string;
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function findWeaponById(weapons: Weapon[] | undefined, weaponId: string): Weapon | null {
+  if (!weapons) return null;
+  return weapons.find((w) => w.id === weaponId) || null;
+}
+
+function updateWeaponInArray(weapons: Weapon[], updatedWeapon: Weapon): Weapon[] {
+  return weapons.map((w) => (w.id === updatedWeapon.id ? updatedWeapon : w));
+}
+
+// =============================================================================
+// ROUTE HANDLER
+// =============================================================================
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ characterId: string; weaponId: string; modId: string }> }
+): Promise<NextResponse<ModRemovalResponse>> {
+  try {
+    const { characterId, weaponId, modId } = await params;
+
+    // Check authentication
+    const userId = await getSession();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await getUserById(userId);
+    if (!user) {
+      return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
+    }
+
+    // Get the character
+    const character = await getCharacter(userId, characterId);
+    if (!character) {
+      return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
+    }
+
+    // Validate permission: Owner or campaign GM
+    let isOwner = true;
+    if (character.ownerId !== userId) {
+      if (character.campaignId) {
+        const campaign = await getCampaignById(character.campaignId);
+        if (!campaign || campaign.gmId !== userId) {
+          return NextResponse.json({ success: false, error: "Not authorized" }, { status: 403 });
+        }
+        isOwner = false;
+      } else {
+        return NextResponse.json({ success: false, error: "Not authorized" }, { status: 403 });
+      }
+    }
+
+    // Find the weapon
+    const weapon = findWeaponById(character.weapons, weaponId);
+    if (!weapon) {
+      return NextResponse.json({ success: false, error: "Weapon not found" }, { status: 404 });
+    }
+
+    // Find the modification to get its cost for potential refund
+    const modToRemove = weapon.modifications?.find((m) => m.catalogId === modId);
+    if (!modToRemove) {
+      return NextResponse.json({ success: false, error: "Modification not found on weapon" }, { status: 404 });
+    }
+
+    // Attempt removal
+    const result = removeModification(weapon, modId);
+    if (!result.success) {
+      return NextResponse.json({
+        success: false,
+        error: result.error || "Failed to remove modification",
+      }, { status: 400 });
+    }
+
+    // Calculate nuyen refund (optional: could be a campaign setting)
+    // For now, we refund 50% of the original cost
+    const refundAmount = Math.floor(modToRemove.cost * 0.5);
+    const newNuyen = character.nuyen + refundAmount;
+
+    // Update character
+    const updatedWeapons = updateWeaponInArray(character.weapons || [], result.weapon);
+
+    await updateCharacterWithAudit(
+      character.ownerId,
+      characterId,
+      {
+        weapons: updatedWeapons,
+        nuyen: newNuyen,
+      },
+      {
+        action: "gear_modified",
+        actor: { userId, role: isOwner ? "owner" : "gm" },
+        details: {
+          type: "weapon_mod_removed",
+          weaponId,
+          weaponName: weapon.name,
+          modId,
+          modName: modToRemove.name,
+          refundAmount,
+          restoredMounts: result.restoredMounts,
+          actorName: user.username,
+        },
+        note: `Removed ${modToRemove.name} from ${weapon.name}, refunded ${refundAmount}¥`,
+      }
+    );
+
+    return NextResponse.json({
+      success: true,
+      weapon: {
+        id: result.weapon.id || "",
+        name: result.weapon.name,
+        modifications: result.weapon.modifications || [],
+        occupiedMounts: result.weapon.occupiedMounts || [],
+      },
+      restoredMounts: result.restoredMounts,
+      nuyenRefunded: refundAmount,
+    });
+  } catch (error) {
+    console.error("Failed to remove modification:", error);
+    return NextResponse.json({ success: false, error: "Failed to remove modification" }, { status: 500 });
+  }
+}

--- a/app/api/characters/[characterId]/weapons/[weaponId]/mods/route.ts
+++ b/app/api/characters/[characterId]/weapons/[weaponId]/mods/route.ts
@@ -1,0 +1,309 @@
+/**
+ * API Route: /api/characters/[characterId]/weapons/[weaponId]/mods
+ *
+ * POST - Install a modification on a weapon
+ * GET - List installed modifications on a weapon
+ *
+ * Satisfies:
+ * - Guarantee: "Weapon modifications MUST be validated against the authoritative
+ *   mount point registry for the weapon's subcategory"
+ * - Guarantee: "The system MUST enforce exclusive occupancy for mount points"
+ * - Constraint: "Resource costs for manual modifications MUST be accurately
+ *   deducted from the participant's character records"
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { getUserById } from "@/lib/storage/users";
+import { getCharacter, updateCharacterWithAudit } from "@/lib/storage/characters";
+import { getCampaignById } from "@/lib/storage/campaigns";
+import type { Weapon, InstalledWeaponMod } from "@/lib/types/character";
+import type { WeaponModificationCatalogItem } from "@/lib/types/edition";
+import {
+  validateModInstallation,
+  installModification,
+  DEFAULT_MOUNT_REGISTRY,
+} from "@/lib/rules/gear/weapon-customization";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+interface InstallModRequest {
+  /** Catalog ID of the modification to install */
+  modId: string;
+  /** Rating selection (if applicable) */
+  rating?: number;
+  /** Override cost (for GM adjustments) */
+  customCost?: number;
+}
+
+interface ModResponse {
+  success: boolean;
+  weapon?: {
+    id: string;
+    name: string;
+    modifications: InstalledWeaponMod[];
+    occupiedMounts: string[];
+  };
+  nuyenRemaining?: number;
+  error?: string;
+  validationErrors?: string[];
+}
+
+// =============================================================================
+// MOCK DATA (Replace with actual catalog loading)
+// =============================================================================
+
+/**
+ * Temporary mock catalog. In production, this would be loaded from the edition's
+ * modification catalog via the ruleset loader.
+ */
+const MOCK_MOD_CATALOG: Record<string, WeaponModificationCatalogItem> = {
+  "smartgun-internal": {
+    id: "smartgun-internal",
+    name: "Smartgun System (Internal)",
+    mount: "internal",
+    cost: 200,
+    availability: 4,
+    restricted: true,
+    accuracyModifier: 2,
+    description: "Provides targeting assistance via DNI or image link.",
+  },
+  "silencer": {
+    id: "silencer",
+    name: "Silencer/Suppressor",
+    mount: "barrel",
+    cost: 500,
+    availability: 9,
+    restricted: true,
+    description: "Reduces sound signature of weapon fire.",
+  },
+  "laser-sight": {
+    id: "laser-sight",
+    name: "Laser Sight",
+    mount: "under",
+    cost: 125,
+    availability: 2,
+    description: "Visible laser for improved targeting.",
+  },
+  "foregrip": {
+    id: "foregrip",
+    name: "Foregrip",
+    mount: "under",
+    cost: 100,
+    availability: 2,
+    recoilCompensation: 1,
+    description: "Provides additional stability for automatic fire.",
+  },
+  "scope-imaging": {
+    id: "scope-imaging",
+    name: "Imaging Scope",
+    mount: "top",
+    cost: 300,
+    availability: 4,
+    description: "Magnified optic with image enhancement.",
+  },
+  "bipod": {
+    id: "bipod",
+    name: "Bipod",
+    mount: "under",
+    cost: 200,
+    availability: 4,
+    recoilCompensation: 2,
+    minimumWeaponSize: "rifle",
+    description: "Stabilizing mount for prone or supported shooting.",
+  },
+};
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function getModFromCatalog(modId: string): WeaponModificationCatalogItem | null {
+  return MOCK_MOD_CATALOG[modId] || null;
+}
+
+function findWeaponById(weapons: Weapon[] | undefined, weaponId: string): Weapon | null {
+  if (!weapons) return null;
+  return weapons.find((w) => w.id === weaponId) || null;
+}
+
+function updateWeaponInArray(weapons: Weapon[], updatedWeapon: Weapon): Weapon[] {
+  return weapons.map((w) => (w.id === updatedWeapon.id ? updatedWeapon : w));
+}
+
+// =============================================================================
+// ROUTE HANDLERS
+// =============================================================================
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ characterId: string; weaponId: string }> }
+): Promise<NextResponse<ModResponse>> {
+  try {
+    const { characterId, weaponId } = await params;
+
+    // Check authentication
+    const userId = await getSession();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await getUserById(userId);
+    if (!user) {
+      return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
+    }
+
+    // Get the character
+    const character = await getCharacter(userId, characterId);
+    if (!character) {
+      return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
+    }
+
+    // Find the weapon
+    const weapon = findWeaponById(character.weapons, weaponId);
+    if (!weapon) {
+      return NextResponse.json({ success: false, error: "Weapon not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      weapon: {
+        id: weapon.id || "",
+        name: weapon.name,
+        modifications: weapon.modifications || [],
+        occupiedMounts: weapon.occupiedMounts || [],
+      },
+    });
+  } catch (error) {
+    console.error("Failed to get weapon modifications:", error);
+    return NextResponse.json({ success: false, error: "Failed to get modifications" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ characterId: string; weaponId: string }> }
+): Promise<NextResponse<ModResponse>> {
+  try {
+    const { characterId, weaponId } = await params;
+
+    // Check authentication
+    const userId = await getSession();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await getUserById(userId);
+    if (!user) {
+      return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
+    }
+
+    // Get the character
+    const character = await getCharacter(userId, characterId);
+    if (!character) {
+      return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
+    }
+
+    // Validate permission: Owner or campaign GM
+    let isOwner = true;
+    if (character.ownerId !== userId) {
+      if (character.campaignId) {
+        const campaign = await getCampaignById(character.campaignId);
+        if (!campaign || campaign.gmId !== userId) {
+          return NextResponse.json({ success: false, error: "Not authorized" }, { status: 403 });
+        }
+        isOwner = false;
+      } else {
+        return NextResponse.json({ success: false, error: "Not authorized" }, { status: 403 });
+      }
+    }
+
+    // Find the weapon
+    const weapon = findWeaponById(character.weapons, weaponId);
+    if (!weapon) {
+      return NextResponse.json({ success: false, error: "Weapon not found" }, { status: 404 });
+    }
+
+    // Parse request
+    const body: InstallModRequest = await request.json();
+    const { modId, rating, customCost } = body;
+
+    if (!modId) {
+      return NextResponse.json({ success: false, error: "modId is required" }, { status: 400 });
+    }
+
+    // Get modification from catalog
+    const mod = getModFromCatalog(modId);
+    if (!mod) {
+      return NextResponse.json({ success: false, error: `Modification "${modId}" not found in catalog` }, { status: 404 });
+    }
+
+    // Validate installation
+    const validation = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+    if (!validation.valid) {
+      return NextResponse.json({
+        success: false,
+        error: "Modification cannot be installed",
+        validationErrors: validation.errors,
+      }, { status: 400 });
+    }
+
+    // Calculate cost
+    const modCost = customCost ?? mod.cost;
+
+    // Check if character has enough nuyen
+    if (character.nuyen < modCost) {
+      return NextResponse.json({
+        success: false,
+        error: `Insufficient nuyen. Need ${modCost}¥, have ${character.nuyen}¥`,
+      }, { status: 400 });
+    }
+
+    // Install the modification
+    const updatedWeapon = installModification(weapon, mod, { rating, cost: modCost });
+
+    // Update character with new weapon and deducted nuyen
+    const updatedWeapons = updateWeaponInArray(character.weapons || [], updatedWeapon);
+    const newNuyen = character.nuyen - modCost;
+
+    await updateCharacterWithAudit(
+      character.ownerId,
+      characterId,
+      {
+        weapons: updatedWeapons,
+        nuyen: newNuyen,
+      },
+      {
+        action: "gear_modified",
+        actor: { userId, role: isOwner ? "owner" : "gm" },
+        details: {
+          type: "weapon_mod_installed",
+          weaponId,
+          weaponName: weapon.name,
+          modId: mod.id,
+          modName: mod.name,
+          cost: modCost,
+          mount: mod.mount,
+          actorName: user.username,
+        },
+        note: `Installed ${mod.name} on ${weapon.name} for ${modCost}¥`,
+      }
+    );
+
+    return NextResponse.json({
+      success: true,
+      weapon: {
+        id: updatedWeapon.id || "",
+        name: updatedWeapon.name,
+        modifications: updatedWeapon.modifications || [],
+        occupiedMounts: updatedWeapon.occupiedMounts || [],
+      },
+      nuyenRemaining: newNuyen,
+    });
+  } catch (error) {
+    console.error("Failed to install modification:", error);
+    return NextResponse.json({ success: false, error: "Failed to install modification" }, { status: 500 });
+  }
+}

--- a/lib/rules/gear/__tests__/weapon-customization.test.ts
+++ b/lib/rules/gear/__tests__/weapon-customization.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Weapon Customization Validation Tests
+ *
+ * Tests for mount point governance, compatibility checking,
+ * built-in modification handling, and modification lifecycle.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Weapon } from "@/lib/types/character";
+import type { WeaponModificationCatalogItem } from "@/lib/types/edition";
+import {
+  validateModInstallation,
+  getAvailableMounts,
+  applyBuiltInModifications,
+  removeModification,
+  installModification,
+  calculateModificationCost,
+  canBeCustomized,
+  DEFAULT_MOUNT_REGISTRY,
+} from "../weapon-customization";
+
+// =============================================================================
+// TEST FIXTURES
+// =============================================================================
+
+const createBaseWeapon = (overrides: Partial<Weapon> = {}): Weapon => ({
+  id: "test-weapon-1",
+  name: "Test Weapon",
+  category: "weapons",
+  quantity: 1,
+  cost: 500,
+  damage: "8P",
+  ap: -1,
+  mode: ["SA", "BF"],
+  subcategory: "assault-rifle",
+  ...overrides,
+});
+
+const createBaseMod = (
+  overrides: Partial<WeaponModificationCatalogItem> = {}
+): WeaponModificationCatalogItem => ({
+  id: "test-mod-1",
+  name: "Test Modification",
+  cost: 100,
+  availability: 4,
+  ...overrides,
+});
+
+// =============================================================================
+// VALIDATION TESTS
+// =============================================================================
+
+describe("validateModInstallation", () => {
+  describe("mount point validation", () => {
+    it("accepts mods for available mount points", () => {
+      const weapon = createBaseWeapon({ subcategory: "assault-rifle" });
+      const mod = createBaseMod({ mount: "top" });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("rejects mods for unavailable mount points", () => {
+      const weapon = createBaseWeapon({ subcategory: "hold-out-pistol" });
+      const mod = createBaseMod({ mount: "stock" }); // Hold-outs don't have stocks
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'Mount point "stock" is not available on hold-out-pistol weapons.'
+      );
+    });
+
+    it("rejects mods for occupied mount points", () => {
+      const weapon = createBaseWeapon({
+        subcategory: "assault-rifle",
+        occupiedMounts: ["top"],
+      });
+      const mod = createBaseMod({ mount: "top" });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Mount point "top" is already occupied.');
+    });
+
+    it("handles multi-mount accessories correctly", () => {
+      const weapon = createBaseWeapon({ subcategory: "assault-rifle" });
+      const mod = createBaseMod({
+        mount: "under",
+        occupiedMounts: ["side"], // Bipod that uses both
+      });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects multi-mount mods when any mount is occupied", () => {
+      const weapon = createBaseWeapon({
+        subcategory: "assault-rifle",
+        occupiedMounts: ["side"],
+      });
+      const mod = createBaseMod({
+        mount: "under",
+        occupiedMounts: ["side"],
+      });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Mount point "side" is already occupied.');
+    });
+  });
+
+  describe("weapon size compatibility", () => {
+    it("accepts mods when weapon meets minimum size", () => {
+      const weapon = createBaseWeapon({ subcategory: "assault-rifle" });
+      const mod = createBaseMod({ minimumWeaponSize: "smg" });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects mods when weapon is too small", () => {
+      const weapon = createBaseWeapon({ subcategory: "light-pistol" });
+      const mod = createBaseMod({ minimumWeaponSize: "rifle" });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'This modification requires a minimum weapon size of "rifle".'
+      );
+    });
+  });
+
+  describe("subcategory compatibility", () => {
+    it("accepts mods in compatibleWeapons list", () => {
+      const weapon = createBaseWeapon({ subcategory: "assault-rifle" });
+      const mod = createBaseMod({
+        compatibleWeapons: ["assault-rifle", "sniper-rifle"],
+      });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects mods not in compatibleWeapons list", () => {
+      const weapon = createBaseWeapon({ subcategory: "assault-rifle" });
+      const mod = createBaseMod({
+        compatibleWeapons: ["shotgun", "sniper-rifle"],
+      });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        "This modification is not compatible with assault-rifle weapons."
+      );
+    });
+
+    it("rejects mods in incompatibleWeapons list", () => {
+      const weapon = createBaseWeapon({ subcategory: "assault-rifle" });
+      const mod = createBaseMod({
+        incompatibleWeapons: ["assault-rifle"],
+      });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        "This modification is explicitly incompatible with assault-rifle weapons."
+      );
+    });
+  });
+
+  describe("unsupported weapons", () => {
+    it("rejects mods for weapons not in registry", () => {
+      const weapon = createBaseWeapon({ subcategory: "throwing-knife" });
+      const mod = createBaseMod({ mount: "top" });
+
+      const result = validateModInstallation(weapon, mod, DEFAULT_MOUNT_REGISTRY);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'Weapon subcategory "throwing-knife" does not support modifications.'
+      );
+    });
+  });
+});
+
+// =============================================================================
+// MOUNT AVAILABILITY TESTS
+// =============================================================================
+
+describe("getAvailableMounts", () => {
+  it("returns all mounts for weapon with none occupied", () => {
+    const weapon = createBaseWeapon({ subcategory: "assault-rifle" });
+
+    const available = getAvailableMounts(weapon, DEFAULT_MOUNT_REGISTRY);
+
+    expect(available).toContain("top");
+    expect(available).toContain("under");
+    expect(available).toContain("barrel");
+  });
+
+  it("excludes occupied mounts", () => {
+    const weapon = createBaseWeapon({
+      subcategory: "assault-rifle",
+      occupiedMounts: ["top", "under"],
+    });
+
+    const available = getAvailableMounts(weapon, DEFAULT_MOUNT_REGISTRY);
+
+    expect(available).not.toContain("top");
+    expect(available).not.toContain("under");
+    expect(available).toContain("barrel");
+  });
+
+  it("returns empty array for unsupported weapons", () => {
+    const weapon = createBaseWeapon({ subcategory: "throwing-knife" });
+
+    const available = getAvailableMounts(weapon, DEFAULT_MOUNT_REGISTRY);
+
+    expect(available).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// BUILT-IN MODIFICATION TESTS
+// =============================================================================
+
+describe("applyBuiltInModifications", () => {
+  it("adds built-in mods with isBuiltIn flag", () => {
+    const weapon = createBaseWeapon();
+    const builtInMods: WeaponModificationCatalogItem[] = [
+      createBaseMod({ id: "smartgun-internal", name: "Smartgun System (Internal)", mount: "internal" }),
+    ];
+
+    const result = applyBuiltInModifications(weapon, builtInMods);
+
+    expect(result.modifications).toHaveLength(1);
+    expect(result.modifications![0].isBuiltIn).toBe(true);
+    expect(result.modifications![0].catalogId).toBe("smartgun-internal");
+  });
+
+  it("sets cost to 0 for built-in mods", () => {
+    const weapon = createBaseWeapon();
+    const builtInMods: WeaponModificationCatalogItem[] = [
+      createBaseMod({ id: "laser-sight", name: "Laser Sight", cost: 125, mount: "under" }),
+    ];
+
+    const result = applyBuiltInModifications(weapon, builtInMods);
+
+    expect(result.modifications![0].cost).toBe(0);
+  });
+
+  it("marks mount points as occupied", () => {
+    const weapon = createBaseWeapon();
+    const builtInMods: WeaponModificationCatalogItem[] = [
+      createBaseMod({ id: "scope", name: "Scope", mount: "top" }),
+    ];
+
+    const result = applyBuiltInModifications(weapon, builtInMods);
+
+    expect(result.occupiedMounts).toContain("top");
+  });
+
+  it("returns unchanged weapon when no built-in mods", () => {
+    const weapon = createBaseWeapon();
+
+    const result = applyBuiltInModifications(weapon, []);
+
+    expect(result).toBe(weapon);
+  });
+});
+
+// =============================================================================
+// MODIFICATION REMOVAL TESTS
+// =============================================================================
+
+describe("removeModification", () => {
+  it("rejects removal of built-in mods", () => {
+    const weapon = createBaseWeapon({
+      modifications: [
+        {
+          catalogId: "smartgun-internal",
+          name: "Smartgun System (Internal)",
+          cost: 0,
+          availability: 4,
+          isBuiltIn: true,
+          capacityUsed: 0,
+        },
+      ],
+      occupiedMounts: ["internal"],
+    });
+
+    const result = removeModification(weapon, "smartgun-internal");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Cannot remove built-in modification");
+  });
+
+  it("successfully removes non-built-in mods", () => {
+    const weapon = createBaseWeapon({
+      modifications: [
+        {
+          catalogId: "silencer",
+          name: "Silencer",
+          mount: "barrel",
+          cost: 500,
+          availability: 8,
+          isBuiltIn: false,
+          capacityUsed: 0,
+        },
+      ],
+      occupiedMounts: ["barrel"],
+    });
+
+    const result = removeModification(weapon, "silencer");
+
+    expect(result.success).toBe(true);
+    expect(result.weapon.modifications).toHaveLength(0);
+    expect(result.restoredMounts).toContain("barrel");
+    expect(result.weapon.occupiedMounts).not.toContain("barrel");
+  });
+
+  it("returns error for non-existent mod", () => {
+    const weapon = createBaseWeapon();
+
+    const result = removeModification(weapon, "non-existent");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found");
+  });
+});
+
+// =============================================================================
+// MODIFICATION INSTALLATION TESTS
+// =============================================================================
+
+describe("installModification", () => {
+  it("adds mod to modifications array", () => {
+    const weapon = createBaseWeapon();
+    const mod = createBaseMod({ id: "scope", name: "Scope", mount: "top" });
+
+    const result = installModification(weapon, mod);
+
+    expect(result.modifications).toHaveLength(1);
+    expect(result.modifications![0].catalogId).toBe("scope");
+    expect(result.modifications![0].isBuiltIn).toBe(false);
+  });
+
+  it("marks mount points as occupied", () => {
+    const weapon = createBaseWeapon();
+    const mod = createBaseMod({ mount: "top" });
+
+    const result = installModification(weapon, mod);
+
+    expect(result.occupiedMounts).toContain("top");
+  });
+
+  it("uses custom cost when provided", () => {
+    const weapon = createBaseWeapon();
+    const mod = createBaseMod({ cost: 100 });
+
+    const result = installModification(weapon, mod, { cost: 150 });
+
+    expect(result.modifications![0].cost).toBe(150);
+  });
+});
+
+// =============================================================================
+// UTILITY FUNCTION TESTS
+// =============================================================================
+
+describe("calculateModificationCost", () => {
+  it("sums costs of non-built-in mods", () => {
+    const weapon = createBaseWeapon({
+      modifications: [
+        { catalogId: "mod1", name: "Mod 1", cost: 100, availability: 4, isBuiltIn: false, capacityUsed: 0 },
+        { catalogId: "mod2", name: "Mod 2", cost: 200, availability: 6, isBuiltIn: false, capacityUsed: 0 },
+      ],
+    });
+
+    const cost = calculateModificationCost(weapon);
+
+    expect(cost).toBe(300);
+  });
+
+  it("excludes built-in mods from cost calculation", () => {
+    const weapon = createBaseWeapon({
+      modifications: [
+        { catalogId: "mod1", name: "Mod 1", cost: 100, availability: 4, isBuiltIn: false, capacityUsed: 0 },
+        { catalogId: "mod2", name: "Mod 2", cost: 0, availability: 4, isBuiltIn: true, capacityUsed: 0 },
+      ],
+    });
+
+    const cost = calculateModificationCost(weapon);
+
+    expect(cost).toBe(100);
+  });
+});
+
+describe("canBeCustomized", () => {
+  it("returns true for weapons with available mounts", () => {
+    const weapon = createBaseWeapon({ subcategory: "assault-rifle" });
+
+    expect(canBeCustomized(weapon, DEFAULT_MOUNT_REGISTRY)).toBe(true);
+  });
+
+  it("returns false for unsupported weapons", () => {
+    const weapon = createBaseWeapon({ subcategory: "throwing-knife" });
+
+    expect(canBeCustomized(weapon, DEFAULT_MOUNT_REGISTRY)).toBe(false);
+  });
+
+  it("returns false when all mounts are occupied", () => {
+    const weapon = createBaseWeapon({
+      subcategory: "hold-out-pistol",
+      occupiedMounts: ["barrel"], // Only mount on hold-outs
+    });
+
+    expect(canBeCustomized(weapon, DEFAULT_MOUNT_REGISTRY)).toBe(false);
+  });
+});

--- a/lib/rules/gear/weapon-customization.ts
+++ b/lib/rules/gear/weapon-customization.ts
@@ -1,0 +1,479 @@
+/**
+ * Weapon Customization Validation Service
+ *
+ * Provides validation and manipulation functions for weapon modifications.
+ * Implements mount point governance, compatibility checking, and built-in
+ * modification handling as defined in the Weapon Customization capability.
+ */
+
+import type { Weapon, InstalledWeaponMod, WeaponMount } from "@/lib/types/character";
+import type {
+  WeaponModificationCatalogItem,
+  WeaponMountType,
+  WeaponSubcategoryMountRegistry,
+  WeaponSizeCategory,
+} from "@/lib/types/edition";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Result of a modification validation check
+ */
+export interface ModValidationResult {
+  /** Whether the modification can be installed */
+  valid: boolean;
+  /** Error messages that prevent installation */
+  errors: string[];
+  /** Warning messages that don't prevent installation */
+  warnings: string[];
+}
+
+/**
+ * Result of a modification removal operation
+ */
+export interface ModRemovalResult {
+  /** Whether the removal was successful */
+  success: boolean;
+  /** Updated weapon after removal */
+  weapon: Weapon;
+  /** Mount points restored by the removal */
+  restoredMounts: WeaponMount[];
+  /** Error message if removal failed */
+  error?: string;
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/**
+ * Size hierarchy for minimum weapon size checks.
+ * Higher index = larger weapon.
+ */
+const SIZE_HIERARCHY: WeaponSizeCategory[] = [
+  "holdout",
+  "light-pistol",
+  "heavy-pistol",
+  "smg",
+  "rifle",
+  "heavy",
+];
+
+/**
+ * Default mount registry for common weapon subcategories (SR5 Core)
+ * This can be overridden by edition-specific data.
+ */
+export const DEFAULT_MOUNT_REGISTRY: WeaponSubcategoryMountRegistry = {
+  "hold-out-pistol": {
+    size: "holdout",
+    availableMounts: ["barrel"],
+  },
+  "light-pistol": {
+    size: "light-pistol",
+    availableMounts: ["barrel", "top"],
+  },
+  "heavy-pistol": {
+    size: "heavy-pistol",
+    availableMounts: ["barrel", "top", "under"],
+  },
+  "machine-pistol": {
+    size: "heavy-pistol",
+    availableMounts: ["barrel", "top", "under"],
+  },
+  "smg": {
+    size: "smg",
+    availableMounts: ["barrel", "top", "under", "stock"],
+  },
+  "assault-rifle": {
+    size: "rifle",
+    availableMounts: ["barrel", "top", "under", "side", "stock"],
+  },
+  "sport-rifle": {
+    size: "rifle",
+    availableMounts: ["barrel", "top", "under", "stock"],
+  },
+  "sniper-rifle": {
+    size: "rifle",
+    availableMounts: ["barrel", "top", "under", "stock"],
+  },
+  "shotgun": {
+    size: "rifle",
+    availableMounts: ["barrel", "top", "under", "stock"],
+  },
+  "light-machine-gun": {
+    size: "heavy",
+    availableMounts: ["barrel", "top", "under", "side", "stock"],
+  },
+  "medium-machine-gun": {
+    size: "heavy",
+    availableMounts: ["barrel", "top", "under", "side"],
+  },
+  "heavy-machine-gun": {
+    size: "heavy",
+    availableMounts: ["barrel", "top"],
+  },
+  "assault-cannon": {
+    size: "heavy",
+    availableMounts: ["top"],
+  },
+};
+
+// =============================================================================
+// VALIDATION FUNCTIONS
+// =============================================================================
+
+/**
+ * Get the size index for comparison operations.
+ * Returns -1 if size is not found (treated as smallest).
+ */
+function getSizeIndex(size: WeaponSizeCategory | undefined): number {
+  if (!size) return -1;
+  return SIZE_HIERARCHY.indexOf(size);
+}
+
+/**
+ * Validate that a modification can be installed on a weapon.
+ *
+ * Checks:
+ * 1. Mount point availability (if mod requires a mount)
+ * 2. Weapon size compatibility (minimum size check)
+ * 3. Subcategory compatibility (allow/block lists)
+ * 4. Multi-mount occupancy (for multi-slot accessories)
+ */
+export function validateModInstallation(
+  weapon: Weapon,
+  mod: WeaponModificationCatalogItem,
+  mountRegistry: WeaponSubcategoryMountRegistry = DEFAULT_MOUNT_REGISTRY
+): ModValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Get mount configuration for this weapon's subcategory
+  const mountConfig = mountRegistry[weapon.subcategory];
+
+  // Check if weapon supports customization
+  if (!mountConfig) {
+    errors.push(
+      `Weapon subcategory "${weapon.subcategory}" does not support modifications.`
+    );
+    return { valid: false, errors, warnings };
+  }
+
+  // Collect all mount points this mod will occupy
+  const requiredMounts: WeaponMountType[] = [];
+  if (mod.mount) {
+    requiredMounts.push(mod.mount);
+  }
+  if (mod.occupiedMounts) {
+    requiredMounts.push(...mod.occupiedMounts);
+  }
+
+  // Check mount point availability
+  if (requiredMounts.length > 0) {
+    const occupiedMounts = weapon.occupiedMounts ?? [];
+
+    for (const mount of requiredMounts) {
+      // Check if mount is available on this weapon type
+      if (!mountConfig.availableMounts.includes(mount)) {
+        errors.push(
+          `Mount point "${mount}" is not available on ${weapon.subcategory} weapons.`
+        );
+        continue;
+      }
+
+      // Check if mount is already occupied
+      if (occupiedMounts.includes(mount)) {
+        errors.push(`Mount point "${mount}" is already occupied.`);
+      }
+    }
+  }
+
+  // Check minimum weapon size
+  if (mod.minimumWeaponSize && mountConfig.size) {
+    const modMinSizeIndex = getSizeIndex(mod.minimumWeaponSize);
+    const weaponSizeIndex = getSizeIndex(mountConfig.size);
+
+    if (weaponSizeIndex < modMinSizeIndex) {
+      errors.push(
+        `This modification requires a minimum weapon size of "${mod.minimumWeaponSize}".`
+      );
+    }
+  }
+
+  // Check compatible weapons list (if specified)
+  if (mod.compatibleWeapons && mod.compatibleWeapons.length > 0) {
+    const isCompatible =
+      mod.compatibleWeapons.includes(weapon.subcategory) ||
+      (weapon.catalogId && mod.compatibleWeapons.includes(weapon.catalogId));
+
+    if (!isCompatible) {
+      errors.push(
+        `This modification is not compatible with ${weapon.subcategory} weapons.`
+      );
+    }
+  }
+
+  // Check incompatible weapons list (if specified)
+  if (mod.incompatibleWeapons && mod.incompatibleWeapons.length > 0) {
+    const isIncompatible =
+      mod.incompatibleWeapons.includes(weapon.subcategory) ||
+      (weapon.catalogId && mod.incompatibleWeapons.includes(weapon.catalogId));
+
+    if (isIncompatible) {
+      errors.push(
+        `This modification is explicitly incompatible with ${weapon.subcategory} weapons.`
+      );
+    }
+  }
+
+  // Check for duplicate modification
+  const existingMod = weapon.modifications?.find(
+    (m) => m.catalogId === mod.id
+  );
+  if (existingMod) {
+    warnings.push(
+      `A modification of this type is already installed. Some weapons allow multiple instances.`
+    );
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Get list of available (unoccupied) mount points for a weapon.
+ */
+export function getAvailableMounts(
+  weapon: Weapon,
+  mountRegistry: WeaponSubcategoryMountRegistry = DEFAULT_MOUNT_REGISTRY
+): WeaponMountType[] {
+  const mountConfig = mountRegistry[weapon.subcategory];
+  if (!mountConfig) {
+    return [];
+  }
+
+  const occupiedMounts = weapon.occupiedMounts ?? [];
+  return mountConfig.availableMounts.filter(
+    (mount) => !occupiedMounts.includes(mount)
+  );
+}
+
+/**
+ * Get all mount points for a weapon subcategory.
+ */
+export function getAllMounts(
+  subcategory: string,
+  mountRegistry: WeaponSubcategoryMountRegistry = DEFAULT_MOUNT_REGISTRY
+): WeaponMountType[] {
+  const mountConfig = mountRegistry[subcategory];
+  return mountConfig?.availableMounts ?? [];
+}
+
+// =============================================================================
+// BUILT-IN MODIFICATION HANDLING
+// =============================================================================
+
+/**
+ * Apply built-in modifications to a weapon.
+ * Built-in mods are automatically installed, marked as immutable,
+ * and do not incur costs.
+ */
+export function applyBuiltInModifications(
+  weapon: Weapon,
+  builtInMods: WeaponModificationCatalogItem[]
+): Weapon {
+  if (builtInMods.length === 0) {
+    return weapon;
+  }
+
+  const modifications: InstalledWeaponMod[] = [...(weapon.modifications ?? [])];
+  const occupiedMounts: WeaponMount[] = [...(weapon.occupiedMounts ?? [])];
+
+  for (const mod of builtInMods) {
+    // Create installed mod record
+    const installedMod: InstalledWeaponMod = {
+      catalogId: mod.id,
+      name: mod.name,
+      mount: mod.mount as WeaponMount | undefined,
+      rating: undefined,
+      cost: 0, // Built-in mods have no cost
+      availability: mod.availability,
+      restricted: mod.restricted,
+      forbidden: mod.forbidden,
+      isBuiltIn: true,
+      capacityUsed: 0,
+    };
+
+    modifications.push(installedMod);
+
+    // Mark mount points as occupied
+    if (mod.mount) {
+      occupiedMounts.push(mod.mount as WeaponMount);
+    }
+    if (mod.occupiedMounts) {
+      for (const mount of mod.occupiedMounts) {
+        occupiedMounts.push(mount as WeaponMount);
+      }
+    }
+  }
+
+  return {
+    ...weapon,
+    modifications,
+    occupiedMounts,
+  };
+}
+
+// =============================================================================
+// MODIFICATION REMOVAL
+// =============================================================================
+
+/**
+ * Remove a modification from a weapon.
+ * Returns an error if the modification is built-in (immutable).
+ */
+export function removeModification(
+  weapon: Weapon,
+  modId: string
+): ModRemovalResult {
+  const modifications = weapon.modifications ?? [];
+  const modIndex = modifications.findIndex((m) => m.catalogId === modId);
+
+  if (modIndex === -1) {
+    return {
+      success: false,
+      weapon,
+      restoredMounts: [],
+      error: `Modification "${modId}" not found on this weapon.`,
+    };
+  }
+
+  const mod = modifications[modIndex];
+
+  // Check if this is a built-in modification
+  if (mod.isBuiltIn) {
+    return {
+      success: false,
+      weapon,
+      restoredMounts: [],
+      error: `Cannot remove built-in modification "${mod.name}". It is an integral part of the weapon.`,
+    };
+  }
+
+  // Determine which mount points to restore
+  const restoredMounts: WeaponMount[] = [];
+  if (mod.mount) {
+    restoredMounts.push(mod.mount);
+  }
+
+  // Remove the modification
+  const updatedModifications = [
+    ...modifications.slice(0, modIndex),
+    ...modifications.slice(modIndex + 1),
+  ];
+
+  // Update occupied mounts
+  const occupiedMounts = (weapon.occupiedMounts ?? []).filter(
+    (mount) => !restoredMounts.includes(mount)
+  );
+
+  return {
+    success: true,
+    weapon: {
+      ...weapon,
+      modifications: updatedModifications,
+      occupiedMounts,
+    },
+    restoredMounts,
+  };
+}
+
+// =============================================================================
+// MODIFICATION INSTALLATION
+// =============================================================================
+
+/**
+ * Install a modification on a weapon.
+ * This function assumes validation has already passed.
+ */
+export function installModification(
+  weapon: Weapon,
+  mod: WeaponModificationCatalogItem,
+  options: {
+    rating?: number;
+    cost?: number;
+  } = {}
+): Weapon {
+  const installedMod: InstalledWeaponMod = {
+    catalogId: mod.id,
+    name: mod.name,
+    mount: mod.mount as WeaponMount | undefined,
+    rating: options.rating,
+    cost: options.cost ?? mod.cost,
+    availability: mod.availability,
+    restricted: mod.restricted,
+    forbidden: mod.forbidden,
+    isBuiltIn: false,
+    capacityUsed: 0, // TODO: Calculate from mod if applicable
+  };
+
+  const modifications = [...(weapon.modifications ?? []), installedMod];
+  const occupiedMounts = [...(weapon.occupiedMounts ?? [])];
+
+  // Mark mount points as occupied
+  if (mod.mount) {
+    occupiedMounts.push(mod.mount as WeaponMount);
+  }
+  if (mod.occupiedMounts) {
+    for (const mount of mod.occupiedMounts) {
+      occupiedMounts.push(mount as WeaponMount);
+    }
+  }
+
+  return {
+    ...weapon,
+    modifications,
+    occupiedMounts,
+  };
+}
+
+// =============================================================================
+// UTILITY FUNCTIONS
+// =============================================================================
+
+/**
+ * Calculate total modification cost for a weapon.
+ * Excludes built-in modifications.
+ */
+export function calculateModificationCost(weapon: Weapon): number {
+  const modifications = weapon.modifications ?? [];
+  return modifications
+    .filter((m) => !m.isBuiltIn)
+    .reduce((total, m) => total + m.cost, 0);
+}
+
+/**
+ * Get all modifications of a specific type installed on a weapon.
+ */
+export function getModificationsByMount(
+  weapon: Weapon,
+  mount: WeaponMount
+): InstalledWeaponMod[] {
+  const modifications = weapon.modifications ?? [];
+  return modifications.filter((m) => m.mount === mount);
+}
+
+/**
+ * Check if a weapon has any available mount points for customization.
+ */
+export function canBeCustomized(
+  weapon: Weapon,
+  mountRegistry: WeaponSubcategoryMountRegistry = DEFAULT_MOUNT_REGISTRY
+): boolean {
+  return getAvailableMounts(weapon, mountRegistry).length > 0;
+}

--- a/lib/rules/loader-types.ts
+++ b/lib/rules/loader-types.ts
@@ -311,6 +311,10 @@ export interface WeaponData extends GearItemData {
   rc?: number;
   ammo?: number;
   blast?: string;
+  /** Built-in modification IDs applied automatically when weapon is selected */
+  builtInMods?: string[];
+  /** Available mount points for this specific weapon (overrides subcategory defaults) */
+  availableMounts?: Array<"top" | "under" | "side" | "barrel" | "stock" | "internal">;
 }
 
 /**
@@ -977,6 +981,10 @@ export interface WeaponModificationCatalogItemData {
   name: string;
   /** Mount point required (undefined means no mount needed) */
   mount?: "top" | "under" | "side" | "barrel" | "stock" | "internal";
+  /** Additional mount points occupied (for multi-slot accessories like bipods) */
+  occupiedMounts?: Array<"top" | "under" | "side" | "barrel" | "stock" | "internal">;
+  /** If true, this mod is built into specific weapons and cannot be removed */
+  isBuiltIn?: boolean;
   /** Weapon types this mod is compatible with */
   compatibleWeapons?: string[];
   /** Weapon types this mod is NOT compatible with */

--- a/lib/types/audit.ts
+++ b/lib/types/audit.ts
@@ -42,7 +42,9 @@ export type AuditAction =
   | "approval_rejected"
   // Damage/Healing actions
   | "damage_applied"
-  | "damage_healed";
+  | "damage_healed"
+  // Gear modification actions
+  | "gear_modified";
 
 // =============================================================================
 // ACTOR TYPES

--- a/lib/types/edition.ts
+++ b/lib/types/edition.ts
@@ -610,6 +610,10 @@ export interface WeaponModificationCatalogItem {
   name: string;
   /** Mount point required (undefined means no mount needed) */
   mount?: WeaponMountType;
+  /** Additional mount points occupied (for multi-slot accessories like bipods) */
+  occupiedMounts?: WeaponMountType[];
+  /** If true, this mod is built into specific weapons and cannot be removed */
+  isBuiltIn?: boolean;
   /** Weapon types this mod is compatible with */
   compatibleWeapons?: string[];
   /** Weapon types this mod is NOT compatible with */
@@ -663,6 +667,33 @@ export interface WeaponModificationCatalogItem {
   /** Source book reference */
   source?: string;
 }
+
+/**
+ * Weapon size categories for compatibility checking
+ */
+export type WeaponSizeCategory =
+  | "holdout"
+  | "light-pistol"
+  | "heavy-pistol"
+  | "smg"
+  | "rifle"
+  | "heavy";
+
+/**
+ * Mount point configuration for a weapon subcategory
+ */
+export interface WeaponSubcategoryMountConfig {
+  /** Available mount points for this subcategory */
+  availableMounts: WeaponMountType[];
+  /** Size category for compatibility checking */
+  size?: WeaponSizeCategory;
+}
+
+/**
+ * Registry mapping weapon subcategories to their mount point configurations.
+ * This is the authoritative source for mount point availability per weapon type.
+ */
+export type WeaponSubcategoryMountRegistry = Record<string, WeaponSubcategoryMountConfig>;
 
 /**
  * Armor modification catalog item in ruleset data


### PR DESCRIPTION
…routes

Phases 1-3 of Weapon Customization capability:

Types:
- Add WeaponSubcategoryMountRegistry for mount point governance
- Add isBuiltIn, occupiedMounts to WeaponModificationCatalogItem
- Add builtInMods, availableMounts to WeaponData
- Add gear_modified to AuditAction

Validation Service (lib/rules/gear/weapon-customization.ts):
- validateModInstallation with mount/size/subcategory checks
- applyBuiltInModifications for cost-exempt immutable mods
- installModification and removeModification with audit support
- 29 unit tests covering all validation scenarios

API Routes:
- POST /api/characters/[characterId]/weapons/[weaponId]/mods
- DELETE /api/characters/[characterId]/weapons/[weaponId]/mods/[modId]
- Nuyen deduction and 50% refund on removal
- Full audit logging integration