### PR TITLE
docs(rules): add detailed SR5 combat rules reference documentation

### DIFF
--- a/docs/rules/5e/game-mechanics/defense-detailed.md
+++ b/docs/rules/5e/game-mechanics/defense-detailed.md
@@ -1,0 +1,328 @@
+# Shadowrun 5E Defense Reference
+
+## Overview
+
+Characters usually have a chance to avoid or defend against incoming attacks before they connect, unless caught by surprise. Even stationary or inanimate targets may have a defense dice pool if they have Partial or Good cover.
+
+---
+
+## Standard Defense
+
+### Base Defense Roll
+
+```
+Reaction + Intuition
+```
+
+This is the default, free defense roll available to all aware defenders.
+
+---
+
+## Ranged Defense
+
+A defender has **two choices** for defending against ranged attacks:
+
+### Standard Defense (Free)
+
+```
+Reaction + Intuition
+```
+
+### Full Defense
+
+- **Cost:** Decrease Initiative Score by 10
+- **Benefit:** Gain bonus equal to **Willpower** on Defense Tests for the whole Combat Turn
+- See Active Defenses section for details
+
+---
+
+## Melee Defense
+
+A defender has **five choices** for defending against melee attacks:
+
+### Standard Defense (Free)
+
+```
+Reaction + Intuition
+```
+
+### Parry (Interrupt Action, -5 Initiative)
+
+**Requirement:** Must have a melee weapon in hand
+
+```
+Reaction + Intuition + (Melee Weapon Skill) [Physical]
+```
+
+- Only lasts for a **single Defense Test**
+- Bringing a skill into the mix means Physical limit applies
+
+### Block (Interrupt Action, -5 Initiative)
+
+**Requirement:** Must be empty-handed and have Unarmed Combat skill
+
+```
+Reaction + Intuition + Unarmed Combat [Physical]
+```
+
+- Only lasts for a **single Defense Test**
+- Physical limit applies
+
+### Dodge (Interrupt Action, -5 Initiative)
+
+**Requirement:** None (any character, armed or unarmed)
+
+```
+Reaction + Intuition + Gymnastics [Physical]
+```
+
+- Only lasts for a **single Defense Test**
+- Physical limit applies
+
+### Full Defense (Interrupt Action, -10 Initiative)
+
+```
+Reaction + Intuition + Willpower
+```
+
+- Lasts for the **entire Combat Turn**
+- Can be combined with Block, Dodge, or Parry
+
+---
+
+## Defense Modifiers
+
+### Positive Modifiers (Defender's Favor)
+
+| Situation                         | Modifier          | Notes                    |
+| --------------------------------- | ----------------- | ------------------------ |
+| Defender has longer Reach         | +Reach difference | Melee only               |
+| Defender receiving a charge       | +1                | Must have Delayed Action |
+| Defender running                  | +2                | Running movement rate    |
+| Defender/target has partial cover | +2                | 25-50% body obscured     |
+| Defender/target has good cover    | +4                | >50% body obscured       |
+| Defender inside moving vehicle    | +3                | Against ranged attacks   |
+
+### Negative Modifiers (Attacker's Favor)
+
+| Situation                                  | Modifier          | Notes                                          |
+| ------------------------------------------ | ----------------- | ---------------------------------------------- |
+| Attacker has longer Reach                  | -Reach difference | Melee only                                     |
+| Defender prone                             | -2                | Does not apply to ranged attacks at >5m        |
+| Defender wounded                           | -Wound modifier   | Per usual wound penalty rules                  |
+| Defender defended against previous attacks | -1 cumulative     | Per additional defense since last Action Phase |
+| Defender in melee, target of ranged attack | -3                | Distraction penalty                            |
+| Flechette narrow spread                    | -1                | Shotgun setting                                |
+| Flechette medium spread                    | -3                | Shotgun setting                                |
+| Flechette wide spread                      | -5                | Shotgun setting                                |
+| Burst Fire / SA Burst                      | -2                | 3 rounds                                       |
+| Long Burst / FA (Simple)                   | -5                | 6 rounds                                       |
+| Full Auto (Complex)                        | -9                | 10 rounds                                      |
+| Targeted by area-effect attack             | -2                | Grenades, spells, etc.                         |
+
+### Special Cases
+
+| Situation                             | Effect                                          |
+| ------------------------------------- | ----------------------------------------------- |
+| Defender unaware of attack            | **No defense possible** (treat as Success Test) |
+| Defender behind cover (still unaware) | Defense pool = cover bonus only                 |
+
+---
+
+## Cover
+
+### Types of Cover
+
+#### Partial Cover (+2 Defense)
+
+- 25-50% of defender's body obscured by intervening terrain or obstacles
+- Examples: brush, foliage, crates, windows, doorways, curtains
+- Requires **Take Cover** action
+
+#### Good Cover (+4 Defense)
+
+- More than 50% of defender's body obscured by intervening terrain or cover
+- Also applies to **prone targets** at least 20 meters from attackers
+- Requires **Take Cover** action
+
+### Cover Interactions
+
+- Cover modifiers apply to both **Ranged Combat** and **Spellcasting**
+- Cover modifier does **not** negate the Blind Fire modifier the attacker suffers
+- When firing at a target that is totally concealed (100% behind cover), both modifiers apply
+
+### Hitting Through Cover
+
+If attacker and defender tie in the Opposed Test while defender is in cover:
+
+- Attacker hits the target **through the cover** they're using
+- If the attack penetrates the barrier, damage can still be dealt
+- See Barriers rules for penetration details
+
+---
+
+## Active Defenses (Interrupt Actions)
+
+Sometimes you want to do more than duck and weave. Active defenses reduce the defender's Initiative Score but provide enhanced protection.
+
+### Full Defense
+
+**Cost:** -10 Initiative Score (Interrupt Action)
+
+**Effect:**
+
+- Bonus to defense dice pool equal to **Willpower**
+- Lasts for the **entire Combat Turn**
+- Can be used against any form of attack
+- Can be combined with Block, Dodge, or Parry
+
+**Requirements:**
+
+- Character must not be surprised
+- Can be declared at any point in a Combat Turn
+- Can be declared when attacked, even before the character's Action Phase
+
+### Dodge
+
+**Cost:** -5 Initiative Score (Interrupt Action)
+
+**Effect:**
+
+```
+Reaction + Intuition + Gymnastics [Physical]
+```
+
+**Requirements:**
+
+- Character must not be surprised
+- Works for any character, armed or unarmed
+- Only lasts for a **single Defense Test**
+
+### Parry
+
+**Cost:** -5 Initiative Score (Interrupt Action)
+
+**Effect:**
+
+```
+Reaction + Intuition + (Melee Weapon Skill) [Physical]
+```
+
+**Requirements:**
+
+- Character must not be surprised
+- Must have melee weapon **in hand**
+- Must have appropriate weapon skill
+- Only lasts for a **single Defense Test**
+- Only usable against **melee attacks**
+
+### Block
+
+**Cost:** -5 Initiative Score (Interrupt Action)
+
+**Effect:**
+
+```
+Reaction + Intuition + Unarmed Combat [Physical]
+```
+
+**Requirements:**
+
+- Character must not be surprised
+- Must be **empty-handed**
+- Must have Unarmed Combat skill
+- Only lasts for a **single Defense Test**
+- Usable against **unarmed or melee attacks**
+
+---
+
+## Defense Summary Table
+
+| Defense Type | Cost     | Dice Pool                | Limit    | Duration    | Usable Against |
+| ------------ | -------- | ------------------------ | -------- | ----------- | -------------- |
+| Standard     | Free     | REA + INT                | None     | Single test | Any            |
+| Full Defense | -10 Init | REA + INT + WIL          | None     | Combat Turn | Any            |
+| Dodge        | -5 Init  | REA + INT + Gymnastics   | Physical | Single test | Melee          |
+| Parry        | -5 Init  | REA + INT + Melee Weapon | Physical | Single test | Melee          |
+| Block        | -5 Init  | REA + INT + Unarmed      | Physical | Single test | Unarmed/Melee  |
+
+---
+
+## Special Defense Situations
+
+### Defender Inside a Moving Vehicle
+
+- Gains **+3 dice** to defense against ranged attacks
+- Reflects difficulty of hitting someone in an unpredictable, moving environment
+
+### Defender Prone
+
+- Suffers **-2 dice pool modifier** to defense
+- Does **not** apply to defending against ranged attacks unless attacker is extremely close (5 meters or less)
+- Prone defenders behind good cover are protected from suppressive fire
+
+### Defender Unaware of Attack
+
+If the defender is unaware of an incoming attack (doesn't see attacker, attacker is behind them, surprised):
+
+- **No defense is possible**
+- Treat the attack as a **Success Test** instead of an Opposed Test
+- Does not apply to defenders already engaged in combat
+
+### Multiple Defenses
+
+If a character has defended against at least one other attack since their last Action Phase:
+
+- Apply **-1 cumulative modifier** for each additional defense roll
+- Resets at the start of character's next Action Phase
+
+---
+
+## Reach in Defense
+
+Reach affects melee defense based on the difference between attacker and defender:
+
+| Situation                 | Effect                               |
+| ------------------------- | ------------------------------------ |
+| Attacker has longer Reach | Defender suffers -(Reach difference) |
+| Defender has longer Reach | Defender gains +(Reach difference)   |
+| Equal Reach               | No modifier                          |
+
+**Note:** Trolls have a natural Reach of 1 that is cumulative with weapon Reach.
+
+---
+
+## Implementation Notes
+
+### For Combat System
+
+- Track defense modifiers from all sources
+- Implement Initiative Score reduction for active defenses
+- Handle cumulative defense penalties
+- Support cover bonuses and penetration rules
+- Track Full Defense duration (entire Combat Turn)
+- Implement Reach calculations for melee defense
+
+### For UI
+
+- Display current defense modifiers
+- Show Initiative cost for active defense options
+- Indicate cover status and bonus
+- Track number of defenses since last Action Phase
+- Highlight when Full Defense is active
+
+### State Tracking Requirements
+
+- Cover status (none, partial, good)
+- Prone status
+- Running status
+- Full Defense active (until end of Combat Turn)
+- Defense count since last Action Phase
+- Active Reach comparisons
+
+---
+
+## Reference
+
+- SR5 Core Rulebook pp. 187-192 (Defending in Combat, Active Defenses)
+- SR5 Core Rulebook pp. 173-175 (Ranged Modifiers, Environmental Modifiers)

--- a/docs/rules/5e/game-mechanics/explosives.md
+++ b/docs/rules/5e/game-mechanics/explosives.md
@@ -1,0 +1,288 @@
+# Shadowrun 5E Explosives Reference
+
+## Overview
+
+Explosives include thrown grenades, launched grenades, rockets, and missiles. All are area-effect weapons that require special rules for determining where they land and how their blast affects targets.
+
+---
+
+## Thrown Grenades
+
+Grenades are small, self-contained explosive or gas-delivery packages.
+
+### Throwing Grenades
+
+**Attack Roll:**
+
+```
+Throwing Weapons + Agility [Physical] (3)
+```
+
+- Modified for range and all usual conditions
+- Uses a **Throw Weapon Simple Action**
+
+**Results:**
+
+- **Success (3+ hits):** Grenade lands exactly where intended
+- **Failure (< 3 hits):** Grenade scatters (see Determine Scatter below)
+
+**Note:** Three hits means no scatter, but it's still possible to hit the target if the scatter roll is low and the thrower got some hits.
+
+### Grenade Detonation Methods
+
+#### Built-in Timer
+
+- Grenade is thrown during the character's Action Phase
+- Detonates in the **next Combat Turn** on the Initiative Score in which it was thrown **minus 10**
+- Regardless of any additional changes to the thrower's Initiative Score
+
+**Example:** Thrown at Initiative Score 15, detonates next Combat Turn at Initiative Score 5.
+
+#### Motion Sensor
+
+**Warning:** Grenades using a motion sensor are **extremely dangerous**.
+
+- Once armed (about a second after sensor activation), explodes after any sudden stop or change in direction
+- This means hitting the wall, floor, or target
+
+**Resolution:**
+
+1. Use standard Ranged Attack rules
+2. If attack **misses** (no net hits):
+   - Roll for scatter
+   - Grenade scatters the **full amount** before exploding immediately
+3. **Glitch:** Grenade does not detonate on initial impact; **doubles** the scatter distance, then explodes
+4. **Critical Glitch:** Thrower waited too long - grenade detonates **immediately**, affecting the attacker and those around them
+
+#### Wireless Link
+
+The safest way to throw a grenade, but requires extra effort.
+
+**Requirements:**
+
+- The thrower (or anyone with a mark on the grenade) can detonate it wirelessly
+- Requires a **direct neural interface** to the linked device
+
+**With DNI:**
+
+- Use **Change Wireless Device Mode Free Action** to detonate
+- **Reduces scatter**
+
+**Without DNI:**
+
+- Must use **Change Linked Device Mode Simple Action** in next or subsequent Action Phases
+- Scatter distance is **not reduced**
+
+---
+
+## Grenade Launchers, Rockets, & Missiles
+
+Resolving a launched grenade, rocket, or missile attack is a two-step process:
+
+1. Determine where the projectile ends up (see Determine Scatter)
+2. Resolve the effect of the explosion (see Blast Effects)
+
+### Attack Roll
+
+```
+Heavy Weapons + Agility [Accuracy] (3)
+```
+
+- Modified for range and all usual conditions
+- Uses a **Fire Weapon Simple Action**
+
+**Results:**
+
+- **Success (3+ hits):** Projectile hits exactly where intended
+- **Failure (< 3 hits):** Projectile scatters (see Determine Scatter)
+
+### Launcher Minimum Range
+
+**Critical:** The shortest possible range for all launchers is **5 meters**.
+
+- Projectiles do not arm until they have traveled 5 meters
+- They **will not detonate** if they hit anything before traveling 5 meters
+- This is a **safety feature** in case of accidental misfire
+
+**Disabling the Safety:**
+
+```
+Armorer + Logic [Mental] (4, 10 minutes) Extended Test
+```
+
+### Projectile Trigger Types
+
+#### Built-in Timer
+
+- Weapon is launched during the character's Action Phase
+- Detonates in the **next Combat Turn** on the same Initiative Score in which it was fired **minus 10**
+- Regardless of any changes to the attacker's Initiative Score
+
+#### Motion Sensor / Impact Trigger
+
+**Warning:** Projectile explosives using motion sensors or impact triggers are **extremely dangerous**.
+
+- Once armed (after projectile has traveled **5 meters** unless safety is disarmed), explodes after any sudden stop or change in direction
+
+**Resolution:**
+
+1. Use standard Ranged Attack rules
+2. If attack **misses** (no net hits):
+   - Roll for scatter
+   - Projectile scatters the **full amount** before exploding immediately
+3. **Glitch:** Projectile does not detonate on initial impact; **doubles** scatter distance, then explodes
+4. **Critical Glitch:** Arming mechanism misfires - explosive detonates **immediately**, affecting the attacker and those around them
+
+#### Wireless Link
+
+The safest way to launch a weapon but requires extra effort.
+
+**Requirements:**
+
+- Firer (or anyone with the projectile subscribed to their PAN) can detonate wirelessly
+- Requires a **direct neural interface** to the linked device
+
+**With DNI:**
+
+- Use **Change Wireless Device Mode Free Action** to detonate
+- **Reduces scatter**
+
+**Without DNI:**
+
+- Must use **Change Linked Device Mode Simple Action** in next or subsequent Action Phases
+- Scatter distance is **not reduced**
+
+---
+
+## Determine Scatter
+
+When the attacker misses their intended landing spot, the GM determines scatter.
+
+### Direction
+
+Roll **2D6** and consult the Scatter Diagram:
+
+- The **7 arrow** indicates the direction of the launch
+- Result of **7**: Projectile continued past the target
+- Result of **12 or 2**: Projectile scatters back toward the attacker
+
+### Distance
+
+The Scatter Table indicates a number of dice rolled based on the projectile type. The final scatter distance is calculated as:
+
+```
+Scatter Distance = (Scatter Dice Roll) - (Attacker's Hits)
+```
+
+**Note:** If scatter distance is reduced to **0 or less**, the projectile hits the target exactly. Additional hits do not add to Damage Values.
+
+### Scatter Reduction
+
+- Wireless detonation with DNI reduces scatter
+- Attacker hits reduce scatter distance
+
+---
+
+## Blast Effects
+
+Grenades, rockets, and missiles are **area-effect weapons**. Their blast affects a given area and any targets within it.
+
+### Distance-Based Damage Reduction
+
+The farther away a target is from the blast point, the less damage they take. Different projectile types lose blast effect at different rates.
+
+**Formula:**
+
+```
+Effective DV = Base DV - (Distance in meters * DV Reduction Rate)
+```
+
+Consult the Grenades/Rockets/Missiles Table for:
+
+- Base Damage Code
+- Damage Value reduction rate per meter
+
+### Blasts in a Confined Space
+
+When a grenade detonates in a confined space (hallway, room):
+
+1. **Determine barrier integrity:** Consult Destroying Barriers rules
+2. If walls/doors **hold up**, the blast is channeled
+3. If barriers **fail**, determine blast effects normally
+
+**Channeled Blast:**
+
+- Shock wave reflects off walls, continuing back in the direction it came from
+- If rebounding shock wave maintains enough DV to reach a character, that character is subject to the appropriate blast effect
+- If character is struck **twice** (once as it headed out, once as it rebounded), the Damage Value equals the **combined DV of the two waves**
+
+**Chunky Salsa Effect:**
+A detonating explosive's blast could theoretically rebound repeatedly off each of the six surfaces in a small, well-built room, raising the effective Damage Value far higher than the original grenade damage.
+
+### Multiple Simultaneous Blasts
+
+When multiple explosives detonate at once on the same Combat Initiative Score and both blasts affect the same character:
+
+**Damage Calculation:**
+
+```
+Combined DV = Highest DV + (Half of each lower DV)
+```
+
+Apply as a single modified Damage Value for Damage Resistance tests.
+
+**Armor Penetration:**
+
+- Use the **best AP**
+- Improve it by **1 for every additional explosion**
+
+---
+
+## Grenade Types Summary
+
+| Type           | Primary Effect  | Notes                        |
+| -------------- | --------------- | ---------------------------- |
+| Fragmentation  | Physical damage | Standard anti-personnel      |
+| High Explosive | Physical damage | Higher base DV, larger blast |
+| Flash-Bang     | Stun + Blind    | Non-lethal                   |
+| Smoke          | Concealment     | Creates visibility penalties |
+| Thermal Smoke  | Concealment     | Blocks thermal/infrared      |
+| Gas            | Toxin delivery  | Varies by gas type           |
+| Flash-Pak      | Blind           | Non-lethal distraction       |
+
+---
+
+## Implementation Notes
+
+### For Combat System
+
+- Track scatter direction and distance when attacks miss
+- Implement blast radius calculations with distance-based damage reduction
+- Handle confined space reflections (chunky salsa effect)
+- Support multiple simultaneous blast calculations
+- Track grenade detonation timing (Initiative Score - 10)
+- Implement 5-meter minimum range for launchers
+
+### For UI
+
+- Visualize blast radius and scatter
+- Show affected targets in blast zone
+- Display countdown for timer-based grenades
+- Indicate wireless-enabled grenades and their status
+
+### Data Requirements
+
+- Grenade/Rocket/Missile table with:
+  - Base DV
+  - AP
+  - Blast radius
+  - DV reduction rate per meter
+  - Scatter dice
+  - Available trigger types
+
+---
+
+## Reference
+
+- SR5 Core Rulebook pp. 181-183 (Grenades, Launchers, Scatter, Blast Effects)
+- SR5 Core Rulebook p. 435 (Grenades/Rockets/Missiles Table)

--- a/docs/rules/5e/game-mechanics/firearms.md
+++ b/docs/rules/5e/game-mechanics/firearms.md
@@ -1,0 +1,268 @@
+# Shadowrun 5E Firearms Reference
+
+## Overview
+
+Firearms throw high-velocity projectiles designed to damage whatever they hit. A weapon's firing mode determines how quickly each round is ready to fire, how quickly you can pull the trigger, and what happens when you do.
+
+## Firing Modes
+
+### Single Shot (SS)
+
+Firing a Single Shot weapon uses a **Simple Action** that cannot be combined with any other attacking Simple Action in the same Action Phase.
+
+- SS weapons can take advantage of the **Multiple Attacks Free Action** if the attacker is wielding two such weapons
+- Examples: bolt-action rifles, single-action revolvers, pump-action shotguns, lever-action rifles, large weapons requiring extra time to chamber due to cartridge size
+- Single Shot fire assumes another round is readied with each shot as long as rounds are available
+
+| Attribute        | Value  |
+| ---------------- | ------ |
+| Action           | Simple |
+| Rounds Used      | 1      |
+| Defense Modifier | 0      |
+| Recoil           | None   |
+
+### Semi-Automatic (SA)
+
+Semi-automatic weapons fire a round every time the trigger is pulled and automatically chamber a fresh round after each shot.
+
+- Uses a **Simple Action** but cannot combine with any other attack Action in the same Action Phase
+- Can take advantage of **Multiple Attacks Free Action** with two semi-automatic weapons
+- Also has the option of using a **Semi-Automatic Burst** (see below)
+
+| Attribute        | Value  |
+| ---------------- | ------ |
+| Action           | Simple |
+| Rounds Used      | 1      |
+| Defense Modifier | 0      |
+
+### Semi-Automatic Burst (SB)
+
+Three semi-automatic shots taken in quick succession.
+
+- Uses a **Complex Action**
+- Increases the chance that a bullet will hit
+- Can take advantage of **Multiple Attacks Free Action** to fire at multiple targets with the same burst
+
+| Attribute        | Value   |
+| ---------------- | ------- |
+| Action           | Complex |
+| Rounds Used      | 3       |
+| Defense Modifier | -2      |
+
+### Burst Fire (BF)
+
+Usually found on SMGs or assault rifles, but some pistols and shotguns can be modified for this mode. In burst-fire mode, a gun rapidly fires three bullets every time the trigger is pulled.
+
+- Uses a **Simple Action** that cannot be combined with any other attack Simple Action in the same Action Phase
+- Can take advantage of **Multiple Attacks Free Action** to fire at multiple targets with the same burst
+
+| Attribute        | Value  |
+| ---------------- | ------ |
+| Action           | Simple |
+| Rounds Used      | 3      |
+| Defense Modifier | -2     |
+
+### Long Burst (LB)
+
+Quickly firing in Burst Fire mode - the gun fires two three-round bursts in rapid succession.
+
+- Uses a **Complex Action**
+- Can take advantage of **Multiple Attacks Free Action** to fire at multiple targets with the same burst
+
+| Attribute        | Value   |
+| ---------------- | ------- |
+| Action           | Complex |
+| Rounds Used      | 6       |
+| Defense Modifier | -5      |
+
+### Full-Auto (FA)
+
+Full-Auto weapons can throw bullets for as long as the attacker keeps the trigger pulled and the rounds last.
+
+- Can be fired as a **Simple Action** (6 bullets) or **Complex Action** (10 bullets)
+- Can take advantage of **Multiple Attacks Free Action** to fire at multiple targets with the same burst
+
+| Action Type | Rounds Used | Defense Modifier |
+| ----------- | ----------- | ---------------- |
+| Simple      | 6           | -5               |
+| Complex     | 10          | -9               |
+
+### Suppressive Fire
+
+A combination of controlled and fully automatic bursts focused over a narrow area and directed at anything that moves.
+
+**Mechanics:**
+
+- Uses a **Complex Action**
+- Consumes **20 rounds of ammo**
+- **Ignores recoil**
+- Creates a triangular suppression zone
+
+**Zone Characteristics:**
+
+- Projects from the shooter outward up to a distance of the shooter's choosing (maximum = weapon range)
+- Width of **10 meters** at its end
+- Height of **2 meters**
+
+**Attack Roll:**
+
+```
+(Weapon Skill) + Agility [Accuracy]
+```
+
+- Include bonuses for: smartlink, laser sight, tracer rounds, other GM-approved modifiers
+- Record the hits
+
+**Zone Effects:**
+
+- The suppressive fire zone lasts until the end of the Combat Turn
+- Firer must not move or commit to any other action to maintain the zone
+- Anyone **in the zone or immediately adjacent** takes a dice pool penalty to all actions equal to the shooter's hits (unless completely unaware, e.g., astral projection)
+
+**Risk of Being Hit:**
+
+Characters who are in the suppressed area (not behind cover or prone), or who move into or out of the area before suppressive fire ends, must make:
+
+```
+Reaction + Edge Test (+ Full Defense dice if chosen)
+Threshold = Suppressive attacker's hits
+```
+
+**Note:** Use full Edge rating regardless of spent points (but not burned Edge points).
+
+**Failure:** Character is hit, suffering damage equal to the weapon's **base Damage Value** modified by special ammunition.
+
+**Avoiding Damage:**
+
+- Characters behind **full cover** or who **drop prone** are not at risk (but suffer normal prone modifiers)
+- Characters may use their **Free Action** to go prone and avoid getting hit
+- If no Free Action remains, can use **Hit the Dirt Interrupt Action** to go prone instead
+
+**Standing Up:**
+
+- Any character who stands up or moves again before suppressive fire stops must make a test to see if hit
+
+**Multiple Overlapping Zones:**
+
+- Only the highest dice pool penalty counts against targets
+- Targets must make a Reaction + Edge test against **all overlapping zones**, taking damage from the ones missed
+- Subject to diminishing pool effect: **-1 die penalty** to defender's dice pool after each roll
+
+## Firing Mode Summary Table
+
+| Mode             | Action  | Rounds | Defense Mod | Notes          |
+| ---------------- | ------- | ------ | ----------- | -------------- |
+| Single Shot (SS) | Simple  | 1      | 0           | No recoil      |
+| Semi-Auto (SA)   | Simple  | 1      | 0           |                |
+| SA Burst (SB)    | Complex | 3      | -2          |                |
+| Burst Fire (BF)  | Simple  | 3      | -2          |                |
+| Long Burst (LB)  | Complex | 6      | -5          |                |
+| Full-Auto (FA)   | Simple  | 6      | -5          |                |
+| Full-Auto (FA)   | Complex | 10     | -9          |                |
+| Suppressive Fire | Complex | 20     | Special     | Ignores recoil |
+
+---
+
+## Shotguns
+
+Shotguns can fire slug rounds (standard) or shot rounds. Shot rounds have little effect against 21st-century body armor.
+
+### Shot Rounds
+
+- Apply **flechette ammunition rules** to the Damage Value
+- Shot rounds spread when fired, creating a cone extending outward from the muzzle
+- Allows hitting multiple targets, but with reduced effectiveness due to spread
+
+### Choke Settings
+
+The choke controls the spread of shot pellets. Changing the choke setting requires:
+
+- **Simple Action** (standard)
+- **Free Action** (if smartlinked)
+
+#### Narrow Spread
+
+| Attribute        | Value           |
+| ---------------- | --------------- |
+| Defense Modifier | -1 (all ranges) |
+| DV Modifier      | None            |
+| Max Targets      | 1               |
+| Called Shots     | Allowed         |
+
+#### Medium Spread
+
+| Range   | DV Mod | Accuracy | Defense Mod | Max Targets | Spread Width |
+| ------- | ------ | -------- | ----------- | ----------- | ------------ |
+| Short   | -1     | -        | -3          | 2           | 2m           |
+| Medium  | -3     | -        | -3          | 3           | 4m           |
+| Long    | -5     | -1       | -3          | 4           | 6m           |
+| Extreme | -7     | -1       | -3          | 6           | 8m           |
+
+**Note:** Medium spreads **cannot** be used with Called Shots.
+
+#### Wide Spread
+
+| Range   | DV Mod | Accuracy | Defense Mod | Max Targets | Spread Width |
+| ------- | ------ | -------- | ----------- | ----------- | ------------ |
+| Short   | -3     | -        | -5          | 2           | 3m           |
+| Medium  | -5     | -        | -5          | 3           | 6m           |
+| Long    | -7     | -1       | -5          | 4           | 9m           |
+| Extreme | -9     | -1       | -5          | 6           | 12m          |
+
+**Note:** Wide spreads **cannot** be used with Called Shots.
+
+---
+
+## Not Enough Bullets
+
+When a firing character is short on ammo, reduce each of the modifiers applied by **1 for each bullet short**.
+
+### Examples
+
+**Full Auto (Complex) - Short on Ammo:**
+
+- Wombat attempts Full Auto (Complex) but only has 7 rounds (needs 10)
+- 10 - 7 = 3 bullet shortage
+- Defense modifier reduced from -9 to -6
+
+**Long Burst - Short on Ammo:**
+
+- Full Deck fires a Long Burst with only 5 rounds (needs 6)
+- 1 round short = -1 to modifier
+- Defense modifier reduced from -5 to -4
+
+### Suppressive Fire - Short on Ammo
+
+If suppressive fire doesn't have enough bullets, the **width of the suppressed area** is reduced by **1 meter for every 2 bullets short** (rounded down).
+
+**Example:**
+
+- Wombat uses Suppressive Fire with only 13 rounds (needs 20)
+- 7 rounds short = 3.5 meters reduction (rounded down to 3m)
+- Zone width reduced from 10m to 7m
+
+---
+
+## Implementation Notes
+
+### For Combat System
+
+- Track ammunition count per weapon
+- Calculate defense modifiers based on firing mode and ammo availability
+- Support choke setting changes (Simple Action or Free with smartlink)
+- Implement suppressive fire zone tracking with position-based effects
+
+### For UI
+
+- Display current firing mode and ammo count
+- Show defense modifier preview for firing mode selection
+- Visualize suppressive fire zones when applicable
+- Indicate choke setting for shotguns
+
+---
+
+## Reference
+
+- SR5 Core Rulebook pp. 178-180 (Firing Modes)
+- SR5 Core Rulebook pp. 180 (Firing Mode Table)
+- SR5 Core Rulebook p. 429 (Shotguns - Street Gear)

--- a/docs/rules/5e/game-mechanics/healing-detailed.md
+++ b/docs/rules/5e/game-mechanics/healing-detailed.md
@@ -1,0 +1,426 @@
+# Shadowrun 5E Healing & Recovery Reference
+
+## Overview
+
+This document covers all healing methods in Shadowrun 5E: First Aid, Natural Recovery, Medicine skill, Medkits/Autodocs, Magical Healing, and Stabilization for characters in critical condition.
+
+---
+
+## First Aid
+
+Characters with the First Aid skill may immediately help reduce the trauma of wounds (Stun or Physical).
+
+### Requirements
+
+- **Must have a medkit** (even if currently out of supplies)
+- **Must be applied within 1 hour** of when the damage was taken
+
+### Test
+
+```
+First Aid + Logic [Mental] (2)
+```
+
+Apply appropriate modifiers from the Healing Modifiers table, including:
+
+- **Wound modifiers** if applying First Aid to yourself or others
+
+### Results
+
+- Each **net hit over the threshold** removes **1 box of damage**
+- **Divide effect in half (rounded up)** if victim is wearing any kind of **full-body armor**
+  - Represents difficulty of treating patient through armor
+
+### Limitations
+
+- Maximum damage healable = **First Aid skill rating**
+- May only be applied **once** for that set of wounds
+- May **not** be applied if the character has been **magically healed**
+
+### Failures
+
+- **Critical Glitch:** Increases damage by **1D3 boxes** (1D6 ÷ 2)
+
+### Combat First Aid
+
+Using First Aid in combat requires:
+
+- **Complex Action**
+- Takes a number of **Combat Turns** equal to the number of boxes of damage being healed
+
+**Workflow:**
+
+- Character applying First Aid must spend **one Complex Action per Combat Turn** providing care
+- May spend the rest of their Action Phases however they like
+
+### Diagnosis
+
+First Aid may also be used to diagnose:
+
+- Character's health
+- Extent of wounds taken
+- Effect of other ailments
+
+**Test:** GM sets threshold appropriate to the character's health or affliction. Award information appropriate to net hits scored.
+
+---
+
+## Natural Recovery
+
+Stun and Physical damage both heal naturally, though at different rates. Medical attention can help hasten the process.
+
+### Tracking Healing
+
+Healing is handled as an **Extended Test**. Hits from each test should be recorded separately in case of interruption.
+
+### Stun Damage Recovery
+
+```
+Body + Willpower (1 hour) Extended Test
+```
+
+- Character must **rest for the entire hour** for it to count
+- Forced naps and unconsciousness count as rest
+- Each hit heals **1 box of Stun damage**
+
+### Physical Damage Recovery
+
+```
+Body × 2 (1 day) Extended Test
+```
+
+- Character must **rest for the entire day** for it to count
+- Forced naps and unconsciousness count as rest
+- Each hit heals **1 box of Physical damage**
+
+**Critical:** Physical damage **cannot be healed through rest** if the character also has **Stun damage**. The Stun damage must be healed first.
+
+### Glitches During Natural Recovery
+
+| Result          | Effect                                                 |
+| --------------- | ------------------------------------------------------ |
+| Glitch          | Doubles the resting time (damage still healed)         |
+| Critical Glitch | Increases damage by 1D3 boxes AND doubles resting time |
+
+### Boosting Natural Recovery
+
+Natural Recovery can be bolstered by:
+
+- Medkits
+- Autodoc drones
+
+---
+
+## Medicine
+
+Characters with the Medicine skill can speed the healing process.
+
+### Test
+
+```
+Medicine + Logic [Mental]
+```
+
+Apply appropriate modifiers, including wound modifiers if applying Medicine to own wounds.
+
+### Effect
+
+Each hit provides **+1 die** to any subsequent healing tests the character makes for **healing through rest**.
+
+### Time Requirements
+
+The character using Medicine skill must spend time tending to the injured character:
+
+| Damage Type       | Required Time       |
+| ----------------- | ------------------- |
+| Physical injuries | 30 minutes per day  |
+| Stun injuries     | 10 minutes per hour |
+
+### Limitations
+
+- May only be applied **once** to each set of wounds
+- **May** be applied even if First Aid and/or magical healing have already been used
+- Additional damage taken afterward counts as a **new set of wounds**
+- **Cannot** be applied in combat situations
+
+### Diagnosis
+
+Medicine may be used to diagnose a character's health in the same manner as First Aid.
+
+---
+
+## Medkits and Autodocs
+
+Modern medkits and autodoc drones rival the capabilities of trained paramedics.
+
+### Uses
+
+1. Aid to a medtech's diagnoses or applied healing
+2. Hooked up to patient and set to apply medical care automatically
+
+### Using in Combat
+
+Using a medkit/autodoc in combat is time-consuming:
+
+1. **Complex Action** to apply the medkit/autodoc
+2. After application, receive a **dice pool modifier equal to the device's rating** when treating a character
+   - Requires **wireless functionality**
+   - For autodocs: use First Aid or Medicine autosoft rating
+
+### Untrained Use
+
+If the character is untrained, they can still make an untrained First Aid test:
+
+- Roll **Logic - 1** die
+- Use **device's rating** in place of First Aid skill
+
+### Automated Care
+
+If a wireless medkit is hooked up to a patient and left unattended:
+
+```
+Roll: Device Rating × 2
+```
+
+For any subsequent tests.
+
+### Remote Control
+
+Medkits and autodocs can be accessed and controlled remotely via Matrix/wireless link.
+
+---
+
+## Magical Healing
+
+The **Heal spell** can be used to repair physical injuries.
+
+### Effect
+
+Each hit from the Spellcasting Test heals **1 box of Physical damage**.
+
+- Maximum = spell's Force
+
+### Limitation
+
+Sorcery **cannot** heal damage resulting from **magical Drain**.
+
+---
+
+## Physical Damage Overflow
+
+Characters who exceed their Physical Condition Monitor and enter overflow damage are at risk of dying.
+
+### Death Threshold
+
+If you go over **(Body)** points of overflow damage:
+
+- **You are dead**
+- Time to permanently check out and meet Mr. Johnson in the Big Shadowrunner Bar in the Sky
+
+### Ongoing Damage (Unstabilized)
+
+If the character's condition is **not stabilized**, they take:
+
+- **1 additional box of damage** every **(Body) minutes**
+- Due to blood loss, shock, and other things affecting a body on the brink of death
+
+---
+
+## Stabilization
+
+Stabilizing a wounded character prevents ongoing overflow damage.
+
+### Stabilization Test
+
+```
+First Aid + Logic [Mental] (3)
+```
+
+OR
+
+```
+Medicine + Logic [Mental] (3)
+```
+
+Apply situational modifiers.
+
+### Success
+
+- Wounded patient **stabilizes**
+- **No longer takes automatic additional damage**
+
+### Failure
+
+- Character **continues to take damage** until they die
+- Additional stabilization tests may be made
+- **-2 cumulative dice pool modifier** per test
+
+### Alternative Methods
+
+- **Medkits and autodocs** may be used to stabilize a character
+- **Stabilize spell** may be used to stabilize a character
+- **Heal spell cannot** be used to stabilize
+
+### After Stabilization
+
+Once a character has been stabilized:
+
+- First Aid
+- Medicine
+- Magical healing
+
+May all be applied normally.
+
+---
+
+## Healing Modifiers Table
+
+| Condition                             | Modifier                 |
+| ------------------------------------- | ------------------------ |
+| Good conditions (sterilized facility) | +0                       |
+| Average conditions (indoors, clean)   | -1                       |
+| Poor conditions (outdoors, dirty)     | -2                       |
+| Bad conditions (rain, sewers)         | -3                       |
+| Terrible conditions (combat, filth)   | -4                       |
+| Patient wearing full-body armor       | Halve healing (round up) |
+| Wound modifiers                       | Apply as normal          |
+
+---
+
+## Healing Method Interactions
+
+### First Aid
+
+| Can be used with | Cannot be used with      |
+| ---------------- | ------------------------ |
+| Medicine (later) | Magical healing (prior)  |
+| Natural Recovery | Second First Aid attempt |
+
+### Medicine
+
+| Can be used with        | Cannot be used with     |
+| ----------------------- | ----------------------- |
+| First Aid (prior)       | Combat situations       |
+| Magical healing (prior) | Second Medicine attempt |
+
+### Magical Healing
+
+| Can be used with | Cannot be used with     |
+| ---------------- | ----------------------- |
+| Medicine (later) | First Aid (after magic) |
+|                  | Healing Drain damage    |
+
+---
+
+## Healing Workflow Summary
+
+### Immediate (Within 1 Hour)
+
+1. **First Aid** - Up to skill rating boxes, threshold 2
+
+### Short-Term
+
+2. **Medicine** - Provides bonus dice to natural recovery
+3. **Magical Healing** - Heal spell, up to Force boxes
+
+### Long-Term
+
+4. **Natural Recovery (Stun)** - Body + Willpower per hour
+5. **Natural Recovery (Physical)** - Body × 2 per day (after Stun healed)
+
+### Critical Condition
+
+- **Stabilize** - Prevent overflow death
+- Then apply normal healing methods
+
+---
+
+## Implementation Notes
+
+### For Combat System
+
+- Track wound sets separately for healing attempt limits
+- Implement First Aid timing window (1 hour)
+- Handle overflow damage timing (Body minutes between damage)
+- Support medkit/autodoc automated healing
+- Track stabilization status
+
+### For UI
+
+- Display time since damage taken (for First Aid window)
+- Show stabilization status for overflow characters
+- Track healing attempts per wound set
+- Display medkit/autodoc application status
+- Countdown for natural recovery intervals
+
+### State Tracking Per Character
+
+- Current wound set ID
+- First Aid applied (yes/no)
+- Medicine applied (yes/no)
+- Magical healing applied (yes/no)
+- Stabilization status
+- Time in overflow
+- Medkit/autodoc connected
+
+### Healing Attempt Limits
+
+| Method           | Limit                             |
+| ---------------- | --------------------------------- |
+| First Aid        | Once per wound set                |
+| Medicine         | Once per wound set                |
+| Magical Healing  | Variable (blocks First Aid after) |
+| Natural Recovery | Unlimited (extended test)         |
+
+---
+
+## Quick Reference
+
+### First Aid
+
+```
+First Aid + Logic [Mental] (2)
+Time: 1 hour window
+Max Healing: Skill rating
+```
+
+### Medicine
+
+```
+Medicine + Logic [Mental]
+Time: 30 min/day (Physical) or 10 min/hour (Stun)
+Effect: +1 die to natural recovery per hit
+```
+
+### Natural Recovery (Stun)
+
+```
+Body + Willpower (1 hour)
+Effect: 1 box per hit
+Requirement: Must rest for full hour
+```
+
+### Natural Recovery (Physical)
+
+```
+Body × 2 (1 day)
+Effect: 1 box per hit
+Requirement: Must rest for full day; no Stun damage
+```
+
+### Stabilization
+
+```
+First Aid OR Medicine + Logic [Mental] (3)
+Effect: Stops overflow damage
+Retry: -2 cumulative per attempt
+```
+
+---
+
+## Reference
+
+- SR5 Core Rulebook pp. 205-208 (Healing)
+- SR5 Core Rulebook p. 170 (Exceeding the Condition Monitor)
+- SR5 Core Rulebook p. 450 (Medkits)
+- SR5 Core Rulebook pp. 288-289 (Heal and Stabilize spells)

--- a/docs/rules/5e/game-mechanics/projectile-weapons.md
+++ b/docs/rules/5e/game-mechanics/projectile-weapons.md
@@ -1,0 +1,213 @@
+# Shadowrun 5E Projectile Weapons Reference
+
+## Overview
+
+Ranged combat rules apply to bows and throwing weapons, with some special rules for each category.
+
+---
+
+## Thrown Weapons
+
+Thrown weapons are used for a variety of different purposes.
+
+### Damage-Dealing Thrown Weapons
+
+Knives, hatchets, and shuriken are intended to injure a target on impact. They act just like projectiles in terms of attack rules.
+
+### Shuriken
+
+Multi-edged airfoil throwing blades available in many different styles.
+
+**Readying:**
+
+- A character can ready **Agility ÷ 2** shuriken per Ready Weapon action
+
+**Example:** A character with Agility 5 can ready 2 shuriken (5 ÷ 2 = 2.5, rounded down to 2) with a single Ready Weapon action.
+
+### Throwing Knife
+
+This category covers a variety of slim knives or spikes.
+
+**Readying:**
+
+- A character can ready **Agility ÷ 2** throwing knives per Ready Weapon action
+
+---
+
+## Grenades (Thrown)
+
+When throwing a grenade, choose a location as a target.
+
+**Attack Roll:**
+
+```
+Throwing Weapons + Agility [Physical] (3)
+```
+
+- Modified for range and all usual conditions
+- Uses a **Throw Weapon Simple Action**
+
+**Results:**
+
+- **Success (3+ hits):** Grenade lands right where intended
+- **Failure (< 3 hits):** Grenade scatters
+
+See the [Explosives Reference](./explosives.md) for detailed grenade rules including detonation methods and scatter.
+
+---
+
+## Bows
+
+Bows can be straight, recurve, reflex, or compound, made of anything from wood to spring steel to modern composites.
+
+### Minimum Strength Rating
+
+Bows have a **minimum Strength rating** that indicates the minimum Strength a character must have to use that weapon effectively.
+
+**Below Minimum Strength:**
+
+- Suffer **-3 dice pool modifier per point below the minimum**
+- This reflects the difficulty of pulling the bow and nocking an arrow
+
+### Range and Damage Calculation
+
+The weapon's **minimum Strength rating** is used to determine:
+
+- Weapon's range
+- Weapon's damage
+
+**Damage Calculation:**
+
+```
+Base Damage = Lower of (Bow Rating, Arrow Rating)
+```
+
+### Bow Attributes
+
+| Bow Type     | Typical Min STR | Notes                 |
+| ------------ | --------------- | --------------------- |
+| Survival Bow | 1-2             | Compact, emergency    |
+| Bow          | 2-4             | Standard bow          |
+| Compound Bow | 3-6             | Mechanical assistance |
+
+---
+
+## Crossbows
+
+Modern crossbows are equipped with **automatic reloading devices** for faster firing rates.
+
+### Reloading
+
+- Reloading **does not require a Ready Weapon action** (for modern crossbows)
+- Exception: Museum pieces/antique crossbows require Ready Weapon to reload
+
+### Magazine
+
+- Feature **internal magazines (m)** holding up to **4 bolts**
+
+### Size Categories
+
+| Category | Notes                          |
+| -------- | ------------------------------ |
+| Light    | Lower damage, faster handling  |
+| Medium   | Balanced                       |
+| Heavy    | Higher damage, slower handling |
+
+---
+
+## Thrown Weapon Ranges
+
+Thrown weapons typically have limited range compared to firearms. Range is often based on:
+
+- Character's Strength
+- Weapon's aerodynamic properties
+- Weapon weight
+
+---
+
+## Attack Resolution
+
+### Standard Thrown Weapon Attack
+
+```
+Throwing Weapons + Agility [Physical]
+```
+
+vs.
+
+```
+Defender: Reaction + Intuition
+```
+
+### Bow/Crossbow Attack
+
+```
+Archery + Agility [Accuracy]
+```
+
+vs.
+
+```
+Defender: Reaction + Intuition
+```
+
+---
+
+## Special Considerations
+
+### Touch-Only Attacks
+
+If the intention of an attack is simply to make contact (discharge a spell, plant an RFID tag, etc.):
+
+- Attacker gains **+2 dice pool bonus**
+- If all that is needed is contact, the **attacker wins on a tie** (not the defender)
+
+### Multiple Thrown Weapons
+
+Characters can use the Multiple Attacks Free Action with thrown weapons, but:
+
+- Dice pool is split between attacks
+- Maximum attacks = half of Combat Skill
+
+### Ammunition Management
+
+| Weapon Type        | Ready Amount | Notes                    |
+| ------------------ | ------------ | ------------------------ |
+| Shuriken           | AGI ÷ 2      | Per Ready Weapon action  |
+| Throwing Knife     | AGI ÷ 2      | Per Ready Weapon action  |
+| Bow                | 1 arrow      | Per Ready Weapon action  |
+| Crossbow (modern)  | N/A          | Auto-feeds from magazine |
+| Crossbow (antique) | 1 bolt       | Per Ready Weapon action  |
+
+---
+
+## Implementation Notes
+
+### For Combat System
+
+- Track minimum Strength requirements for bows
+- Calculate readied projectile quantities based on Agility
+- Implement damage calculation using min(Bow Rating, Arrow Rating)
+- Support auto-reload for modern crossbows
+- Handle multiple thrown weapons in single action
+
+### For UI
+
+- Display minimum Strength warning when below requirement
+- Show number of projectiles that can be readied
+- Track crossbow magazine capacity
+- Indicate Strength-based range calculations
+
+### Data Requirements
+
+- Thrown weapon stats (damage, accuracy, range)
+- Bow stats including minimum Strength rating
+- Crossbow magazine capacities
+- Arrow/bolt damage ratings
+
+---
+
+## Reference
+
+- SR5 Core Rulebook pp. 181-182 (Projectiles)
+- SR5 Core Rulebook pp. 424-425 (Projectile Weapons - Street Gear)

--- a/docs/rules/5e/game-mechanics/sensors-gunnery.md
+++ b/docs/rules/5e/game-mechanics/sensors-gunnery.md
@@ -1,0 +1,241 @@
+# Shadowrun 5E Sensors & Gunnery Reference
+
+## Overview
+
+This document covers vehicle-mounted weapons (gunnery), drone weapon systems, and sensor-based detection and targeting.
+
+---
+
+## Gunnery
+
+The rules and modifiers for ranged combat apply to vehicle-mounted weapons.
+
+### Manual Operation (Door Guns, Mounted Weapons)
+
+**Attack Roll:**
+
+```
+Gunnery + Agility [Accuracy]
+```
+
+### Remote Operated Systems
+
+**Attack Roll:**
+
+```
+Gunnery + Logic [Accuracy]
+```
+
+### Action Requirements
+
+- **Complex Action** required for shooting weapons mounted on a vehicle in any firing mode
+- This applies regardless of the weapon's normal firing mode action
+
+### Handheld Weapons from Vehicles
+
+Characters shooting handheld weapons (not vehicle-mounted) from vehicles:
+
+- Follow normal rules for ranged combat
+- Suffer **-2 dice penalty** for firing from a moving vehicle
+- **Stationary vehicles** do not confer this penalty
+- May inflict the **Firing from Cover** modifier if applicable
+
+---
+
+## Drone Gunnery
+
+Drones attack using their onboard systems and autosofts.
+
+### Attack Roll
+
+```
+Pilot + [Weapon] Targeting Autosoft [Accuracy]
+```
+
+### Requirements
+
+- Drones **must** have an autosoft appropriate to the weapon they are wielding
+- Drones **cannot fire a weapon untrained**
+- No autosoft = no attack capability with that weapon
+
+### Example
+
+A drone with Pilot 3 and Ares Alpha Targeting autosoft 4 would roll:
+
+```
+3 (Pilot) + 4 (Targeting) = 7 dice [limited by weapon Accuracy]
+```
+
+---
+
+## Sensor Attacks
+
+### Detection
+
+To detect a person, critter, or vehicle with sensors, make a successful Sensor Test.
+
+#### For Characters/Vehicles with Operator
+
+```
+Perception + Intuition [Sensor]
+```
+
+#### For Autonomous Vehicles/Drones
+
+```
+Pilot + Clearsight [Sensor]
+```
+
+### Opposed Detection (Target Evading)
+
+If the target is trying to evade detection, make this an Opposed Test:
+
+| Target Type         | Defense Roll                                 |
+| ------------------- | -------------------------------------------- |
+| Metahumans/Critters | Infiltration + Agility [Physical]            |
+| Driven Vehicles     | Infiltration (Vehicle) + Reaction [Handling] |
+| Drones              | Pilot + [Model] Stealth [Handling]           |
+
+**Note:** Since vehicle stealth is limited by the driver's ability, the dice applied for Infiltration skill should not exceed the driver's appropriate Vehicle skill.
+
+### Signature Modifiers
+
+Sensors are designed to detect the "signature" (emissions, composition, sound, etc.) of other vehicles. Modifiers from the **Signature Table** apply to the detecting vehicle's dice pool.
+
+---
+
+## Sensor Targeting
+
+A character can use the vehicle's Sensor Attribute to help with Gunnery. Two options are available:
+
+### Passive Targeting
+
+The vehicle's Sensor attribute **substitutes for the Accuracy** of the weapon as the advanced targeting system compensates for weapon design flaws.
+
+**Attack Roll:**
+
+```
+Gunnery + Logic [Sensor]
+```
+
+**Modifiers:**
+
+- Target's **Signature modifiers** are applied as a dice pool modifier
+
+### Active Targeting
+
+Active targeting uses a vehicle's Sensors to **lock onto** a target.
+
+#### Step 1: Acquire Target Lock
+
+- Requires a **Simple Action**
+- Make a **Sensor Test** to lock onto target
+
+**If Lock Succeeds:**
+
+- Net hits are applied as a **negative modifier to the Defense Test** on the attack
+
+**If No Hits:**
+
+- Sensors fail to lock onto target
+- Active targeting attack **cannot be made**
+
+#### Step 2: Maintain Lock
+
+- Once locked, active targeting can be used against the target **without additional Sensor Tests**
+- Lock is maintained until target breaks sensor contact
+
+#### Breaking Sensor Lock
+
+If target breaks sensor contact, a new target lock must be acquired.
+
+**Breaking Contact:**
+
+- Use an action to **Evade Detection**
+- This is an Opposed Test using the appropriate Sensor Defense Test
+
+### Sensor Defense Table
+
+| Target Type         | Defense Roll                                 |
+| ------------------- | -------------------------------------------- |
+| Metahumans/Critters | Infiltration + Agility [Physical]            |
+| Driven Vehicles     | Infiltration (Vehicle) + Reaction [Handling] |
+| Drones              | Pilot + [Model] Stealth [Handling]           |
+
+---
+
+## Targeting Method Comparison
+
+| Method            | Attack Roll       | Limit      | Special                         |
+| ----------------- | ----------------- | ---------- | ------------------------------- |
+| Manual            | Gunnery + AGI     | Accuracy   | Standard                        |
+| Remote            | Gunnery + LOG     | Accuracy   | Standard                        |
+| Drone Auto        | Pilot + Targeting | Accuracy   | Requires autosoft               |
+| Passive Targeting | Gunnery + LOG     | **Sensor** | Signature mods apply            |
+| Active Targeting  | Standard          | Standard   | Applies lock penalty to defense |
+
+---
+
+## Vehicle Weapon Actions
+
+| Action Type | Use Case                                   |
+| ----------- | ------------------------------------------ |
+| Complex     | Fire any vehicle-mounted weapon (any mode) |
+| Simple      | Use sensors to detect/lock targets         |
+| Free        | Change linked device mode (with DNI)       |
+| Simple      | Change linked device mode (without DNI)    |
+
+---
+
+## Implementation Notes
+
+### For Combat System
+
+- Support separate Gunnery skill for vehicle weapons
+- Implement Pilot + Autosoft rolls for drones
+- Track sensor locks on targets
+- Apply signature modifiers to detection
+- Support passive targeting (Sensor as limit)
+- Support active targeting (lock provides defense penalty)
+
+### For UI
+
+- Display sensor lock status
+- Show available targeting modes
+- Indicate required autosofts for drones
+- Display signature ratings for vehicles
+
+### Data Requirements
+
+- Vehicle sensor ratings
+- Weapon targeting autosofts
+- Vehicle/drone signature ratings
+- Clearsight autosoft ratings
+
+---
+
+## Quick Reference
+
+### Gunnery Attack Summary
+
+```
+Manual Mount:       Gunnery + Agility [Accuracy]
+Remote System:      Gunnery + Logic [Accuracy]
+Passive Targeting:  Gunnery + Logic [Sensor]
+Active Targeting:   Standard attack + lock bonus vs defense
+Drone Attack:       Pilot + Targeting Autosoft [Accuracy]
+```
+
+### Detection Summary
+
+```
+Character/Vehicle:  Perception + Intuition [Sensor]
+Autonomous:         Pilot + Clearsight [Sensor]
+```
+
+---
+
+## Reference
+
+- SR5 Core Rulebook pp. 183-184 (Gunnery, Drone Gunnery, Sensor Attacks)
+- SR5 Core Rulebook p. 269 (Autosofts)

--- a/docs/rules/5e/game-mechanics/special-actions.md
+++ b/docs/rules/5e/game-mechanics/special-actions.md
@@ -1,0 +1,425 @@
+# Shadowrun 5E Special Combat Actions Reference
+
+## Overview
+
+This document covers special combat actions including surprise, interception, knockdown, subduing, multiple attacks, called shots, and the dead man's trigger.
+
+---
+
+## Surprise
+
+Sometimes things happen when you least expect them. Surprise simulates those moments you didn't see coming.
+
+### What Can Be Surprised
+
+- All characters and critters can be surprised
+- **Cannot be surprised:** non-sentient objects (astral barriers, foci, programs, IC, bricks)
+
+### When Surprise Occurs
+
+- Surprise occurs on a **character-by-character basis**
+- A character walking into an ambush may be surprised by one enemy but not another
+- Not all characters in a team may be surprised by the same events
+- Surprise normally occurs at the **beginning of combat**
+- Can also occur **within a Combat Turn** if unexpected forces enter the fray
+
+### Surprise and Perception
+
+Surprised characters are unaware that danger is imminent. This occurs because:
+
+1. They failed to perceive something (didn't get enough hits to notice the concealed sniper)
+2. The GM decides they didn't have a chance to perceive it (walked into a room full of armed guards)
+
+**Perception Check:**
+In some circumstances, GMs may give a character a chance to be alerted via a secret Perception Test. Success means the character:
+
+- Hears approaching footsteps
+- Notices the smell of cigarette vapor
+- Gets that "tingly feeling" that someone is behind them
+
+**Alert Bonus:** Characters who succeed receive a **+3 bonus** on their Surprise Test.
+
+**Combat Sense:** Anyone with Combat Sense spell or Adept power **always** gets a Perception Test, but can still be surprised if they don't receive enough hits.
+
+### Surprise Tests
+
+**All participants** must make a Surprise Test:
+
+```
+Reaction + Intuition (3)
+```
+
+**Modifiers:**
+
+- Characters who have been alerted: **+3 dice pool modifier**
+- Surprise Tests have **no Limit**
+
+**Results:**
+
+| Result          | Effect                                                                                                                                              |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Success         | Character acts normally                                                                                                                             |
+| Failure         | Lose 10 from Initiative Score; considered surprised until next Action Phase; **no Defense Test** when attacked                                      |
+| Glitch          | Can still react, but startles (jump, knock into something, drop something held)                                                                     |
+| Critical Glitch | Completely stunned; does not act for the first Action Phase; if entering combat after, receives both -10 for failure AND -10 for entering mid-fight |
+
+**Edge Option:** Spending a point of Edge avoids surprise. Still lose Initiative Score points, but can use defense rolls.
+
+### Ambushing
+
+Characters who plan an ambush and delay their actions while lying in wait receive:
+
+- **+6 dice pool modifier** on the Surprise Test
+- **Automatically not surprised** by characters they are ambushing (if aware of target's movement/actions)
+
+**Ambusher Unaware:**
+If the ambusher is unaware of their prey's activities (waiting for someone to enter a room, watching for a spirit to materialize):
+
+- Still receives the **+6 modifier**
+- **Must still check for surprise** as they may not be ready when target appears
+
+**Note:** If an ambushed character gets a higher Initiative Score than the ambushers, they can act first.
+
+### Surprise in Combat
+
+When new characters are unexpectedly introduced to an ongoing combat:
+
+- **All characters** (existing and new) must make Surprise Tests
+- If any are surprised, adjust Initiative Scores
+- Return to regular Combat Turn
+- Surprised characters cannot make defense rolls during this Action Phase
+
+### Effects of Surprise
+
+Surprised characters **cannot:**
+
+- Take any actions that directly affect, impede, or counteract non-surprised characters
+- Attack non-surprised characters
+- Dodge or defend against attacks from non-surprised characters
+- React to the other characters' actions in any way
+- React to friendly warnings (can't "duck" when friend shouts warning)
+
+Surprised characters **can:**
+
+- Carry out other actions not specifically directed at surprising characters
+- Drop prone
+- Ready a weapon (but not fire it)
+
+---
+
+## Interception
+
+If movement takes a character within one meter (+1 meter per point of Reach) of an opponent, and the character attempts to pass without attacking:
+
+### Intercepting
+
+- Opponent can use an **Interrupt Action**
+- **Cost:** Voluntarily decrease Initiative Score by 5
+- Make a melee attack against the passing character
+
+**Weapon Options:**
+
+- If melee weapon ready: use normal melee weapon skill
+- Otherwise: use Unarmed Combat skill
+- If wielding firearm: can use weapon as club (Clubs skill)
+
+This attack follows normal Melee Combat rules.
+
+### Interception Success
+
+If after the Resistance Test the passing character takes damage **equal to their Body**:
+
+- Character is **intercepted**
+- **Cannot continue movement**
+
+**Note:** Prone combatants cannot intercept.
+
+### Avoiding Interception
+
+Agile characters can avoid Interception attempts without engaging in combat:
+
+**Test:**
+
+```
+Agility + Gymnastics (1) [Physical]
+```
+
+- Uses a **Complex Action** with their movement
+- Each hit above the threshold allows the character to move past **one opponent**
+
+---
+
+## Knockdown
+
+Characters who take damage may be knocked down by the attack or its staggering effects.
+
+### Automatic Knockdown
+
+If a character takes boxes of damage (Stun or Physical, after Damage Resistance Test) from a single attack that **exceed their Physical limit**:
+
+- Attack automatically knocks them down
+- Acts as a forced, free **Drop Prone** action
+
+**Absolute Threshold:** Any character who takes **10 or more boxes** of damage after a Resistance Test in a single attack is **always** knocked down.
+
+### Special Knockdown Weapons
+
+Certain less-than-lethal weapons are specifically designed to knock a target down:
+
+- **Gel rounds:** Reduce the Physical limit of the character by **2** when comparing to DV for knockdown
+
+### Intentional Knockdown (Called Shot)
+
+A character making a melee attack may attempt to intentionally knock their opponent down using a Called Shot (see Called Shots section).
+
+---
+
+## Subduing
+
+Sometimes characters need to subdue an opponent without beating them into unconsciousness.
+
+### Initiating a Grapple
+
+Resolve melee combat normally using the **Unarmed Combat skill**.
+
+**If the attacker successfully hits:**
+
+Compare:
+
+```
+Attacker's Strength + Net Hits vs. Defender's Physical Limit
+```
+
+If attacker's total **exceeds** defender's Physical limit:
+
+- Attacker **grapples and immobilizes** the defender
+- This subduing attack causes **no damage** to the defender
+
+### While Subdued
+
+- Defender is considered **prone** for any attacks made against them
+- Defender **cannot take any actions requiring physical movement**
+- Grappling character does not need to make tests to maintain the grapple
+- Grappler must spend **one Complex Action per Action Phase** to hold the position
+
+### Breaking Free
+
+Defender must take a **Complex Action** and succeed in:
+
+```
+Unarmed Combat + Strength [Physical]
+Threshold = Attacker's original grappling net hits
+```
+
+Success: Defender escapes the grapple.
+
+### Grappler Options
+
+Each Complex Action spent to maintain the grapple, the grappler may also choose ONE:
+
+#### Improve Grip
+
+- Make an additional Unarmed Combat Attack Test
+- Defender opposes as normal
+- Attacker gets **Superior Position bonus (+2)**
+- If attacker scores more hits: net hits added to previous grappling net hits
+- If defender scores more hits: reduce attacker's net hits (grip is slipping)
+
+#### Inflict Damage
+
+- Inflict **Stun Damage** with DV equal to grappler's **Strength**
+- Requires no test
+- Defender resists as normal
+- **Armor applies**
+
+#### Knockdown
+
+- Follow rules for Called Shots knockdown
+- Attacker gets **Superior Position bonus (+2)**
+
+---
+
+## Multiple Attacks
+
+Characters can attack more than once in a single Action Phase by using the **Multiple Attacks Free Action**.
+
+### How It Works
+
+1. Calculate attacker's dice pool with **all modifiers** (Wound, Environmental, Situational, and **full recoil of all attacks** if ranged)
+2. **Split the pool** as evenly as possible between all attacks
+3. Each attack is handled **separately**
+
+**Warning:** As dice pools get smaller, chances of a glitch rise.
+
+### Edge Usage
+
+- Dice gained by spending Edge applies **before** the pool is split
+- Dice from both pools can be re-rolled with a **single use of Edge**
+
+### Attack Limit
+
+Total number of attacks in a single Action Phase is limited to:
+
+```
+Maximum Attacks = 1/2 Attacker's Combat Skill (round down)
+```
+
+---
+
+## Called Shots
+
+Sometimes just taking a normal shot isn't enough. Called shots allow specific targeting or special maneuvers.
+
+### General Rules
+
+- **Cost:** -4 dice pool penalty + Free Action (in addition to basic attack action)
+- GM determines which options are allowed in their game
+
+### Called Shot Options
+
+#### Blast Out of Hands
+
+- Knock an item out of target's hand
+- Target takes **no damage**
+- Normal -4 modifier plus situational modifiers (wounds, lighting, range)
+- Defender rolls as normal
+- Item sent flying, coming to rest **(net hits)** meters from defender
+- Item travels away from the shooter
+
+#### Dirty Trick
+
+Shooting plasterboard to kick up dust, kicking dirt in opponent's eyes, etc.
+
+- If attack succeeds with even **one net hit**
+- Opponent takes **-4 dice pool modifier** on their next action
+
+#### Harder Knock
+
+Shoot a gel round into opponent's face, punch someone in the throat, etc.
+
+- Changes damage code on **Stun-based weapons to Physical**
+- No other change to DV
+
+#### Knock Down (Melee Only)
+
+Bowl opponent over, sweep feet, pull off balance, etc.
+
+- Must declare intent during Declare Actions
+- Make melee attack as normal
+- If scoring more hits than defender, compare:
+
+```
+Attacker's Strength + Net Hits vs. Defender's Physical Limit
+```
+
+- If exceeds: defender is knocked to the ground
+- Causes **no damage** to target
+- Attacker chooses to follow defender down (free Drop Prone) or stay standing
+- **Glitch:** Attacker falls as well
+- **Critical Glitch:** Attacker falls while defender stays standing
+
+#### Shake Up
+
+Intentional shot past the ear, skipping rounds off the ground to keep opponent running.
+
+- Target loses **5 from Initiative Score** along with normal damage
+- If Initiative Score drops below 0: target loses last Action Phase for this Initiative Pass
+- Even if defender **completely resists all damage**, as long as shot hit, they still lose Initiative Score
+
+#### Splitting the Damage
+
+Intentionally shooting the trauma plate on armor, hitting thicker padding, etc.
+
+**Requirements:**
+
+- Target must be wearing armor
+- Attacker's AP must be **less than** that armor (can't use with APDS vs armor clothing)
+
+**Effect:**
+
+- Damage is split between the two condition monitors
+- If odd damage, Stun Damage is the higher value
+- If modified total DV is **less than** modified Armor Value: attack does only half damage, all applied to Stun
+
+#### Trick Shot
+
+Shooting a cigarette out of someone's mouth, tacking opponent's sleeve to wall with a knife, slicing a playing card in midair.
+
+- Usually requires some setup (can't happen mid-combat)
+- Standard -4 modifier plus situational modifiers
+- Note the number of hits scored
+- Those hits act as **positive dice pool modifier** for Intimidation Test made by attacker or known ally after the shot
+
+#### Vitals
+
+Aiming for a particularly vital area (brain, heart, major arteries).
+
+- **Effect:** Extra **+2 DV** on the attack
+- These areas are smaller and harder to hit (hence the -4 penalty)
+
+---
+
+## Dead Man's Trigger
+
+A character may perform **one final action** before dying or falling unconscious.
+
+### Requirements (All Three Must Be Met)
+
+1. **Initiative Score of at least 1** for the Combat Turn
+   - If all Initiative Score is used up, out of luck
+
+2. **Spend 1 Edge point**
+   - This just activates the Dead Man's Trigger
+   - Doesn't add extra Edge dice to any tests
+   - Character may spend extra Edge to augment tests as normal
+   - If no Edge left, out of luck
+
+3. **Succeed in a Body + Willpower (3) Test**
+   - This takes place **after** the Edge point is spent
+
+### If Successful
+
+Character may perform **one final action** of any kind:
+
+- **No movement** allowed
+- Resolved as normal
+- Can be modified by any Free Action as well
+
+---
+
+## Implementation Notes
+
+### For Combat System
+
+- Implement Surprise Tests at combat start and when new combatants enter
+- Track "surprised" status per character
+- Support interception when characters move past enemies
+- Implement grapple state with Complex Action maintenance
+- Handle multiple attack dice pool splitting
+- Support all called shot variants
+- Implement Dead Man's Trigger state check
+
+### For UI
+
+- Display surprise status and Initiative penalties
+- Show interception opportunities during movement
+- Track grapple state and options
+- Visualize dice pool splitting for multiple attacks
+- Called shot selection interface
+- Dead Man's Trigger prompt when conditions are met
+
+### State Tracking
+
+- Surprise status per character
+- Grapple state (who is grappling whom, net hits for escape threshold)
+- Called shot declarations
+- Multiple attack pool divisions
+- Edge spent for Dead Man's Trigger
+
+---
+
+## Reference
+
+- SR5 Core Rulebook pp. 192-196 (Surprise, Interception, Knockdown, Subduing, Called Shots)
+- SR5 Core Rulebook p. 195 (Called Shots)
+- SR5 Core Rulebook p. 196 (Multiple Attacks, Dead Man's Trigger)

--- a/docs/rules/5e/game-mechanics/vehicles-detailed.md
+++ b/docs/rules/5e/game-mechanics/vehicles-detailed.md
@@ -1,0 +1,626 @@
+# Shadowrun 5E Vehicles & Chase Combat Reference
+
+## Overview
+
+Vehicles provide expedient transportation and exciting combat opportunities. When a scene centers on vehicles, the primary theme is speed - vehicles are moving fast, the situation is changing fast, and the rules should resolve fast.
+
+---
+
+## Vehicle Stats
+
+### Handling
+
+Represents the vehicle's agility and responsiveness.
+
+- Base limit for Vehicle Tests where **maneuverability** is the most important feature
+
+### Speed
+
+Represents the maximum velocity the vehicle can achieve (top-end speed).
+
+- Base limit for Vehicle Tests that emphasize **raw speed**
+
+### Acceleration
+
+Defines how quickly a vehicle can change its current speed and close distance.
+
+- Value represents the maximum number of **Range Categories** the vehicle can move in a single Combat Turn
+
+### Body
+
+Represents a combination of structural integrity and size.
+
+- Larger vehicles tend to have more open spaces that are not high risk when attacked
+- Used as part of the dice pool for **resisting damage** (like a metahuman character)
+
+### Armor
+
+Represents the vehicle's "toughness" and ability to take a hit and still function.
+
+- Does not necessarily represent metal plating
+- Can indicate general resistance due to structural integrity and strength
+- Second value (with Body) that forms the dice pool for **damage resistance**
+
+### Pilot
+
+Rating defining the capabilities of the built-in computer piloting system.
+
+- All vehicles in the Sixth World come equipped with this
+- For vehicles **not actively piloted by a metahuman**, takes the place of:
+  - All Mental attributes
+  - Reaction
+  - For any tests the vehicle needs to make
+
+### Sensor
+
+Rating representing the suite of information-gathering/detection devices.
+
+- Acts as the **limit** for Perception and other detection tests using the vehicle's systems
+
+### Condition Monitor
+
+| Vehicle Type | Condition Monitor |
+| ------------ | ----------------- |
+| Vehicles     | 12 + ceil(Body/2) |
+| Drones       | 6 + ceil(Body/2)  |
+
+### Special Vehicle Properties
+
+- Vehicles **ignore Stun damage**
+- **Electricity-based attacks** are considered Physical Damage to vehicles
+- Any attack where modified DV **does not exceed** the Armor of the vehicle does **nothing**
+
+---
+
+## Vehicle Tests
+
+No test is required for non-combat, everyday situations (unless character is Incompetent).
+
+### When Vehicle Tests Are Required
+
+Tests are needed in dangerous or extreme situations with vehicles.
+
+### Test Format
+
+```
+Vehicle Skill + Reaction [Handling]
+```
+
+### Threshold Guidelines
+
+| Difficulty | Threshold | Examples                  |
+| ---------- | --------- | ------------------------- |
+| Easy       | 1         | Standard maneuvering      |
+| Average    | 2         | Moderate difficulty       |
+| Hard       | 4         | Challenging maneuvers     |
+| Extreme    | 6         | Very difficult situations |
+
+### Terrain Modifiers
+
+Terrain affects the threshold of Vehicle Tests:
+
+| Terrain Type                 | Threshold Modifier |
+| ---------------------------- | ------------------ |
+| Open/Clear                   | 0                  |
+| Light (minor obstacles)      | +1                 |
+| Restricted (narrow, winding) | +2                 |
+| Tight (very limited space)   | +3                 |
+| Severe (extreme hazards)     | +4                 |
+
+---
+
+## Vehicle Speeds (Long Distance)
+
+### Foot
+
+| Mode            | Speed        | Notes                             |
+| --------------- | ------------ | --------------------------------- |
+| Walking         | 5 kph        | Straight line in urban/flat rural |
+| Hustling        | 10 kph       | Causes Fatigue damage             |
+| Mountains/Rough | 1.25-2.5 kph | Half to quarter normal            |
+
+### Bicycle
+
+| Mode     | Speed  | Notes                    |
+| -------- | ------ | ------------------------ |
+| Road     | 25 kph | Streets and flat terrain |
+| Off-road | ~6 kph | Quarter speed            |
+
+Long periods or uneven terrain cause Fatigue.
+
+### Ground Craft (with GridGuide)
+
+| Environment         | Speed   |
+| ------------------- | ------- |
+| Urban               | 80 kph  |
+| Rural/Cross-country | 120 kph |
+
+### Watercraft
+
+| Type              | Speed               |
+| ----------------- | ------------------- |
+| Kayaks/Canoes     | 3 kph (still water) |
+| Against current   | 0.75 kph (quarter)  |
+| With current      | 12 kph (quadruple)  |
+| Small powerboats  | 25 kph              |
+| Larger powerboats | 65 kph              |
+| Speedboats        | 130 kph             |
+| Cigarette boats   | 200 kph             |
+| Yachts            | 60 kph              |
+| Cruise ships      | 35 kph              |
+
+### Rotorcraft
+
+| Environment                | Speed   |
+| -------------------------- | ------- |
+| Open terrain               | 220 kph |
+| Urban airspace             | 140 kph |
+| Rural airspace (tilt-wing) | 300 kph |
+
+### Aircraft
+
+| Type                    | Speed     |
+| ----------------------- | --------- |
+| Prop planes             | 250 kph   |
+| Small jets              | 1,000 kph |
+| Large jets (commercial) | 800 kph   |
+
+---
+
+## Piloting Modifiers
+
+### Environmental Modifiers
+
+| Condition           | Modifier                                                 |
+| ------------------- | -------------------------------------------------------- |
+| Impaired Visibility | Use Visibility column from Environmental Modifiers Table |
+| Limited Light       | Use Light column from Environmental Modifiers Table      |
+
+These modifiers are mitigated and neutralized the same way as for other circumstances.
+
+### Pilot-Related Modifiers
+
+| Condition                | Effect                                                 |
+| ------------------------ | ------------------------------------------------------ |
+| Pilot unaware of event   | No Vehicle Test allowed against surprising threats     |
+| Pilot wounded            | Apply wound modifiers to Vehicle tests                 |
+| Piloting damaged vehicle | Apply vehicle's damage modifier as penalty to Handling |
+
+### Technology Modifiers
+
+| Control Method          | Effect                                                   |
+| ----------------------- | -------------------------------------------------------- |
+| Augmented Reality       | Increase limit of tests by **+1**                        |
+| Virtual Reality         | Increase limit of tests by **+2**                        |
+| Jumped In (Control Rig) | Decrease threshold by **Control Rig rating** (minimum 1) |
+
+---
+
+## Crashes
+
+Crashes occur during:
+
+- Ramming actions
+- When driver on a collision course fails a vehicle test
+- Whenever the GM says so
+
+### Crash Damage
+
+When a vehicle crashes, both vehicle and passengers must resist damage:
+
+```
+Damage = Vehicle's Body
+Resistance = Body + Armor - 6 AP
+```
+
+**Damage Type:**
+
+- **Stun** if vehicle's Body (base damage) is **less than** character's Armor
+- **Physical** if vehicle's Body is **equal to or greater than** character's Armor
+
+### Mental Trauma
+
+Any character caught in a crash must make:
+
+```
+Composure (4) Test
+```
+
+**Failure:** Penalty to actions equal to how many hits they missed the threshold by, for that number of Combat Turns.
+
+---
+
+## Tactical Vehicle Combat
+
+When transportation mode is mixed between vehicles and pedestrians (start of getaway, drive-by shooting).
+
+### Movement
+
+- Based on movement rate from vehicle's Speed rating
+- Driver chooses movement rate at **beginning of each Combat Turn**
+
+### Initiative
+
+Resolved as normal.
+
+### Actions
+
+| Requirement       | Action                                                |
+| ----------------- | ----------------------------------------------------- |
+| Driver must spend | At least **1 Complex Action** per Combat Turn driving |
+| Failure           | Vehicle is **uncontrolled** at end of Combat Turn     |
+
+### Uncontrolled Vehicles
+
+- All characters apply **-2 dice pool modifier** to all actions
+- If driver doesn't make Vehicle Test to regain control in one Combat Turn:
+  - **If Pilot rating exists:** Autopilot kicks in and drives with traffic flow
+  - **If no Pilot program:** Vehicle continues last heading, slowing down (or maintaining speed if accelerator locked) until GM says it crashes
+
+### Vehicle Actions
+
+#### Free Actions
+
+**Change Linked Device Mode (with DNI):**
+
+- Activate/deactivate sensors, ECM, weapons, etc.
+- Call up status report (position, heading, speed, damage, orders)
+- Activated systems come online at start of **next Action Phase**
+
+#### Simple Actions
+
+**Use Sensors:**
+
+- Detect or lock onto targets
+
+**Use Simple Device:**
+
+- Manually activate/deactivate sensors, ECM/ECCM, weapon systems, other onboard systems
+
+#### Complex Actions
+
+**Control Vehicle:**
+
+- Not really an action, but expenditure to represent efforts to keep vehicle under control
+- Doesn't need to be driver's first action
+- Until taken, vehicle is considered uncontrolled
+
+**Fire a Vehicle Weapon:**
+
+- Fire a vehicle-mounted weapon
+
+**Make Vehicle Test:**
+
+- Execute a maneuver requiring a Vehicle Test
+- Failed tests may result in uncontrolled vehicle or crash
+- Glitched tests almost always result in a crash
+- Critical Glitched tests **always** result in a crash
+
+---
+
+## Ramming
+
+If a driver wants to ram something (or someone) with the vehicle, treat it as a **melee attack**.
+
+### Requirements
+
+Target must be within vehicle's Walking or Running Rate.
+
+- **-3 dice modifier** applies if driver has to resort to running
+
+### Attack Roll
+
+```
+Vehicle Skill + Reaction
+```
+
+### Defense Roll
+
+| Target Type     | Defense                         |
+| --------------- | ------------------------------- |
+| Pedestrian      | Reaction + Intuition            |
+| Another Vehicle | Reaction + Intuition [Handling] |
+
+**Pedestrian Options:**
+
+- Can use Full Defense or Dodge Interrupt Action
+- **Cannot** use Block or Parry
+
+### If Driver Gets More Hits
+
+- Ram succeeds
+- Make Damage Resistance Test as normal
+
+### Ramming Damage
+
+| Vehicle Speed | Base DV           |
+| ------------- | ----------------- |
+| Walking       | Body              |
+| Running       | Body + (Speed/10) |
+| Sprinting     | Body + (Speed/5)  |
+
+**Note:** Ramming vehicle must resist only **half** that amount (round up).
+
+### Passenger Damage Resistance
+
+```
+Body + Armor - 6 AP
+```
+
+### After Ramming
+
+Each driver must make an additional Vehicle Test to avoid losing control:
+
+| Role           | Threshold |
+| -------------- | --------- |
+| Ramming driver | 2         |
+| Rammed driver  | 3         |
+
+**Failure:** Vehicle is uncontrolled and cannot perform any actions until control is regained.
+
+---
+
+## Chase Combat
+
+Used when a combat situation involves two or more parties all in moving vehicles.
+
+### Chase Combat Turn Sequence
+
+1. Determine Chase Environment for this Combat Turn
+2. Establish relative Chase Ranges for participating vehicles
+3. Roll Initiative for all characters
+4. Take actions in Initiative order
+   - Drivers may perform Chase Actions OR regular combat actions
+   - Passengers may only perform regular combat actions
+
+### Chase Ranges
+
+Distance between vehicles is measured in Chase Ranges - brackets rather than exact distances.
+
+| Range   | Speed Environment | Handling Environment |
+| ------- | ----------------- | -------------------- |
+| Short   | 0-50m             | 0-25m                |
+| Medium  | 51-150m           | 26-75m               |
+| Long    | 151-300m          | 76-150m              |
+| Extreme | 301m+             | 151m+                |
+
+Vehicles acting together can be grouped and assumed at the same range.
+
+### Chase Environments
+
+#### Speed Environment
+
+- Movement is not significantly inhibited
+- Maneuvering is minimal
+- High speeds are possible
+- Examples: major highway, open field, calm waters, clear skies
+- May have very long sight lines (especially water or air)
+
+#### Handling Environment
+
+- Space is limited
+- Quick reflexes and maneuverability more important than speed
+- Top speed is almost never an option
+- Examples: winding residential streets, rocky foothills/canyons, crowded harbor, flying at street level through a city
+
+---
+
+## Chase Actions (Complex Actions)
+
+### Catch-Up/Break Away (Any Range)
+
+Vehicle wishes to close distance or get away.
+
+**Range Change Limit:** Equal to vehicle's **Acceleration**
+
+**Test:**
+
+```
+Reaction + Vehicle Skill [Speed or Handling] (Maneuver Threshold)
+```
+
+- For every hit above threshold: shift **one Range Category** toward or away from opponent
+- If move results in leaving Extreme range: pursuer gets own test to keep target in sight
+
+### Cut-Off (Short Range Only)
+
+Acting vehicle makes sudden move to cut off target, forcing it to crash.
+
+**Opposed Test:**
+
+```
+Reaction + Vehicle Skill [Handling]
+```
+
+**If acting vehicle achieves more hits:**
+
+- Target must make immediate Vehicle Test to avoid crashing
+- Threshold = net hits on the test
+
+### Ram (Short Range Only)
+
+Acting vehicle attempts to collide with target.
+
+**Opposed Test:**
+
+```
+Vehicle Skill + Reaction [Speed or Handling]
+```
+
+- Use **Speed** limit in Speed Environment
+- Use **Handling** limit in Handling Environment
+
+**If ramming vehicle achieves more hits:**
+
+- Vehicles have collided
+- Target takes damage = **Body of ramming vehicle + net hits**
+- Ramming vehicle takes damage = **half its Body**
+
+### Stunt (Any Range)
+
+Last-second veer onto an off-ramp, tight turn into a side street, threading the needle through a tight area.
+
+**Test:**
+
+```
+Vehicle Skill + Reaction [Speed or Handling]
+```
+
+- Use **Speed** limit in Speed Environment
+- Use **Handling** limit in Handling Environment
+
+**GM sets threshold** based on environment, difficulty, and terrain.
+
+**Failure:**
+
+- Vehicle goes out of control
+- Could crash, slow down (allowing pursuers to gain a Range Category), or other consequences
+
+**Success:**
+
+- All pursuing vehicles must immediately make Vehicle Test at the **same threshold** to maintain pursuit range
+- Failure: pursuer falls behind by one Range Category
+- If pursuer already at Extreme Range: fleeing vehicle escapes pursuit
+
+---
+
+## Passenger Actions in Chase Combat
+
+Passengers may take individual actions, but attacking targets outside the vehicle is difficult.
+
+### Penalty
+
+**-2 penalty** to all attack rolls when attacking targets outside the vehicle while using a weapon not mounted to the vehicle.
+
+---
+
+## Attacks Against Vehicles
+
+### Defense Roll
+
+| Situation                 | Defense Roll                |
+| ------------------------- | --------------------------- |
+| Driver-controlled vehicle | Reaction + Intuition        |
+| Drone                     | Pilot + Autosoft [Handling] |
+
+### Evasive Driving
+
+The vehicle equivalent of Full Defense.
+
+**Cost:** -10 Initiative Score (Free Action)
+
+**Effect:**
+
+- Add dice equal to **Intuition** to defense dice pool
+- Lasts for entire Combat Turn
+- **Cannot** be used against ramming attacks
+
+---
+
+## Vehicle Damage
+
+### Damage Resistance
+
+```
+Body + Armor
+```
+
+**Note:** If attack's modified DV is **less than** vehicle's modified Armor, no damage is applied.
+
+**GM Tip:** For vehicles with large Body dice pools, use the trade-in-dice-for-hits rule (4 dice = 1 hit) to simplify.
+
+### Called Shots on Vehicles
+
+Follow normal Called Shot rules (-4 penalty).
+
+**Additional Option:** Target and destroy a specific component:
+
+- Window
+- Sensor
+- Tire
+- Etc.
+
+GM determines exact effect based on DV inflicted. Usually component is destroyed.
+
+**Shot-out tires:** -2 dice pool modifier per flat tire to Vehicle Tests.
+
+**Note:** This targets the vehicle, not passengers.
+
+---
+
+## Damage and Passengers
+
+### Targeting Choice
+
+Attacks must specifically target either:
+
+- **Passengers** (vehicle is unaffected)
+- **Vehicle** (passengers are not affected)
+
+### Exceptions (Affect Both)
+
+- Ramming
+- Suppressive fire
+- Area-effect weapons (grenades, rockets)
+
+### Attacking Passengers
+
+Normal Attack Test with:
+
+- Passengers always considered under **Good Cover** (+4)
+- Additional **+3 modifier** for being inside a moving vehicle
+- **Blind Fire modifier** may apply
+- Passengers suffer **-2 dice pool modifier** to Defense Test (limited movement inside vehicle)
+- Passengers gain protection from vehicle's chassis: add **vehicle's Armor** to personal armor
+
+### Ramming, Suppressive Fire, and Area-Effect
+
+Both passengers and vehicles resist the damage equally.
+
+---
+
+## Air and Naval Warfare
+
+Rules presented are primarily for land, sea, and air combat on a **close scale** with conventional (shadowrunner-level) weapons.
+
+For large-scale, long-range combat:
+
+- Use these rules
+- Extend ranges to those for assault cannons and missiles
+- Ensure everyone understands added danger (ramming at 5,000 meters altitude)
+
+---
+
+## Implementation Notes
+
+### For Combat System
+
+- Track vehicle stats (Handling, Speed, Acceleration, Body, Armor, Pilot, Sensor)
+- Implement Chase Range tracking
+- Support both tactical and chase combat modes
+- Calculate crash damage and composure tests
+- Handle ramming mechanics
+- Support Evasive Driving interrupt
+
+### For UI
+
+- Display Chase Range between vehicles
+- Show Environment type (Speed/Handling)
+- Track vehicle damage vs condition monitor
+- Display available Chase Actions based on range
+- Indicate passenger penalty for attacks
+
+### State Tracking
+
+- Current Chase Range between all vehicle pairs/groups
+- Chase Environment type
+- Vehicle control status (controlled/uncontrolled)
+- Evasive Driving active status
+- Damaged components
+
+---
+
+## Reference
+
+- SR5 Core Rulebook pp. 199-205 (Vehicles, Vehicle Combat, Chase Combat)
+- SR5 Core Rulebook pp. 266-269 (Rigging, Control Rigs)


### PR DESCRIPTION
Add comprehensive reference documentation for SR5 combat mechanics extracted from the core rulebook. These docs support future gameplay implementation.

New files:
- firearms.md: Firing modes, suppressive fire, shotgun chokes, ammo shortage
- explosives.md: Grenades, rockets, missiles, scatter, blast effects
- projectile-weapons.md: Bows, crossbows, thrown weapons
- sensors-gunnery.md: Vehicle/drone gunnery, sensor targeting
- defense-detailed.md: Defense modifiers, cover, active defenses
- special-actions.md: Surprise, interception, knockdown, subduing, called shots
- vehicles-detailed.md: Vehicle stats, tests, chase combat
- healing-detailed.md: First aid, natural recovery, medicine, stabilization