### PR TITLE
feat(fixtures): add SR5 example character fixtures for all 16 archetypes

### DIFF
--- a/__tests__/example-characters.test.ts
+++ b/__tests__/example-characters.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Tests for SR5 Example Character Fixtures
+ *
+ * Validates that all example character JSON files:
+ * 1. Load without errors
+ * 2. Have required fields
+ * 3. Have valid structure matching the Character type
+ * 4. Have valid derived stats
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+// ============================================================================
+// Types (minimal subset for testing)
+// ============================================================================
+
+interface CharacterAttributes {
+  body: number;
+  agility: number;
+  reaction: number;
+  strength: number;
+  willpower: number;
+  logic: number;
+  intuition: number;
+  charisma: number;
+}
+
+interface CharacterSpecialAttributes {
+  edge: number;
+  essence: number;
+  magic?: number;
+  resonance?: number;
+}
+
+interface CharacterDerivedStats {
+  physicalLimit: number;
+  mentalLimit: number;
+  socialLimit: number;
+  initiativeBase: number;
+  initiativeDice: number;
+  physicalConditionMonitor: number;
+  stunConditionMonitor: number;
+  composure: number;
+  judgeIntentions: number;
+  memory: number;
+  liftCarry: number;
+}
+
+interface ExampleCharacter {
+  id: string;
+  ownerId: string;
+  editionId: string;
+  editionCode: string;
+  name: string;
+  metatype: string;
+  status: string;
+  attributes: CharacterAttributes;
+  specialAttributes: CharacterSpecialAttributes;
+  magicalPath: string;
+  skills: Record<string, number>;
+  derivedStats: CharacterDerivedStats;
+  karmaTotal: number;
+  createdAt: string;
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+const EXAMPLE_CHARS_DIR = path.join(process.cwd(), "data/editions/sr5/example-characters");
+
+const EXPECTED_CHARACTER_COUNT = 16;
+
+const REQUIRED_FIELDS = [
+  "id",
+  "ownerId",
+  "editionId",
+  "editionCode",
+  "name",
+  "metatype",
+  "status",
+  "attributes",
+  "specialAttributes",
+  "magicalPath",
+  "skills",
+  "derivedStats",
+  "karmaTotal",
+  "createdAt",
+];
+
+const VALID_METATYPES = ["human", "elf", "dwarf", "ork", "troll"];
+const VALID_MAGICAL_PATHS = ["mundane", "magician", "adept", "mystic-adept", "technomancer"];
+const VALID_STATUSES = ["draft", "active", "retired", "deceased"];
+
+let characterFiles: string[] = [];
+const characters: Map<string, ExampleCharacter> = new Map();
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function calculatePhysicalLimit(attr: CharacterAttributes): number {
+  return Math.ceil((attr.strength * 2 + attr.body + attr.reaction) / 3);
+}
+
+function calculateMentalLimit(attr: CharacterAttributes): number {
+  return Math.ceil((attr.logic * 2 + attr.intuition + attr.willpower) / 3);
+}
+
+function calculateSocialLimit(attr: CharacterAttributes, essence: number): number {
+  return Math.ceil((attr.charisma * 2 + attr.willpower + essence) / 3);
+}
+
+function calculatePhysicalConditionMonitor(body: number): number {
+  return 8 + Math.ceil(body / 2);
+}
+
+function calculateStunConditionMonitor(willpower: number): number {
+  return 8 + Math.ceil(willpower / 2);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Example Character Fixtures", () => {
+  beforeAll(() => {
+    // Load all character files
+    if (fs.existsSync(EXAMPLE_CHARS_DIR)) {
+      characterFiles = fs.readdirSync(EXAMPLE_CHARS_DIR).filter((f) => f.endsWith(".json"));
+
+      for (const file of characterFiles) {
+        const filePath = path.join(EXAMPLE_CHARS_DIR, file);
+        const content = fs.readFileSync(filePath, "utf-8");
+        const char = JSON.parse(content) as ExampleCharacter;
+        characters.set(file, char);
+      }
+    }
+  });
+
+  describe("Fixture Directory", () => {
+    it("should have the example characters directory", () => {
+      expect(fs.existsSync(EXAMPLE_CHARS_DIR)).toBe(true);
+    });
+
+    it(`should have exactly ${EXPECTED_CHARACTER_COUNT} character files`, () => {
+      expect(characterFiles.length).toBe(EXPECTED_CHARACTER_COUNT);
+    });
+
+    it("should have all expected character archetypes", () => {
+      const expectedFiles = [
+        "face-elf.json",
+        "gang-leader-ork.json",
+        "bounty-hunter-troll.json",
+        "infiltrator-dwarf.json",
+        "mercenary-human.json",
+        "street-samurai-ork.json",
+        "combat-mage-human.json",
+        "shaman-elf.json",
+        "decker-dwarf.json",
+        "technomancer-human.json",
+        "drone-rigger-ork.json",
+        "rigger-troll.json",
+        "tribal-warrior-troll.json",
+        "alchemist-human.json",
+        "martial-artist-human.json",
+        "assassin-elf.json",
+      ];
+
+      for (const expectedFile of expectedFiles) {
+        expect(characterFiles).toContain(expectedFile);
+      }
+    });
+  });
+
+  describe("JSON Structure", () => {
+    it("should parse all files as valid JSON", () => {
+      for (const file of characterFiles) {
+        const filePath = path.join(EXAMPLE_CHARS_DIR, file);
+        expect(() => {
+          const content = fs.readFileSync(filePath, "utf-8");
+          JSON.parse(content);
+        }).not.toThrow();
+      }
+    });
+
+    it("should have all required fields in each character", () => {
+      for (const [_file, char] of characters) {
+        for (const field of REQUIRED_FIELDS) {
+          expect(char).toHaveProperty(field, expect.anything());
+        }
+      }
+    });
+  });
+
+  describe("Character Data Validity", () => {
+    it("should have valid metatypes", () => {
+      for (const [_file, char] of characters) {
+        expect(VALID_METATYPES).toContain(char.metatype);
+      }
+    });
+
+    it("should have valid magical paths", () => {
+      for (const [_file, char] of characters) {
+        expect(VALID_MAGICAL_PATHS).toContain(char.magicalPath);
+      }
+    });
+
+    it("should have valid status", () => {
+      for (const [_file, char] of characters) {
+        expect(VALID_STATUSES).toContain(char.status);
+      }
+    });
+
+    it("should have positive essence values", () => {
+      for (const [_file, char] of characters) {
+        expect(char.specialAttributes.essence).toBeGreaterThan(0);
+        expect(char.specialAttributes.essence).toBeLessThanOrEqual(6);
+      }
+    });
+
+    it("should have valid edge values (1-7)", () => {
+      for (const [_file, char] of characters) {
+        expect(char.specialAttributes.edge).toBeGreaterThanOrEqual(1);
+        expect(char.specialAttributes.edge).toBeLessThanOrEqual(7);
+      }
+    });
+
+    it("should have skills as non-empty object", () => {
+      for (const [_file, char] of characters) {
+        expect(Object.keys(char.skills).length).toBeGreaterThan(0);
+      }
+    });
+
+    it("should have skill ratings between 1 and 7", () => {
+      for (const [_file, char] of characters) {
+        for (const [_skill, rating] of Object.entries(char.skills)) {
+          expect(rating).toBeGreaterThanOrEqual(1);
+          expect(rating).toBeLessThanOrEqual(7);
+        }
+      }
+    });
+  });
+
+  describe("Attribute Validity", () => {
+    it("should have all core attributes", () => {
+      const coreAttributes = [
+        "body",
+        "agility",
+        "reaction",
+        "strength",
+        "willpower",
+        "logic",
+        "intuition",
+        "charisma",
+      ];
+
+      for (const [_file, char] of characters) {
+        for (const attr of coreAttributes) {
+          expect(char.attributes).toHaveProperty(attr);
+          expect(typeof char.attributes[attr as keyof CharacterAttributes]).toBe("number");
+        }
+      }
+    });
+
+    it("should have attributes within valid ranges (1-10 for base metatypes)", () => {
+      for (const [_file, char] of characters) {
+        for (const [attr, value] of Object.entries(char.attributes)) {
+          expect(value).toBeGreaterThanOrEqual(1);
+          // Trolls can have higher body/strength
+          if (char.metatype === "troll" && (attr === "body" || attr === "strength")) {
+            expect(value).toBeLessThanOrEqual(14);
+          } else {
+            expect(value).toBeLessThanOrEqual(10);
+          }
+        }
+      }
+    });
+  });
+
+  describe("Derived Stats", () => {
+    it("should have all required derived stats", () => {
+      const requiredStats = [
+        "physicalLimit",
+        "mentalLimit",
+        "socialLimit",
+        "initiativeBase",
+        "initiativeDice",
+        "physicalConditionMonitor",
+        "stunConditionMonitor",
+        "composure",
+        "judgeIntentions",
+        "memory",
+        "liftCarry",
+      ];
+
+      for (const [_file, char] of characters) {
+        for (const stat of requiredStats) {
+          expect(char.derivedStats).toHaveProperty(stat);
+          expect(typeof char.derivedStats[stat as keyof CharacterDerivedStats]).toBe("number");
+        }
+      }
+    });
+
+    it("should have reasonable physical limit (within 2 of calculated, for augmentations)", () => {
+      for (const [_file, char] of characters) {
+        const calculated = calculatePhysicalLimit(char.attributes);
+        const actual = char.derivedStats.physicalLimit;
+        // Allow variance for augmentations and qualities
+        expect(Math.abs(calculated - actual)).toBeLessThanOrEqual(4);
+      }
+    });
+
+    it("should have reasonable mental limit (within 2 of calculated)", () => {
+      for (const [_file, char] of characters) {
+        const calculated = calculateMentalLimit(char.attributes);
+        const actual = char.derivedStats.mentalLimit;
+        expect(Math.abs(calculated - actual)).toBeLessThanOrEqual(2);
+      }
+    });
+
+    it("should have reasonable social limit (within 2 of calculated)", () => {
+      for (const [_file, char] of characters) {
+        const calculated = calculateSocialLimit(char.attributes, char.specialAttributes.essence);
+        const actual = char.derivedStats.socialLimit;
+        expect(Math.abs(calculated - actual)).toBeLessThanOrEqual(2);
+      }
+    });
+
+    it("should have reasonable physical condition monitor (within 1 for Toughness)", () => {
+      for (const [_file, char] of characters) {
+        const calculated = calculatePhysicalConditionMonitor(char.attributes.body);
+        const actual = char.derivedStats.physicalConditionMonitor;
+        // Toughness quality adds +1, bone lacing can add +2 body
+        expect(Math.abs(calculated - actual)).toBeLessThanOrEqual(2);
+      }
+    });
+
+    it("should have reasonable stun condition monitor", () => {
+      for (const [_file, char] of characters) {
+        const calculated = calculateStunConditionMonitor(char.attributes.willpower);
+        const actual = char.derivedStats.stunConditionMonitor;
+        expect(Math.abs(calculated - actual)).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it("should have positive initiative values", () => {
+      for (const [_file, char] of characters) {
+        expect(char.derivedStats.initiativeBase).toBeGreaterThan(0);
+        expect(char.derivedStats.initiativeDice).toBeGreaterThanOrEqual(1);
+      }
+    });
+  });
+
+  describe("Magical Characters", () => {
+    it("should have magic attribute for magicians/adepts", () => {
+      for (const [_file, char] of characters) {
+        if (["magician", "adept", "mystic-adept"].includes(char.magicalPath)) {
+          expect(char.specialAttributes.magic).toBeDefined();
+          expect(char.specialAttributes.magic).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("should have resonance attribute for technomancers", () => {
+      for (const [_file, char] of characters) {
+        if (char.magicalPath === "technomancer") {
+          expect(char.specialAttributes.resonance).toBeDefined();
+          expect(char.specialAttributes.resonance).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("should have spells for magicians", () => {
+      for (const [_file, char] of characters) {
+        if (char.magicalPath === "magician") {
+          expect(char).toHaveProperty("spells");
+          expect(Array.isArray(char.spells)).toBe(true);
+          expect((char.spells as unknown[]).length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("should have adept powers for adepts", () => {
+      for (const [_file, char] of characters) {
+        if (char.magicalPath === "adept") {
+          expect(char).toHaveProperty("adeptPowers");
+          expect(Array.isArray(char.adeptPowers)).toBe(true);
+          expect((char.adeptPowers as unknown[]).length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it("should have complex forms for technomancers", () => {
+      for (const [_file, char] of characters) {
+        if (char.magicalPath === "technomancer") {
+          expect(char).toHaveProperty("complexForms");
+          expect(Array.isArray(char.complexForms)).toBe(true);
+          expect((char.complexForms as unknown[]).length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe("Character Metadata", () => {
+    it("should have system as owner", () => {
+      for (const [_file, char] of characters) {
+        expect(char.ownerId).toBe("system");
+      }
+    });
+
+    it("should have sr5 edition", () => {
+      for (const [_file, char] of characters) {
+        expect(char.editionId).toBe("sr5");
+        expect(char.editionCode).toBe("sr5");
+      }
+    });
+
+    it("should have draft status", () => {
+      for (const [_file, char] of characters) {
+        expect(char.status).toBe("draft");
+      }
+    });
+
+    it("should have metadata with source", () => {
+      for (const [_file, char] of characters) {
+        expect(char).toHaveProperty("metadata");
+        expect((char.metadata as Record<string, unknown>).source).toBe(
+          "SR5 Core Rulebook Example Character"
+        );
+      }
+    });
+
+    it("should have valid karma values", () => {
+      for (const [_file, char] of characters) {
+        expect(char.karmaTotal).toBe(25); // SR5 default starting karma
+        expect(char).toHaveProperty("karmaCurrent");
+        expect(char).toHaveProperty("karmaSpentAtCreation");
+      }
+    });
+  });
+});

--- a/data/editions/sr5/example-characters/README.md
+++ b/data/editions/sr5/example-characters/README.md
@@ -1,0 +1,151 @@
+# SR5 Example Character Fixtures
+
+This directory contains JSON fixture files for all 16 example characters from the Shadowrun 5th Edition Core Rulebook. These fixtures serve as:
+
+1. **Reference implementations** - Demonstrate correct character structure
+2. **Test data** - Used in unit tests and validation
+3. **Recreation validation** - Verify UI can recreate rulebook characters
+
+## Character List
+
+| File                        | Archetype      | Metatype | Magical Path | Priority Focus                     |
+| --------------------------- | -------------- | -------- | ------------ | ---------------------------------- |
+| `face-elf.json`             | Face           | Elf      | Mundane      | Social skills                      |
+| `gang-leader-ork.json`      | Gang Leader    | Ork      | Mundane      | Leadership + cyberarm              |
+| `bounty-hunter-troll.json`  | Bounty Hunter  | Troll    | Mundane      | Tracking + legal SIN               |
+| `infiltrator-dwarf.json`    | Infiltrator    | Dwarf    | Mundane      | B&E + stealth cyberware            |
+| `mercenary-human.json`      | Mercenary      | Human    | Mundane      | Heavy weapons + vehicles           |
+| `street-samurai-ork.json`   | Street Samurai | Ork      | Mundane      | Heavy cyberware (0.88 essence)     |
+| `combat-mage-human.json`    | Combat Mage    | Human    | Magician     | Hermetic tradition, combat spells  |
+| `shaman-elf.json`           | Shaman         | Elf      | Magician     | Shamanic tradition, Bear mentor    |
+| `alchemist-human.json`      | Alchemist      | Human    | Magician     | Alchemy focus, Snake mentor        |
+| `decker-dwarf.json`         | Decker         | Dwarf    | Mundane      | Matrix specialist + cyberdeck      |
+| `technomancer-human.json`   | Technomancer   | Human    | Technomancer | Living Persona + complex forms     |
+| `drone-rigger-ork.json`     | Drone Rigger   | Ork      | Mundane      | Control Rig 2 + drone fleet        |
+| `rigger-troll.json`         | Rigger         | Troll    | Mundane      | Vehicle specialist + armed fleet   |
+| `tribal-warrior-troll.json` | Tribal Warrior | Troll    | Mundane      | Archery + heavy cyberware          |
+| `martial-artist-human.json` | Martial Artist | Human    | Adept        | Unarmed combat adept powers        |
+| `assassin-elf.json`         | Assassin       | Elf      | Adept        | Firearms adept + enhanced reflexes |
+
+## Character Categories
+
+### Tier 1 - Mundane (No Magic/Minimal Augmentation)
+
+- Face, Gang Leader, Bounty Hunter
+
+### Tier 2 - Augmented (Cyberware/Bioware Focus)
+
+- Street Samurai, Infiltrator, Mercenary, Tribal Warrior
+
+### Tier 3 - Matrix Specialists
+
+- Decker, Technomancer
+
+### Tier 4 - Riggers
+
+- Drone Rigger, Rigger
+
+### Tier 5 - Full Mages
+
+- Combat Mage, Shaman, Alchemist
+
+### Tier 6 - Physical Adepts
+
+- Martial Artist, Assassin
+
+## Fixture Structure
+
+Each fixture follows the `Character` type from `/lib/types/character.ts`:
+
+```json
+{
+  "id": "example-{archetype}-{metatype}",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "name": "{Archetype} (Example)",
+  "metatype": "{metatype}",
+  "status": "draft",
+  "attributes": { ... },
+  "specialAttributes": { ... },
+  "magicalPath": "{mundane|magician|adept|technomancer}",
+  "skills": { ... },
+  "derivedStats": { ... },
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "{Archetype Description}",
+    "notes": "Priority selection and key features"
+  }
+}
+```
+
+## Validation
+
+### Script Validation
+
+Run the validation script to check all fixtures:
+
+```bash
+pnpm dlx tsx scripts/validate-example-characters.ts
+```
+
+Options:
+
+- `--verbose` - Show detailed warnings
+- `--help` - Show help
+
+### Unit Tests
+
+Run the fixture unit tests:
+
+```bash
+pnpm test -- __tests__/example-characters.test.ts
+```
+
+Tests verify:
+
+- All 16 files exist with valid JSON
+- Required fields present
+- Valid metatypes, magical paths, statuses
+- Reasonable attribute ranges
+- Derived stats calculations (with tolerance for augmentations)
+- Magical characters have appropriate spells/powers/complex forms
+
+## Reference Documentation
+
+Source documentation for each character in `/docs/data_tables/creation/`:
+
+- `example-character-face-elf.md`
+- `example-character-gang-leader-ork.md`
+- etc.
+
+## Usage
+
+### In Tests
+
+```typescript
+import * as fs from "fs";
+import * as path from "path";
+
+const EXAMPLE_CHARS_DIR = "data/editions/sr5/example-characters";
+const decker = JSON.parse(
+  fs.readFileSync(path.join(EXAMPLE_CHARS_DIR, "decker-dwarf.json"), "utf-8")
+);
+```
+
+### For UI Validation
+
+Load fixtures and compare with characters created through the UI to verify:
+
+- Attribute allocation matches
+- Skill selections correct
+- Equipment properly configured
+- Derived stats calculate correctly
+
+## Notes
+
+- All fixtures use `status: "draft"` as reference data
+- Owner is `system` for system-owned reference data
+- Karma total is 25 (SR5 default starting karma)
+- Derived stats may vary slightly from raw calculations due to augmentations/qualities
+- Catalog IDs reference items in `/data/editions/sr5/core-rulebook.json`

--- a/data/editions/sr5/example-characters/alchemist-human.json
+++ b/data/editions/sr5/example-characters/alchemist-human.json
@@ -1,0 +1,258 @@
+{
+  "id": "example-alchemist-human",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Alchemist (Example)",
+  "metatype": "human",
+  "description": "A human mage following the mentor spirit Snake, specializing in alchemy and summoning. This character operates as a private investigator in the magical community, using their arcane talents and preparation-based magic for subtle problem-solving. Strong mental attributes and a vehicle make them mobile and perceptive.",
+  "status": "draft",
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 4,
+    "strength": 3,
+    "willpower": 5,
+    "logic": 3,
+    "intuition": 6,
+    "charisma": 5
+  },
+  "specialAttributes": {
+    "edge": 3,
+    "essence": 6.0,
+    "magic": 4
+  },
+  "magicalPath": "magician",
+  "tradition": "hermetic",
+  "mentorSpirit": "snake",
+  "skills": {
+    "alchemy": 5,
+    "arcana": 4,
+    "banishing": 4,
+    "binding": 3,
+    "clubs": 2,
+    "counterspelling": 4,
+    "impersonation": 3,
+    "etiquette": 2,
+    "leadership": 2,
+    "negotiation": 2,
+    "perception": 5,
+    "summoning": 5
+  },
+  "skillSpecializations": {
+    "arcana": ["Magical Theory"],
+    "impersonation": ["Human"]
+  },
+  "knowledgeSkills": [
+    { "name": "Magical Community", "category": "street", "rating": 4, "specialization": "Seattle" },
+    { "name": "Magical Forensics", "category": "professional", "rating": 3 },
+    { "name": "Police Procedures", "category": "professional", "rating": 3 },
+    { "name": "Sprawl Dive Bars", "category": "interests", "rating": 3 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Spanish", "rating": 0, "isNative": true },
+    { "name": "Sperethiel", "rating": 4, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "bilingual", "rating": 1, "specification": "Spanish" },
+    { "qualityId": "first-impression", "rating": 1 },
+    { "qualityId": "mentor-spirit", "rating": 1, "specification": "Snake" },
+    { "qualityId": "national-sin", "rating": 1, "specification": "Aztlan" }
+  ],
+  "negativeQualities": [
+    { "qualityId": "addiction", "rating": 1, "specification": "Alcohol (Mild)" },
+    { "qualityId": "bad-luck", "rating": 1 }
+  ],
+  "spells": [
+    { "id": "spell-analyze-truth", "catalogId": "analyze-truth", "name": "Analyze Truth" },
+    { "id": "spell-armor", "catalogId": "armor", "name": "Armor" },
+    { "id": "spell-clairvoyance", "catalogId": "clairvoyance", "name": "Clairvoyance" },
+    {
+      "id": "spell-detect-individual",
+      "catalogId": "detect-individual",
+      "name": "Detect Individual"
+    },
+    { "id": "spell-flamethrower", "catalogId": "flamethrower", "name": "Flamethrower" },
+    { "id": "spell-heal", "catalogId": "heal", "name": "Heal" },
+    { "id": "spell-physical-barrier", "catalogId": "physical-barrier", "name": "Physical Barrier" },
+    { "id": "spell-stealth", "catalogId": "stealth", "name": "Stealth" }
+  ],
+  "contacts": [
+    {
+      "name": "Talismonger",
+      "type": "Magic",
+      "connection": 3,
+      "loyalty": 2,
+      "notes": "Magical supplies"
+    },
+    {
+      "name": "Police Detective",
+      "type": "Government",
+      "connection": 3,
+      "loyalty": 4,
+      "notes": "Law enforcement connection"
+    },
+    {
+      "name": "Bartender",
+      "type": "Service",
+      "connection": 1,
+      "loyalty": 2,
+      "notes": "Information source"
+    }
+  ],
+  "gear": [
+    {
+      "name": "Magical Lodge Materials",
+      "category": "magical",
+      "quantity": 1,
+      "cost": 2500,
+      "rating": 5
+    }
+  ],
+  "foci": [
+    {
+      "catalogId": "alchemy-focus",
+      "name": "Alchemy Focus",
+      "type": "alchemy",
+      "force": 4,
+      "bonded": true,
+      "karmaToBond": 8,
+      "cost": 16000,
+      "availability": 12,
+      "legality": "restricted"
+    },
+    {
+      "catalogId": "counterspelling-focus",
+      "name": "Counterspelling Focus (Combat Spells)",
+      "type": "counterspelling",
+      "force": 4,
+      "bonded": true,
+      "karmaToBond": 8,
+      "cost": 16000,
+      "availability": 12,
+      "legality": "restricted",
+      "notes": "Combat Spells"
+    }
+  ],
+  "vehicles": [
+    {
+      "catalogId": "chrysler-nissan-jackrabbit",
+      "name": "Chrysler-Nissan Jackrabbit",
+      "type": "ground",
+      "handling": "4/3",
+      "speed": 3,
+      "acceleration": 2,
+      "body": 8,
+      "armor": 4,
+      "pilot": 1,
+      "sensor": 2,
+      "seats": 2,
+      "cost": 10000,
+      "notes": "Compact economy car"
+    }
+  ],
+  "armor": [
+    {
+      "catalogId": "lined-coat",
+      "name": "Lined Coat",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 9,
+      "capacity": 9,
+      "cost": 900,
+      "quantity": 1,
+      "equipped": true
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "staff",
+      "name": "Staff",
+      "category": "weapons",
+      "subcategory": "club",
+      "damage": "6P",
+      "ap": 0,
+      "mode": [],
+      "reach": 2,
+      "accuracy": 6,
+      "cost": 100,
+      "quantity": 1,
+      "notes": "Can be used as magical focus housing"
+    },
+    {
+      "catalogId": "stun-baton",
+      "name": "Stun Baton",
+      "category": "weapons",
+      "subcategory": "club",
+      "damage": "9S(e)",
+      "ap": -5,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 4,
+      "cost": 750,
+      "quantity": 1,
+      "notes": "10 charges, electrical damage"
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "sony-emperor",
+      "name": "Sony Emperor",
+      "deviceRating": 2,
+      "cost": 700
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 4 },
+      "licenses": [{ "type": "fake", "rating": 4, "name": "Private Detective License" }]
+    },
+    {
+      "name": "National Identity",
+      "sin": { "type": "national", "rating": 0, "nation": "Aztlan" },
+      "licenses": []
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "middle",
+      "monthlyCost": 5000,
+      "prepaidMonths": 2
+    }
+  ],
+  "nuyen": 1250,
+  "startingNuyen": 50000,
+  "derivedStats": {
+    "physicalLimit": 5,
+    "mentalLimit": 6,
+    "socialLimit": 7,
+    "initiativeBase": 10,
+    "initiativeDice": 1,
+    "astralInitiativeBase": 12,
+    "astralInitiativeDice": 2,
+    "physicalConditionMonitor": 10,
+    "stunConditionMonitor": 11,
+    "composure": 10,
+    "judgeIntentions": 11,
+    "memory": 9,
+    "liftCarry": 6
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 9,
+  "karmaSpentAtCreation": 16,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Alchemist / Magical Investigator",
+    "notes": "Priority: A-Attributes, B-Magic, C-Skills, D-Resources, E-Metatype(Human). Hermetic Tradition (Drain: Willpower + Logic). Snake Mentor Spirit: +2 dice Detection/Illusion spells. National SIN from Aztlan provides legal identity. Bad Luck quality: glitches become critical glitches."
+  }
+}

--- a/data/editions/sr5/example-characters/assassin-elf.json
+++ b/data/editions/sr5/example-characters/assassin-elf.json
@@ -1,0 +1,365 @@
+{
+  "id": "example-assassin-elf",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Assassin (Example)",
+  "metatype": "elf",
+  "description": "A Lakota elf physical adept following the Assassin's Creed, specializing in firearms and infiltration. This character combines supernatural reflexes with extensive weapons training, making them a deadly combatant. High Edge provides luck when it matters most, while adept powers enhance accuracy and reaction time.",
+  "status": "draft",
+  "attributes": {
+    "body": 3,
+    "agility": 6,
+    "reaction": 3,
+    "strength": 2,
+    "willpower": 2,
+    "logic": 2,
+    "intuition": 3,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 5,
+    "essence": 6.0,
+    "magic": 6
+  },
+  "magicalPath": "adept",
+  "adeptPowers": [
+    {
+      "catalogId": "attribute-boost",
+      "name": "Attribute Boost (Agility)",
+      "powerPointCost": 1.0,
+      "rating": 4,
+      "notes": "Boost AGI by up to 4 (causes drain)"
+    },
+    {
+      "catalogId": "combat-sense",
+      "name": "Combat Sense",
+      "powerPointCost": 0.5,
+      "rating": 1,
+      "notes": "+1 dice to defense tests"
+    },
+    {
+      "catalogId": "enhanced-accuracy",
+      "name": "Enhanced Accuracy (Pistols)",
+      "powerPointCost": 0.25,
+      "notes": "+1 Accuracy with pistols"
+    },
+    {
+      "catalogId": "enhanced-accuracy",
+      "name": "Enhanced Accuracy (Automatics)",
+      "powerPointCost": 0.25,
+      "notes": "+1 Accuracy with automatics"
+    },
+    {
+      "catalogId": "improved-reflexes",
+      "name": "Improved Reflexes",
+      "powerPointCost": 2.5,
+      "rating": 2,
+      "notes": "+2 Reaction, +2 Initiative dice"
+    },
+    {
+      "catalogId": "mystic-armor",
+      "name": "Mystic Armor",
+      "powerPointCost": 1.0,
+      "rating": 2,
+      "notes": "+2 armor"
+    },
+    {
+      "catalogId": "spell-resistance",
+      "name": "Spell Resistance",
+      "powerPointCost": 0.5,
+      "rating": 1,
+      "notes": "+1 dice to resist spells"
+    }
+  ],
+  "skills": {
+    "blades": 4,
+    "con": 3,
+    "automatics": 5,
+    "longarms": 5,
+    "pistols": 5,
+    "first-aid": 3,
+    "gymnastics": 5,
+    "perception": 4,
+    "pilot-ground-craft": 3,
+    "running": 4,
+    "sneaking": 4,
+    "swimming": 2,
+    "tracking": 3
+  },
+  "skillSpecializations": {
+    "sneaking": ["Urban"]
+  },
+  "knowledgeSkills": [
+    { "name": "Egyptian Ceramics", "category": "interests", "rating": 2 },
+    { "name": "Weapon Manufacturers", "category": "professional", "rating": 4 }
+  ],
+  "languages": [
+    { "name": "Lakota", "rating": 0, "isNative": true },
+    { "name": "English", "rating": 5, "isNative": false },
+    { "name": "Sperethiel", "rating": 4, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "guts", "rating": 1 },
+    { "qualityId": "natural-athlete", "rating": 1 }
+  ],
+  "negativeQualities": [
+    { "qualityId": "addiction", "rating": 1, "specification": "BTLs (Mild)" },
+    { "qualityId": "code-of-honor", "rating": 1, "specification": "Assassin's Creed" }
+  ],
+  "racialQualities": ["Low-Light Vision", "+1 Agility", "+2 Charisma"],
+  "contacts": [
+    {
+      "name": "Black Market Gun Dealer",
+      "type": "Arms",
+      "connection": 3,
+      "loyalty": 3,
+      "notes": "Weapons and ammo"
+    },
+    {
+      "name": "Target Range Operator",
+      "type": "Service",
+      "connection": 3,
+      "loyalty": 2,
+      "notes": "Practice and intel"
+    }
+  ],
+  "gear": [
+    {
+      "name": "Contacts",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 75,
+      "rating": 3,
+      "notes": "Smartlink, Vision Enhancement 2"
+    },
+    {
+      "name": "Earbuds",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 75,
+      "rating": 3,
+      "notes": "Audio Enhancement 1, Spatial Recognizer"
+    },
+    {
+      "name": "DocWagon Contract",
+      "category": "services",
+      "quantity": 1,
+      "cost": 50000,
+      "notes": "Platinum (1 year)"
+    },
+    {
+      "name": "Medkit",
+      "category": "medical",
+      "quantity": 1,
+      "cost": 500,
+      "rating": 4,
+      "notes": "2 resupplies"
+    },
+    { "name": "Trauma Patch", "category": "medical", "quantity": 2, "cost": 1000 },
+    {
+      "name": "Gecko Tape Gloves",
+      "category": "survival",
+      "quantity": 1,
+      "cost": 250,
+      "notes": "Wall climbing"
+    },
+    { "name": "Maglock Passkey", "category": "tools", "quantity": 1, "cost": 6000, "rating": 3 }
+  ],
+  "vehicles": [
+    {
+      "catalogId": "hyundai-shin-hyung",
+      "name": "Hyundai Shin-Hyung",
+      "type": "ground",
+      "handling": "4/3",
+      "speed": 3,
+      "acceleration": 2,
+      "body": 10,
+      "armor": 6,
+      "pilot": 1,
+      "sensor": 2,
+      "cost": 28000,
+      "notes": "Sedan"
+    }
+  ],
+  "armor": [
+    {
+      "catalogId": "armor-jacket",
+      "name": "Armor Jacket",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 12,
+      "capacity": 12,
+      "cost": 1000,
+      "quantity": 1,
+      "equipped": true,
+      "notes": "Chemical Protection 3, Fire Resistance 3, Non-conductivity 4"
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "ares-predator-v",
+      "name": "Ares Predator V",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "8P",
+      "ap": -1,
+      "mode": ["SA"],
+      "accuracy": 5,
+      "ammoCapacity": 15,
+      "cost": 725,
+      "quantity": 2,
+      "notes": "Smartlink, 100 regular + 100 Stick-n-Shock"
+    },
+    {
+      "catalogId": "ingram-smartgun-x",
+      "name": "Ingram Smartgun X",
+      "category": "weapons",
+      "subcategory": "smg",
+      "damage": "8P",
+      "ap": 0,
+      "mode": ["BF", "FA"],
+      "recoil": 2,
+      "accuracy": 4,
+      "ammoCapacity": 32,
+      "cost": 800,
+      "quantity": 1,
+      "notes": "Gas-vent 2, suppressor, smartlink, 100 regular + 100 explosive"
+    },
+    {
+      "catalogId": "pjss-model-55",
+      "name": "PJSS Model 55",
+      "category": "weapons",
+      "subcategory": "shotgun",
+      "damage": "11P",
+      "ap": -1,
+      "mode": ["SS"],
+      "recoil": 1,
+      "accuracy": 6,
+      "ammoCapacity": 2,
+      "cost": 1000,
+      "quantity": 1,
+      "notes": "Integrated shock pad, 100 regular + 100 explosive"
+    },
+    {
+      "catalogId": "ruger-super-warhawk",
+      "name": "Ruger Super Warhawk",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "9P",
+      "ap": -2,
+      "mode": ["SS"],
+      "accuracy": 5,
+      "ammoCapacity": 6,
+      "cost": 400,
+      "quantity": 1,
+      "notes": "100 rounds regular"
+    },
+    {
+      "catalogId": "steyr-tmp",
+      "name": "Steyr TMP",
+      "category": "weapons",
+      "subcategory": "machine-pistol",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SA", "BF", "FA"],
+      "accuracy": 5,
+      "ammoCapacity": 30,
+      "cost": 350,
+      "quantity": 1,
+      "notes": "Laser sight, 100 each: regular, explosive, Stick-n-Shock"
+    },
+    {
+      "catalogId": "yamaha-raiden",
+      "name": "Yamaha Raiden",
+      "category": "weapons",
+      "subcategory": "assault-rifle",
+      "damage": "11P",
+      "ap": -2,
+      "mode": ["BF", "FA"],
+      "recoil": 1,
+      "accuracy": 6,
+      "ammoCapacity": 60,
+      "cost": 2600,
+      "quantity": 1,
+      "notes": "Suppressor, smartlink, 100 regular + 100 explosive"
+    },
+    {
+      "catalogId": "knife",
+      "name": "Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "3P",
+      "ap": -1,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 5,
+      "cost": 10,
+      "quantity": 1
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "renraku-sensei",
+      "name": "Renraku Sensei",
+      "deviceRating": 3,
+      "cost": 1000
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 5 },
+      "licenses": [
+        { "type": "fake", "rating": 5, "name": "Gun License" },
+        { "type": "fake", "rating": 5, "name": "Gun License" },
+        { "type": "fake", "rating": 5, "name": "Gun License" },
+        { "type": "fake", "rating": 5, "name": "Gun License" },
+        { "type": "fake", "rating": 5, "name": "Gun License" }
+      ]
+    },
+    {
+      "name": "Secondary Identity",
+      "sin": { "type": "fake", "rating": 5 },
+      "licenses": []
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "low",
+      "monthlyCost": 2000,
+      "prepaidMonths": 1
+    }
+  ],
+  "nuyen": 1690,
+  "startingNuyen": 50000,
+  "derivedStats": {
+    "physicalLimit": 4,
+    "mentalLimit": 3,
+    "socialLimit": 5,
+    "initiativeBase": 8,
+    "initiativeDice": 3,
+    "physicalConditionMonitor": 10,
+    "stunConditionMonitor": 9,
+    "composure": 5,
+    "judgeIntentions": 6,
+    "memory": 4,
+    "liftCarry": 5
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 8,
+  "karmaSpentAtCreation": 17,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Assassin / Physical Adept",
+    "notes": "Priority: A-Attributes, B-Magic(Adept), C-Skills, D-Resources, E-Metatype(Elf). Improved Reflexes 2: +2 Reaction, +2 Initiative dice (base 8+3D6). Total Armor: 14 (12 jacket + 2 Mystic Armor). Enhanced Accuracy improves pistol and automatic weapon accuracy by +1."
+  }
+}

--- a/data/editions/sr5/example-characters/bounty-hunter-troll.json
+++ b/data/editions/sr5/example-characters/bounty-hunter-troll.json
@@ -1,0 +1,357 @@
+{
+  "id": "example-bounty-hunter-troll",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Bounty Hunter (Example)",
+  "metatype": "troll",
+  "description": "A Salish-Sidhe national troll working as a bounty hunter. This character combines traditional hunting skills with modern firearms and extensive gear for pursuing targets.",
+  "status": "draft",
+  "attributes": {
+    "body": 7,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 8,
+    "willpower": 3,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6.0
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "animal-handling": 2,
+    "archery": 4,
+    "armorer": 1,
+    "gymnastics": 4,
+    "running": 4,
+    "swimming": 4,
+    "automotive-mechanic": 1,
+    "blades": 3,
+    "clubs": 3,
+    "computer": 1,
+    "con": 2,
+    "electronic-warfare": 1,
+    "first-aid": 3,
+    "etiquette": 2,
+    "leadership": 2,
+    "negotiation": 2,
+    "intimidation": 5,
+    "locksmith": 3,
+    "longarms": 4,
+    "navigation": 4,
+    "survival": 4,
+    "tracking": 4,
+    "palming": 1,
+    "perception": 3,
+    "pilot-ground-craft": 2,
+    "pistols": 4,
+    "sneaking": 3,
+    "throwing-weapons": 1,
+    "unarmed-combat": 5
+  },
+  "knowledgeSkills": [
+    { "name": "Parazoology", "category": "academic", "rating": 2 },
+    { "name": "Police Procedures", "category": "professional", "rating": 4 },
+    { "name": "Salish-Sidhe Tribal Law", "category": "academic", "rating": 3 }
+  ],
+  "languages": [
+    { "name": "Siouan (Crow)", "rating": 0, "isNative": true },
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Spanish", "rating": 3, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "bilingual", "rating": 1, "specification": "English" },
+    { "qualityId": "guts", "rating": 1 },
+    { "qualityId": "natural-athlete", "rating": 1 }
+  ],
+  "negativeQualities": [{ "qualityId": "allergy", "rating": 2, "specification": "Soy (Mild)" }],
+  "racialQualities": ["Thermographic Vision", "+1 Reach", "+1 Dermal Armor"],
+  "sinnerQuality": "national",
+  "contacts": [
+    {
+      "name": "Parole Officer",
+      "type": "Law Enforcement",
+      "connection": 2,
+      "loyalty": 2,
+      "notes": "Legal supervision"
+    },
+    {
+      "name": "Tribal Official",
+      "type": "Government",
+      "connection": 2,
+      "loyalty": 2,
+      "notes": "Salish-Sidhe government"
+    }
+  ],
+  "gear": [
+    { "name": "Armorer Kit", "category": "tools", "quantity": 1, "cost": 500 },
+    { "name": "Auto Mechanics Kit", "category": "tools", "quantity": 1, "cost": 500 },
+    { "name": "Climbing Gear", "category": "survival", "quantity": 1, "cost": 200 },
+    { "name": "Flashlight", "category": "survival", "quantity": 1, "cost": 25 },
+    { "name": "Lockpick Set", "category": "tools", "quantity": 1, "cost": 250 },
+    { "name": "Survival Kit", "category": "survival", "quantity": 1, "cost": 200 },
+    { "name": "Medkit", "category": "medical", "quantity": 1, "cost": 500, "rating": 4 },
+    { "name": "Binoculars (Optical)", "category": "electronics", "quantity": 1, "cost": 50 },
+    {
+      "name": "Sensor Array (Handheld)",
+      "category": "sensors",
+      "quantity": 1,
+      "cost": 3000,
+      "rating": 3
+    },
+    { "name": "Manacles", "category": "restraints", "quantity": 1, "cost": 20 },
+    { "name": "Metal Restraints", "category": "restraints", "quantity": 2, "cost": 40 },
+    { "name": "Plastic Restraints", "category": "restraints", "quantity": 20, "cost": 100 },
+    { "name": "RFID Tags (Security)", "category": "rfid", "quantity": 10, "cost": 100 },
+    { "name": "RFID Tags (Stealth)", "category": "rfid", "quantity": 10, "cost": 100 },
+    { "name": "Rope (100m)", "category": "survival", "quantity": 1, "cost": 50 }
+  ],
+  "armor": [
+    {
+      "catalogId": "lined-coat",
+      "name": "Lined Coat",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 9,
+      "capacity": 9,
+      "capacityUsed": 3,
+      "cost": 900,
+      "quantity": 1,
+      "equipped": true,
+      "modifications": [
+        {
+          "catalogId": "shock-frills",
+          "name": "Shock Frills",
+          "capacityUsed": 3,
+          "cost": 250,
+          "availability": 6,
+          "legality": "restricted"
+        }
+      ]
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "bow",
+      "name": "Bow (Rating 8)",
+      "category": "weapons",
+      "subcategory": "bow",
+      "damage": "10P",
+      "ap": -2,
+      "mode": ["SS"],
+      "accuracy": 6,
+      "cost": 600,
+      "quantity": 1,
+      "rating": 8,
+      "notes": "20 arrows"
+    },
+    {
+      "catalogId": "colt-america-l36",
+      "name": "Colt America L36",
+      "category": "weapons",
+      "subcategory": "light-pistol",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 7,
+      "ammoCapacity": 11,
+      "cost": 320,
+      "quantity": 1,
+      "notes": "2 spare clips, 110 rounds"
+    },
+    {
+      "catalogId": "defiance-t-250",
+      "name": "Defiance T-250",
+      "category": "weapons",
+      "subcategory": "shotgun",
+      "damage": "10P",
+      "ap": -1,
+      "mode": ["SS", "SA"],
+      "accuracy": 4,
+      "ammoCapacity": 5,
+      "cost": 450,
+      "quantity": 1,
+      "notes": "50 standard + 20 Stick-n-Shock"
+    },
+    {
+      "catalogId": "remington-950",
+      "name": "Remington 950",
+      "category": "weapons",
+      "subcategory": "sniper-rifle",
+      "damage": "12P",
+      "ap": -4,
+      "mode": ["SS"],
+      "accuracy": 7,
+      "ammoCapacity": 5,
+      "cost": 2100,
+      "quantity": 1,
+      "notes": "50 rounds"
+    },
+    {
+      "catalogId": "ruger-super-warhawk",
+      "name": "Ruger Super Warhawk",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "9P",
+      "ap": -2,
+      "mode": ["SS"],
+      "accuracy": 5,
+      "ammoCapacity": 6,
+      "cost": 400,
+      "quantity": 1,
+      "notes": "2 speed loaders, 60 rounds"
+    },
+    {
+      "catalogId": "yamaha-pulsar",
+      "name": "Yamaha Pulsar",
+      "category": "weapons",
+      "subcategory": "taser",
+      "damage": "9S(e)",
+      "ap": -5,
+      "mode": ["SA"],
+      "accuracy": 5,
+      "ammoCapacity": 4,
+      "cost": 180,
+      "quantity": 1,
+      "notes": "10 darts"
+    },
+    {
+      "catalogId": "flash-bang-grenade",
+      "name": "Flash-Bang Grenade",
+      "category": "weapons",
+      "subcategory": "grenade",
+      "damage": "10S",
+      "ap": -4,
+      "mode": [],
+      "cost": 100,
+      "quantity": 2
+    },
+    {
+      "catalogId": "smoke-grenade",
+      "name": "Smoke Grenade",
+      "category": "weapons",
+      "subcategory": "grenade",
+      "damage": "-",
+      "ap": 0,
+      "mode": [],
+      "cost": 40,
+      "quantity": 2
+    },
+    {
+      "catalogId": "extendable-baton",
+      "name": "Extendable Baton",
+      "category": "weapons",
+      "subcategory": "club",
+      "damage": "10S",
+      "ap": 0,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 5,
+      "cost": 100,
+      "quantity": 1
+    },
+    {
+      "catalogId": "stun-baton",
+      "name": "Stun Baton",
+      "category": "weapons",
+      "subcategory": "club",
+      "damage": "9S(e)",
+      "ap": -5,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 4,
+      "cost": 750,
+      "quantity": 1
+    },
+    {
+      "catalogId": "survival-knife",
+      "name": "Survival Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "10P",
+      "ap": -1,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 5,
+      "cost": 100,
+      "quantity": 1
+    }
+  ],
+  "vehicles": [
+    {
+      "id": "bounty-hunter-vehicle-1",
+      "name": "Toyota Gopher",
+      "type": "ground",
+      "handling": 4,
+      "speed": 3,
+      "acceleration": 1,
+      "body": 14,
+      "armor": 6,
+      "pilot": 1,
+      "sensor": 1,
+      "seats": 3,
+      "notes": "Pickup truck"
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "renraku-sensei",
+      "name": "Renraku Sensei",
+      "deviceRating": 3,
+      "cost": 1000
+    }
+  ],
+  "identities": [
+    {
+      "name": "Legal Identity",
+      "sin": {
+        "type": "real",
+        "sinnerQuality": "national"
+      },
+      "licenses": [],
+      "notes": "Salish-Sidhe National SIN"
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "low",
+      "monthlyCost": 2000,
+      "prepaidMonths": 2
+    }
+  ],
+  "nuyen": 4116,
+  "startingNuyen": 50000,
+  "derivedStats": {
+    "physicalLimit": 9,
+    "mentalLimit": 4,
+    "socialLimit": 5,
+    "initiativeBase": 6,
+    "initiativeDice": 1,
+    "physicalConditionMonitor": 12,
+    "stunConditionMonitor": 10,
+    "composure": 5,
+    "judgeIntentions": 5,
+    "memory": 6,
+    "liftCarry": 15
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Bounty Hunter / Tracker",
+    "notes": "Priority: A-Skills, B-Attributes, C-Metatype(Troll), D-Resources, E-Magic. Legal SINner (Salish-Sidhe National)."
+  }
+}

--- a/data/editions/sr5/example-characters/combat-mage-human.json
+++ b/data/editions/sr5/example-characters/combat-mage-human.json
@@ -1,0 +1,186 @@
+{
+  "id": "example-combat-mage-human",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Combat Mage (Example)",
+  "metatype": "human",
+  "description": "A human combat mage with a 'Troll Poser' distinctive style, specializing in offensive spellcasting and astral combat. Follows the Hermetic Tradition.",
+  "status": "draft",
+  "attributes": {
+    "body": 5,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 5,
+    "intuition": 3,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6.0,
+    "magic": 6
+  },
+  "magicalPath": "magician",
+  "tradition": "hermetic",
+  "skills": {
+    "assensing": 3,
+    "astral-combat": 3,
+    "banishing": 3,
+    "blades": 2,
+    "counterspelling": 5,
+    "first-aid": 3,
+    "perception": 3,
+    "pistols": 3,
+    "spellcasting": 5,
+    "summoning": 4
+  },
+  "knowledgeSkills": [
+    { "name": "Action Trids", "category": "interests", "rating": 3 },
+    { "name": "Critters", "category": "academic", "rating": 3 },
+    { "name": "Magic Theory", "category": "academic", "rating": 4 },
+    { "name": "Urban Brawl", "category": "interests", "rating": 3 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Spanish", "rating": 3, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "focused-concentration", "rating": 3 },
+    { "qualityId": "high-pain-tolerance", "rating": 1 }
+  ],
+  "negativeQualities": [
+    { "qualityId": "distinctive-style", "rating": 1, "specification": "Troll Poser" },
+    { "qualityId": "prejudiced", "rating": 1, "specification": "Elves (Biased)" }
+  ],
+  "spells": [
+    { "id": "spell-ball-lightning", "catalogId": "ball-lightning", "name": "Ball Lightning" },
+    { "id": "spell-clout", "catalogId": "clout", "name": "Clout" },
+    { "id": "spell-combat-sense", "catalogId": "combat-sense", "name": "Combat Sense" },
+    { "id": "spell-flamethrower", "catalogId": "flamethrower", "name": "Flamethrower" },
+    { "id": "spell-heal", "catalogId": "heal", "name": "Heal" },
+    {
+      "id": "spell-increase-agility",
+      "catalogId": "increase-attribute",
+      "name": "Increase Agility",
+      "selectedAttribute": "agility"
+    },
+    {
+      "id": "spell-increase-reflexes",
+      "catalogId": "increase-reflexes",
+      "name": "Increase Reflexes"
+    },
+    { "id": "spell-manaball", "catalogId": "manaball", "name": "Manaball" },
+    { "id": "spell-physical-mask", "catalogId": "physical-mask", "name": "Physical Mask" },
+    { "id": "spell-stunbolt", "catalogId": "stunbolt", "name": "Stunbolt" }
+  ],
+  "contacts": [
+    {
+      "name": "Talismonger",
+      "type": "Magic",
+      "connection": 3,
+      "loyalty": 3,
+      "notes": "Magical supplies and reagents"
+    }
+  ],
+  "gear": [
+    {
+      "name": "Contacts",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 200,
+      "rating": 2,
+      "notes": "Vision Enhancement 2"
+    }
+  ],
+  "armor": [
+    {
+      "catalogId": "armor-jacket",
+      "name": "Armor Jacket",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 12,
+      "capacity": 12,
+      "cost": 1000,
+      "quantity": 1,
+      "equipped": true
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "colt-america-l36",
+      "name": "Colt America L36",
+      "category": "weapons",
+      "subcategory": "light-pistol",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 7,
+      "ammoCapacity": 11,
+      "cost": 320,
+      "quantity": 1,
+      "notes": "75 rounds regular ammo"
+    },
+    {
+      "catalogId": "combat-knife",
+      "name": "Combat Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "7P",
+      "ap": -3,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 6,
+      "cost": 300,
+      "quantity": 1
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 2 },
+      "licenses": [{ "type": "fake", "rating": 2, "name": "Magic License" }]
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "low",
+      "monthlyCost": 2000,
+      "prepaidMonths": 2
+    }
+  ],
+  "nuyen": 80,
+  "startingNuyen": 6000,
+  "derivedStats": {
+    "physicalLimit": 5,
+    "mentalLimit": 6,
+    "socialLimit": 5,
+    "initiativeBase": 6,
+    "initiativeDice": 1,
+    "astralInitiativeBase": 6,
+    "astralInitiativeDice": 2,
+    "physicalConditionMonitor": 11,
+    "stunConditionMonitor": 10,
+    "composure": 6,
+    "judgeIntentions": 5,
+    "memory": 8,
+    "liftCarry": 8
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Combat Mage",
+    "notes": "Priority: A-Magic, B-Attributes, C-Metatype(Human), D-Skills, E-Resources. Hermetic Tradition (Drain: Willpower + Logic)."
+  }
+}

--- a/data/editions/sr5/example-characters/decker-dwarf.json
+++ b/data/editions/sr5/example-characters/decker-dwarf.json
@@ -1,0 +1,312 @@
+{
+  "id": "example-decker-dwarf",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Decker (Example)",
+  "metatype": "dwarf",
+  "description": "A dwarf decker with an ethical Code of Honor protecting metahumans. Excels at Matrix operations with enhanced Logic from a cerebral booster and natural Aptitude for hacking.",
+  "status": "draft",
+  "attributes": {
+    "body": 3,
+    "agility": 2,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 5,
+    "logic": 5,
+    "intuition": 4,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 5.0
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "automatics": 4,
+    "cybercombat": 6,
+    "electronic-warfare": 6,
+    "computer": 6,
+    "hardware": 6,
+    "software": 6,
+    "aeronautics-mechanic": 4,
+    "automotive-mechanic": 4,
+    "industrial-mechanic": 4,
+    "nautical-mechanic": 4,
+    "etiquette": 4,
+    "first-aid": 3,
+    "hacking": 7,
+    "locksmith": 4,
+    "pilot-aircraft": 3,
+    "pilot-ground-craft": 3,
+    "pistols": 4,
+    "unarmed-combat": 3
+  },
+  "skillSpecializations": {
+    "hacking": ["Hack on the Fly"]
+  },
+  "knowledgeSkills": [
+    { "name": "Cannibalizing Hardware", "category": "professional", "rating": 5 },
+    { "name": "Detective Novels", "category": "interests", "rating": 3 },
+    { "name": "Matrix Security", "category": "professional", "rating": 4 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Japanese", "rating": 3, "isNative": false },
+    { "name": "Salish", "rating": 3, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "analytical-mind", "rating": 1 },
+    { "qualityId": "aptitude", "rating": 1, "specification": "Hacking" },
+    { "qualityId": "code-slinger", "rating": 1, "specification": "Brute Force" }
+  ],
+  "negativeQualities": [
+    { "qualityId": "allergy", "rating": 2, "specification": "Sunlight (Mild)" },
+    { "qualityId": "code-of-honor", "rating": 1, "specification": "Metahumans" }
+  ],
+  "racialQualities": [
+    "Thermographic Vision",
+    "+2 Body",
+    "+1 Willpower",
+    "Toxin/Pathogen Resistance (+2 dice)"
+  ],
+  "cyberware": [
+    {
+      "catalogId": "cerebral-booster",
+      "name": "Cerebral Booster",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.4,
+      "essenceCost": 0.4,
+      "rating": 1,
+      "cost": 31500,
+      "availability": 12,
+      "legality": "restricted",
+      "attributeBonuses": { "logic": 1 }
+    },
+    {
+      "catalogId": "cybereyes",
+      "name": "Cybereyes",
+      "category": "eyeware",
+      "grade": "standard",
+      "baseEssenceCost": 0.2,
+      "essenceCost": 0.2,
+      "rating": 1,
+      "cost": 4000,
+      "availability": 3,
+      "notes": "Low-light, Thermographic"
+    },
+    {
+      "catalogId": "datajack",
+      "name": "Datajack",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.1,
+      "essenceCost": 0.1,
+      "cost": 1000,
+      "availability": 2
+    },
+    {
+      "catalogId": "skilljack",
+      "name": "Skilljack",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.2,
+      "essenceCost": 0.2,
+      "rating": 2,
+      "cost": 20000,
+      "availability": 8,
+      "notes": "Use skillsofts up to rating 2"
+    },
+    {
+      "catalogId": "sleep-regulator",
+      "name": "Sleep Regulator",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.1,
+      "essenceCost": 0.1,
+      "cost": 12000,
+      "availability": 6
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Corporate Janitor",
+      "type": "Corporate",
+      "connection": 1,
+      "loyalty": 2,
+      "notes": "Inside information"
+    },
+    {
+      "name": "Wizgang Leader",
+      "type": "Gang",
+      "connection": 2,
+      "loyalty": 1,
+      "notes": "Street-level Matrix contact"
+    }
+  ],
+  "gear": [
+    { "name": "Lockpick Set", "category": "tools", "quantity": 1, "cost": 250 },
+    {
+      "name": "DocWagon Contract",
+      "category": "services",
+      "quantity": 1,
+      "cost": 5000,
+      "notes": "Basic"
+    },
+    { "name": "Medkit", "category": "medical", "quantity": 1, "cost": 1500, "rating": 6 },
+    {
+      "name": "Linguasoft (Sperethiel)",
+      "category": "skillsoft",
+      "quantity": 1,
+      "cost": 250,
+      "rating": 2
+    },
+    {
+      "name": "Knowsoft (Vehicle Schematics)",
+      "category": "skillsoft",
+      "quantity": 1,
+      "cost": 250,
+      "rating": 2
+    },
+    {
+      "name": "Knowsoft (Corporate Security Procedures)",
+      "category": "skillsoft",
+      "quantity": 1,
+      "cost": 250,
+      "rating": 2
+    }
+  ],
+  "cyberdecks": [
+    {
+      "catalogId": "hermes-chariot",
+      "name": "Hermes Chariot",
+      "deviceRating": 2,
+      "dataProcessing": 5,
+      "firewall": 2,
+      "attack": 4,
+      "sleaze": 4,
+      "cost": 123000,
+      "availability": 8,
+      "legality": "restricted"
+    }
+  ],
+  "programs": [
+    { "catalogId": "armor", "name": "Armor", "category": "hacking", "cost": 250 },
+    {
+      "catalogId": "biofeedback-filter",
+      "name": "Biofeedback Filter",
+      "category": "hacking",
+      "cost": 250
+    },
+    { "catalogId": "edit", "name": "Edit", "category": "hacking", "cost": 250 },
+    { "catalogId": "encryption", "name": "Encryption", "category": "hacking", "cost": 250 },
+    { "catalogId": "hammer", "name": "Hammer", "category": "hacking", "cost": 250 },
+    { "catalogId": "signal-scrub", "name": "Signal Scrub", "category": "hacking", "cost": 250 },
+    { "catalogId": "toolbox", "name": "Toolbox", "category": "hacking", "cost": 250 }
+  ],
+  "armor": [
+    {
+      "catalogId": "armor-jacket",
+      "name": "Armor Jacket",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 12,
+      "capacity": 12,
+      "cost": 1000,
+      "quantity": 1,
+      "equipped": true
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "ceska-black-scorpion",
+      "name": "Ceska Black Scorpion",
+      "category": "weapons",
+      "subcategory": "machine-pistol",
+      "damage": "6P",
+      "ap": 0,
+      "mode": ["SA", "BF"],
+      "recoil": 1,
+      "accuracy": 5,
+      "ammoCapacity": 35,
+      "cost": 270,
+      "quantity": 1,
+      "notes": "90 rounds regular"
+    },
+    {
+      "catalogId": "remington-roomsweeper",
+      "name": "Remington Roomsweeper",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "7P",
+      "ap": -1,
+      "mode": ["SA"],
+      "accuracy": 4,
+      "ammoCapacity": 8,
+      "cost": 300,
+      "quantity": 1,
+      "notes": "30 rounds regular"
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "meta-link",
+      "name": "Meta Link",
+      "deviceRating": 1,
+      "cost": 100,
+      "notes": "Burner commlink"
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 4 },
+      "licenses": []
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "middle",
+      "monthlyCost": 5000,
+      "prepaidMonths": 2
+    }
+  ],
+  "nuyen": 11,
+  "startingNuyen": 50000,
+  "derivedStats": {
+    "physicalLimit": 4,
+    "mentalLimit": 7,
+    "socialLimit": 5,
+    "initiativeBase": 7,
+    "initiativeDice": 1,
+    "matrixInitiativeAR": 7,
+    "matrixInitiativeDiceAR": 1,
+    "matrixInitiativeColdVR": 9,
+    "matrixInitiativeDiceColdVR": 3,
+    "matrixInitiativeHotVR": 9,
+    "matrixInitiativeDiceHotVR": 4,
+    "physicalConditionMonitor": 10,
+    "stunConditionMonitor": 11,
+    "composure": 7,
+    "judgeIntentions": 6,
+    "memory": 10,
+    "liftCarry": 6
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Decker / Matrix Specialist",
+    "notes": "Priority: A-Skills, B-Attributes, C-Metatype(Dwarf), D-Resources, E-Magic. Aptitude (Hacking) allows rating 7. Cerebral Booster provides +1 Logic."
+  }
+}

--- a/data/editions/sr5/example-characters/drone-rigger-ork.json
+++ b/data/editions/sr5/example-characters/drone-rigger-ork.json
@@ -1,0 +1,366 @@
+{
+  "id": "example-drone-rigger-ork",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Drone Rigger (Example)",
+  "metatype": "ork",
+  "description": "An ork rigger specializing in drone operations with an impressive fleet of aerial, ground, and walker drones. This character operates as a one-person army, controlling multiple armed drones while maintaining a vehicle for transport. The Juryrigger quality allows improvised repairs in the field.",
+  "status": "draft",
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 5,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 5,
+    "intuition": 2,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 3.2
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "armorer": 5,
+    "computer": 2,
+    "hardware": 2,
+    "software": 2,
+    "aeronautics-mechanic": 3,
+    "automotive-mechanic": 3,
+    "industrial-mechanic": 3,
+    "nautical-mechanic": 3,
+    "etiquette": 3,
+    "gunnery": 5,
+    "perception": 3,
+    "pilot-aircraft": 6,
+    "pilot-ground-craft": 6,
+    "pilot-walker": 5,
+    "pistols": 3
+  },
+  "knowledgeSkills": [
+    { "name": "Automotive Mechanics", "category": "professional", "rating": 5 },
+    { "name": "Drone Designs", "category": "professional", "rating": 2 },
+    { "name": "Vehicle Chop Shops", "category": "street", "rating": 4 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Or'zet", "rating": 3, "isNative": false }
+  ],
+  "positiveQualities": [{ "qualityId": "juryrigger", "rating": 1 }],
+  "negativeQualities": [],
+  "racialQualities": ["Low-Light Vision", "+3 Body", "+2 Strength"],
+  "cyberware": [
+    {
+      "catalogId": "implanted-commlink",
+      "name": "Implanted Commlink (Transys Avalon)",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.2,
+      "essenceCost": 0.2,
+      "cost": 8000,
+      "availability": 8,
+      "notes": "Device Rating 6, hot-sim module"
+    },
+    {
+      "catalogId": "control-rig",
+      "name": "Control Rig",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.0,
+      "rating": 2,
+      "cost": 97000,
+      "availability": 12,
+      "legality": "restricted",
+      "notes": "+2 dice vehicle/drone tests, +2 limits"
+    },
+    {
+      "catalogId": "reaction-enhancers",
+      "name": "Reaction Enhancers",
+      "category": "bodyware",
+      "grade": "standard",
+      "baseEssenceCost": 0.6,
+      "essenceCost": 0.6,
+      "rating": 2,
+      "cost": 26000,
+      "availability": 8,
+      "attributeBonuses": { "reaction": 2 }
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Barrens Mechanic",
+      "type": "Service",
+      "connection": 2,
+      "loyalty": 3,
+      "notes": "Cheap repairs"
+    },
+    {
+      "name": "Drone Dealer",
+      "type": "Arms",
+      "connection": 3,
+      "loyalty": 3,
+      "notes": "Drone acquisition"
+    }
+  ],
+  "gear": [
+    {
+      "name": "Goggles",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 100,
+      "rating": 4,
+      "notes": "Image Link, Smartlink, Thermographic Vision, Vision Magnification"
+    },
+    { "name": "Aeronautics Mechanic Kit", "category": "tools", "quantity": 1, "cost": 500 },
+    { "name": "Armorer Shop", "category": "tools", "quantity": 1, "cost": 5000 },
+    { "name": "Automotive Mechanic Facility", "category": "tools", "quantity": 1, "cost": 50000 },
+    { "name": "Miniwelder", "category": "tools", "quantity": 1, "cost": 250 },
+    {
+      "name": "DocWagon Contract",
+      "category": "services",
+      "quantity": 1,
+      "cost": 25000,
+      "notes": "Gold (1 year)"
+    }
+  ],
+  "drones": [
+    {
+      "catalogId": "cyberspace-designs-dalmatian",
+      "name": "Cyberspace Designs Dalmatian",
+      "type": "aerial",
+      "handling": 5,
+      "speed": 4,
+      "acceleration": 3,
+      "body": 5,
+      "armor": 5,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 10000,
+      "quantity": 1,
+      "notes": "VTOL, Surveillance"
+    },
+    {
+      "catalogId": "lockheed-optic-x2",
+      "name": "Lockheed Optic-X2",
+      "type": "aerial",
+      "handling": 4,
+      "speed": 4,
+      "acceleration": 3,
+      "body": 2,
+      "armor": 2,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 15000,
+      "quantity": 1,
+      "notes": "VSTOL, Recon"
+    },
+    {
+      "catalogId": "mct-fly-spy",
+      "name": "MCT Fly-Spy",
+      "type": "aerial",
+      "handling": 4,
+      "speed": 3,
+      "acceleration": 2,
+      "body": 1,
+      "armor": 0,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 2000,
+      "quantity": 2,
+      "notes": "Micro surveillance"
+    },
+    {
+      "catalogId": "mct-nissan-roto-drone",
+      "name": "MCT-Nissan Roto-Drone",
+      "type": "rotorcraft",
+      "handling": 4,
+      "speed": 4,
+      "acceleration": 2,
+      "body": 4,
+      "armor": 4,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 5000,
+      "quantity": 1,
+      "notes": "Ares Alpha mounted, 250 rounds regular"
+    },
+    {
+      "catalogId": "mct-nissan-roto-drone",
+      "name": "MCT-Nissan Roto-Drone #2",
+      "type": "rotorcraft",
+      "handling": 4,
+      "speed": 4,
+      "acceleration": 2,
+      "body": 4,
+      "armor": 4,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 5000,
+      "quantity": 1,
+      "notes": "Yamaha Pulsar (taser) mounted"
+    },
+    {
+      "catalogId": "gm-nissan-doberman",
+      "name": "GM-Nissan Doberman",
+      "type": "ground",
+      "handling": 5,
+      "speed": 3,
+      "acceleration": 1,
+      "body": 4,
+      "armor": 4,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 5000,
+      "quantity": 1,
+      "notes": "Tracked, AK-97 mounted, 100 rounds APDS"
+    },
+    {
+      "catalogId": "steel-lynx",
+      "name": "Steel Lynx Combat Drone",
+      "type": "ground",
+      "handling": 5,
+      "speed": 4,
+      "acceleration": 2,
+      "body": 6,
+      "armor": 12,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 25000,
+      "quantity": 1,
+      "notes": "Wheeled, Stoner-Ares M202 (Heavy) mounted, 150 rounds explosive"
+    },
+    {
+      "catalogId": "aztechnology-crawler",
+      "name": "Aztechnology Crawler",
+      "type": "walker",
+      "handling": 4,
+      "speed": 3,
+      "acceleration": 1,
+      "body": 3,
+      "armor": 3,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 5000,
+      "quantity": 1
+    },
+    {
+      "catalogId": "shiawase-kanmushi",
+      "name": "Shiawase Kanmushi",
+      "type": "walker",
+      "handling": 4,
+      "speed": 2,
+      "acceleration": 1,
+      "body": 0,
+      "armor": 0,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 1000,
+      "quantity": 2,
+      "notes": "Micro bugs"
+    }
+  ],
+  "vehicles": [
+    {
+      "catalogId": "rover-model-2072",
+      "name": "Rover Model 2072",
+      "type": "ground",
+      "handling": "5/5",
+      "speed": 4,
+      "acceleration": 2,
+      "body": 15,
+      "armor": 12,
+      "pilot": 2,
+      "sensor": 4,
+      "seats": 6,
+      "cost": 44000,
+      "notes": "SUV, Rigger interface, weapon mount with Ares Alpha (250 rounds regular) and Grenade Launcher (12 thermal smoke minigrenades)"
+    }
+  ],
+  "armor": [
+    {
+      "catalogId": "armor-vest",
+      "name": "Armor Vest",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 9,
+      "capacity": 9,
+      "cost": 500,
+      "quantity": 1,
+      "equipped": true
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "ares-predator-v",
+      "name": "Ares Predator V",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "8P",
+      "ap": -1,
+      "mode": ["SA"],
+      "accuracy": 5,
+      "ammoCapacity": 15,
+      "cost": 725,
+      "quantity": 1,
+      "notes": "Smartlink, 75 rounds"
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 4 },
+      "licenses": [
+        { "type": "fake", "rating": 4, "name": "Gun License" },
+        { "type": "fake", "rating": 4, "name": "Drone License" }
+      ]
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "medium",
+      "monthlyCost": 5000,
+      "prepaidMonths": 3,
+      "notes": "Special Work Area (Vehicle Facility), Obscure location"
+    }
+  ],
+  "nuyen": 1150,
+  "startingNuyen": 450000,
+  "derivedStats": {
+    "physicalLimit": 6,
+    "mentalLimit": 6,
+    "socialLimit": 4,
+    "initiativeBase": 9,
+    "initiativeDice": 1,
+    "matrixInitiativeAR": 9,
+    "matrixInitiativeDiceAR": 1,
+    "matrixInitiativeColdVR": 10,
+    "matrixInitiativeDiceColdVR": 3,
+    "matrixInitiativeHotVR": 10,
+    "matrixInitiativeDiceHotVR": 4,
+    "physicalConditionMonitor": 10,
+    "stunConditionMonitor": 10,
+    "composure": 6,
+    "judgeIntentions": 4,
+    "memory": 7,
+    "liftCarry": 7
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 15,
+  "karmaSpentAtCreation": 10,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Drone Rigger",
+    "notes": "Priority: A-Resources, B-Attributes, C-Metatype(Ork), D-Skills, E-Magic. Control Rig 2 provides +2 dice and +2 limits when jumped in. Reaction Enhancers +2 already factored into derived stats."
+  }
+}

--- a/data/editions/sr5/example-characters/face-elf.json
+++ b/data/editions/sr5/example-characters/face-elf.json
@@ -1,0 +1,354 @@
+{
+  "id": "example-face-elf",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Face (Example)",
+  "metatype": "elf",
+  "description": "An elf face specializing in social manipulation, electronic warfare, and looking good while doing it. This character leverages natural elven charisma with an extensive network of contacts across various social strata.",
+  "status": "draft",
+  "attributes": {
+    "body": 3,
+    "agility": 4,
+    "reaction": 3,
+    "strength": 2,
+    "willpower": 4,
+    "logic": 4,
+    "intuition": 4,
+    "charisma": 7
+  },
+  "specialAttributes": {
+    "edge": 4,
+    "essence": 6.0
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "con": 4,
+    "impersonation": 4,
+    "performance": 4,
+    "blades": 2,
+    "clubs": 4,
+    "electronic-warfare": 4,
+    "computer": 4,
+    "hardware": 4,
+    "software": 4,
+    "etiquette": 5,
+    "first-aid": 1,
+    "forgery": 4,
+    "intimidation": 4,
+    "leadership": 4,
+    "locksmith": 4,
+    "negotiation": 5,
+    "perception": 4,
+    "pilot-ground-craft": 1,
+    "pistols": 4,
+    "disguise": 2,
+    "palming": 2,
+    "sneaking": 2,
+    "unarmed-combat": 2
+  },
+  "knowledgeSkills": [
+    { "name": "Business", "category": "academic", "rating": 4 },
+    { "name": "High Fashion", "category": "interests", "rating": 4 },
+    { "name": "Sports", "category": "interests", "rating": 4 }
+  ],
+  "languages": [
+    { "name": "Cantonese", "rating": 0, "isNative": true },
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Japanese", "rating": 4, "isNative": false }
+  ],
+  "positiveQualities": [
+    {
+      "qualityId": "bilingual",
+      "rating": 1,
+      "specification": "English"
+    },
+    {
+      "qualityId": "first-impression",
+      "rating": 1
+    }
+  ],
+  "negativeQualities": [
+    {
+      "qualityId": "addiction",
+      "rating": 1,
+      "specification": "Alcohol (Mild)"
+    }
+  ],
+  "racialQualities": ["Low-Light Vision"],
+  "contacts": [
+    {
+      "name": "City Official",
+      "type": "Government",
+      "connection": 3,
+      "loyalty": 2,
+      "notes": "Government access"
+    },
+    {
+      "name": "Club Owner",
+      "type": "Nightlife",
+      "connection": 2,
+      "loyalty": 2,
+      "notes": "Nightlife connections"
+    },
+    {
+      "name": "Fixer",
+      "type": "Fixer",
+      "connection": 3,
+      "loyalty": 2,
+      "notes": "Jobs and equipment"
+    },
+    {
+      "name": "Media Producer",
+      "type": "Media",
+      "connection": 2,
+      "loyalty": 3,
+      "notes": "Media manipulation"
+    },
+    {
+      "name": "Mr. Johnson",
+      "type": "Corporate",
+      "connection": 4,
+      "loyalty": 1,
+      "notes": "Corporate work"
+    },
+    {
+      "name": "Street Ganger",
+      "type": "Gang",
+      "connection": 2,
+      "loyalty": 2,
+      "notes": "Street-level intel"
+    },
+    {
+      "name": "Ticket Scalper",
+      "type": "Entertainment",
+      "connection": 1,
+      "loyalty": 1,
+      "notes": "Event access"
+    }
+  ],
+  "gear": [
+    { "name": "Bug Scanner", "category": "electronics", "quantity": 1, "cost": 400 },
+    { "name": "Data Tap", "category": "electronics", "quantity": 1, "cost": 300 },
+    { "name": "Area Jammer", "category": "electronics", "quantity": 1, "cost": 600, "rating": 4 },
+    { "name": "Tag Eraser", "category": "electronics", "quantity": 1, "cost": 450 },
+    {
+      "name": "White Noise Generator",
+      "category": "electronics",
+      "quantity": 1,
+      "cost": 150,
+      "rating": 6
+    },
+    { "name": "Hardware Toolkit", "category": "tools", "quantity": 1, "cost": 500 },
+    { "name": "Lockpick Set", "category": "tools", "quantity": 1, "cost": 250 },
+    {
+      "name": "Glasses",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 100,
+      "rating": 1,
+      "notes": "Image Link"
+    },
+    { "name": "Micro-Transceivers", "category": "electronics", "quantity": 2, "cost": 100 },
+    { "name": "Stealth Tags", "category": "rfid", "quantity": 20, "cost": 200 }
+  ],
+  "armor": [
+    {
+      "catalogId": "actioneer-business-clothes",
+      "name": "Actioneer Business Clothes",
+      "category": "armor",
+      "subcategory": "clothing",
+      "armorRating": 8,
+      "capacity": 8,
+      "capacityUsed": 0,
+      "cost": 1500,
+      "quantity": 1,
+      "equipped": true
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "browning-ultra-power",
+      "name": "Browning Ultra-Power",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "8P",
+      "ap": -1,
+      "mode": ["SA"],
+      "accuracy": 5,
+      "ammoCapacity": 10,
+      "cost": 640,
+      "quantity": 1,
+      "modifications": [
+        {
+          "catalogId": "silencer",
+          "name": "Silencer",
+          "cost": 500,
+          "availability": 9,
+          "legality": "forbidden",
+          "capacityUsed": 0
+        }
+      ],
+      "notes": "2 spare clips, 100 rounds regular ammo"
+    },
+    {
+      "catalogId": "colt-america-l36",
+      "name": "Colt America L36",
+      "category": "weapons",
+      "subcategory": "light-pistol",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 7,
+      "ammoCapacity": 11,
+      "cost": 320,
+      "quantity": 1,
+      "notes": "Concealed holster, 2 spare clips, 110 rounds"
+    },
+    {
+      "catalogId": "walther-palm-pistol",
+      "name": "Walther Palm Pistol",
+      "category": "weapons",
+      "subcategory": "hold-out-pistol",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SS", "BF"],
+      "accuracy": 4,
+      "ammoCapacity": 2,
+      "cost": 180,
+      "quantity": 1,
+      "notes": "Concealed holster, 10 rounds"
+    },
+    {
+      "catalogId": "yamaha-pulsar",
+      "name": "Yamaha Pulsar",
+      "category": "weapons",
+      "subcategory": "taser",
+      "damage": "7S(e)",
+      "ap": -5,
+      "mode": ["SA"],
+      "accuracy": 5,
+      "ammoCapacity": 4,
+      "cost": 180,
+      "quantity": 1,
+      "notes": "40 darts"
+    },
+    {
+      "catalogId": "smoke-grenade",
+      "name": "Smoke Grenade",
+      "category": "weapons",
+      "subcategory": "grenade",
+      "damage": "-",
+      "ap": 0,
+      "mode": [],
+      "accuracy": 0,
+      "cost": 40,
+      "quantity": 2,
+      "notes": "10m Radius smoke"
+    },
+    {
+      "catalogId": "extendable-baton",
+      "name": "Extendable Baton",
+      "category": "weapons",
+      "subcategory": "club",
+      "damage": "4S",
+      "ap": 0,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 5,
+      "cost": 100,
+      "quantity": 1,
+      "notes": "Collapsible"
+    },
+    {
+      "catalogId": "knife",
+      "name": "Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "3P",
+      "ap": -1,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 5,
+      "cost": 10,
+      "quantity": 1
+    }
+  ],
+  "vehicles": [
+    {
+      "id": "face-vehicle-1",
+      "name": "Ford Americar",
+      "type": "ground",
+      "handling": 4,
+      "speed": 3,
+      "acceleration": 2,
+      "body": 11,
+      "armor": 4,
+      "pilot": 1,
+      "sensor": 2,
+      "seats": 4,
+      "notes": "Standard sedan"
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "hermes-ikon",
+      "name": "Hermes Ikon",
+      "deviceRating": 5,
+      "cost": 3000
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": {
+        "type": "fake",
+        "rating": 4
+      },
+      "licenses": [
+        { "type": "fake", "rating": 4, "name": "Concealed Carry Permit" },
+        { "type": "fake", "rating": 4, "name": "Gun License" }
+      ]
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "medium",
+      "monthlyCost": 5000,
+      "prepaidMonths": 1,
+      "notes": "Standard medium lifestyle"
+    }
+  ],
+  "nuyen": 6000,
+  "startingNuyen": 50000,
+  "derivedStats": {
+    "physicalLimit": 4,
+    "mentalLimit": 6,
+    "socialLimit": 8,
+    "initiativeBase": 7,
+    "initiativeDice": 1,
+    "physicalConditionMonitor": 10,
+    "stunConditionMonitor": 10,
+    "composure": 11,
+    "judgeIntentions": 11,
+    "memory": 8,
+    "liftCarry": 5
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "page": "SR5 p.112-113",
+    "archetype": "Face / Social Infiltrator",
+    "notes": "Priority: A-Skills, B-Attributes, C-Metatype(Elf), D-Resources, E-Magic"
+  }
+}

--- a/data/editions/sr5/example-characters/gang-leader-ork.json
+++ b/data/editions/sr5/example-characters/gang-leader-ork.json
@@ -1,0 +1,332 @@
+{
+  "id": "example-gang-leader-ork",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Gang Leader (Example)",
+  "metatype": "ork",
+  "description": "An ork gang leader and street-level fixer from the Seattle sprawl. This character combines physical presence with social skills to lead a gang and handle negotiations.",
+  "status": "draft",
+  "attributes": {
+    "body": 7,
+    "agility": 4,
+    "reaction": 4,
+    "strength": 7,
+    "willpower": 4,
+    "logic": 4,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 4.8
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "armorer": 1,
+    "gymnastics": 2,
+    "running": 2,
+    "swimming": 2,
+    "automatics": 1,
+    "blades": 3,
+    "clubs": 3,
+    "computer": 1,
+    "con": 1,
+    "cybertechnology": 1,
+    "etiquette": 2,
+    "first-aid": 1,
+    "intimidation": 5,
+    "leadership": 3,
+    "locksmith": 1,
+    "aeronautics-mechanic": 1,
+    "automotive-mechanic": 1,
+    "industrial-mechanic": 1,
+    "nautical-mechanic": 1,
+    "navigation": 1,
+    "negotiation": 3,
+    "perception": 3,
+    "performance": 3,
+    "pilot-ground-craft": 2,
+    "pistols": 3,
+    "disguise": 2,
+    "palming": 2,
+    "sneaking": 2,
+    "throwing-weapons": 1,
+    "unarmed-combat": 5
+  },
+  "skillSpecializations": {
+    "etiquette": ["Street"]
+  },
+  "knowledgeSkills": [
+    { "name": "Business", "category": "academic", "rating": 2 },
+    { "name": "Seattle Street Gangs", "category": "street", "rating": 4 },
+    { "name": "Sprawl Life", "category": "street", "rating": 3 },
+    { "name": "Street Drugs", "category": "street", "rating": 2 }
+  ],
+  "languages": [
+    { "name": "English (City Speak)", "rating": 0, "isNative": true },
+    { "name": "Or'zet", "rating": 2, "isNative": false }
+  ],
+  "positiveQualities": [
+    {
+      "qualityId": "guts",
+      "rating": 1
+    },
+    {
+      "qualityId": "home-ground",
+      "rating": 1,
+      "specification": "You Know a Guy"
+    }
+  ],
+  "negativeQualities": [
+    {
+      "qualityId": "dependent",
+      "rating": 3,
+      "specification": "Several brothers and sisters"
+    },
+    {
+      "qualityId": "distinctive-style",
+      "rating": 1
+    },
+    {
+      "qualityId": "prejudiced",
+      "rating": 2,
+      "specification": "Elves (Outspoken)"
+    }
+  ],
+  "racialQualities": ["Low-Light Vision"],
+  "cyberware": [
+    {
+      "catalogId": "cyberarm",
+      "name": "Cyberarm (Obvious)",
+      "category": "cyberlimb",
+      "grade": "used",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.2,
+      "cost": 11250,
+      "availability": 4,
+      "notes": "Standard stats, visible wear"
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Fixer",
+      "type": "Fixer",
+      "connection": 3,
+      "loyalty": 1,
+      "notes": "General jobs and gear"
+    },
+    {
+      "name": "Sprawl Ganger",
+      "type": "Gang",
+      "connection": 2,
+      "loyalty": 5,
+      "notes": "Highly loyal gang member"
+    },
+    {
+      "name": "Street Kid",
+      "type": "Street",
+      "connection": 1,
+      "loyalty": 3,
+      "notes": "Information source"
+    }
+  ],
+  "gear": [
+    { "name": "Armorer Kit", "category": "tools", "quantity": 1, "cost": 500 },
+    { "name": "Automotive Mechanics Kit", "category": "tools", "quantity": 1, "cost": 500 },
+    { "name": "Cybertechnology Kit", "category": "tools", "quantity": 1, "cost": 500 },
+    { "name": "Industrial Mechanic Kit", "category": "tools", "quantity": 1, "cost": 500 },
+    { "name": "Survival Kit", "category": "survival", "quantity": 1, "cost": 200 },
+    { "name": "Medkit", "category": "medical", "quantity": 1, "cost": 500, "rating": 3 },
+    {
+      "name": "Glasses",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 100,
+      "rating": 1,
+      "notes": "Image Link"
+    },
+    { "name": "Jazz", "category": "drugs", "quantity": 4, "cost": 300, "notes": "Combat drug" },
+    { "name": "Plastic Restraints", "category": "restraints", "quantity": 10, "cost": 50 }
+  ],
+  "armor": [
+    {
+      "catalogId": "armor-jacket",
+      "name": "Armored Jacket",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 12,
+      "capacity": 12,
+      "capacityUsed": 6,
+      "cost": 1000,
+      "quantity": 1,
+      "equipped": true,
+      "modifications": [
+        {
+          "catalogId": "nonconductivity",
+          "name": "Nonconductivity",
+          "rating": 6,
+          "capacityUsed": 6,
+          "cost": 1500,
+          "availability": 6
+        }
+      ]
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "colt-america-l36",
+      "name": "Colt America L36",
+      "category": "weapons",
+      "subcategory": "light-pistol",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 7,
+      "ammoCapacity": 11,
+      "cost": 320,
+      "quantity": 1,
+      "notes": "Concealed holster, 2 spare clips, 110 rounds"
+    },
+    {
+      "catalogId": "ruger-super-warhawk",
+      "name": "Ruger Super Warhawk",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "9P",
+      "ap": -2,
+      "mode": ["SS"],
+      "accuracy": 5,
+      "ammoCapacity": 6,
+      "cost": 400,
+      "quantity": 1,
+      "notes": "2 speed loaders, 60 rounds"
+    },
+    {
+      "catalogId": "streetline-special",
+      "name": "Streetline Special",
+      "category": "weapons",
+      "subcategory": "hold-out-pistol",
+      "damage": "6P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 4,
+      "ammoCapacity": 6,
+      "cost": 120,
+      "quantity": 1,
+      "notes": "Concealed history, 30 rounds"
+    },
+    {
+      "catalogId": "combat-axe",
+      "name": "Combat Axe",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "12P",
+      "ap": -4,
+      "mode": [],
+      "reach": 2,
+      "accuracy": 4,
+      "cost": 500,
+      "quantity": 1
+    },
+    {
+      "catalogId": "extendable-baton",
+      "name": "Extendable Baton",
+      "category": "weapons",
+      "subcategory": "club",
+      "damage": "7S",
+      "ap": 0,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 5,
+      "cost": 100,
+      "quantity": 1,
+      "notes": "Collapsible"
+    },
+    {
+      "catalogId": "knife",
+      "name": "Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "7P",
+      "ap": -1,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 5,
+      "cost": 10,
+      "quantity": 1
+    }
+  ],
+  "vehicles": [
+    {
+      "id": "gang-leader-vehicle-1",
+      "name": "Harley-Davidson Scorpion",
+      "type": "ground",
+      "handling": 4,
+      "speed": 4,
+      "acceleration": 2,
+      "body": 8,
+      "armor": 6,
+      "pilot": 1,
+      "sensor": 2,
+      "seats": 1,
+      "notes": "Motorcycle"
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "renraku-sensei",
+      "name": "Renraku Sensei",
+      "deviceRating": 3,
+      "cost": 1000
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": {
+        "type": "fake",
+        "rating": 3
+      },
+      "licenses": [{ "type": "fake", "rating": 3, "name": "Gun License" }]
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "low",
+      "monthlyCost": 2000,
+      "prepaidMonths": 2
+    }
+  ],
+  "nuyen": 1500,
+  "startingNuyen": 50000,
+  "derivedStats": {
+    "physicalLimit": 9,
+    "mentalLimit": 5,
+    "socialLimit": 6,
+    "initiativeBase": 7,
+    "initiativeDice": 1,
+    "physicalConditionMonitor": 12,
+    "stunConditionMonitor": 10,
+    "composure": 8,
+    "judgeIntentions": 7,
+    "memory": 7,
+    "liftCarry": 14
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Gang Leader / Street Boss",
+    "notes": "Priority: A-Attributes, B-Skills, C-Metatype(Ork), D-Resources, E-Magic"
+  }
+}

--- a/data/editions/sr5/example-characters/infiltrator-dwarf.json
+++ b/data/editions/sr5/example-characters/infiltrator-dwarf.json
@@ -1,0 +1,250 @@
+{
+  "id": "example-infiltrator-dwarf",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Infiltrator (Example)",
+  "metatype": "dwarf",
+  "description": "A dwarf breaking-and-entering specialist with exceptional agility and physical prowess. This character combines natural athletic ability with specialized infiltration gear to bypass security systems.",
+  "status": "draft",
+  "attributes": {
+    "body": 5,
+    "agility": 6,
+    "reaction": 4,
+    "strength": 5,
+    "willpower": 4,
+    "logic": 4,
+    "intuition": 5,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 5,
+    "essence": 5.6
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "computer": 2,
+    "escape-artist": 3,
+    "etiquette": 3,
+    "automatics": 2,
+    "longarms": 2,
+    "pistols": 2,
+    "gymnastics": 5,
+    "hardware": 2,
+    "perception": 3,
+    "running": 3,
+    "sneaking": 5,
+    "swimming": 2
+  },
+  "knowledgeSkills": [
+    { "name": "Building Layouts", "category": "professional", "rating": 4 },
+    { "name": "Corporate Security Systems", "category": "professional", "rating": 5 },
+    { "name": "Extreme Sports", "category": "interests", "rating": 2 },
+    { "name": "Infiltration Techniques", "category": "professional", "rating": 3 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Japanese", "rating": 4, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "catlike", "rating": 1 },
+    { "qualityId": "double-jointed", "rating": 1 },
+    { "qualityId": "natural-athlete", "rating": 1 }
+  ],
+  "negativeQualities": [],
+  "racialQualities": [
+    "Thermographic Vision",
+    "+2 Body",
+    "+1 Willpower",
+    "Toxin/Pathogen Resistance (+2 dice)"
+  ],
+  "cyberware": [
+    {
+      "catalogId": "cybereyes",
+      "name": "Cybereyes",
+      "category": "eyeware",
+      "grade": "standard",
+      "baseEssenceCost": 0.3,
+      "essenceCost": 0.3,
+      "rating": 2,
+      "capacity": 8,
+      "capacityUsed": 7,
+      "cost": 6000,
+      "availability": 6,
+      "enhancements": [
+        { "name": "Low-Light Vision", "capacity": 2 },
+        { "name": "Smartlink", "capacity": 3 },
+        { "name": "Thermographic Vision", "capacity": 2 },
+        { "name": "Vision Enhancement 1", "capacity": 0 }
+      ]
+    },
+    {
+      "catalogId": "datajack",
+      "name": "Datajack",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.1,
+      "essenceCost": 0.1,
+      "cost": 1000,
+      "availability": 2
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Fixer",
+      "type": "Fixer",
+      "connection": 4,
+      "loyalty": 3,
+      "notes": "Jobs and equipment"
+    },
+    {
+      "name": "Corporate Security Contractor",
+      "type": "Security",
+      "connection": 3,
+      "loyalty": 5,
+      "notes": "Inside information on security"
+    }
+  ],
+  "gear": [
+    { "name": "Climbing Gear", "category": "survival", "quantity": 1, "cost": 200 },
+    { "name": "Crowbar", "category": "tools", "quantity": 1, "cost": 20 },
+    {
+      "name": "Grapple Gun",
+      "category": "survival",
+      "quantity": 1,
+      "cost": 500,
+      "notes": "Stealth rope 500m, catalyst stick, micro wire 200m"
+    },
+    {
+      "name": "Maglock Passkey",
+      "category": "electronics",
+      "quantity": 1,
+      "cost": 4500,
+      "rating": 3
+    },
+    { "name": "Rappelling Gloves", "category": "survival", "quantity": 1, "cost": 70 },
+    { "name": "Tag Eraser", "category": "electronics", "quantity": 1, "cost": 450 },
+    { "name": "Micro-Transceiver", "category": "electronics", "quantity": 1, "cost": 100 }
+  ],
+  "armor": [
+    {
+      "catalogId": "chameleon-suit",
+      "name": "Chameleon Suit",
+      "category": "armor",
+      "subcategory": "full-body-armor",
+      "armorRating": 9,
+      "capacity": 9,
+      "capacityUsed": 2,
+      "cost": 1700,
+      "quantity": 1,
+      "equipped": true,
+      "modifications": [
+        {
+          "catalogId": "thermal-damping",
+          "name": "Thermal Damping",
+          "rating": 2,
+          "capacityUsed": 2,
+          "cost": 1000,
+          "availability": 10,
+          "legality": "restricted"
+        }
+      ]
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "streetline-special",
+      "name": "Streetline Special",
+      "category": "weapons",
+      "subcategory": "hold-out-pistol",
+      "damage": "6P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 4,
+      "ammoCapacity": 6,
+      "cost": 120,
+      "quantity": 1,
+      "notes": "Spare clip, 60 rounds"
+    },
+    {
+      "catalogId": "ares-predator-v",
+      "name": "Ares Predator V",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "7P",
+      "ap": -4,
+      "mode": ["SA"],
+      "accuracy": 5,
+      "ammoCapacity": 15,
+      "cost": 725,
+      "quantity": 1,
+      "modifications": [
+        {
+          "catalogId": "silencer",
+          "name": "Silencer",
+          "cost": 500,
+          "availability": 9,
+          "legality": "forbidden",
+          "capacityUsed": 0
+        }
+      ],
+      "notes": "Smartlink, spare clip, 50 rounds"
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "erika-elite",
+      "name": "Erika Elite",
+      "deviceRating": 4,
+      "cost": 2500
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": {
+        "type": "fake",
+        "rating": 4
+      },
+      "licenses": [{ "type": "fake", "rating": 4, "name": "Gun License" }]
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "low",
+      "monthlyCost": 2000,
+      "prepaidMonths": 3
+    }
+  ],
+  "nuyen": 270,
+  "startingNuyen": 50000,
+  "derivedStats": {
+    "physicalLimit": 7,
+    "mentalLimit": 6,
+    "socialLimit": 6,
+    "initiativeBase": 9,
+    "initiativeDice": 1,
+    "physicalConditionMonitor": 11,
+    "stunConditionMonitor": 10,
+    "composure": 8,
+    "judgeIntentions": 9,
+    "memory": 9,
+    "liftCarry": 10
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Infiltrator / B&E Specialist",
+    "notes": "Priority: A-Attributes, B-Skills, C-Metatype(Dwarf), D-Resources, E-Magic. High Edge (5) for critical moments."
+  }
+}

--- a/data/editions/sr5/example-characters/martial-artist-human.json
+++ b/data/editions/sr5/example-characters/martial-artist-human.json
@@ -1,0 +1,301 @@
+{
+  "id": "example-martial-artist-human",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Martial Artist (Example)",
+  "metatype": "human",
+  "description": "A human martial artist adept following a strict Code of Honor, specializing in unarmed combat and acrobatics. This character embodies the street-level vigilante archetype, using supernatural martial arts abilities to protect the weak. Bilingual in English and Mandarin with deep knowledge of Kung Fu and Seattle's urban landscape.",
+  "status": "draft",
+  "attributes": {
+    "body": 5,
+    "agility": 5,
+    "reaction": 5,
+    "strength": 5,
+    "willpower": 3,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 4,
+    "essence": 6.0,
+    "magic": 5
+  },
+  "magicalPath": "adept",
+  "adeptPowers": [
+    {
+      "catalogId": "critical-strike",
+      "name": "Critical Strike (Unarmed Combat)",
+      "powerPointCost": 1.0,
+      "rating": 2,
+      "notes": "+2 DV with unarmed attacks"
+    },
+    {
+      "catalogId": "improved-ability",
+      "name": "Improved Ability (Unarmed Combat)",
+      "powerPointCost": 1.5,
+      "rating": 3,
+      "notes": "+3 dice for Unarmed Combat"
+    },
+    {
+      "catalogId": "improved-reflexes",
+      "name": "Improved Reflexes",
+      "powerPointCost": 1.5,
+      "rating": 1,
+      "notes": "+1 Reaction, +1 Initiative die"
+    },
+    {
+      "catalogId": "improved-senses",
+      "name": "Improved Senses (Low-Light Vision)",
+      "powerPointCost": 0.25,
+      "notes": "See in low light"
+    },
+    {
+      "catalogId": "killing-hands",
+      "name": "Killing Hands",
+      "powerPointCost": 0.5,
+      "notes": "Unarmed attacks deal Physical damage"
+    },
+    {
+      "catalogId": "light-body",
+      "name": "Light Body",
+      "powerPointCost": 0.25,
+      "rating": 1,
+      "notes": "Reduce effective falling distance"
+    }
+  ],
+  "skills": {
+    "archery": 4,
+    "gymnastics": 4,
+    "running": 4,
+    "swimming": 4,
+    "blades": 4,
+    "clubs": 4,
+    "computer": 1,
+    "con": 1,
+    "disguise": 1,
+    "escape-artist": 3,
+    "etiquette": 2,
+    "first-aid": 1,
+    "intimidation": 3,
+    "locksmith": 2,
+    "negotiation": 1,
+    "navigation": 1,
+    "survival": 1,
+    "tracking": 1,
+    "perception": 3,
+    "sneaking": 4,
+    "throwing-weapons": 3,
+    "unarmed-combat": 6
+  },
+  "knowledgeSkills": [
+    { "name": "Kung Fu", "category": "interests", "rating": 4 },
+    { "name": "Seattle Parkour", "category": "street", "rating": 4 },
+    { "name": "Seattle Squats", "category": "street", "rating": 2 },
+    { "name": "Triads", "category": "street", "rating": 2 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Mandarin", "rating": 0, "isNative": true }
+  ],
+  "positiveQualities": [
+    { "qualityId": "bilingual", "rating": 1, "specification": "Mandarin" },
+    { "qualityId": "double-jointed", "rating": 1 },
+    { "qualityId": "natural-athlete", "rating": 1 },
+    { "qualityId": "pain-resistance", "rating": 1 }
+  ],
+  "negativeQualities": [
+    {
+      "qualityId": "code-of-honor",
+      "rating": 1,
+      "specification": "Only lethal force against those who use it first, protect the weak, overthrow the corrupt"
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Crusading Reporter",
+      "type": "Media",
+      "connection": 2,
+      "loyalty": 3,
+      "notes": "Media exposure"
+    },
+    {
+      "name": "Street Kid",
+      "type": "Shadow",
+      "connection": 1,
+      "loyalty": 3,
+      "notes": "Street-level intel"
+    },
+    {
+      "name": "Triad Member",
+      "type": "Underworld",
+      "connection": 3,
+      "loyalty": 2,
+      "notes": "Underworld connections"
+    }
+  ],
+  "gear": [
+    {
+      "name": "Glasses",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 100,
+      "rating": 1,
+      "notes": "Image Link"
+    },
+    { "name": "Climbing Gear", "category": "survival", "quantity": 1, "cost": 200 },
+    { "name": "Flashlight", "category": "survival", "quantity": 1, "cost": 25 },
+    { "name": "Lockpicks", "category": "tools", "quantity": 1, "cost": 250 },
+    { "name": "Survival Kit", "category": "survival", "quantity": 1, "cost": 200 },
+    { "name": "Respirator", "category": "survival", "quantity": 1, "cost": 50, "rating": 1 }
+  ],
+  "armor": [
+    {
+      "catalogId": "urban-explorer-jumpsuit",
+      "name": "Urban Explorer Jumpsuit",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 9,
+      "capacity": 9,
+      "cost": 650,
+      "quantity": 1,
+      "equipped": true,
+      "notes": "Flexible, good for acrobatics"
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "bow",
+      "name": "Bow (Rating 5)",
+      "category": "weapons",
+      "subcategory": "bow",
+      "damage": "7P",
+      "ap": -2,
+      "mode": ["SS"],
+      "accuracy": 6,
+      "cost": 500,
+      "quantity": 1,
+      "rating": 5,
+      "notes": "10 arrows"
+    },
+    {
+      "catalogId": "throwing-knife",
+      "name": "Throwing Knife",
+      "category": "weapons",
+      "subcategory": "throwing-weapon",
+      "damage": "6P",
+      "ap": -1,
+      "mode": [],
+      "accuracy": 0,
+      "cost": 25,
+      "quantity": 2
+    },
+    {
+      "catalogId": "club",
+      "name": "Club",
+      "category": "weapons",
+      "subcategory": "club",
+      "damage": "8P",
+      "ap": 0,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 4,
+      "cost": 30,
+      "quantity": 1
+    },
+    {
+      "catalogId": "extendable-baton",
+      "name": "Extendable Baton",
+      "category": "weapons",
+      "subcategory": "club",
+      "damage": "7P",
+      "ap": 0,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 5,
+      "cost": 100,
+      "quantity": 1,
+      "notes": "Collapsible"
+    },
+    {
+      "catalogId": "knife",
+      "name": "Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "6P",
+      "ap": -1,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 5,
+      "cost": 10,
+      "quantity": 2
+    },
+    {
+      "catalogId": "survival-knife",
+      "name": "Survival Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "7P",
+      "ap": -1,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 5,
+      "cost": 100,
+      "quantity": 1
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "meta-link",
+      "name": "Meta Link",
+      "deviceRating": 1,
+      "cost": 100
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 1 },
+      "licenses": []
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "squatter",
+      "monthlyCost": 500,
+      "prepaidMonths": 2
+    }
+  ],
+  "nuyen": 0,
+  "startingNuyen": 6000,
+  "derivedStats": {
+    "physicalLimit": 7,
+    "mentalLimit": 4,
+    "socialLimit": 5,
+    "initiativeBase": 9,
+    "initiativeDice": 2,
+    "physicalConditionMonitor": 11,
+    "stunConditionMonitor": 10,
+    "composure": 6,
+    "judgeIntentions": 6,
+    "memory": 6,
+    "liftCarry": 10
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Martial Artist / Physical Adept",
+    "notes": "Priority: A-Attributes, B-Skills, C-Magic(Adept), D-Metatype(Human), E-Resources. Unarmed Combat effective 9 dice (6 base + 3 Improved Ability). Unarmed damage: 7P (STR 5 + Critical Strike 2) with Killing Hands for Physical damage. Improved Reflexes 1: +1 Reaction, +1 Initiative die (base 9+2D6)."
+  }
+}

--- a/data/editions/sr5/example-characters/mercenary-human.json
+++ b/data/editions/sr5/example-characters/mercenary-human.json
@@ -1,0 +1,471 @@
+{
+  "id": "example-mercenary-human",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Mercenary (Example)",
+  "metatype": "human",
+  "description": "A highly trained human mercenary with military background, specializing in firearms and heavy weapons. This character follows a strict Code of Honor protecting civilians and non-combatants.",
+  "status": "draft",
+  "attributes": {
+    "body": 4,
+    "agility": 5,
+    "reaction": 4,
+    "strength": 3,
+    "willpower": 3,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 5,
+    "essence": 5.0
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "archery": 3,
+    "armorer": 3,
+    "gymnastics": 3,
+    "running": 3,
+    "swimming": 3,
+    "automotive-mechanic": 1,
+    "automatics": 4,
+    "blades": 4,
+    "clubs": 4,
+    "unarmed-combat": 4,
+    "computer": 1,
+    "demolitions": 3,
+    "first-aid": 1,
+    "gunnery": 3,
+    "heavy-weapons": 3,
+    "etiquette": 3,
+    "leadership": 3,
+    "negotiation": 3,
+    "intimidation": 4,
+    "longarms": 5,
+    "navigation": 1,
+    "perception": 3,
+    "pilot-ground-craft": 2,
+    "pistols": 5,
+    "sneaking": 3,
+    "survival": 2,
+    "throwing-weapons": 3
+  },
+  "knowledgeSkills": [
+    { "name": "Bogota", "category": "street", "rating": 3 },
+    { "name": "Catholicism", "category": "interests", "rating": 2 },
+    { "name": "Military Procedures", "category": "professional", "rating": 4 },
+    { "name": "Politics", "category": "academic", "rating": 3 },
+    { "name": "Psychology", "category": "academic", "rating": 2 },
+    { "name": "Sociology", "category": "academic", "rating": 2 }
+  ],
+  "languages": [
+    { "name": "Spanish", "rating": 0, "isNative": true },
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Aztlaner Spanish", "rating": 2, "isNative": false },
+    { "name": "Latin", "rating": 1, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "bilingual", "rating": 1, "specification": "English" },
+    { "qualityId": "guts", "rating": 1 },
+    { "qualityId": "high-pain-tolerance", "rating": 1 }
+  ],
+  "negativeQualities": [
+    { "qualityId": "addiction", "rating": 1, "specification": "Alcohol (Mild)" },
+    { "qualityId": "code-of-honor", "rating": 1, "specification": "Civilians and Noncombatants" }
+  ],
+  "cyberware": [
+    {
+      "catalogId": "cyberarm",
+      "name": "Obvious Cyberarm (Right)",
+      "category": "cyberlimb",
+      "grade": "standard",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.0,
+      "cost": 15000,
+      "availability": 4,
+      "attributeBonuses": { "strength": 2 },
+      "notes": "Custom Agility 5, Custom Strength 5"
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Arms Dealer",
+      "type": "Arms",
+      "connection": 2,
+      "loyalty": 3,
+      "notes": "Weapons and ammo"
+    },
+    {
+      "name": "Bartender",
+      "type": "Service",
+      "connection": 2,
+      "loyalty": 3,
+      "notes": "Information"
+    },
+    { "name": "Fixer", "type": "Fixer", "connection": 2, "loyalty": 2, "notes": "Jobs" },
+    {
+      "name": "Mr. Johnson",
+      "type": "Corporate",
+      "connection": 4,
+      "loyalty": 2,
+      "notes": "Corporate contracts"
+    }
+  ],
+  "gear": [
+    { "name": "Armorer Kit", "category": "tools", "quantity": 1, "cost": 500 },
+    { "name": "Climbing Gear", "category": "survival", "quantity": 1, "cost": 200 },
+    { "name": "Flashlight", "category": "survival", "quantity": 1, "cost": 25 },
+    { "name": "Gas Mask", "category": "survival", "quantity": 1, "cost": 200 },
+    {
+      "name": "Grapple Gun",
+      "category": "survival",
+      "quantity": 1,
+      "cost": 500,
+      "notes": "200m standard rope"
+    },
+    { "name": "Survival Kit", "category": "survival", "quantity": 1, "cost": 200 },
+    { "name": "Medkit", "category": "medical", "quantity": 1, "cost": 500, "rating": 3 },
+    {
+      "name": "Goggles",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 100,
+      "rating": 4,
+      "notes": "Flare Compensation, Image Link, Low-Light Vision, Smartlink"
+    },
+    { "name": "Jazz", "category": "drugs", "quantity": 8, "cost": 600 },
+    { "name": "Kamikaze", "category": "drugs", "quantity": 1, "cost": 100 },
+    { "name": "Area Jammer", "category": "electronics", "quantity": 1, "cost": 600, "rating": 4 },
+    { "name": "Micro-Transceivers", "category": "electronics", "quantity": 2, "cost": 200 },
+    {
+      "name": "Smart Firing Platform",
+      "category": "weapons-accessory",
+      "quantity": 1,
+      "cost": 2500
+    }
+  ],
+  "armor": [
+    {
+      "catalogId": "armor-vest",
+      "name": "Armor Vest",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 9,
+      "capacity": 9,
+      "cost": 500,
+      "quantity": 1,
+      "equipped": true
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "ares-alpha",
+      "name": "Ares Alpha",
+      "category": "weapons",
+      "subcategory": "assault-rifle",
+      "damage": "11P",
+      "ap": -2,
+      "mode": ["SA", "BF", "FA"],
+      "recoil": 2,
+      "accuracy": 5,
+      "ammoCapacity": 42,
+      "cost": 2650,
+      "quantity": 1,
+      "notes": "w/ Grenade Launcher, 4 spare clips, 420 regular, 200 explosive, 150 Stick-n-Shock"
+    },
+    {
+      "catalogId": "ares-desert-strike",
+      "name": "Ares Desert Strike",
+      "category": "weapons",
+      "subcategory": "sniper-rifle",
+      "damage": "14P",
+      "ap": -5,
+      "mode": ["SA"],
+      "recoil": 1,
+      "accuracy": 7,
+      "ammoCapacity": 14,
+      "cost": 17500,
+      "quantity": 1,
+      "notes": "Bipod, 200 rounds explosive"
+    },
+    {
+      "catalogId": "hk-227",
+      "name": "HK-227",
+      "category": "weapons",
+      "subcategory": "smg",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SA", "BF", "FA"],
+      "recoil": 1,
+      "accuracy": 5,
+      "ammoCapacity": 28,
+      "cost": 730,
+      "quantity": 1,
+      "notes": "2 spare clips, 280 regular"
+    },
+    {
+      "catalogId": "ingram-valiant",
+      "name": "Ingram Valiant",
+      "category": "weapons",
+      "subcategory": "lmg",
+      "damage": "9P",
+      "ap": -2,
+      "mode": ["BF", "FA"],
+      "recoil": 2,
+      "accuracy": 5,
+      "ammoCapacity": 50,
+      "cost": 5800,
+      "quantity": 1,
+      "notes": "Belt of 200 rounds"
+    },
+    {
+      "catalogId": "ares-crusader-ii",
+      "name": "Ares Crusader II",
+      "category": "weapons",
+      "subcategory": "machine-pistol",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SA", "BF"],
+      "recoil": 2,
+      "accuracy": 5,
+      "ammoCapacity": 40,
+      "cost": 830,
+      "quantity": 1,
+      "notes": "Silencer, 2 spare clips, 400 regular"
+    },
+    {
+      "catalogId": "fichetti-security-600",
+      "name": "Fichetti Security 600",
+      "category": "weapons",
+      "subcategory": "light-pistol",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SA"],
+      "recoil": 1,
+      "accuracy": 6,
+      "ammoCapacity": 30,
+      "cost": 350,
+      "quantity": 1,
+      "notes": "Concealed holster, 300 rounds"
+    },
+    {
+      "catalogId": "ruger-super-warhawk",
+      "name": "Ruger Super Warhawk",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "9P",
+      "ap": -2,
+      "mode": ["SS"],
+      "accuracy": 5,
+      "ammoCapacity": 6,
+      "cost": 400,
+      "quantity": 1,
+      "notes": "Quick draw holster, 4 speed loaders, 60 regular, 50 explosive"
+    },
+    {
+      "catalogId": "enfield-as-7",
+      "name": "Enfield AS-7",
+      "category": "weapons",
+      "subcategory": "shotgun",
+      "damage": "13P",
+      "ap": -1,
+      "mode": ["SA", "BF"],
+      "accuracy": 4,
+      "ammoCapacity": 10,
+      "cost": 1100,
+      "quantity": 1,
+      "notes": "4 spare clips, 200 regular, 100 gel, 200 Stick-n-Shock"
+    },
+    {
+      "catalogId": "defiance-ex-shocker",
+      "name": "Defiance EX Shocker",
+      "category": "weapons",
+      "subcategory": "taser",
+      "damage": "9S(e)",
+      "ap": -5,
+      "mode": ["SA"],
+      "accuracy": 4,
+      "ammoCapacity": 4,
+      "cost": 250,
+      "quantity": 1,
+      "notes": "20 darts"
+    },
+    {
+      "catalogId": "bow",
+      "name": "Bow (Rating 3)",
+      "category": "weapons",
+      "subcategory": "bow",
+      "damage": "5P",
+      "ap": -1,
+      "mode": ["SS"],
+      "accuracy": 6,
+      "cost": 300,
+      "quantity": 1,
+      "rating": 3,
+      "notes": "20 arrows"
+    },
+    {
+      "catalogId": "high-explosive-grenade",
+      "name": "High-Explosive Grenade",
+      "category": "weapons",
+      "subcategory": "grenade",
+      "damage": "16P",
+      "ap": -2,
+      "mode": [],
+      "cost": 100,
+      "quantity": 4
+    },
+    {
+      "catalogId": "thermal-smoke-grenade",
+      "name": "Thermal Smoke Grenade",
+      "category": "weapons",
+      "subcategory": "grenade",
+      "damage": "-",
+      "ap": 0,
+      "mode": [],
+      "cost": 60,
+      "quantity": 4
+    },
+    {
+      "catalogId": "shuriken",
+      "name": "Shuriken",
+      "category": "weapons",
+      "subcategory": "throwing-weapon",
+      "damage": "4P",
+      "ap": -1,
+      "mode": [],
+      "accuracy": 4,
+      "cost": 25,
+      "quantity": 2
+    },
+    {
+      "catalogId": "katana",
+      "name": "Katana",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "6P",
+      "ap": -3,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 7,
+      "cost": 1000,
+      "quantity": 2
+    },
+    {
+      "catalogId": "combat-knife",
+      "name": "Combat Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "5P",
+      "ap": -3,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 6,
+      "cost": 300,
+      "quantity": 1
+    },
+    {
+      "catalogId": "survival-knife",
+      "name": "Survival Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "5P",
+      "ap": -1,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 5,
+      "cost": 100,
+      "quantity": 1
+    },
+    {
+      "catalogId": "extendable-baton",
+      "name": "Extendable Baton",
+      "category": "weapons",
+      "subcategory": "club",
+      "damage": "5S",
+      "ap": 0,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 5,
+      "cost": 100,
+      "quantity": 1
+    }
+  ],
+  "vehicles": [
+    {
+      "id": "mercenary-vehicle-1",
+      "name": "Toyota Gopher",
+      "type": "ground",
+      "handling": 4,
+      "speed": 3,
+      "acceleration": 1,
+      "body": 14,
+      "armor": 6,
+      "pilot": 1,
+      "sensor": 1,
+      "seats": 3,
+      "notes": "Pickup truck"
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "erika-elite",
+      "name": "Erika Elite",
+      "deviceRating": 4,
+      "cost": 2500
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": {
+        "type": "fake",
+        "rating": 3
+      },
+      "licenses": [
+        { "type": "fake", "rating": 3, "name": "Concealed Carry License" },
+        { "type": "fake", "rating": 3, "name": "Gun License" },
+        { "type": "fake", "rating": 3, "name": "Hunting License" }
+      ]
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "low",
+      "monthlyCost": 2000,
+      "prepaidMonths": 1
+    }
+  ],
+  "nuyen": 4800,
+  "startingNuyen": 450000,
+  "derivedStats": {
+    "physicalLimit": 5,
+    "mentalLimit": 4,
+    "socialLimit": 5,
+    "initiativeBase": 7,
+    "initiativeDice": 1,
+    "physicalConditionMonitor": 10,
+    "stunConditionMonitor": 10,
+    "composure": 6,
+    "judgeIntentions": 6,
+    "memory": 6,
+    "liftCarry": 7
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Mercenary / Street Samurai",
+    "notes": "Priority: A-Resources, B-Skills, C-Attributes, D-Metatype(Human), E-Magic. Extensive arsenal covering all combat scenarios."
+  }
+}

--- a/data/editions/sr5/example-characters/rigger-troll.json
+++ b/data/editions/sr5/example-characters/rigger-troll.json
@@ -1,0 +1,335 @@
+{
+  "id": "example-rigger-troll",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Rigger (Example)",
+  "metatype": "troll",
+  "description": "A troll rigger specializing in vehicle operation across multiple platforms - ground, water, and air. This character combines a control rig with muscle toners for improved reflexes and maintains a small fleet of armed vehicles. The Middle lifestyle with attached garage provides workspace for vehicle maintenance.",
+  "status": "draft",
+  "attributes": {
+    "body": 5,
+    "agility": 2,
+    "reaction": 5,
+    "strength": 5,
+    "willpower": 3,
+    "logic": 2,
+    "intuition": 5,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 4.1
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "electronic-warfare": 2,
+    "etiquette": 2,
+    "gunnery": 5,
+    "navigation": 1,
+    "negotiation": 3,
+    "pilot-aircraft": 5,
+    "pilot-ground-craft": 6,
+    "pilot-watercraft": 2,
+    "pistols": 3
+  },
+  "knowledgeSkills": [
+    { "name": "Backstreets", "category": "street", "rating": 3 },
+    { "name": "Sci-Fi Flicks", "category": "interests", "rating": 2 },
+    { "name": "Seattle Waterways", "category": "street", "rating": 1 },
+    { "name": "Smuggling Routes", "category": "street", "rating": 4 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Salish", "rating": 2, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "gearhead", "rating": 1 },
+    { "qualityId": "natural-hardening", "rating": 1 }
+  ],
+  "negativeQualities": [
+    { "qualityId": "allergy", "rating": 2, "specification": "Sunlight (Moderate)" }
+  ],
+  "racialQualities": [
+    "Thermographic Vision",
+    "+1 Reach",
+    "+1 Dermal Armor",
+    "+4 Body",
+    "+4 Strength"
+  ],
+  "cyberware": [
+    {
+      "catalogId": "control-rig",
+      "name": "Control Rig",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.0,
+      "rating": 2,
+      "cost": 97000,
+      "availability": 12,
+      "legality": "restricted",
+      "notes": "+2 dice vehicle tests, +2 vehicle limits when jumped in"
+    },
+    {
+      "catalogId": "datajack",
+      "name": "Datajack",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.1,
+      "essenceCost": 0.1,
+      "cost": 1000,
+      "availability": 2
+    },
+    {
+      "catalogId": "smartlink",
+      "name": "Smartlink",
+      "category": "eyeware",
+      "grade": "standard",
+      "baseEssenceCost": 0.2,
+      "essenceCost": 0.2,
+      "cost": 4000,
+      "availability": 4,
+      "legality": "restricted",
+      "notes": "+2 Accuracy with smartguns"
+    }
+  ],
+  "bioware": [
+    {
+      "catalogId": "muscle-toner",
+      "name": "Muscle Toner",
+      "category": "bioware",
+      "grade": "standard",
+      "baseEssenceCost": 0.4,
+      "essenceCost": 0.4,
+      "rating": 2,
+      "cost": 32000,
+      "availability": 8,
+      "legality": "restricted",
+      "attributeBonuses": { "agility": 2 }
+    },
+    {
+      "catalogId": "smuggling-compartment",
+      "name": "Smuggling Compartment",
+      "category": "bioware",
+      "grade": "standard",
+      "baseEssenceCost": 0.2,
+      "essenceCost": 0.2,
+      "cost": 7500,
+      "availability": 6,
+      "legality": "forbidden",
+      "notes": "Hidden storage"
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Mechanic",
+      "type": "Service",
+      "connection": 3,
+      "loyalty": 4,
+      "notes": "Vehicle repairs and modifications"
+    },
+    {
+      "name": "Coast Guard Captain",
+      "type": "Government",
+      "connection": 2,
+      "loyalty": 3,
+      "notes": "Maritime information"
+    },
+    { "name": "Fixer", "type": "Fixer", "connection": 1, "loyalty": 1, "notes": "Jobs" }
+  ],
+  "gear": [
+    {
+      "name": "Sunglasses",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 100,
+      "rating": 4,
+      "notes": "Low-light, Flare Compensation, Vision Enhancement 2"
+    },
+    {
+      "name": "DocWagon Contract",
+      "category": "services",
+      "quantity": 1,
+      "cost": 50000,
+      "notes": "Platinum (1 year)"
+    },
+    { "name": "Medkit", "category": "medical", "quantity": 1, "cost": 1500, "rating": 6 }
+  ],
+  "vehicles": [
+    {
+      "catalogId": "harley-davidson-scorpion",
+      "name": "Harley-Davidson Scorpion",
+      "type": "ground",
+      "handling": "4/3",
+      "speed": 4,
+      "acceleration": 2,
+      "body": 8,
+      "armor": 9,
+      "pilot": 1,
+      "sensor": 2,
+      "cost": 12000,
+      "notes": "Motorcycle, Rigger interface, 2 standard weapon mounts with Ares Alpha (100 APDS) and Enfield AS-7 (100 explosive)"
+    },
+    {
+      "catalogId": "northrup-wasp",
+      "name": "Northrup Wasp",
+      "type": "aircraft",
+      "handling": 5,
+      "speed": 5,
+      "acceleration": 3,
+      "body": 10,
+      "armor": 8,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 50000,
+      "notes": "LAV, Rigger interface, heavy weapon mount with Stoner-Ares M202 (500 explosive)"
+    },
+    {
+      "catalogId": "gmc-bulldog",
+      "name": "GMC Bulldog",
+      "type": "ground",
+      "handling": 3,
+      "speed": 3,
+      "acceleration": 1,
+      "body": 16,
+      "armor": 12,
+      "pilot": 1,
+      "sensor": 2,
+      "seats": 6,
+      "cost": 35000,
+      "notes": "Step Van, Rigger interface"
+    }
+  ],
+  "armor": [
+    {
+      "catalogId": "armor-jacket",
+      "name": "Armor Jacket",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 12,
+      "capacity": 12,
+      "cost": 1000,
+      "quantity": 1,
+      "equipped": true
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "ares-light-fire-75",
+      "name": "Ares Light Fire 75",
+      "category": "weapons",
+      "subcategory": "light-pistol",
+      "damage": "6P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 6,
+      "ammoCapacity": 16,
+      "cost": 1250,
+      "quantity": 1,
+      "notes": "Smartlink, 50 rounds"
+    },
+    {
+      "catalogId": "ares-predator-v",
+      "name": "Ares Predator V",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "8P",
+      "ap": -1,
+      "mode": ["SA"],
+      "accuracy": 5,
+      "ammoCapacity": 15,
+      "cost": 725,
+      "quantity": 1,
+      "notes": "Smartlink, 50 rounds APDS"
+    },
+    {
+      "catalogId": "streetline-special",
+      "name": "Streetline Special",
+      "category": "weapons",
+      "subcategory": "hold-out",
+      "damage": "6P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 4,
+      "ammoCapacity": 6,
+      "cost": 120,
+      "quantity": 1,
+      "notes": "50 rounds"
+    },
+    {
+      "catalogId": "defiance-ex-shocker",
+      "name": "Defiance EX Shocker",
+      "category": "weapons",
+      "subcategory": "taser",
+      "damage": "9S(e)",
+      "ap": -5,
+      "mode": ["SS"],
+      "accuracy": 4,
+      "ammoCapacity": 4,
+      "cost": 250,
+      "quantity": 1,
+      "notes": "50 darts"
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "transys-avalon",
+      "name": "Transys Avalon",
+      "deviceRating": 6,
+      "cost": 5000
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 4 },
+      "licenses": []
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "middle",
+      "monthlyCost": 5000,
+      "prepaidMonths": 3,
+      "notes": "Attached three-car garage (Special Work Area)"
+    }
+  ],
+  "nuyen": 1145,
+  "startingNuyen": 450000,
+  "derivedStats": {
+    "physicalLimit": 7,
+    "mentalLimit": 4,
+    "socialLimit": 6,
+    "initiativeBase": 10,
+    "initiativeDice": 1,
+    "matrixInitiativeAR": 10,
+    "matrixInitiativeDiceAR": 1,
+    "matrixInitiativeColdVR": 10,
+    "matrixInitiativeDiceColdVR": 2,
+    "matrixInitiativeHotVR": 10,
+    "matrixInitiativeDiceHotVR": 3,
+    "physicalConditionMonitor": 11,
+    "stunConditionMonitor": 10,
+    "composure": 7,
+    "judgeIntentions": 9,
+    "memory": 7,
+    "liftCarry": 10
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 4,
+  "karmaSpentAtCreation": 21,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Rigger / Wheelman",
+    "notes": "Priority: A-Resources, B-Attributes, C-Metatype(Troll), D-Skills, E-Magic. Control Rig 2 (+2 dice, +2 limits) + Gearhead (+2 dice, +1 limit) = exceptional vehicle operator. Total Armor: 13 (12 jacket + 1 racial dermal armor)."
+  }
+}

--- a/data/editions/sr5/example-characters/shaman-elf.json
+++ b/data/editions/sr5/example-characters/shaman-elf.json
@@ -1,0 +1,254 @@
+{
+  "id": "example-shaman-elf",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Shaman (Example)",
+  "metatype": "elf",
+  "description": "A Salish-Sidhe elf shaman following the path of Bear, specializing in healing and support magic. This character combines traditional tribal shamanism with alchemical knowledge.",
+  "status": "draft",
+  "attributes": {
+    "body": 4,
+    "agility": 4,
+    "reaction": 4,
+    "strength": 5,
+    "willpower": 4,
+    "logic": 4,
+    "intuition": 4,
+    "charisma": 6
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6.0,
+    "magic": 3
+  },
+  "magicalPath": "magician",
+  "tradition": "shamanic",
+  "mentorSpirit": "bear",
+  "skills": {
+    "alchemy": 4,
+    "animal-handling": 2,
+    "assensing": 3,
+    "gymnastics": 1,
+    "running": 1,
+    "swimming": 1,
+    "banishing": 2,
+    "blades": 3,
+    "conjuring": 6,
+    "disguise": 1,
+    "etiquette": 2,
+    "first-aid": 4,
+    "intimidation": 2,
+    "medicine": 4,
+    "navigation": 1,
+    "negotiation": 2,
+    "perception": 1,
+    "performance": 2,
+    "sneaking": 1,
+    "counterspelling": 4,
+    "ritual-spellcasting": 4,
+    "spellcasting": 4,
+    "survival": 1,
+    "throwing-weapons": 1,
+    "unarmed-combat": 1
+  },
+  "knowledgeSkills": [
+    { "name": "Politics", "category": "academic", "rating": 2 },
+    { "name": "Salish-Sidhe Nation", "category": "street", "rating": 3 },
+    { "name": "Sprawl Life", "category": "street", "rating": 4 },
+    { "name": "Tarislar", "category": "street", "rating": 4 },
+    { "name": "Tir Tairngire", "category": "street", "rating": 2 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Salish", "rating": 2, "isNative": false },
+    { "name": "Sperethiel", "rating": 0, "isNative": true }
+  ],
+  "positiveQualities": [
+    { "qualityId": "bilingual", "rating": 1, "specification": "Sperethiel" },
+    { "qualityId": "mentor-spirit", "rating": 1, "specification": "Bear" },
+    { "qualityId": "spirit-affinity", "rating": 1, "specification": "Beast Spirits" }
+  ],
+  "negativeQualities": [
+    { "qualityId": "gremlins", "rating": 2 },
+    { "qualityId": "prejudiced", "rating": 1, "specification": "Hermetic Magicians (Biased)" },
+    { "qualityId": "simsense-vertigo", "rating": 1 }
+  ],
+  "racialQualities": ["Low-Light Vision"],
+  "spells": [
+    { "id": "spell-antidote", "catalogId": "antidote", "name": "Antidote" },
+    { "id": "spell-cure-disease", "catalogId": "cure-disease", "name": "Cure Disease" },
+    { "id": "spell-entertainment", "catalogId": "entertainment", "name": "Entertainment" },
+    { "id": "spell-heal", "catalogId": "heal", "name": "Heal" },
+    { "id": "spell-mana-bolt", "catalogId": "manabolt", "name": "Mana Bolt" }
+  ],
+  "contacts": [
+    { "name": "Street Ganger", "type": "Gang", "connection": 2, "loyalty": 3 },
+    {
+      "name": "Talismonger",
+      "type": "Magic",
+      "connection": 2,
+      "loyalty": 3,
+      "notes": "Magical supplies"
+    },
+    {
+      "name": "Tamanous Member",
+      "type": "Underworld",
+      "connection": 1,
+      "loyalty": 1,
+      "notes": "Organlegger contact"
+    },
+    {
+      "name": "Tarislar Politician",
+      "type": "Government",
+      "connection": 3,
+      "loyalty": 3,
+      "notes": "Elven district influence"
+    },
+    {
+      "name": "Tribal Bureaucrat",
+      "type": "Government",
+      "connection": 2,
+      "loyalty": 2,
+      "notes": "Salish-Sidhe official"
+    }
+  ],
+  "gear": [
+    { "name": "Alchemy Kit", "category": "magical", "quantity": 1, "cost": 500 },
+    {
+      "name": "Magical Lodge Materials",
+      "category": "magical",
+      "quantity": 1,
+      "cost": 1500,
+      "rating": 3
+    },
+    { "name": "Biomonitor", "category": "medical", "quantity": 1, "cost": 300 },
+    { "name": "Medkit", "category": "medical", "quantity": 1, "cost": 500, "rating": 4 },
+    { "name": "Medkit Supplies", "category": "medical", "quantity": 1, "cost": 200 },
+    { "name": "Flashlight", "category": "survival", "quantity": 1, "cost": 25 }
+  ],
+  "foci": [
+    {
+      "catalogId": "spell-focus-health",
+      "name": "Spell Focus (Health)",
+      "type": "spell",
+      "force": 2,
+      "bonded": true,
+      "karmaToBond": 4,
+      "cost": 8000,
+      "availability": 8,
+      "legality": "restricted"
+    }
+  ],
+  "armor": [
+    {
+      "catalogId": "lined-coat",
+      "name": "Lined Coat",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 9,
+      "capacity": 9,
+      "cost": 900,
+      "quantity": 1,
+      "equipped": true
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "combat-knife",
+      "name": "Combat Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "7P",
+      "ap": -3,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 6,
+      "cost": 300,
+      "quantity": 1
+    },
+    {
+      "catalogId": "survival-knife",
+      "name": "Survival Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "7P",
+      "ap": -1,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 5,
+      "cost": 100,
+      "quantity": 1
+    },
+    {
+      "catalogId": "throwing-knife",
+      "name": "Throwing Knife",
+      "category": "weapons",
+      "subcategory": "throwing-weapon",
+      "damage": "6P",
+      "ap": -1,
+      "mode": [],
+      "accuracy": 0,
+      "cost": 25,
+      "quantity": 3
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "renraku-sensei",
+      "name": "Renraku Sensei",
+      "deviceRating": 3,
+      "cost": 1000
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 3 },
+      "licenses": [
+        { "type": "fake", "rating": 3, "name": "Magic License" },
+        { "type": "fake", "rating": 3, "name": "Medicine License" }
+      ]
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "squatter",
+      "monthlyCost": 500,
+      "prepaidMonths": 2
+    }
+  ],
+  "nuyen": 0,
+  "startingNuyen": 6000,
+  "derivedStats": {
+    "physicalLimit": 6,
+    "mentalLimit": 6,
+    "socialLimit": 8,
+    "initiativeBase": 8,
+    "initiativeDice": 1,
+    "astralInitiativeBase": 8,
+    "astralInitiativeDice": 3,
+    "physicalConditionMonitor": 10,
+    "stunConditionMonitor": 10,
+    "composure": 10,
+    "judgeIntentions": 10,
+    "memory": 8,
+    "liftCarry": 9
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Shaman / Healer",
+    "notes": "Priority: A-Attributes, B-Skills, C-Magic, D-Metatype(Elf), E-Resources. Shamanic Tradition (Drain: Willpower + Charisma), Mentor Spirit: Bear."
+  }
+}

--- a/data/editions/sr5/example-characters/street-samurai-ork.json
+++ b/data/editions/sr5/example-characters/street-samurai-ork.json
@@ -1,0 +1,490 @@
+{
+  "id": "example-street-samurai-ork",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Street Samurai (Example)",
+  "metatype": "ork",
+  "description": "A classic chrome warrior with extensive cyberware including cyberlimbs, synaptic booster, and cybereyes. Follows the Code of Honor (Bushido).",
+  "status": "draft",
+  "attributes": {
+    "body": 7,
+    "agility": 6,
+    "reaction": 5,
+    "strength": 5,
+    "willpower": 3,
+    "logic": 2,
+    "intuition": 3,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 0.88
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "automatics": 5,
+    "blades": 5,
+    "longarms": 3,
+    "pilot-ground-craft": 1,
+    "pistols": 4,
+    "sneaking": 2,
+    "unarmed-combat": 2
+  },
+  "knowledgeSkills": [
+    { "name": "Great Restaurants", "category": "interests", "rating": 2 },
+    { "name": "Law Enforcement", "category": "street", "rating": 2 },
+    { "name": "Poetry", "category": "academic", "rating": 1 },
+    { "name": "Safe Houses", "category": "street", "rating": 3 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "Japanese", "rating": 2, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "ambidextrous", "rating": 1 },
+    { "qualityId": "code-of-honor", "rating": 1, "specification": "Bushido" },
+    { "qualityId": "guts", "rating": 1 },
+    { "qualityId": "home-ground", "rating": 1, "specification": "Street Politics" }
+  ],
+  "negativeQualities": [{ "qualityId": "incompetent", "rating": 1, "specification": "Acting" }],
+  "racialQualities": ["Low-Light Vision"],
+  "cyberware": [
+    {
+      "catalogId": "cybereyes",
+      "name": "Cybereyes (Rating 3)",
+      "category": "eyeware",
+      "grade": "standard",
+      "baseEssenceCost": 0.4,
+      "essenceCost": 0.4,
+      "rating": 3,
+      "cost": 10000,
+      "availability": 9,
+      "notes": "Flare compensation, low-light, smartlink, thermographic, vision enhancement 2, vision magnification"
+    },
+    {
+      "catalogId": "dermal-plating",
+      "name": "Dermal Plating (Rating 2)",
+      "category": "bodyware",
+      "grade": "alpha",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 0.8,
+      "rating": 2,
+      "cost": 12000,
+      "availability": 12,
+      "legality": "restricted",
+      "armorBonus": 2
+    },
+    {
+      "catalogId": "cyberarm",
+      "name": "Cyberarm (Right)",
+      "category": "cyberlimb",
+      "grade": "standard",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.0,
+      "cost": 15000,
+      "availability": 4,
+      "notes": "Obvious, STR 11, AGI 9, w/ external clip port, cyber sub-machine gun"
+    },
+    {
+      "catalogId": "cyberarm",
+      "name": "Cyberarm (Left)",
+      "category": "cyberlimb",
+      "grade": "standard",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.0,
+      "cost": 15000,
+      "availability": 4,
+      "notes": "Obvious, STR 11, AGI 9, Armor 2, cyber spur, cyberslide"
+    },
+    {
+      "catalogId": "enhanced-articulation",
+      "name": "Enhanced Articulation",
+      "category": "bodyware",
+      "grade": "standard",
+      "baseEssenceCost": 0.3,
+      "essenceCost": 0.3,
+      "cost": 24000,
+      "availability": 12
+    },
+    {
+      "catalogId": "platelet-factories",
+      "name": "Platelet Factories",
+      "category": "bodyware",
+      "grade": "standard",
+      "baseEssenceCost": 0.2,
+      "essenceCost": 0.2,
+      "cost": 17000,
+      "availability": 12,
+      "notes": "+1 die to resist bleeding"
+    },
+    {
+      "catalogId": "reflex-recorder",
+      "name": "Reflex Recorder (Blades)",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.1,
+      "essenceCost": 0.1,
+      "cost": 14000,
+      "availability": 10,
+      "notes": "+1 to Blades"
+    },
+    {
+      "catalogId": "reflex-recorder",
+      "name": "Reflex Recorder (Longarms)",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.1,
+      "essenceCost": 0.1,
+      "cost": 14000,
+      "availability": 10,
+      "notes": "+1 to Longarms"
+    },
+    {
+      "catalogId": "reflex-recorder",
+      "name": "Reflex Recorder (Sneaking)",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.1,
+      "essenceCost": 0.1,
+      "cost": 14000,
+      "availability": 10,
+      "notes": "+1 to Sneaking"
+    },
+    {
+      "catalogId": "reflex-recorder",
+      "name": "Reflex Recorder (Unarmed Combat)",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.1,
+      "essenceCost": 0.1,
+      "cost": 14000,
+      "availability": 10,
+      "notes": "+1 to Unarmed Combat"
+    },
+    {
+      "catalogId": "synaptic-booster",
+      "name": "Synaptic Booster (Rating 2)",
+      "category": "bodyware",
+      "grade": "standard",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.0,
+      "rating": 2,
+      "cost": 190000,
+      "availability": 12,
+      "legality": "restricted",
+      "attributeBonuses": { "reaction": 2 },
+      "initiativeDiceBonus": 2
+    },
+    {
+      "catalogId": "synthacardium",
+      "name": "Synthacardium (Rating 1)",
+      "category": "bodyware",
+      "grade": "standard",
+      "baseEssenceCost": 0.1,
+      "essenceCost": 0.1,
+      "rating": 1,
+      "cost": 30000,
+      "availability": 8,
+      "notes": "+1 die to physical tests"
+    }
+  ],
+  "contacts": [{ "name": "Fixer", "type": "Fixer", "connection": 4, "loyalty": 2 }],
+  "gear": [
+    { "name": "Medkit", "category": "medical", "quantity": 1, "cost": 500, "rating": 3 },
+    { "name": "Medkit", "category": "medical", "quantity": 1, "cost": 1500, "rating": 6 },
+    { "name": "Spatial Recognizer", "category": "audio-enhancement", "quantity": 1, "cost": 1000 },
+    { "name": "Area Jammer", "category": "electronics", "quantity": 1, "cost": 600, "rating": 4 },
+    { "name": "Micro-Transceiver", "category": "electronics", "quantity": 1, "cost": 100 },
+    {
+      "name": "White Noise Generator",
+      "category": "electronics",
+      "quantity": 1,
+      "cost": 150,
+      "rating": 6
+    },
+    { "name": "Stim Patches", "category": "medical", "quantity": 5, "cost": 250, "rating": 6 },
+    { "name": "Trauma Patches", "category": "medical", "quantity": 2, "cost": 1000 }
+  ],
+  "armor": [
+    {
+      "catalogId": "lined-coat",
+      "name": "Lined Coat",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 9,
+      "capacity": 9,
+      "capacityUsed": 9,
+      "cost": 900,
+      "quantity": 1,
+      "equipped": true,
+      "modifications": [
+        {
+          "catalogId": "chemical-protection",
+          "name": "Chemical Protection",
+          "rating": 3,
+          "capacityUsed": 3,
+          "cost": 750,
+          "availability": 6
+        },
+        {
+          "catalogId": "fire-resistance",
+          "name": "Fire Resistance",
+          "rating": 3,
+          "capacityUsed": 3,
+          "cost": 750,
+          "availability": 6
+        },
+        {
+          "catalogId": "nonconductivity",
+          "name": "Nonconductivity",
+          "rating": 3,
+          "capacityUsed": 3,
+          "cost": 750,
+          "availability": 6
+        }
+      ]
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "katana",
+      "name": "Katana",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "14P",
+      "ap": -3,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 7,
+      "cost": 1000,
+      "quantity": 1,
+      "notes": "STR-based damage with cyberlimbs"
+    },
+    {
+      "catalogId": "sword",
+      "name": "Sword",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "14P",
+      "ap": -2,
+      "mode": [],
+      "reach": 1,
+      "accuracy": 6,
+      "cost": 500,
+      "quantity": 1
+    },
+    {
+      "catalogId": "spur",
+      "name": "Spurs (Cyber)",
+      "category": "weapons",
+      "subcategory": "cyber-weapon",
+      "damage": "14P",
+      "ap": -2,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 9,
+      "cost": 0,
+      "quantity": 1,
+      "notes": "Built into left cyberarm"
+    },
+    {
+      "catalogId": "ares-light-fire-75",
+      "name": "Ares Light Fire 75",
+      "category": "weapons",
+      "subcategory": "light-pistol",
+      "damage": "6P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 6,
+      "ammoCapacity": 16,
+      "cost": 1250,
+      "quantity": 1,
+      "notes": "3 spare clips, 100 rounds regular ammo"
+    },
+    {
+      "catalogId": "ares-predator-v",
+      "name": "Ares Predator V",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "8P",
+      "ap": -5,
+      "mode": ["SA"],
+      "accuracy": 5,
+      "ammoCapacity": 15,
+      "cost": 725,
+      "quantity": 1,
+      "notes": "APDS ammo (100 rounds), 3 spare clips"
+    },
+    {
+      "catalogId": "hk-227",
+      "name": "HK-227",
+      "category": "weapons",
+      "subcategory": "smg",
+      "damage": "8P",
+      "ap": -1,
+      "mode": ["SA", "BF", "FA"],
+      "recoil": 1,
+      "accuracy": 5,
+      "ammoCapacity": 28,
+      "cost": 730,
+      "quantity": 1,
+      "notes": "3 spare clips, 100 rounds explosive ammo"
+    },
+    {
+      "catalogId": "fn-har",
+      "name": "FN HAR",
+      "category": "weapons",
+      "subcategory": "assault-rifle",
+      "damage": "10P",
+      "ap": -6,
+      "mode": ["SA", "BF", "FA"],
+      "recoil": 2,
+      "accuracy": 5,
+      "ammoCapacity": 35,
+      "cost": 2100,
+      "quantity": 1,
+      "notes": "Integral smartlink, 3 spare clips, 100 rounds APDS ammo"
+    },
+    {
+      "catalogId": "enfield-as-7",
+      "name": "Enfield AS-7",
+      "category": "weapons",
+      "subcategory": "shotgun",
+      "damage": "15P(f)",
+      "ap": 4,
+      "mode": ["SA", "BF"],
+      "accuracy": 4,
+      "ammoCapacity": 10,
+      "cost": 1100,
+      "quantity": 1,
+      "notes": "Internal smartlink, 3 spare clips, 100 rounds flechette ammo"
+    },
+    {
+      "catalogId": "ingram-valiant",
+      "name": "Ingram Valiant",
+      "category": "weapons",
+      "subcategory": "lmg",
+      "damage": "10P",
+      "ap": -3,
+      "mode": ["BF", "FA"],
+      "recoil": 2,
+      "accuracy": 5,
+      "ammoCapacity": 50,
+      "cost": 5800,
+      "quantity": 1,
+      "notes": "Integral smartlink, 3 spare clips, 100 rounds explosive ammo"
+    },
+    {
+      "catalogId": "high-explosive-grenade",
+      "name": "High Explosive Grenade",
+      "category": "weapons",
+      "subcategory": "grenade",
+      "damage": "16P",
+      "ap": -2,
+      "mode": [],
+      "cost": 100,
+      "quantity": 3,
+      "notes": "Non-aerodynamic, Blast -2/m"
+    }
+  ],
+  "vehicles": [
+    {
+      "id": "street-samurai-vehicle-1",
+      "name": "Harley-Davidson Scorpion",
+      "type": "ground",
+      "handling": 4,
+      "speed": 4,
+      "acceleration": 2,
+      "body": 8,
+      "armor": 9,
+      "pilot": 1,
+      "sensor": 2,
+      "seats": 1
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "hermes-ikon",
+      "name": "Hermes Ikon",
+      "deviceRating": 5,
+      "cost": 3000
+    }
+  ],
+  "identities": [
+    {
+      "name": "Identity 1",
+      "sin": { "type": "fake", "rating": 4 },
+      "licenses": [
+        { "type": "fake", "rating": 4, "name": "Concealed Carry" },
+        { "type": "fake", "rating": 4, "name": "Firearms" },
+        { "type": "fake", "rating": 4, "name": "Augmentations" }
+      ]
+    },
+    {
+      "name": "Identity 2",
+      "sin": { "type": "fake", "rating": 4 },
+      "licenses": [
+        { "type": "fake", "rating": 4, "name": "Concealed Carry" },
+        { "type": "fake", "rating": 4, "name": "Firearms" },
+        { "type": "fake", "rating": 4, "name": "Augmentations" }
+      ]
+    },
+    {
+      "name": "Identity 3",
+      "sin": { "type": "fake", "rating": 4 },
+      "licenses": [
+        { "type": "fake", "rating": 4, "name": "Concealed Carry" },
+        { "type": "fake", "rating": 4, "name": "Firearms" },
+        { "type": "fake", "rating": 4, "name": "Augmentations" }
+      ]
+    },
+    {
+      "name": "Identity 4",
+      "sin": { "type": "fake", "rating": 4 },
+      "licenses": [
+        { "type": "fake", "rating": 4, "name": "Concealed Carry" },
+        { "type": "fake", "rating": 4, "name": "Firearms" },
+        { "type": "fake", "rating": 4, "name": "Augmentations" }
+      ]
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "middle",
+      "monthlyCost": 5000,
+      "prepaidMonths": 3
+    }
+  ],
+  "nuyen": 2555,
+  "startingNuyen": 450000,
+  "derivedStats": {
+    "physicalLimit": 8,
+    "mentalLimit": 4,
+    "socialLimit": 3,
+    "initiativeBase": 10,
+    "initiativeDice": 3,
+    "physicalConditionMonitor": 12,
+    "stunConditionMonitor": 10,
+    "composure": 5,
+    "judgeIntentions": 5,
+    "memory": 5,
+    "liftCarry": 12
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Street Samurai / Chrome Warrior",
+    "notes": "Priority: A-Resources, B-Attributes, C-Metatype(Ork), D-Skills, E-Magic. Extensive cyberware including dual cyberarms with enhanced stats."
+  }
+}

--- a/data/editions/sr5/example-characters/technomancer-human.json
+++ b/data/editions/sr5/example-characters/technomancer-human.json
@@ -1,0 +1,305 @@
+{
+  "id": "example-technomancer-human",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Technomancer (Example)",
+  "metatype": "human",
+  "description": "A human technomancer with an innate connection to the Matrix. This character manipulates the digital world through sheer will and Resonance rather than hardware. Strong electronic warfare skills combined with complex forms make them a formidable Matrix operative. A former NeoNET employee with lingering prejudice against NeoNET citizens.",
+  "status": "draft",
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 5,
+    "logic": 5,
+    "intuition": 6,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 3,
+    "essence": 6.0,
+    "resonance": 5
+  },
+  "magicalPath": "technomancer",
+  "skills": {
+    "compiling": 3,
+    "computer": 4,
+    "cybercombat": 4,
+    "decompiling": 2,
+    "electronic-warfare": 6,
+    "first-aid": 1,
+    "hacking": 4,
+    "hardware": 2,
+    "software": 4,
+    "gymnastics": 1,
+    "running": 1,
+    "swimming": 1,
+    "etiquette": 4,
+    "leadership": 4,
+    "negotiation": 4,
+    "navigation": 1,
+    "pilot-aircraft": 1,
+    "pilot-ground-craft": 1,
+    "pilot-watercraft": 1,
+    "pistols": 2,
+    "sneaking": 2
+  },
+  "knowledgeSkills": [
+    { "name": "Business", "category": "academic", "rating": 4, "specialization": "Finance" },
+    {
+      "name": "Club Music",
+      "category": "interests",
+      "rating": 2,
+      "specialization": "Classic Dubstep"
+    },
+    { "name": "Economics", "category": "academic", "rating": 4 },
+    { "name": "NeoNET", "category": "professional", "rating": 4 },
+    { "name": "Sports", "category": "interests", "rating": 2, "specialization": "Baseball" },
+    { "name": "Street Life", "category": "street", "rating": 1 }
+  ],
+  "languages": [
+    { "name": "English", "rating": 0, "isNative": true },
+    { "name": "German", "rating": 2, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "analytical-mind", "rating": 1 },
+    { "qualityId": "codeslinger", "rating": 1, "specification": "Snoop" },
+    { "qualityId": "home-ground", "rating": 1, "specification": "Digital Turf: NeoNET" }
+  ],
+  "negativeQualities": [
+    { "qualityId": "combat-paralysis", "rating": 1 },
+    { "qualityId": "insomnia", "rating": 2 },
+    { "qualityId": "prejudiced", "rating": 1, "specification": "NeoNET Citizens (Vocal)" }
+  ],
+  "complexForms": [
+    {
+      "catalogId": "cleaner",
+      "name": "Cleaner",
+      "target": "Persona",
+      "duration": "P",
+      "fadingValue": "L-2"
+    },
+    {
+      "catalogId": "data-mask",
+      "name": "Data Mask",
+      "target": "Persona",
+      "duration": "S",
+      "fadingValue": "L-1"
+    },
+    {
+      "catalogId": "editor",
+      "name": "Editor",
+      "target": "File",
+      "duration": "P",
+      "fadingValue": "L-2"
+    },
+    {
+      "catalogId": "pulse-storm",
+      "name": "Pulse Storm",
+      "target": "Device",
+      "duration": "I",
+      "fadingValue": "L+1"
+    },
+    {
+      "catalogId": "resonance-spike",
+      "name": "Resonance Spike",
+      "target": "Device",
+      "duration": "I",
+      "fadingValue": "L"
+    }
+  ],
+  "livingPersona": {
+    "deviceRating": 5,
+    "attack": 4,
+    "sleaze": 6,
+    "dataProcessing": 5,
+    "firewall": 5
+  },
+  "contacts": [
+    {
+      "name": "Blogger",
+      "type": "Media",
+      "connection": 2,
+      "loyalty": 3,
+      "notes": "Information and publicity"
+    },
+    {
+      "name": "BTL Dealer",
+      "type": "Underworld",
+      "connection": 1,
+      "loyalty": 1,
+      "notes": "Matrix underworld"
+    },
+    {
+      "name": "Technomancer",
+      "type": "Shadow",
+      "connection": 2,
+      "loyalty": 3,
+      "notes": "Fellow Resonance user"
+    }
+  ],
+  "gear": [
+    { "name": "Data Tap", "category": "electronics", "quantity": 1, "cost": 300 },
+    {
+      "name": "Earbuds",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 50,
+      "rating": 1,
+      "notes": "Select Sound Filter 1"
+    },
+    {
+      "name": "Glasses",
+      "category": "sensor-housing",
+      "quantity": 1,
+      "cost": 100,
+      "rating": 1,
+      "notes": "Image Link"
+    },
+    { "name": "Headjammer", "category": "electronics", "quantity": 1, "cost": 600, "rating": 6 },
+    { "name": "Datachips (Blank)", "category": "electronics", "quantity": 50, "cost": 25 },
+    { "name": "Flashlight", "category": "survival", "quantity": 1, "cost": 25 },
+    { "name": "Mapsoft (Seattle)", "category": "software", "quantity": 1, "cost": 100 },
+    { "name": "Medkit", "category": "medical", "quantity": 1, "cost": 250, "rating": 3 },
+    { "name": "Respirator", "category": "survival", "quantity": 1, "cost": 50, "rating": 1 },
+    { "name": "RFID Tags", "category": "electronics", "quantity": 50, "cost": 5 },
+    { "name": "Stealth Tags", "category": "electronics", "quantity": 30, "cost": 300 },
+    { "name": "Plastic Restraints", "category": "security", "quantity": 10, "cost": 20 }
+  ],
+  "drones": [
+    {
+      "catalogId": "mct-fly-spy",
+      "name": "MCT Fly-Spy",
+      "type": "aerial",
+      "handling": 4,
+      "speed": 3,
+      "acceleration": 2,
+      "body": 1,
+      "armor": 0,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 2000,
+      "quantity": 1,
+      "notes": "Micro surveillance"
+    },
+    {
+      "catalogId": "shiawase-kanmushi",
+      "name": "Shiawase Kanmushi",
+      "type": "walker",
+      "handling": 4,
+      "speed": 2,
+      "acceleration": 1,
+      "body": 0,
+      "armor": 0,
+      "pilot": 3,
+      "sensor": 3,
+      "cost": 1000,
+      "quantity": 2,
+      "notes": "Micro bugs"
+    }
+  ],
+  "armor": [
+    {
+      "catalogId": "armor-vest",
+      "name": "Armor Vest",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 9,
+      "capacity": 9,
+      "cost": 500,
+      "quantity": 1,
+      "equipped": true
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "colt-america-l36",
+      "name": "Colt America L36",
+      "category": "weapons",
+      "subcategory": "light-pistol",
+      "damage": "7P",
+      "ap": 0,
+      "mode": ["SA"],
+      "accuracy": 7,
+      "ammoCapacity": 11,
+      "cost": 320,
+      "quantity": 1,
+      "notes": "Spare clip, 110 rounds"
+    },
+    {
+      "catalogId": "knife",
+      "name": "Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "4P",
+      "ap": -1,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 5,
+      "cost": 10,
+      "quantity": 1
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "renraku-sensei",
+      "name": "Renraku Sensei",
+      "deviceRating": 3,
+      "cost": 1000,
+      "notes": "Backup/decoy commlink"
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 3 },
+      "licenses": []
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "low",
+      "monthlyCost": 2000,
+      "prepaidMonths": 2
+    }
+  ],
+  "nuyen": 0,
+  "startingNuyen": 6000,
+  "derivedStats": {
+    "physicalLimit": 4,
+    "mentalLimit": 7,
+    "socialLimit": 6,
+    "initiativeBase": 9,
+    "initiativeDice": 1,
+    "matrixInitiativeAR": 9,
+    "matrixInitiativeDiceAR": 1,
+    "matrixInitiativeColdVR": 11,
+    "matrixInitiativeDiceColdVR": 3,
+    "matrixInitiativeHotVR": 11,
+    "matrixInitiativeDiceHotVR": 4,
+    "physicalConditionMonitor": 10,
+    "stunConditionMonitor": 11,
+    "composure": 9,
+    "judgeIntentions": 10,
+    "memory": 11,
+    "liftCarry": 6
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 0,
+  "karmaSpentAtCreation": 25,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Technomancer / Matrix Specialist",
+    "notes": "Priority: A-Resonance, B-Skills, C-Metatype(Human), D-Attributes, E-Resources. Living Persona: DR 5, Attack 4, Sleaze 6, DP 5, FW 5. Combat Paralysis: -3 Initiative, act last in first round."
+  }
+}

--- a/data/editions/sr5/example-characters/tribal-warrior-troll.json
+++ b/data/editions/sr5/example-characters/tribal-warrior-troll.json
@@ -1,0 +1,367 @@
+{
+  "id": "example-tribal-warrior-troll",
+  "ownerId": "system",
+  "editionId": "sr5",
+  "editionCode": "sr5",
+  "creationMethodId": "priority",
+  "rulesetSnapshotId": "sr5-core-snapshot",
+  "attachedBookIds": ["sr5-core-rulebook"],
+  "name": "Tribal Warrior (Example)",
+  "metatype": "troll",
+  "description": "A Salish-Sidhe tribal warrior who combines traditional archery skills with modern cyberware enhancements. This character excels at ranged combat with a bow while maintaining respectable pistol and unarmed combat abilities. Heavy augmentation has pushed essence to its limits in exchange for enhanced physical capabilities.",
+  "status": "draft",
+  "attributes": {
+    "body": 10,
+    "agility": 2,
+    "reaction": 3,
+    "strength": 7,
+    "willpower": 3,
+    "logic": 2,
+    "intuition": 3,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 1.56
+  },
+  "magicalPath": "mundane",
+  "skills": {
+    "animal-handling": 2,
+    "archery": 5,
+    "pistols": 6,
+    "running": 3,
+    "survival": 2,
+    "unarmed-combat": 4
+  },
+  "knowledgeSkills": [
+    { "name": "Leatherworking", "category": "professional", "rating": 3 },
+    { "name": "Hunting", "category": "interests", "rating": 2 },
+    { "name": "Tribal Culture", "category": "street", "rating": 2, "specialization": "Salish" }
+  ],
+  "languages": [
+    { "name": "Salish", "rating": 0, "isNative": true },
+    { "name": "English", "rating": 2, "isNative": false }
+  ],
+  "positiveQualities": [
+    { "qualityId": "high-pain-tolerance", "rating": 2 },
+    { "qualityId": "toughness", "rating": 1 }
+  ],
+  "negativeQualities": [
+    { "qualityId": "allergy", "rating": 2, "specification": "Seafood (Moderate)" }
+  ],
+  "racialQualities": [
+    "Thermographic Vision",
+    "+1 Reach",
+    "+1 Dermal Armor",
+    "+4 Body",
+    "+4 Strength"
+  ],
+  "cyberware": [
+    {
+      "catalogId": "bone-lacing-aluminum",
+      "name": "Aluminum Bone Lacing",
+      "category": "bodyware",
+      "grade": "standard",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.0,
+      "cost": 18000,
+      "availability": 10,
+      "legality": "restricted",
+      "attributeBonuses": { "body": 2 },
+      "notes": "+2 unarmed DV"
+    },
+    {
+      "catalogId": "cybereyes",
+      "name": "Cybereyes",
+      "category": "eyeware",
+      "grade": "standard",
+      "baseEssenceCost": 0.3,
+      "essenceCost": 0.3,
+      "rating": 2,
+      "cost": 6000,
+      "availability": 6,
+      "notes": "Flare Compensation, Low-Light Vision, Smartlink, Thermographic Vision"
+    },
+    {
+      "catalogId": "dermal-plating",
+      "name": "Dermal Plating",
+      "category": "bodyware",
+      "grade": "standard",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.0,
+      "rating": 2,
+      "cost": 12000,
+      "availability": 8,
+      "legality": "restricted",
+      "notes": "+2 Armor"
+    },
+    {
+      "catalogId": "skilljack",
+      "name": "Skilljack",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 0.2,
+      "essenceCost": 0.2,
+      "rating": 3,
+      "cost": 30000,
+      "availability": 10,
+      "notes": "Use activesofts up to rating 3"
+    },
+    {
+      "catalogId": "skillwires",
+      "name": "Skillwires",
+      "category": "bodyware",
+      "grade": "standard",
+      "baseEssenceCost": 0.9,
+      "essenceCost": 0.9,
+      "rating": 3,
+      "cost": 24000,
+      "availability": 10,
+      "legality": "restricted",
+      "notes": "Run activesofts at rating 3"
+    },
+    {
+      "catalogId": "synaptic-booster",
+      "name": "Synaptic Booster",
+      "category": "headware",
+      "grade": "standard",
+      "baseEssenceCost": 1.0,
+      "essenceCost": 1.0,
+      "rating": 2,
+      "cost": 190000,
+      "availability": 12,
+      "legality": "restricted",
+      "attributeBonuses": { "reaction": 2 },
+      "notes": "+2 Initiative dice"
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Tribal Leader",
+      "type": "Government",
+      "connection": 3,
+      "loyalty": 3,
+      "notes": "Salish-Sidhe Nation"
+    }
+  ],
+  "gear": [
+    {
+      "name": "Helmet",
+      "category": "armor-accessory",
+      "quantity": 1,
+      "cost": 100,
+      "notes": "Trodes, +2 armor"
+    },
+    {
+      "name": "Ballistic Shield",
+      "category": "armor-accessory",
+      "quantity": 1,
+      "cost": 1200,
+      "notes": "+6 armor"
+    },
+    { "name": "Subvocal Microphone", "category": "electronics", "quantity": 1, "cost": 50 },
+    {
+      "name": "Throwing Activesoft",
+      "category": "skillsoft",
+      "quantity": 1,
+      "cost": 600,
+      "rating": 3
+    },
+    {
+      "name": "Blades Activesoft",
+      "category": "skillsoft",
+      "quantity": 1,
+      "cost": 600,
+      "rating": 3
+    },
+    {
+      "name": "Sneaking Activesoft",
+      "category": "skillsoft",
+      "quantity": 1,
+      "cost": 600,
+      "rating": 3
+    },
+    {
+      "name": "English Linguasoft",
+      "category": "skillsoft",
+      "quantity": 1,
+      "cost": 150,
+      "rating": 3
+    },
+    { "name": "Arrows (Rating 7)", "category": "ammunition", "quantity": 40, "cost": 200 },
+    { "name": "APDS Ammo (Heavy Pistol)", "category": "ammunition", "quantity": 100, "cost": 1200 },
+    { "name": "Explosive Ammo", "category": "ammunition", "quantity": 100, "cost": 800 },
+    { "name": "Taser Darts", "category": "ammunition", "quantity": 50, "cost": 250 },
+    { "name": "Spare Clips (Heavy Pistol)", "category": "ammunition", "quantity": 3, "cost": 15 },
+    { "name": "Speed Loaders", "category": "ammunition", "quantity": 3, "cost": 75 }
+  ],
+  "armor": [
+    {
+      "catalogId": "armor-jacket",
+      "name": "Armor Jacket",
+      "category": "armor",
+      "subcategory": "armor",
+      "armorRating": 12,
+      "capacity": 12,
+      "cost": 1000,
+      "quantity": 1,
+      "equipped": true,
+      "notes": "Chemical Protection 3, Fire Resistance 3, Non-conductivity 3"
+    }
+  ],
+  "weapons": [
+    {
+      "catalogId": "bow",
+      "name": "Bow (Rating 7)",
+      "category": "weapons",
+      "subcategory": "bow",
+      "damage": "9P",
+      "ap": -3,
+      "mode": ["SS"],
+      "accuracy": 6,
+      "cost": 700,
+      "quantity": 1,
+      "rating": 7
+    },
+    {
+      "catalogId": "ares-predator-v",
+      "name": "Ares Predator V",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "8P",
+      "ap": -5,
+      "mode": ["SA"],
+      "accuracy": 5,
+      "ammoCapacity": 15,
+      "cost": 725,
+      "quantity": 1,
+      "notes": "Smartlink, with APDS ammo"
+    },
+    {
+      "catalogId": "ruger-super-warhawk",
+      "name": "Ruger Super Warhawk",
+      "category": "weapons",
+      "subcategory": "heavy-pistol",
+      "damage": "10P",
+      "ap": -3,
+      "mode": ["SS"],
+      "accuracy": 5,
+      "ammoCapacity": 6,
+      "cost": 400,
+      "quantity": 1,
+      "notes": "Integral smartlink, explosive ammo"
+    },
+    {
+      "catalogId": "defiance-ex-shocker",
+      "name": "Defiance EX Shocker",
+      "category": "weapons",
+      "subcategory": "taser",
+      "damage": "11S(e)",
+      "ap": -5,
+      "mode": ["SS"],
+      "accuracy": 4,
+      "ammoCapacity": 4,
+      "cost": 250,
+      "quantity": 1
+    },
+    {
+      "catalogId": "combat-axe",
+      "name": "Combat Axe",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "12P",
+      "ap": -4,
+      "mode": [],
+      "reach": 2,
+      "accuracy": 4,
+      "cost": 500,
+      "quantity": 1
+    },
+    {
+      "catalogId": "combat-knife",
+      "name": "Combat Knife",
+      "category": "weapons",
+      "subcategory": "blade",
+      "damage": "9P",
+      "ap": -3,
+      "mode": [],
+      "reach": 0,
+      "accuracy": 6,
+      "cost": 300,
+      "quantity": 1
+    },
+    {
+      "catalogId": "frag-grenade",
+      "name": "Fragmentation Grenade",
+      "category": "weapons",
+      "subcategory": "grenade",
+      "damage": "18P(f)",
+      "ap": 5,
+      "mode": [],
+      "cost": 100,
+      "quantity": 3
+    },
+    {
+      "catalogId": "thermal-smoke-grenade",
+      "name": "Thermal Smoke Grenade",
+      "category": "weapons",
+      "subcategory": "grenade",
+      "damage": "-",
+      "ap": 0,
+      "mode": [],
+      "cost": 60,
+      "quantity": 3
+    }
+  ],
+  "commlinks": [
+    {
+      "catalogId": "transys-avalon",
+      "name": "Transys Avalon",
+      "deviceRating": 6,
+      "cost": 5000,
+      "notes": "Sim module"
+    }
+  ],
+  "identities": [
+    {
+      "name": "Primary Identity",
+      "sin": { "type": "fake", "rating": 4 },
+      "licenses": []
+    }
+  ],
+  "lifestyles": [
+    {
+      "type": "low",
+      "monthlyCost": 2000,
+      "prepaidMonths": 3
+    }
+  ],
+  "nuyen": 3915,
+  "startingNuyen": 450000,
+  "derivedStats": {
+    "physicalLimit": 11,
+    "mentalLimit": 4,
+    "socialLimit": 3,
+    "initiativeBase": 8,
+    "initiativeDice": 3,
+    "physicalConditionMonitor": 13,
+    "stunConditionMonitor": 10,
+    "composure": 5,
+    "judgeIntentions": 5,
+    "memory": 5,
+    "liftCarry": 17
+  },
+  "condition": {
+    "physicalDamage": 0,
+    "stunDamage": 0
+  },
+  "karmaTotal": 25,
+  "karmaCurrent": 2,
+  "karmaSpentAtCreation": 23,
+  "createdAt": "2026-01-20T00:00:00.000Z",
+  "metadata": {
+    "source": "SR5 Core Rulebook Example Character",
+    "archetype": "Tribal Warrior / Ranged Combatant",
+    "notes": "Priority: A-Resources, B-Attributes, C-Metatype(Troll), D-Skills, E-Magic. Body 12 (10 base + 2 bone lacing). Total Armor: 19 base (12 jacket + 2 dermal plating + 4 bone lacing + 1 racial), 25 with shield. High Pain Tolerance 2 ignores first 2 wound modifiers. Toughness adds +1 Physical CM box. Synaptic Booster 2 provides +2 Reaction and +2 Initiative dice."
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "check-tests": "pnpm dlx tsx scripts/check-test-coverage.ts",
     "check-tests:all": "pnpm dlx tsx scripts/check-test-coverage.ts --all",
     "check-tests:strict": "pnpm dlx tsx scripts/check-test-coverage.ts --strict",
+    "validate-characters": "pnpm dlx tsx scripts/validate-example-characters.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/validate-example-characters.ts
+++ b/scripts/validate-example-characters.ts
@@ -1,0 +1,586 @@
+#!/usr/bin/env npx ts-node
+/**
+ * Example Character Validation Script
+ *
+ * Validates SR5 example character JSON fixtures to ensure:
+ * 1. All fixtures have valid JSON structure
+ * 2. All catalog IDs reference existing items in core-rulebook.json
+ * 3. Derived stats are calculated correctly
+ * 4. Required fields are present
+ *
+ * Usage:
+ *   npx ts-node scripts/validate-example-characters.ts [options]
+ *
+ * Options:
+ *   --verbose    Show detailed validation output
+ *   --fix        (Future) Auto-fix simple issues
+ *   --help       Show help
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ValidationError {
+  file: string;
+  type: "structure" | "catalog" | "derived_stats" | "missing_field";
+  field?: string;
+  message: string;
+  expected?: unknown;
+  actual?: unknown;
+}
+
+interface ValidationWarning {
+  file: string;
+  field?: string;
+  message: string;
+}
+
+interface ValidationResult {
+  file: string;
+  valid: boolean;
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+}
+
+interface Character {
+  id: string;
+  name: string;
+  metatype: string;
+  attributes: {
+    body: number;
+    agility: number;
+    reaction: number;
+    strength: number;
+    willpower: number;
+    logic: number;
+    intuition: number;
+    charisma: number;
+  };
+  specialAttributes: {
+    edge: number;
+    essence: number;
+    magic?: number;
+    resonance?: number;
+  };
+  derivedStats: {
+    physicalLimit: number;
+    mentalLimit: number;
+    socialLimit: number;
+    initiativeBase: number;
+    initiativeDice: number;
+    physicalConditionMonitor: number;
+    stunConditionMonitor: number;
+    composure: number;
+    judgeIntentions: number;
+    memory: number;
+    liftCarry: number;
+  };
+  [key: string]: unknown;
+}
+
+interface CatalogData {
+  skills: Map<string, unknown>;
+  qualities: Map<string, unknown>;
+  weapons: Map<string, unknown>;
+  armor: Map<string, unknown>;
+  gear: Map<string, unknown>;
+  cyberware: Map<string, unknown>;
+  bioware: Map<string, unknown>;
+  spells: Map<string, unknown>;
+  adeptPowers: Map<string, unknown>;
+  complexForms: Map<string, unknown>;
+  vehicles: Map<string, unknown>;
+  drones: Map<string, unknown>;
+  programs: Map<string, unknown>;
+  foci: Map<string, unknown>;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const EXAMPLE_CHARS_DIR = path.join(PROJECT_ROOT, "data/editions/sr5/example-characters");
+const CORE_RULEBOOK_PATH = path.join(PROJECT_ROOT, "data/editions/sr5/core-rulebook.json");
+
+const REQUIRED_FIELDS = [
+  "id",
+  "ownerId",
+  "editionId",
+  "editionCode",
+  "name",
+  "metatype",
+  "status",
+  "attributes",
+  "specialAttributes",
+  "magicalPath",
+  "skills",
+  "derivedStats",
+  "karmaTotal",
+  "createdAt",
+];
+
+// ============================================================================
+// Catalog Loading
+// ============================================================================
+
+function loadCatalogData(): CatalogData {
+  const data = JSON.parse(fs.readFileSync(CORE_RULEBOOK_PATH, "utf-8"));
+
+  const catalogData: CatalogData = {
+    skills: new Map(),
+    qualities: new Map(),
+    weapons: new Map(),
+    armor: new Map(),
+    gear: new Map(),
+    cyberware: new Map(),
+    bioware: new Map(),
+    spells: new Map(),
+    adeptPowers: new Map(),
+    complexForms: new Map(),
+    vehicles: new Map(),
+    drones: new Map(),
+    programs: new Map(),
+    foci: new Map(),
+  };
+
+  // Extract skills
+  const skillsModule = data.modules?.skills?.payload;
+  if (skillsModule?.activeSkills) {
+    for (const skill of skillsModule.activeSkills) {
+      catalogData.skills.set(skill.id, skill);
+    }
+  }
+
+  // Extract qualities
+  const qualitiesModule = data.modules?.qualities?.payload;
+  if (qualitiesModule?.positive) {
+    for (const quality of qualitiesModule.positive) {
+      catalogData.qualities.set(quality.id, quality);
+    }
+  }
+  if (qualitiesModule?.negative) {
+    for (const quality of qualitiesModule.negative) {
+      catalogData.qualities.set(quality.id, quality);
+    }
+  }
+
+  // Extract weapons (nested structure)
+  const weaponsModule = data.modules?.gear?.payload?.weapons;
+  if (weaponsModule) {
+    for (const category of Object.values(weaponsModule)) {
+      if (Array.isArray(category)) {
+        for (const weapon of category) {
+          if (weapon.id) {
+            catalogData.weapons.set(weapon.id, weapon);
+          }
+        }
+      }
+    }
+  }
+
+  // Extract armor
+  const armorModule = data.modules?.gear?.payload?.armor;
+  if (Array.isArray(armorModule)) {
+    for (const item of armorModule) {
+      if (item.id) {
+        catalogData.armor.set(item.id, item);
+      }
+    }
+  }
+
+  // Extract cyberware
+  const cyberwareModule = data.modules?.cyberware?.payload?.catalog;
+  if (Array.isArray(cyberwareModule)) {
+    for (const item of cyberwareModule) {
+      if (item.id) {
+        catalogData.cyberware.set(item.id, item);
+      }
+    }
+  }
+
+  // Extract bioware
+  const biowareModule = data.modules?.bioware?.payload?.catalog;
+  if (Array.isArray(biowareModule)) {
+    for (const item of biowareModule) {
+      if (item.id) {
+        catalogData.bioware.set(item.id, item);
+      }
+    }
+  }
+
+  // Extract spells
+  const spellsModule = data.modules?.magic?.payload?.spells;
+  if (Array.isArray(spellsModule)) {
+    for (const spell of spellsModule) {
+      if (spell.id) {
+        catalogData.spells.set(spell.id, spell);
+      }
+    }
+  }
+
+  // Extract adept powers
+  const adeptPowersModule = data.modules?.magic?.payload?.adeptPowers;
+  if (Array.isArray(adeptPowersModule)) {
+    for (const power of adeptPowersModule) {
+      if (power.id) {
+        catalogData.adeptPowers.set(power.id, power);
+      }
+    }
+  }
+
+  // Extract complex forms
+  const complexFormsModule = data.modules?.magic?.payload?.complexForms;
+  if (Array.isArray(complexFormsModule)) {
+    for (const form of complexFormsModule) {
+      if (form.id) {
+        catalogData.complexForms.set(form.id, form);
+      }
+    }
+  }
+
+  // Extract vehicles
+  const vehiclesModule = data.modules?.vehicles?.payload?.vehicles;
+  if (Array.isArray(vehiclesModule)) {
+    for (const vehicle of vehiclesModule) {
+      if (vehicle.id) {
+        catalogData.vehicles.set(vehicle.id, vehicle);
+      }
+    }
+  }
+
+  // Extract drones
+  const dronesModule = data.modules?.vehicles?.payload?.drones;
+  if (Array.isArray(dronesModule)) {
+    for (const drone of dronesModule) {
+      if (drone.id) {
+        catalogData.drones.set(drone.id, drone);
+      }
+    }
+  }
+
+  // Extract programs
+  const programsModule = data.modules?.matrix?.payload?.programs;
+  if (Array.isArray(programsModule)) {
+    for (const program of programsModule) {
+      if (program.id) {
+        catalogData.programs.set(program.id, program);
+      }
+    }
+  }
+
+  // Extract foci
+  const fociModule = data.modules?.magic?.payload?.foci;
+  if (Array.isArray(fociModule)) {
+    for (const focus of fociModule) {
+      if (focus.id) {
+        catalogData.foci.set(focus.id, focus);
+      }
+    }
+  }
+
+  return catalogData;
+}
+
+// ============================================================================
+// Derived Stats Calculation
+// ============================================================================
+
+function calculateDerivedStats(char: Character) {
+  const attr = char.attributes;
+  const essence = char.specialAttributes.essence;
+
+  // Physical Limit: [(STR×2)+BOD+REA] / 3 (round up)
+  const physicalLimit = Math.ceil((attr.strength * 2 + attr.body + attr.reaction) / 3);
+
+  // Mental Limit: [(LOG×2)+INT+WIL] / 3 (round up)
+  const mentalLimit = Math.ceil((attr.logic * 2 + attr.intuition + attr.willpower) / 3);
+
+  // Social Limit: [(CHA×2)+WIL+ESS] / 3 (round up)
+  const socialLimit = Math.ceil((attr.charisma * 2 + attr.willpower + essence) / 3);
+
+  // Initiative Base: REA + INT
+  const initiativeBase = attr.reaction + attr.intuition;
+
+  // Physical Condition Monitor: 8 + (BOD/2) round up
+  const physicalConditionMonitor = 8 + Math.ceil(attr.body / 2);
+
+  // Stun Condition Monitor: 8 + (WIL/2) round up
+  const stunConditionMonitor = 8 + Math.ceil(attr.willpower / 2);
+
+  // Composure: CHA + WIL
+  const composure = attr.charisma + attr.willpower;
+
+  // Judge Intentions: CHA + INT
+  const judgeIntentions = attr.charisma + attr.intuition;
+
+  // Memory: LOG + WIL
+  const memory = attr.logic + attr.willpower;
+
+  // Lift/Carry: STR + BOD
+  const liftCarry = attr.strength + attr.body;
+
+  return {
+    physicalLimit,
+    mentalLimit,
+    socialLimit,
+    initiativeBase,
+    initiativeDice: 1, // Base is always 1
+    physicalConditionMonitor,
+    stunConditionMonitor,
+    composure,
+    judgeIntentions,
+    memory,
+    liftCarry,
+  };
+}
+
+// ============================================================================
+// Validation Functions
+// ============================================================================
+
+function validateCharacter(
+  filePath: string,
+  catalog: CatalogData,
+  _verbose: boolean
+): ValidationResult {
+  const fileName = path.basename(filePath);
+  const result: ValidationResult = {
+    file: fileName,
+    valid: true,
+    errors: [],
+    warnings: [],
+  };
+
+  // Load and parse JSON
+  let char: Character;
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    char = JSON.parse(content);
+  } catch (error) {
+    result.valid = false;
+    result.errors.push({
+      file: fileName,
+      type: "structure",
+      message: `Failed to parse JSON: ${error}`,
+    });
+    return result;
+  }
+
+  // Check required fields
+  for (const field of REQUIRED_FIELDS) {
+    if (!(field in char)) {
+      result.valid = false;
+      result.errors.push({
+        file: fileName,
+        type: "missing_field",
+        field,
+        message: `Missing required field: ${field}`,
+      });
+    }
+  }
+
+  // Validate skills reference valid skill IDs
+  if (char.skills && typeof char.skills === "object") {
+    for (const skillId of Object.keys(char.skills as Record<string, number>)) {
+      if (!catalog.skills.has(skillId)) {
+        result.warnings.push({
+          file: fileName,
+          field: `skills.${skillId}`,
+          message: `Skill ID "${skillId}" not found in catalog`,
+        });
+      }
+    }
+  }
+
+  // Validate qualities
+  const validateQualityArray = (
+    qualities: Array<{ qualityId: string }> | undefined,
+    fieldName: string
+  ) => {
+    if (Array.isArray(qualities)) {
+      for (const quality of qualities) {
+        if (quality.qualityId && !catalog.qualities.has(quality.qualityId)) {
+          result.warnings.push({
+            file: fileName,
+            field: `${fieldName}.${quality.qualityId}`,
+            message: `Quality ID "${quality.qualityId}" not found in catalog`,
+          });
+        }
+      }
+    }
+  };
+
+  validateQualityArray(char.positiveQualities as Array<{ qualityId: string }>, "positiveQualities");
+  validateQualityArray(char.negativeQualities as Array<{ qualityId: string }>, "negativeQualities");
+
+  // Validate spells
+  if (Array.isArray(char.spells)) {
+    for (const spell of char.spells as Array<{ catalogId: string; name: string }>) {
+      if (spell.catalogId && !catalog.spells.has(spell.catalogId)) {
+        result.warnings.push({
+          file: fileName,
+          field: `spells.${spell.catalogId}`,
+          message: `Spell ID "${spell.catalogId}" not found in catalog`,
+        });
+      }
+    }
+  }
+
+  // Validate adept powers
+  if (Array.isArray(char.adeptPowers)) {
+    for (const power of char.adeptPowers as Array<{ catalogId: string; name: string }>) {
+      if (power.catalogId && !catalog.adeptPowers.has(power.catalogId)) {
+        result.warnings.push({
+          file: fileName,
+          field: `adeptPowers.${power.catalogId}`,
+          message: `Adept power ID "${power.catalogId}" not found in catalog`,
+        });
+      }
+    }
+  }
+
+  // Validate derived stats
+  if (char.attributes && char.specialAttributes && char.derivedStats) {
+    const calculated = calculateDerivedStats(char);
+    const actual = char.derivedStats;
+
+    const checkStat = (name: keyof typeof calculated, allowVariance: number = 0) => {
+      const calcValue = calculated[name];
+      const actualValue = actual[name];
+      if (actualValue !== undefined && Math.abs(calcValue - actualValue) > allowVariance) {
+        result.warnings.push({
+          file: fileName,
+          field: `derivedStats.${name}`,
+          message: `Derived stat "${name}" may be incorrect (calculated: ${calcValue}, actual: ${actualValue})`,
+        });
+      }
+    };
+
+    // Check key derived stats (some may have bonuses from augmentations)
+    checkStat("physicalLimit", 2); // Allow variance for augmentations
+    checkStat("mentalLimit", 2);
+    checkStat("socialLimit", 2);
+    checkStat("composure");
+    checkStat("judgeIntentions");
+    checkStat("memory");
+    checkStat("liftCarry", 2);
+    checkStat("physicalConditionMonitor", 1); // Toughness can add +1
+  }
+
+  return result;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+function parseArgs(): { verbose: boolean; fix: boolean } {
+  const args = process.argv.slice(2);
+  const config = { verbose: false, fix: false };
+
+  for (const arg of args) {
+    switch (arg) {
+      case "--verbose":
+        config.verbose = true;
+        break;
+      case "--fix":
+        config.fix = true;
+        break;
+      case "--help":
+        console.log(`
+Example Character Validation Script
+
+Usage: npx ts-node scripts/validate-example-characters.ts [options]
+
+Options:
+  --verbose    Show detailed validation output
+  --fix        (Future) Auto-fix simple issues
+  --help       Show this help
+        `);
+        process.exit(0);
+    }
+  }
+
+  return config;
+}
+
+async function main() {
+  const config = parseArgs();
+
+  console.log("Example Character Validation");
+  console.log("============================");
+  console.log("");
+
+  // Check if directory exists
+  if (!fs.existsSync(EXAMPLE_CHARS_DIR)) {
+    console.error(`Error: Example characters directory not found: ${EXAMPLE_CHARS_DIR}`);
+    process.exit(1);
+  }
+
+  // Load catalog data
+  console.log("Loading catalog data from core-rulebook.json...");
+  const catalog = loadCatalogData();
+  console.log(
+    `  Loaded: ${catalog.skills.size} skills, ${catalog.qualities.size} qualities, ${catalog.weapons.size} weapons, ${catalog.spells.size} spells`
+  );
+  console.log("");
+
+  // Find all character files
+  const files = fs.readdirSync(EXAMPLE_CHARS_DIR).filter((f) => f.endsWith(".json"));
+
+  console.log(`Found ${files.length} character fixture files`);
+  console.log("");
+
+  // Validate each file
+  const results: ValidationResult[] = [];
+  let totalErrors = 0;
+  let totalWarnings = 0;
+
+  for (const file of files) {
+    const filePath = path.join(EXAMPLE_CHARS_DIR, file);
+    const result = validateCharacter(filePath, catalog, config.verbose);
+    results.push(result);
+
+    totalErrors += result.errors.length;
+    totalWarnings += result.warnings.length;
+
+    const status = result.valid ? "✓" : "✗";
+    const errorCount = result.errors.length > 0 ? ` (${result.errors.length} errors)` : "";
+    const warningCount = result.warnings.length > 0 ? ` (${result.warnings.length} warnings)` : "";
+
+    console.log(`${status} ${file}${errorCount}${warningCount}`);
+
+    if (config.verbose && (result.errors.length > 0 || result.warnings.length > 0)) {
+      for (const error of result.errors) {
+        console.log(`    ERROR: ${error.message}`);
+      }
+      for (const warning of result.warnings) {
+        console.log(`    WARNING: ${warning.message}`);
+      }
+    }
+  }
+
+  // Summary
+  console.log("");
+  console.log("Summary");
+  console.log("-------");
+  const validCount = results.filter((r) => r.valid).length;
+  console.log(`Valid files: ${validCount}/${files.length}`);
+  console.log(`Total errors: ${totalErrors}`);
+  console.log(`Total warnings: ${totalWarnings}`);
+
+  // Exit with error code if any validation failed
+  if (totalErrors > 0) {
+    process.exit(1);
+  }
+
+  console.log("");
+  console.log("All example character fixtures are valid!");
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Create JSON fixture files for all example characters from the SR5 Core Rulebook. These serve as test data, reference implementations, and validation targets for the character creation system.

Characters included:
- Mundane: Face (Elf), Gang Leader (Ork), Bounty Hunter (Troll)
- Augmented: Street Samurai (Ork), Infiltrator (Dwarf), Mercenary (Human), Tribal Warrior (Troll)
- Matrix: Decker (Dwarf), Technomancer (Human)
- Riggers: Drone Rigger (Ork), Rigger (Troll)
- Mages: Combat Mage (Human), Shaman (Elf), Alchemist (Human)
- Adepts: Martial Artist (Human), Assassin (Elf)

Also adds:
- Validation script (pnpm validate-characters)
- Unit tests (31 tests covering structure and derived stats)
- README documentation

Closes #131