### PR TITLE
feat(gear): add missing equipment for SR5 example characters

### DIFF
--- a/data/editions/sr5/core-rulebook.json
+++ b/data/editions/sr5/core-rulebook.json
@@ -7065,6 +7065,10 @@
           {
             "id": "miscellaneous",
             "name": "Miscellaneous"
+          },
+          {
+            "id": "magical-supplies",
+            "name": "Magical Supplies"
           }
         ],
         "weapons": {
@@ -10152,6 +10156,27 @@
             "legality": "restricted"
           },
           {
+            "id": "alchemy-kit",
+            "name": "Alchemy Kit",
+            "category": "tools",
+            "cost": 500,
+            "availability": 4,
+            "description": "Tools and materials for creating alchemical preparations. Required for Alchemy skill tests.",
+            "page": 306,
+            "source": "Core"
+          },
+          {
+            "id": "armorer-shop",
+            "name": "Armorer Shop",
+            "category": "tools",
+            "cost": 5000,
+            "availability": 8,
+            "description": "Upgraded facility for weapon and armor modifications. Provides +2 dice pool bonus to Armorer tests.",
+            "legality": "restricted",
+            "page": 443,
+            "source": "Core"
+          },
+          {
             "id": "disguise-kit",
             "name": "Disguise Kit",
             "category": "tools",
@@ -11323,6 +11348,31 @@
                 "cost": 400,
                 "availability": 2
               }
+            }
+          },
+          {
+            "id": "magical-lodge-materials",
+            "name": "Magical Lodge Materials",
+            "category": "magical-supplies",
+            "description": "Durable materials for constructing or upgrading a magical lodge. Required for ritual spellcasting and certain magical activities. Cost and availability scale with Force rating.",
+            "hasRating": true,
+            "minRating": 1,
+            "maxRating": 12,
+            "page": 280,
+            "source": "Core",
+            "ratings": {
+              "1": { "cost": 500, "availability": 2 },
+              "2": { "cost": 1000, "availability": 4 },
+              "3": { "cost": 1500, "availability": 6 },
+              "4": { "cost": 2000, "availability": 8 },
+              "5": { "cost": 2500, "availability": 10 },
+              "6": { "cost": 3000, "availability": 12 },
+              "7": { "cost": 3500, "availability": 14 },
+              "8": { "cost": 4000, "availability": 16 },
+              "9": { "cost": 4500, "availability": 18 },
+              "10": { "cost": 5000, "availability": 20 },
+              "11": { "cost": 5500, "availability": 22 },
+              "12": { "cost": 6000, "availability": 24 }
             }
           }
         ],


### PR DESCRIPTION
Add three gear items needed by example character builds:
- alchemy-kit: 500¥, Avail 4 (tools for alchemical preparations)
- armorer-shop: 5,000¥, Avail 8R (upgraded facility for mods)
- magical-lodge-materials: Force×500¥, Avail Force×2 (rating 1-12)

Also adds magical-supplies category to gear categories.

Closes #133