### PR TITLE
feat(weapons): add stackable quantity support for throwing weapons and grenades

### DIFF
--- a/components/creation/WeaponsPanel.tsx
+++ b/components/creation/WeaponsPanel.tsx
@@ -406,7 +406,7 @@ export function WeaponsPanel({ state, updateState }: WeaponsPanelProps) {
 
   // Add weapon (actual implementation - called after affordability check)
   const actuallyAddWeapon = useCallback(
-    (weapon: WeaponData) => {
+    (weapon: WeaponData, quantity: number = 1) => {
       const newWeapon: Weapon = {
         id: `${weapon.id}-${Date.now()}`,
         catalogId: weapon.id,
@@ -421,7 +421,7 @@ export function WeaponsPanel({ state, updateState }: WeaponsPanelProps) {
         accuracy: weapon.accuracy,
         cost: weapon.cost,
         availability: weapon.availability,
-        quantity: 1,
+        quantity,
         modifications: [],
         occupiedMounts: [],
       };
@@ -442,18 +442,21 @@ export function WeaponsPanel({ state, updateState }: WeaponsPanelProps) {
 
   // Add weapon (with karma conversion prompt if needed)
   const addWeapon = useCallback(
-    (weapon: WeaponData) => {
+    (weapon: WeaponData, quantity: number = 1) => {
+      const totalCost = weapon.cost * quantity;
+
       // Check if already affordable
-      if (weapon.cost <= remaining) {
-        actuallyAddWeapon(weapon);
+      if (totalCost <= remaining) {
+        actuallyAddWeapon(weapon, quantity);
         return;
       }
 
       // Check if karma conversion could help
-      const conversionInfo = karmaConversionPrompt.checkPurchase(weapon.cost);
+      const conversionInfo = karmaConversionPrompt.checkPurchase(totalCost);
       if (conversionInfo?.canConvert) {
-        karmaConversionPrompt.promptConversion(weapon.name, weapon.cost, () => {
-          actuallyAddWeapon(weapon);
+        const itemName = quantity > 1 ? `${weapon.name} (x${quantity})` : weapon.name;
+        karmaConversionPrompt.promptConversion(itemName, totalCost, () => {
+          actuallyAddWeapon(weapon, quantity);
         });
         return;
       }

--- a/data/editions/sr5/core-rulebook.json
+++ b/data/editions/sr5/core-rulebook.json
@@ -8085,7 +8085,9 @@
               "damage": "(STR+1)P",
               "ap": -1,
               "accuracy": "physical",
-              "legality": "restricted"
+              "legality": "restricted",
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "throwing-knife",
@@ -8097,7 +8099,9 @@
               "damage": "(STR+1)P",
               "ap": -1,
               "accuracy": "physical",
-              "legality": "restricted"
+              "legality": "restricted",
+              "stackable": true,
+              "consumable": true
             }
           ],
           "bows": [
@@ -8231,7 +8235,9 @@
               "ap": -4,
               "blast": "-4/m",
               "availability": 18,
-              "legality": "forbidden"
+              "legality": "forbidden",
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "flash-bang-grenade",
@@ -8243,7 +8249,9 @@
               "damage": "10S",
               "ap": -4,
               "blast": "10m radius",
-              "legality": "restricted"
+              "legality": "restricted",
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "flash-pak",
@@ -8253,7 +8261,9 @@
               "damage": "Special",
               "cost": 125,
               "blast": "Special",
-              "availability": 4
+              "availability": 4,
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "fragmentation-grenade",
@@ -8265,7 +8275,9 @@
               "damage": "18P(f)",
               "ap": 2,
               "blast": "-1/m",
-              "legality": "forbidden"
+              "legality": "forbidden",
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "fragmentation-rocket",
@@ -8277,7 +8289,9 @@
               "ap": 5,
               "blast": "-1/m",
               "availability": 12,
-              "legality": "forbidden"
+              "legality": "forbidden",
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "gas",
@@ -8287,7 +8301,9 @@
               "damage": "as Chemical",
               "cost": 0,
               "blast": "10m Radius",
-              "availability": 2
+              "availability": 2,
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "gas-grenade-cs-tear",
@@ -8299,7 +8315,9 @@
               "damage": "Nausea",
               "ap": 0,
               "blast": "10m radius",
-              "legality": "restricted"
+              "legality": "restricted",
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "high-explosive-grenade",
@@ -8311,7 +8329,9 @@
               "damage": "16P",
               "ap": -2,
               "blast": "-2/m",
-              "legality": "forbidden"
+              "legality": "forbidden",
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "high-explosive-rocket",
@@ -8323,7 +8343,9 @@
               "ap": -2,
               "blast": "-2/m",
               "availability": 18,
-              "legality": "forbidden"
+              "legality": "forbidden",
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "smoke-grenade",
@@ -8335,7 +8357,9 @@
               "damage": "-",
               "ap": 0,
               "blast": "10m radius",
-              "legality": "restricted"
+              "legality": "restricted",
+              "stackable": true,
+              "consumable": true
             },
             {
               "id": "thermal-smoke-grenade",
@@ -8347,7 +8371,9 @@
               "damage": "-",
               "ap": 0,
               "blast": "10m radius",
-              "legality": "restricted"
+              "legality": "restricted",
+              "stackable": true,
+              "consumable": true
             }
           ]
         },


### PR DESCRIPTION
## Summary
- Add `stackable` and `consumable` flags to throwing weapons (2) and grenades (11) in core-rulebook.json
- Add BulkQuantitySelector UI to WeaponPurchaseModal for stackable items with 1x/2x/5x/10x presets
- Update WeaponsPanel to handle quantity in purchase and karma conversion flows
- Display quantity badge (x2, x5, etc.) in WeaponRow for items with quantity > 1
- Hide wireless indicator, mods, and ammo sections for throwing weapons and grenades (not applicable)

## Test plan
- [x] Open character creation, navigate to Weapons section
- [x] Click "Add" in Throwing & Grenades category
- [x] Select a grenade or throwing weapon
- [x] Verify BulkQuantitySelector appears with quantity presets
- [x] Purchase multiple items, verify cost multiplies correctly
- [x] Verify WeaponRow shows quantity badge (e.g., "x5")
- [x] Verify total cost in budget reflects quantity
- [x] Expand a grenade row - verify stats show but no mods/ammo sections
- [x] Test karma conversion prompt shows quantity in item name

🤖 Generated with [Claude Code](https://claude.ai/claude-code)