### PR TITLE
feat(env): add environment detection and badge display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,14 @@
 # Node environment (development, production, test)
 NODE_ENV=test
 
+# Application environment for UI display
+# Values: local, docker, staging, production
+# - local: Purple badge, full details (pnpm dev)
+# - docker: Blue badge, full details (local Docker)
+# - staging: Amber badge, full details (Portainer/pre-prod)
+# - production: No badge displayed
+NEXT_PUBLIC_APP_ENV=local
+
 # Application port
 PORT=3000
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -68,6 +68,8 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             NEXT_TELEMETRY_DISABLED=1
+            NEXT_PUBLIC_APP_ENV=staging
+            NEXT_PUBLIC_GIT_SHA=${{ github.sha }}
 
       - name: Image digest
         run: echo "Image pushed with digest ${{ steps.build-and-push.outputs.digest }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,13 @@ pnpm lint             # ESLint
 pnpm type-check       # TypeScript checking
 pnpm check            # Combined lint + type-check + knip
 
+# Docker (local development)
+pnpm docker:dev       # Build and start containers
+pnpm docker:build     # Build image with git SHA
+pnpm docker:up        # Start containers
+pnpm docker:down      # Stop containers
+pnpm docker:logs      # Follow container logs
+
 # Code Quality
 pnpm format           # Prettier formatting
 pnpm knip             # Dead code detection
@@ -46,6 +53,8 @@ pnpm verify-data      # Validate JSON data files
 pnpm validate-docs    # Validate CLAUDE.md against codebase
 pnpm check-tests      # Check for missing tests (non-blocking)
 ```
+
+**Environments:** `local` (pnpm dev), `docker` (pnpm docker:dev), `staging` (Portainer), `production` (hidden badge)
 
 **Git Hooks:** pre-commit (lint-staged, type-check), pre-push (knip, CLAUDE.md validation)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ FROM node:20-alpine AS builder
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
+# Build arguments for environment configuration
+# These are embedded into the Next.js build at compile time
+ARG NEXT_PUBLIC_APP_ENV=docker
+ARG NEXT_PUBLIC_GIT_SHA=unknown
+
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -24,6 +29,8 @@ COPY . .
 # Set environment for build
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
+ENV NEXT_PUBLIC_APP_ENV=${NEXT_PUBLIC_APP_ENV}
+ENV NEXT_PUBLIC_GIT_SHA=${NEXT_PUBLIC_GIT_SHA}
 
 # Build the application
 RUN pnpm build

--- a/README.md
+++ b/README.md
@@ -62,20 +62,36 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-### Docker Deployment
+### Docker Development
 
 ```bash
-# Build the Docker image
-docker build -t shadow-master .
+# Build and start with one command
+pnpm docker:dev
 
-# Run the container
-docker run -p 3000:3000 shadow-master
-
-# Or use Docker Compose
-docker-compose up
+# Or step by step
+pnpm docker:build      # Build image
+pnpm docker:up         # Start containers
+pnpm docker:logs       # View logs
+pnpm docker:down       # Stop containers
 ```
 
-For more details, see our **[Portainer Setup Guide](docs/deployment/portainer-setup.md)** or the **[CI/CD Pipeline documentation](docs/deployment/cicd-guide.md)**.
+This starts:
+
+- **Shadow Master** at http://localhost:3000
+- **Mailpit** (email testing) at http://localhost:8025
+
+### Environments
+
+| Environment    | How to Run        | Badge Color |
+| -------------- | ----------------- | ----------- |
+| **local**      | `pnpm dev`        | Purple      |
+| **docker**     | `pnpm docker:dev` | Blue        |
+| **staging**    | Portainer/GHCR    | Amber       |
+| **production** | Web hosting       | Hidden      |
+
+The environment badge shows version, git SHA, and build time (hidden in production).
+
+For production deployment, see our **[Portainer Setup Guide](docs/deployment/portainer-setup.md)** or the **[CI/CD Pipeline documentation](docs/deployment/cicd-guide.md)**.
 
 ---
 

--- a/app/users/AuthenticatedLayout.tsx
+++ b/app/users/AuthenticatedLayout.tsx
@@ -4,6 +4,7 @@ import { Link, Button, Menu, MenuTrigger, MenuItem, Popover } from "react-aria-c
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { useState, useEffect } from "react";
 import { NotificationBell } from "@/components/NotificationBell";
+import { EnvironmentBadge } from "@/components/EnvironmentBadge";
 
 interface AuthenticatedLayoutProps {
   children: React.ReactNode;
@@ -159,12 +160,15 @@ export default function AuthenticatedLayout({
                 />
               </svg>
             </Button>
-            <Link
-              href="/"
-              className="text-xl font-semibold text-black transition-colors hover:text-zinc-700 dark:text-zinc-50 dark:hover:text-zinc-300"
-            >
-              Shadow Master
-            </Link>
+            <div className="flex flex-col">
+              <Link
+                href="/"
+                className="text-xl font-semibold text-black transition-colors hover:text-zinc-700 dark:text-zinc-50 dark:hover:text-zinc-300"
+              >
+                Shadow Master
+              </Link>
+              <EnvironmentBadge />
+            </div>
           </div>
           <div className="flex items-center gap-3">
             {/* Notifications */}

--- a/components/EnvironmentBadge.tsx
+++ b/components/EnvironmentBadge.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * Environment Badge Component
+ *
+ * Displays current environment, version, git SHA, and build date.
+ * Styled differently per environment, hidden in production.
+ */
+
+import { getBuildInfo, getEnvironmentDisplay, formatRelativeTime } from "@/lib/env";
+
+/**
+ * Environment badge shown under the app title
+ *
+ * Displays: env • version • sha • time
+ * Example: local • v0.1.0 • abc123 • 2h ago
+ */
+export function EnvironmentBadge() {
+  const buildInfo = getBuildInfo();
+  const display = getEnvironmentDisplay(buildInfo.env);
+
+  // Don't render anything in production
+  if (!display.showIndicator) {
+    return null;
+  }
+
+  const shortSha = buildInfo.gitSha.slice(0, 7);
+  const relativeTime = formatRelativeTime(buildInfo.buildDate);
+
+  return (
+    <div className={`flex items-center gap-1.5 text-xs ${display.textColor}`}>
+      {/* Environment label */}
+      <span className="font-medium">{display.label}</span>
+
+      <Separator />
+
+      {/* Version */}
+      <span>v{buildInfo.version}</span>
+
+      {display.showDetails && (
+        <>
+          <Separator />
+
+          {/* Git SHA */}
+          <span className="font-mono opacity-75">{shortSha}</span>
+
+          <Separator />
+
+          {/* Build time */}
+          <span className="opacity-75">{relativeTime}</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Compact version for smaller spaces
+ */
+export function EnvironmentBadgeCompact() {
+  const buildInfo = getBuildInfo();
+  const display = getEnvironmentDisplay(buildInfo.env);
+
+  if (!display.showIndicator) {
+    return null;
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${display.bgColor} ${display.textColor}`}
+    >
+      {display.label}
+    </span>
+  );
+}
+
+/**
+ * Separator dot
+ */
+function Separator() {
+  return <span className="opacity-50">•</span>;
+}

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -90,7 +90,6 @@ services:
       - WATCHTOWER_INCLUDE_RESTARTING=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ~/.docker/config.json:/config.json:ro
     labels:
       - "com.centurylinklabs.watchtower.enable=false"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - NEXT_PUBLIC_APP_ENV=docker
+        # Pass git SHA for environment badge (run: GIT_SHA=$(git rev-parse --short HEAD) docker compose build)
+        - NEXT_PUBLIC_GIT_SHA=${GIT_SHA:-unknown}
     image: shadow-master:local
     container_name: shadow-master-app
     ports:

--- a/lib/env/index.ts
+++ b/lib/env/index.ts
@@ -1,0 +1,158 @@
+/**
+ * Environment Detection and Configuration
+ *
+ * Provides utilities for detecting the current environment and
+ * accessing build-time metadata like version and git SHA.
+ */
+
+/**
+ * Application environment types
+ */
+export type AppEnvironment = "local" | "docker" | "staging" | "production";
+
+/**
+ * Build metadata injected at build time
+ */
+export interface BuildInfo {
+  /** Application environment */
+  env: AppEnvironment;
+  /** Version from package.json */
+  version: string;
+  /** Git commit SHA (short) */
+  gitSha: string;
+  /** Build timestamp (ISO string) */
+  buildDate: string;
+  /** Whether this is a development build */
+  isDev: boolean;
+}
+
+/**
+ * Environment display configuration
+ */
+export interface EnvironmentDisplay {
+  /** Display label */
+  label: string;
+  /** Tailwind color classes for text */
+  textColor: string;
+  /** Tailwind color classes for background (badges) */
+  bgColor: string;
+  /** Whether to show the environment indicator */
+  showIndicator: boolean;
+  /** Whether to show full details (SHA, date) */
+  showDetails: boolean;
+}
+
+/**
+ * Display configuration per environment
+ */
+const ENV_DISPLAY: Record<AppEnvironment, EnvironmentDisplay> = {
+  local: {
+    label: "local",
+    textColor: "text-purple-400",
+    bgColor: "bg-purple-500/20",
+    showIndicator: true,
+    showDetails: true,
+  },
+  docker: {
+    label: "docker",
+    textColor: "text-blue-400",
+    bgColor: "bg-blue-500/20",
+    showIndicator: true,
+    showDetails: true,
+  },
+  staging: {
+    label: "staging",
+    textColor: "text-amber-400",
+    bgColor: "bg-amber-500/20",
+    showIndicator: true,
+    showDetails: true,
+  },
+  production: {
+    label: "",
+    textColor: "text-neutral-500",
+    bgColor: "bg-neutral-500/20",
+    showIndicator: false,
+    showDetails: false,
+  },
+};
+
+/**
+ * Validate and parse environment string
+ */
+function parseEnvironment(env: string | undefined): AppEnvironment {
+  const validEnvs: AppEnvironment[] = ["local", "docker", "staging", "production"];
+  const parsed = (env?.toLowerCase() || "local") as AppEnvironment;
+  return validEnvs.includes(parsed) ? parsed : "local";
+}
+
+/**
+ * Format relative time (e.g., "2h ago", "3d ago")
+ */
+export function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays > 30) {
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  }
+  if (diffDays > 0) {
+    return `${diffDays}d ago`;
+  }
+  if (diffHours > 0) {
+    return `${diffHours}h ago`;
+  }
+  if (diffMinutes > 0) {
+    return `${diffMinutes}m ago`;
+  }
+  return "just now";
+}
+
+/**
+ * Format date for display
+ */
+export function formatBuildDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/**
+ * Get build information from environment variables
+ *
+ * These are injected at build time via next.config.ts
+ */
+export function getBuildInfo(): BuildInfo {
+  return {
+    env: parseEnvironment(process.env.NEXT_PUBLIC_APP_ENV),
+    version: process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0",
+    gitSha: process.env.NEXT_PUBLIC_GIT_SHA || "unknown",
+    buildDate: process.env.NEXT_PUBLIC_BUILD_DATE || new Date().toISOString(),
+    isDev: process.env.NODE_ENV === "development",
+  };
+}
+
+/**
+ * Get display configuration for the current environment
+ */
+export function getEnvironmentDisplay(env?: AppEnvironment): EnvironmentDisplay {
+  const buildInfo = getBuildInfo();
+  const targetEnv = env || buildInfo.env;
+  return ENV_DISPLAY[targetEnv];
+}
+
+/**
+ * Check if we should show the environment indicator
+ */
+export function shouldShowEnvironmentIndicator(): boolean {
+  const buildInfo = getBuildInfo();
+  const display = getEnvironmentDisplay(buildInfo.env);
+  return display.showIndicator;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,39 @@
 import type { NextConfig } from "next";
+import { execSync } from "child_process";
+
+// Get git SHA at build time
+// Prefers NEXT_PUBLIC_GIT_SHA env var (for Docker builds), falls back to git command
+function getGitSha(): string {
+  // Check for pre-set value (Docker builds pass this as build arg)
+  if (process.env.NEXT_PUBLIC_GIT_SHA && process.env.NEXT_PUBLIC_GIT_SHA !== "unknown") {
+    return process.env.NEXT_PUBLIC_GIT_SHA;
+  }
+  // Fall back to git command (local development)
+  try {
+    return execSync("git rev-parse --short HEAD").toString().trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+// Get version from package.json
+function getVersion(): string {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require("./package.json");
+    return pkg.version || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
 
 const nextConfig: NextConfig = {
+  // Inject build-time environment variables
+  env: {
+    NEXT_PUBLIC_APP_VERSION: getVersion(),
+    NEXT_PUBLIC_GIT_SHA: getGitSha(),
+    NEXT_PUBLIC_BUILD_DATE: new Date().toISOString(),
+  },
   // Enable standalone output for Docker optimization
   // This creates a minimal production server with only the files needed to run
   output: "standalone",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,12 @@
     "audit:creation:strict": "pnpm dlx tsx scripts/audit/creation-ux-audit.ts --strict",
     "audit:creation:verbose": "pnpm dlx tsx scripts/audit/creation-ux-audit.ts --verbose",
     "audit:creation:report": "pnpm dlx tsx scripts/audit/creation-ux-audit.ts --output=markdown",
+    "docker:build": "GIT_SHA=$(git rev-parse --short HEAD) docker compose build",
+    "docker:build:fresh": "GIT_SHA=$(git rev-parse --short HEAD) docker compose build --no-cache",
+    "docker:up": "docker compose up -d",
+    "docker:down": "docker compose down",
+    "docker:dev": "GIT_SHA=$(git rev-parse --short HEAD) docker compose up --build -d",
+    "docker:logs": "docker compose logs -f",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -438,7 +438,45 @@ pnpm validate-docs           # Validate CLAUDE.md against codebase
 pnpm check-tests             # Check staged files for missing tests
 pnpm check-tests:all         # Check all source files
 pnpm check-tests:strict      # Fail if tests are missing
+
+# Docker (local development)
+pnpm docker:build            # Build image with git SHA
+pnpm docker:build:fresh      # Build from scratch (no cache)
+pnpm docker:up               # Start containers
+pnpm docker:down             # Stop containers
+pnpm docker:dev              # Build and start in one command
+pnpm docker:logs             # Follow container logs
 ```
+
+### Docker Commands
+
+The Docker commands automatically pass the git SHA for the environment badge.
+
+```bash
+# Quick start - build and run
+pnpm docker:dev
+
+# Or step by step
+pnpm docker:build        # Build image
+pnpm docker:up           # Start containers
+
+# View logs
+pnpm docker:logs
+
+# Stop everything
+pnpm docker:down
+
+# Rebuild without cache (after Dockerfile changes)
+pnpm docker:build:fresh
+pnpm docker:up
+```
+
+**Services started:**
+
+- `shadow-master-app` - Next.js application at http://localhost:3000
+- `mailpit` - Email testing UI at http://localhost:8025
+
+**Environment badge:** The Docker environment shows "docker" with version, git SHA, and build time.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add environment badge showing env/version/SHA/build date in header
- Support four environments: local, docker, staging, production
- Badge hidden in production, color-coded for others (purple/blue/amber)
- Add Docker pnpm commands for easier local Docker development
- Pass git SHA as build arg for Docker builds
- Fix Watchtower config for public GHCR image

## Changes

| File | Change |
|------|--------|
| `lib/env/index.ts` | Environment detection utilities |
| `components/EnvironmentBadge.tsx` | Badge component |
| `app/users/AuthenticatedLayout.tsx` | Added badge to header |
| `next.config.ts` | Build-time version/SHA/date injection |
| `Dockerfile` | Build args for env + git SHA |
| `docker-compose.yml` | Passes docker env + GIT_SHA |
| `docker-compose.portainer.yml` | Fixed Watchtower credential mount |
| `.github/workflows/docker-build.yml` | Passes staging env + SHA |
| `package.json` | Docker commands (docker:dev, etc.) |
| `README.md` | Updated Docker section + environments table |
| `CLAUDE.md` | Added Docker commands + environments note |

## Environments

| Environment | How to Run | Badge |
|-------------|------------|-------|
| local | `pnpm dev` | Purple |
| docker | `pnpm docker:dev` | Blue |
| staging | Portainer/GHCR | Amber |
| production | Web hosting | Hidden |

## Test plan

- [x] Run `pnpm dev` and verify purple "local" badge appears
- [ ] Run `pnpm docker:dev` and verify blue "docker" badge with git SHA
- [ ] Verify badge shows version, SHA (7 chars), and relative time
- [ ] Verify badge is hidden when `NEXT_PUBLIC_APP_ENV=production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)