### PR TITLE
feat(creation): update armor modals to two-column bulk-add pattern

### DIFF
--- a/components/creation/armor/ArmorPanel.tsx
+++ b/components/creation/armor/ArmorPanel.tsx
@@ -172,8 +172,7 @@ export function ArmorPanel({ state, updateState }: ArmorPanelProps) {
         },
       });
 
-      // Close modal after purchase
-      setIsPurchaseModalOpen(false);
+      // Note: Modal stays open for bulk-add workflow - user clicks "Done" to close
     },
     [selectedArmor, state.selections, updateState]
   );
@@ -359,8 +358,7 @@ export function ArmorPanel({ state, updateState }: ArmorPanelProps) {
         },
       });
 
-      // Close modal
-      setModifyingArmorId(null);
+      // Note: Modal stays open for bulk-add workflow - user clicks "Done" to close
     },
     [modifyingArmorId, selectedArmor, state.selections, updateState]
   );


### PR DESCRIPTION
## Summary

- Updates ArmorPurchaseModal and ArmorModificationModal to follow the SkillModal/SpellModal two-column pattern with bulk-add workflow
- Modal stays open after adding items, allowing users to add multiple items without reopening
- Adds "Done" + "Add" button pattern in footer instead of action button in detail pane
- Shows session counter ("X added" / "X installed") to track progress
- ArmorPurchaseModal now shows sticky category headers when viewing "All Armor"

## Test plan

- [ ] Open ArmorPurchaseModal, search for "jacket", purchase item - verify modal stays open with search preserved and counter shows "1 added"
- [ ] Purchase another item - verify counter updates to "2 added"
- [ ] Click Done - verify modal closes
- [ ] Open ArmorModificationModal, install a mod with rating - verify modal stays open with "1 installed"
- [ ] Install another mod - verify counter updates
- [ ] Click Done - verify modal closes
- [ ] Verify sticky category headers appear when "All Armor" is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)