### PR TITLE
fix(creation): standardize icon buttons and polish UI across creation…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ next-env.d.ts
 /data/activity
 /data/security
 /data/combat
+/docs/capabilities/plans/verification-reports
 
 # backups
 /backups

--- a/components/creation/IdentitiesCard.tsx
+++ b/components/creation/IdentitiesCard.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useMemo, useCallback, useState } from "react";
-import { Plus, X, FileText, AlertTriangle, Home } from "lucide-react";
+import { Plus, X, FileText, AlertTriangle, Home, Edit2 } from "lucide-react";
 import type {
   CreationState,
   Identity,
@@ -961,18 +961,21 @@ function IdentityCard({
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center">
           <button
             onClick={onEdit}
-            className="rounded px-3 py-1.5 text-xs font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-700"
+            className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+            title="Edit identity"
           >
-            Edit
+            <Edit2 className="h-3.5 w-3.5" />
           </button>
+          <div className="mx-1 h-5 w-px bg-zinc-300 dark:bg-zinc-600" />
           <button
             onClick={onRemove}
-            className="rounded px-3 py-1.5 text-xs font-medium text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+            className="rounded p-1 text-zinc-400 hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+            title="Remove identity"
           >
-            Remove
+            <X className="h-3.5 w-3.5" />
           </button>
         </div>
       </div>
@@ -1009,18 +1012,21 @@ function IdentityCard({
                       )}
                     </span>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center">
                     <button
                       onClick={() => onEditLicense(licenseIndex)}
-                      className="text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400"
+                      className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+                      title="Edit license"
                     >
-                      Edit
+                      <Edit2 className="h-3.5 w-3.5" />
                     </button>
+                    <div className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
                     <button
                       onClick={() => onRemoveLicense(licenseIndex)}
-                      className="text-xs text-red-600 hover:text-red-700 dark:text-red-400"
+                      className="rounded p-1 text-zinc-400 hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+                      title="Remove license"
                     >
-                      Remove
+                      <X className="h-3.5 w-3.5" />
                     </button>
                   </div>
                 </div>
@@ -1073,18 +1079,21 @@ function IdentityCard({
                         </span>
                       </div>
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center">
                       <button
                         onClick={() => onEditLifestyle(lifestyle.id!)}
-                        className="text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400"
+                        className="rounded p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+                        title="Edit lifestyle"
                       >
-                        Edit
+                        <Edit2 className="h-3.5 w-3.5" />
                       </button>
+                      <div className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
                       <button
                         onClick={() => onRemoveLifestyle(lifestyle.id!)}
-                        className="text-xs text-red-600 hover:text-red-700 dark:text-red-400"
+                        className="rounded p-1 text-zinc-400 hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+                        title="Remove lifestyle"
                       >
-                        Remove
+                        <X className="h-3.5 w-3.5" />
                       </button>
                     </div>
                   </div>
@@ -1472,20 +1481,18 @@ export function IdentitiesCard({ state, updateState }: IdentitiesCardProps) {
     <>
       <CreationCard
         title="Identities & SINs"
-        description={`${identities.length} identit${identities.length !== 1 ? "ies" : "y"}${totalCosts.total > 0 ? ` • ¥${totalCosts.total.toLocaleString()}` : ""}`}
         status={needsRealSIN ? "error" : identities.length > 0 ? "valid" : "warning"}
+        headerAction={
+          <button
+            onClick={openAddIdentityModal}
+            className="flex items-center gap-1.5 rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-amber-600"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Identity
+          </button>
+        }
       >
         <div className="space-y-3">
-          {/* Cost Summary */}
-          {totalCosts.total > 0 && (
-            <div className="flex items-center justify-between rounded-lg bg-zinc-50 px-3 py-2 text-sm dark:bg-zinc-800">
-              <span className="text-zinc-600 dark:text-zinc-400">SINs & Licenses Cost:</span>
-              <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                ¥{totalCosts.total.toLocaleString()}
-              </span>
-            </div>
-          )}
-
           {/* SINner Quality Warning */}
           {needsRealSIN && (
             <div className="flex items-start gap-2 rounded-lg bg-amber-50 p-3 text-sm dark:bg-amber-900/20">
@@ -1518,20 +1525,30 @@ export function IdentitiesCard({ state, updateState }: IdentitiesCardProps) {
             </div>
           )}
 
-          {/* Add Identity Button */}
-          <button
-            onClick={openAddIdentityModal}
-            className="flex w-full items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-zinc-300 py-3 text-sm font-medium text-zinc-600 transition-colors hover:border-blue-400 hover:bg-blue-50 hover:text-blue-700 dark:border-zinc-600 dark:text-zinc-400 dark:hover:border-blue-500 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
-          >
-            <Plus className="h-4 w-4" />
-            Add Identity
-          </button>
-
-          {/* Empty state hint */}
+          {/* Empty state */}
           {identities.length === 0 && (
-            <p className="text-center text-xs text-zinc-500 dark:text-zinc-400">
-              Every runner needs at least one identity with a SIN.
-            </p>
+            <>
+              <div className="rounded-lg border-2 border-dashed border-zinc-200 p-3 text-center dark:border-zinc-700">
+                <p className="text-xs text-zinc-400 dark:text-zinc-500">No identities added</p>
+              </div>
+              <p className="text-center text-xs text-zinc-500 dark:text-zinc-400">
+                Every runner needs at least one identity with a SIN.
+              </p>
+            </>
+          )}
+
+          {/* Summary */}
+          {identities.length > 0 && (
+            <div className="flex items-center justify-between rounded-lg bg-zinc-50 px-3 py-2 dark:bg-zinc-800/50">
+              <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                Total: {identities.length} identit{identities.length !== 1 ? "ies" : "y"}
+                {identities.reduce((sum, i) => sum + (i.licenses?.length || 0), 0) > 0 &&
+                  `, ${identities.reduce((sum, i) => sum + (i.licenses?.length || 0), 0)} license${identities.reduce((sum, i) => sum + (i.licenses?.length || 0), 0) !== 1 ? "s" : ""}`}
+              </span>
+              <span className="text-xs font-bold text-zinc-900 dark:text-zinc-100">
+                {totalCosts.total.toLocaleString()}¥
+              </span>
+            </div>
           )}
         </div>
       </CreationCard>

--- a/components/creation/VehiclesCard.tsx
+++ b/components/creation/VehiclesCard.tsx
@@ -510,7 +510,9 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
                         {v.name}
                       </span>
                       <div className="flex items-center gap-1">
-                        <span className="text-xs text-zinc-500">{formatCurrency(v.cost)}¥</span>
+                        <span className="shrink-0 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                          ¥{formatCurrency(v.cost)}
+                        </span>
                         <div className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
                         <button
                           onClick={() => removeVehicle(v.id)}
@@ -565,7 +567,9 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
                         {d.name}
                       </span>
                       <div className="flex items-center gap-1">
-                        <span className="text-xs text-zinc-500">{formatCurrency(d.cost)}¥</span>
+                        <span className="shrink-0 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                          ¥{formatCurrency(d.cost)}
+                        </span>
                         <div className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
                         <button
                           onClick={() => removeDrone(d.id!)}
@@ -620,7 +624,9 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
                         {r.name}
                       </span>
                       <div className="flex items-center gap-1">
-                        <span className="text-xs text-zinc-500">{formatCurrency(r.cost)}¥</span>
+                        <span className="shrink-0 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                          ¥{formatCurrency(r.cost)}
+                        </span>
                         <div className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
                         <button
                           onClick={() => removeRCC(r.id!)}
@@ -675,7 +681,9 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
                         {a.name} R{a.rating}
                       </span>
                       <div className="flex items-center gap-1">
-                        <span className="text-xs text-zinc-500">{formatCurrency(a.cost)}¥</span>
+                        <span className="shrink-0 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                          ¥{formatCurrency(a.cost)}
+                        </span>
                         <div className="mx-1 h-4 w-px bg-zinc-300 dark:bg-zinc-600" />
                         <button
                           onClick={() => removeAutosoft(a.id!)}

--- a/components/creation/vehicles/AutosoftModal.tsx
+++ b/components/creation/vehicles/AutosoftModal.tsx
@@ -200,8 +200,10 @@ export function AutosoftModal({ isOpen, onClose, onAdd, remainingNuyen }: Autoso
                           )}
                         </div>
                         {/* Rating selector */}
-                        <div className="mt-2 flex items-center gap-2">
-                          <span className="text-xs text-zinc-500 dark:text-zinc-400">Rating:</span>
+                        <div className="mt-2 flex items-center gap-1">
+                          <span className="mr-2 text-xs text-zinc-500 dark:text-zinc-400">
+                            1-{maxAvailable}
+                          </span>
                           <button
                             onClick={() =>
                               updateRating(
@@ -212,13 +214,13 @@ export function AutosoftModal({ isOpen, onClose, onAdd, remainingNuyen }: Autoso
                               )
                             }
                             disabled={rating <= 1}
-                            className="rounded p-0.5 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 disabled:opacity-30 dark:hover:bg-zinc-700"
+                            className="flex h-7 w-7 items-center justify-center rounded-lg bg-zinc-200 text-zinc-600 transition-colors hover:bg-zinc-300 disabled:opacity-30 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600"
                           >
                             <Minus className="h-3.5 w-3.5" />
                           </button>
-                          <span className="w-6 text-center text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                          <div className="flex h-7 w-8 items-center justify-center rounded-lg bg-zinc-200 text-sm font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-100">
                             {rating}
-                          </span>
+                          </div>
                           <button
                             onClick={() =>
                               updateRating(
@@ -229,11 +231,10 @@ export function AutosoftModal({ isOpen, onClose, onAdd, remainingNuyen }: Autoso
                               )
                             }
                             disabled={rating >= maxAvailable}
-                            className="rounded p-0.5 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 disabled:opacity-30 dark:hover:bg-zinc-700"
+                            className="flex h-7 w-7 items-center justify-center rounded-lg bg-emerald-600 text-white transition-colors hover:bg-emerald-700 disabled:opacity-30"
                           >
                             <Plus className="h-3.5 w-3.5" />
                           </button>
-                          <span className="text-xs text-zinc-400">/ {maxAvailable}</span>
                         </div>
                       </div>
                       <div className="ml-3 flex flex-col items-end gap-2">


### PR DESCRIPTION
… cards

- IdentitiesCard: Replace Edit/Remove text buttons with icon buttons (Edit2/X) matching other cards, add visual separators, move Add button to header, improve empty state and summary layout
- VehiclesCard: Standardize cost display format to ¥{cost} with consistent font styling
- AutosoftModal: Improve rating selector with styled +/- buttons matching other modals
- Add verification-reports directory to gitignore