### PR TITLE
feat(creation): update weapon modals to two-column bulk-add pattern

### DIFF
--- a/components/creation/weapons/AmmunitionModal.tsx
+++ b/components/creation/weapons/AmmunitionModal.tsx
@@ -3,17 +3,19 @@
 /**
  * AmmunitionModal
  *
- * Modal for purchasing ammunition for a specific weapon.
- * Shows compatible ammunition types with damage/AP modifiers,
- * legality warnings, and quantity selection.
+ * Two-column modal for purchasing ammunition for a specific weapon.
+ * Left pane: Ammo list sorted by name
+ * Right pane: Selected ammo details with quantity selector
+ *
+ * Follows the SkillModal/SpellModal pattern for consistent UX.
  */
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { useGear, useRuleset, type GearItemData } from "@/lib/rules/RulesetContext";
 import { isMountBased, type ModifiableItem } from "@/lib/rules/modifications";
 import type { Weapon } from "@/lib/types";
-import { BaseModalRoot } from "@/components/ui";
-import { ShieldAlert, AlertTriangle, Package, X, Ban } from "lucide-react";
+import { BaseModalRoot, ModalHeader, ModalBody, ModalFooter } from "@/components/ui";
+import { ShieldAlert, AlertTriangle, Package, Check } from "lucide-react";
 import { BulkQuantitySelector } from "@/components/creation/shared/BulkQuantitySelector";
 
 // =============================================================================
@@ -127,6 +129,58 @@ export interface PurchasedAmmunition {
 }
 
 // =============================================================================
+// AMMO LIST ITEM
+// =============================================================================
+
+function AmmoListItem({
+  ammo,
+  isSelected,
+  canAfford,
+  onClick,
+}: {
+  ammo: GearItemData;
+  isSelected: boolean;
+  canAfford: boolean;
+  onClick: () => void;
+}) {
+  const roundsPerBox = getRoundsPerBox(ammo);
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={!canAfford}
+      className={`flex w-full items-center justify-between px-4 py-2 text-left text-sm transition-colors ${
+        isSelected
+          ? "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+          : !canAfford
+            ? "cursor-not-allowed bg-zinc-50 text-zinc-400 dark:bg-zinc-800/50 dark:text-zinc-500"
+            : "rounded-md text-zinc-700 hover:outline hover:outline-1 hover:outline-amber-400 dark:text-zinc-300 dark:hover:outline-amber-500"
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <span className={!canAfford ? "line-through" : ""}>{ammo.name}</span>
+        {ammo.legality === "forbidden" && (
+          <span className="flex items-center gap-0.5 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-900/40 dark:text-red-300">
+            F
+          </span>
+        )}
+        {ammo.legality === "restricted" && (
+          <span className="flex items-center gap-0.5 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+            R
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+        <span>
+          {formatCurrency(ammo.cost)}¥/{roundsPerBox}
+        </span>
+        {!canAfford && <Check className="h-4 w-4 text-emerald-500" />}
+      </div>
+    </button>
+  );
+}
+
+// =============================================================================
 // COMPONENT
 // =============================================================================
 
@@ -139,8 +193,9 @@ export function AmmunitionModal({
 }: AmmunitionModalProps) {
   const gearCatalog = useGear();
   const { ruleset } = useRuleset();
-  const [selectedAmmo, setSelectedAmmo] = useState<GearItemData | null>(null);
+  const [selectedAmmoId, setSelectedAmmoId] = useState<string | null>(null);
   const [selectedPacks, setSelectedPacks] = useState(1);
+  const [addedThisSession, setAddedThisSession] = useState(0);
 
   // Create modifiable item for capability system
   const modifiableItem: ModifiableItem = useMemo(
@@ -161,10 +216,18 @@ export function AmmunitionModal({
     if (!supportsAmmunition) return [];
 
     // Filter to ammunition with subcategory "ammunition"
-    return gearCatalog.ammunition.filter(
-      (ammo) => ammo.subcategory === "ammunition" && isAmmoCompatible(ammo, weapon.subcategory)
-    );
+    return gearCatalog.ammunition
+      .filter(
+        (ammo) => ammo.subcategory === "ammunition" && isAmmoCompatible(ammo, weapon.subcategory)
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
   }, [gearCatalog, weapon.subcategory, supportsAmmunition]);
+
+  // Get selected ammo data
+  const selectedAmmo = useMemo(() => {
+    if (!selectedAmmoId) return null;
+    return ammunition.find((a) => a.id === selectedAmmoId) || null;
+  }, [ammunition, selectedAmmoId]);
 
   // Calculate derived values
   const roundsPerBox = selectedAmmo ? getRoundsPerBox(selectedAmmo) : 10;
@@ -172,207 +235,279 @@ export function AmmunitionModal({
   const totalCost = selectedAmmo ? selectedPacks * selectedAmmo.cost : 0;
   const canAfford = totalCost <= remaining;
 
+  // Full reset on close
+  const resetState = useCallback(() => {
+    setSelectedAmmoId(null);
+    setSelectedPacks(1);
+    setAddedThisSession(0);
+  }, []);
+
+  // Partial reset after adding (preserves nothing since there's no filtering)
+  const resetForNextAmmo = useCallback(() => {
+    setSelectedAmmoId(null);
+    setSelectedPacks(1);
+  }, []);
+
+  // Handle close
+  const handleClose = useCallback(() => {
+    resetState();
+    onClose();
+  }, [resetState, onClose]);
+
   // Handle purchase
-  const handlePurchase = () => {
+  const handlePurchase = useCallback(() => {
     if (!selectedAmmo || !canAfford) return;
     // Pass the number of boxes to the parent
     onPurchase(selectedAmmo, selectedPacks);
-    setSelectedAmmo(null);
-    setSelectedPacks(1);
-  };
-
-  // Reset selection when modal opens
-  const handleClose = () => {
-    setSelectedAmmo(null);
-    setSelectedPacks(1);
-    onClose();
-  };
+    setAddedThisSession((prev) => prev + 1);
+    resetForNextAmmo();
+  }, [selectedAmmo, canAfford, selectedPacks, onPurchase, resetForNextAmmo]);
 
   // Check if weapon uses ammo - now using capability system
   const usesAmmo = supportsAmmunition;
 
+  // If weapon doesn't use ammo, show a simplified modal
+  if (!usesAmmo) {
+    return (
+      <BaseModalRoot isOpen={isOpen} onClose={handleClose} size="md">
+        {({ close }) => (
+          <>
+            <ModalHeader title="Purchase Ammunition" onClose={close}>
+              <span className="text-sm text-zinc-500 dark:text-zinc-400">{weapon.name}</span>
+            </ModalHeader>
+
+            <ModalBody>
+              <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
+                <Package className="h-12 w-12 text-zinc-300 dark:text-zinc-600" />
+                <p className="mt-3 text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                  No Ammunition Required
+                </p>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  This weapon doesn&apos;t use ammunition.
+                </p>
+              </div>
+            </ModalBody>
+
+            <ModalFooter>
+              <div />
+              <button
+                onClick={close}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+              >
+                Close
+              </button>
+            </ModalFooter>
+          </>
+        )}
+      </BaseModalRoot>
+    );
+  }
+
   return (
-    <BaseModalRoot isOpen={isOpen} onClose={handleClose} size="2xl">
+    <BaseModalRoot isOpen={isOpen} onClose={handleClose} size="full" className="max-w-4xl">
       {({ close }) => (
-        <div className="flex max-h-[85vh] flex-col overflow-hidden">
-          {/* Header */}
-          <div className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
-            <div>
-              <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-                Purchase Ammunition
-              </h2>
-              <p className="mt-0.5 text-sm text-zinc-500 dark:text-zinc-400">For: {weapon.name}</p>
-            </div>
-            <button
-              onClick={close}
-              className="rounded-lg p-2 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800"
-            >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
+        <>
+          <ModalHeader title="Purchase Ammunition" onClose={close}>
+            <span className="text-sm text-zinc-500 dark:text-zinc-400">{weapon.name}</span>
+          </ModalHeader>
 
-          {/* Content */}
-          <div className="flex-1 overflow-y-auto p-6">
-            {!usesAmmo ? (
-              <div className="flex flex-col items-center justify-center py-12 text-center">
-                <Package className="h-12 w-12 text-zinc-300 dark:text-zinc-600" />
-                <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">
-                  This weapon doesn&apos;t use ammunition
-                </p>
-              </div>
-            ) : ammunition.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-12 text-center">
-                <Package className="h-12 w-12 text-zinc-300 dark:text-zinc-600" />
-                <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">
-                  No compatible ammunition available
-                </p>
-              </div>
-            ) : (
-              <div className="space-y-4">
-                {/* Ammunition List */}
-                <div className="space-y-2">
-                  {ammunition.map((ammo) => {
-                    const isSelected = selectedAmmo?.id === ammo.id;
-                    const tooExpensive = ammo.cost > remaining;
-                    const ammoRoundsPerBox = getRoundsPerBox(ammo);
-
-                    return (
-                      <div
+          <ModalBody scrollable={false}>
+            {/* Content - Split Pane */}
+            <div className="flex flex-1 overflow-hidden">
+              {/* Left Pane: Ammo List */}
+              <div className="w-1/2 overflow-y-auto border-r border-zinc-200 dark:border-zinc-700">
+                {ammunition.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-12 text-center">
+                    <Package className="h-12 w-12 text-zinc-300 dark:text-zinc-600" />
+                    <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">
+                      No compatible ammunition available
+                    </p>
+                  </div>
+                ) : (
+                  <div className="py-2">
+                    {/* Sticky category header */}
+                    <div className="sticky top-0 z-10 bg-zinc-100 px-4 py-2 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                      Available Ammunition
+                    </div>
+                    {ammunition.map((ammo) => (
+                      <AmmoListItem
                         key={ammo.id}
-                        className={`rounded-lg border transition-all ${
-                          isSelected
-                            ? "border-amber-500 bg-amber-50 ring-1 ring-amber-500 dark:bg-amber-900/20"
-                            : tooExpensive
-                              ? "border-zinc-200 bg-zinc-50 opacity-50 dark:border-zinc-700 dark:bg-zinc-800/50"
-                              : "border-zinc-200 hover:border-zinc-300 dark:border-zinc-700"
+                        ammo={ammo}
+                        isSelected={selectedAmmoId === ammo.id}
+                        canAfford={ammo.cost <= remaining}
+                        onClick={() => {
+                          setSelectedAmmoId(ammo.id);
+                          setSelectedPacks(1);
+                        }}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Right Pane: Ammo Details */}
+              <div className="w-1/2 overflow-y-auto p-6">
+                {selectedAmmo ? (
+                  <div className="space-y-6">
+                    {/* Ammo Info */}
+                    <div>
+                      <h3 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+                        {selectedAmmo.name}
+                      </h3>
+                      <div className="mt-1 flex items-center gap-3 text-sm text-zinc-500 dark:text-zinc-400">
+                        <span>{roundsPerBox} rounds per box</span>
+                        <span>Avail: {selectedAmmo.availability}</span>
+                      </div>
+                    </div>
+
+                    {/* Description */}
+                    {selectedAmmo.description && (
+                      <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                        {selectedAmmo.description}
+                      </p>
+                    )}
+
+                    {/* Stats */}
+                    <div className="space-y-3">
+                      <h4 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                        Modifiers
+                      </h4>
+                      <div className="grid grid-cols-2 gap-2 text-sm">
+                        <div className="flex justify-between rounded bg-zinc-50 px-3 py-2 dark:bg-zinc-800">
+                          <span className="text-zinc-500 dark:text-zinc-400">Damage</span>
+                          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                            {"damageModifier" in selectedAmmo
+                              ? String(selectedAmmo.damageModifier)
+                              : "-"}
+                          </span>
+                        </div>
+                        <div className="flex justify-between rounded bg-zinc-50 px-3 py-2 dark:bg-zinc-800">
+                          <span className="text-zinc-500 dark:text-zinc-400">AP</span>
+                          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                            {"apModifier" in selectedAmmo
+                              ? `${Number(selectedAmmo.apModifier) >= 0 ? "+" : ""}${selectedAmmo.apModifier}`
+                              : "-"}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Legality Warning */}
+                    {(selectedAmmo.legality === "restricted" ||
+                      selectedAmmo.legality === "forbidden") && (
+                      <div
+                        className={`rounded-lg p-3 ${
+                          selectedAmmo.legality === "forbidden"
+                            ? "bg-red-50 dark:bg-red-900/20"
+                            : "bg-amber-50 dark:bg-amber-900/20"
                         }`}
                       >
-                        {/* Ammo Header - Clickable */}
-                        <button
-                          onClick={() => {
-                            if (isSelected) {
-                              // Clicking again deselects
-                              setSelectedAmmo(null);
-                              setSelectedPacks(1);
-                            } else {
-                              setSelectedAmmo(ammo);
-                              setSelectedPacks(1);
-                            }
-                          }}
-                          disabled={tooExpensive}
-                          className={`w-full p-3 text-left ${tooExpensive ? "cursor-not-allowed" : ""}`}
+                        <div
+                          className={`flex items-center gap-2 text-sm font-medium ${
+                            selectedAmmo.legality === "forbidden"
+                              ? "text-red-700 dark:text-red-300"
+                              : "text-amber-700 dark:text-amber-300"
+                          }`}
                         >
-                          <div className="flex items-start justify-between">
-                            <div className="flex-1">
-                              <div className="flex items-center gap-2">
-                                <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                                  {ammo.name}
-                                </span>
-                                {ammo.legality === "forbidden" && (
-                                  <span className="flex items-center gap-0.5 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-900/40 dark:text-red-300">
-                                    <ShieldAlert className="h-3 w-3" />
-                                    Forbidden
-                                  </span>
-                                )}
-                                {ammo.legality === "restricted" && (
-                                  <span className="flex items-center gap-0.5 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
-                                    <AlertTriangle className="h-3 w-3" />
-                                    Restricted
-                                  </span>
-                                )}
-                              </div>
-
-                              {/* Stats */}
-                              <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-zinc-500 dark:text-zinc-400">
-                                {(() => {
-                                  const dmg = "damageModifier" in ammo ? ammo.damageModifier : null;
-                                  return dmg ? <span>DV: {String(dmg)}</span> : null;
-                                })()}
-                                {(() => {
-                                  const ap = "apModifier" in ammo ? ammo.apModifier : null;
-                                  if (ap === null || ap === undefined) return null;
-                                  return (
-                                    <span>
-                                      AP: {Number(ap) >= 0 ? "+" : ""}
-                                      {String(ap)}
-                                    </span>
-                                  );
-                                })()}
-                                <span>Avail: {ammo.availability}</span>
-                              </div>
-
-                              {/* Description */}
-                              {ammo.description && (
-                                <p className="mt-1.5 text-xs text-zinc-500 dark:text-zinc-400">
-                                  {ammo.description}
-                                </p>
-                              )}
-                            </div>
-
-                            {/* Price per box */}
-                            <div className="ml-4 text-right">
-                              <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                                {formatCurrency(ammo.cost)}¥
-                              </span>
-                              <p className="text-[10px] text-zinc-400">
-                                per {ammoRoundsPerBox} rounds
-                              </p>
-                            </div>
-                          </div>
-                        </button>
-
-                        {/* Expanded Quantity Selector */}
-                        {isSelected && (
-                          <div
-                            className="border-t border-amber-200 bg-amber-50/50 p-3 dark:border-amber-800 dark:bg-amber-900/10"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <BulkQuantitySelector
-                              packSize={ammoRoundsPerBox}
-                              unitLabel="rounds"
-                              pricePerPack={ammo.cost}
-                              remaining={remaining}
-                              selectedPacks={selectedPacks}
-                              onPacksChange={setSelectedPacks}
-                              packLabel="box"
-                            />
-                          </div>
-                        )}
+                          {selectedAmmo.legality === "forbidden" ? (
+                            <ShieldAlert className="h-4 w-4" />
+                          ) : (
+                            <AlertTriangle className="h-4 w-4" />
+                          )}
+                          {selectedAmmo.legality === "forbidden" ? "Forbidden" : "Restricted"}
+                        </div>
+                        <p
+                          className={`mt-1 text-xs ${
+                            selectedAmmo.legality === "forbidden"
+                              ? "text-red-600 dark:text-red-400"
+                              : "text-amber-600 dark:text-amber-400"
+                          }`}
+                        >
+                          {selectedAmmo.legality === "forbidden"
+                            ? "Illegal to own. Possession triggers serious legal consequences."
+                            : "Requires a license. May draw law enforcement attention."}
+                        </p>
                       </div>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-          </div>
+                    )}
 
-          {/* Footer */}
-          <div className="flex items-center justify-between border-t border-zinc-200 px-6 py-4 dark:border-zinc-700">
+                    {/* Quantity Selector */}
+                    <BulkQuantitySelector
+                      packSize={roundsPerBox}
+                      unitLabel="rounds"
+                      pricePerPack={selectedAmmo.cost}
+                      remaining={remaining}
+                      selectedPacks={selectedPacks}
+                      onPacksChange={setSelectedPacks}
+                      packLabel="box"
+                    />
+
+                    {/* Cost Indicator */}
+                    <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                          Total Cost
+                        </span>
+                        <span
+                          className={`font-semibold ${
+                            canAfford
+                              ? "text-amber-600 dark:text-amber-400"
+                              : "text-red-600 dark:text-red-400"
+                          }`}
+                        >
+                          {formatCurrency(totalCost)}¥
+                        </span>
+                      </div>
+                      <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                        {totalRounds} rounds ({selectedPacks}{" "}
+                        {selectedPacks === 1 ? "box" : "boxes"})
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex h-full flex-col items-center justify-center text-zinc-400">
+                    <Package className="h-12 w-12" />
+                    <p className="mt-4 text-sm">Select ammunition from the list</p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </ModalBody>
+
+          <ModalFooter>
             <div className="text-sm text-zinc-500 dark:text-zinc-400">
-              Budget remaining:{" "}
-              <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                {formatCurrency(remaining)}¥
+              {addedThisSession > 0 && (
+                <span className="mr-2 text-emerald-600 dark:text-emerald-400">
+                  {addedThisSession} purchased
+                </span>
+              )}
+              <span>
+                Budget:{" "}
+                <span className="font-mono font-medium text-zinc-900 dark:text-zinc-100">
+                  {formatCurrency(remaining)}¥
+                </span>
               </span>
             </div>
             <div className="flex gap-3">
               <button
                 onClick={close}
-                className="rounded-lg border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
               >
-                Cancel
+                Done
               </button>
               <button
                 onClick={handlePurchase}
                 disabled={!selectedAmmo || !canAfford}
-                className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:bg-zinc-300 dark:disabled:bg-zinc-700"
+                className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+                  selectedAmmo && canAfford
+                    ? "bg-amber-500 text-white hover:bg-amber-600"
+                    : "cursor-not-allowed bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
+                }`}
               >
-                {selectedAmmo
-                  ? `Purchase ${selectedPacks}× (${totalRounds} rounds) - ${formatCurrency(totalCost)}¥`
-                  : "Purchase"}
+                Add Ammo
               </button>
             </div>
-          </div>
-        </div>
+          </ModalFooter>
+        </>
       )}
     </BaseModalRoot>
   );

--- a/components/creation/weapons/WeaponPurchaseModal.tsx
+++ b/components/creation/weapons/WeaponPurchaseModal.tsx
@@ -11,14 +11,14 @@
  * when opened from a specific category section.
  */
 
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { WeaponData, WeaponModificationCatalogItemData } from "@/lib/rules/RulesetContext";
 import { useWeaponModifications } from "@/lib/rules/RulesetContext";
 import type { ItemLegality } from "@/lib/types";
-import { BaseModalRoot } from "@/components/ui";
+import { BaseModalRoot, ModalHeader, ModalBody, ModalFooter } from "@/components/ui";
 import { BulkQuantitySelector } from "@/components/creation/shared/BulkQuantitySelector";
-import { Search, Wifi, AlertTriangle, X, Wrench } from "lucide-react";
+import { Search, Wifi, AlertTriangle, Wrench, Crosshair } from "lucide-react";
 
 // =============================================================================
 // CONSTANTS
@@ -211,6 +211,7 @@ export function WeaponPurchaseModal({
   const [selectedCategory, setSelectedCategory] = useState<WeaponCategory>("all");
   const [selectedWeapon, setSelectedWeapon] = useState<WeaponData | null>(null);
   const [selectedPacks, setSelectedPacks] = useState(1);
+  const [addedThisSession, setAddedThisSession] = useState(0);
 
   // Helper to look up modification names from built-in mod IDs
   const getBuiltInModDetails = useMemo(() => {
@@ -295,46 +296,55 @@ export function WeaponPurchaseModal({
     overscan: 5,
   });
 
-  // Reset selection when modal opens
-  const handleClose = () => {
+  // Full reset on close
+  const resetState = useCallback(() => {
     setSearchQuery("");
     setSelectedCategory("all");
     setSelectedWeapon(null);
     setSelectedPacks(1);
-    onClose();
-  };
+    setAddedThisSession(0);
+  }, []);
 
-  const handlePurchase = () => {
+  // Partial reset after adding (preserves search/filters)
+  const resetForNextWeapon = useCallback(() => {
+    setSelectedWeapon(null);
+    setSelectedPacks(1);
+  }, []);
+
+  // Handle close
+  const handleClose = useCallback(() => {
+    resetState();
+    onClose();
+  }, [resetState, onClose]);
+
+  const handlePurchase = useCallback(() => {
     if (selectedWeapon && totalCost <= remaining) {
       const quantity = isStackable ? selectedPacks : 1;
       onPurchase(selectedWeapon, quantity);
-      setSelectedWeapon(null);
-      setSelectedPacks(1);
+      setAddedThisSession((prev) => prev + 1);
+      resetForNextWeapon();
     }
-  };
+  }, [
+    selectedWeapon,
+    totalCost,
+    remaining,
+    isStackable,
+    selectedPacks,
+    onPurchase,
+    resetForNextWeapon,
+  ]);
 
   const conceal = selectedWeapon ? getBaseConcealability(selectedWeapon.subcategory || "") : 0;
   const canAffordSelected = selectedWeapon ? totalCost <= remaining : false;
 
   return (
-    <BaseModalRoot isOpen={isOpen} onClose={handleClose} size="2xl">
+    <BaseModalRoot isOpen={isOpen} onClose={handleClose} size="full" className="max-w-4xl">
       {({ close }) => (
-        <div className="flex max-h-[85vh] flex-col">
-          {/* Header */}
-          <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 dark:border-zinc-700">
-            <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-              Select Weapon
-            </h2>
-            <button
-              onClick={close}
-              className="rounded-lg p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800"
-            >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
+        <>
+          <ModalHeader title="Select Weapon" onClose={close} />
 
           {/* Search & Filters */}
-          <div className="px-6 py-3 border-b border-zinc-100 dark:border-zinc-800 space-y-3">
+          <div className="border-b border-zinc-200 px-6 py-3 dark:border-zinc-700">
             {/* Search */}
             <div className="relative">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
@@ -343,19 +353,19 @@ export function WeaponPurchaseModal({
                 placeholder="Search weapons..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full rounded-lg border border-zinc-200 bg-white py-2 pl-10 pr-4 text-sm text-zinc-900 placeholder-zinc-400 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                className="w-full rounded-lg border border-zinc-200 bg-zinc-50 py-2 pl-10 pr-4 text-sm text-zinc-900 placeholder-zinc-400 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
               />
             </div>
 
             {/* Category Pills */}
-            <div className="flex flex-wrap gap-1.5">
+            <div className="mt-3 flex flex-wrap gap-2">
               {WEAPON_CATEGORIES.map((cat) => (
                 <button
                   key={cat.id}
                   onClick={() => setSelectedCategory(cat.id)}
-                  className={`px-2.5 py-1 text-xs font-medium rounded-full transition-colors ${
+                  className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
                     selectedCategory === cat.id
-                      ? "bg-emerald-600 text-white"
+                      ? "bg-amber-500 text-white"
                       : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
                   }`}
                 >
@@ -365,285 +375,307 @@ export function WeaponPurchaseModal({
             </div>
           </div>
 
-          {/* Content - Split Pane */}
-          <div className="flex-1 flex overflow-hidden">
-            {/* Left: Weapon List - Virtualized */}
-            <div
-              ref={scrollContainerRef}
-              className="w-1/2 border-r border-zinc-100 dark:border-zinc-800 overflow-y-auto p-4"
-            >
-              {filteredWeapons.length === 0 ? (
-                <p className="text-sm text-zinc-500 text-center py-8">No weapons found</p>
-              ) : (
-                <div
-                  style={{
-                    height: `${rowVirtualizer.getTotalSize()}px`,
-                    width: "100%",
-                    position: "relative",
-                  }}
-                >
-                  {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                    const weapon = filteredWeapons[virtualRow.index];
-                    return (
-                      <div
-                        key={weapon.id}
-                        style={{
-                          position: "absolute",
-                          top: 0,
-                          left: 0,
-                          width: "100%",
-                          height: `${virtualRow.size}px`,
-                          transform: `translateY(${virtualRow.start}px)`,
-                          padding: "4px 0",
-                        }}
-                      >
-                        <WeaponListItem
-                          weapon={weapon}
-                          isSelected={selectedWeapon?.id === weapon.id}
-                          canAfford={weapon.cost <= remaining}
-                          onClick={() => setSelectedWeapon(weapon)}
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-
-            {/* Right: Detail Preview */}
-            <div className="w-1/2 overflow-y-auto p-4">
-              {selectedWeapon ? (
-                <div className="space-y-4">
-                  {/* Weapon Name */}
-                  <div>
-                    <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-                      {selectedWeapon.name}
-                    </h3>
-                    <p className="text-sm text-zinc-500 dark:text-zinc-400 capitalize">
-                      {selectedWeapon.subcategory?.replace("-", " ") || selectedWeapon.category}
-                    </p>
+          <ModalBody scrollable={false}>
+            {/* Content - Split Pane */}
+            <div className="flex flex-1 overflow-hidden">
+              {/* Left Pane: Weapon List - Virtualized */}
+              <div
+                ref={scrollContainerRef}
+                className="w-1/2 overflow-y-auto border-r border-zinc-200 dark:border-zinc-700"
+              >
+                {filteredWeapons.length === 0 ? (
+                  <p className="text-sm text-zinc-500 text-center py-8">No weapons found</p>
+                ) : (
+                  <div
+                    style={{
+                      height: `${rowVirtualizer.getTotalSize()}px`,
+                      width: "100%",
+                      position: "relative",
+                    }}
+                  >
+                    {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                      const weapon = filteredWeapons[virtualRow.index];
+                      return (
+                        <div
+                          key={weapon.id}
+                          style={{
+                            position: "absolute",
+                            top: 0,
+                            left: 0,
+                            width: "100%",
+                            height: `${virtualRow.size}px`,
+                            transform: `translateY(${virtualRow.start}px)`,
+                            padding: "4px 0",
+                          }}
+                        >
+                          <WeaponListItem
+                            weapon={weapon}
+                            isSelected={selectedWeapon?.id === weapon.id}
+                            canAfford={weapon.cost <= remaining}
+                            onClick={() => setSelectedWeapon(weapon)}
+                          />
+                        </div>
+                      );
+                    })}
                   </div>
+                )}
+              </div>
 
-                  {/* Stats Grid */}
-                  <div className="space-y-3">
-                    <h4 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-                      Statistics
-                    </h4>
-                    <div className="grid grid-cols-2 gap-2 text-sm">
-                      <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
-                        <span className="text-zinc-500 dark:text-zinc-400">Damage</span>
-                        <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                          {selectedWeapon.damage}
-                        </span>
-                      </div>
-                      <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
-                        <span className="text-zinc-500 dark:text-zinc-400">AP</span>
-                        <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                          {selectedWeapon.ap}
-                        </span>
-                      </div>
-                      <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
-                        <span className="text-zinc-500 dark:text-zinc-400">Accuracy</span>
-                        <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                          {selectedWeapon.accuracy || "-"}
-                        </span>
-                      </div>
-                      <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
-                        <span className="text-zinc-500 dark:text-zinc-400">Mode</span>
-                        <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                          {formatModes(selectedWeapon.mode)}
-                        </span>
-                      </div>
-                      <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
-                        <span className="text-zinc-500 dark:text-zinc-400">RC</span>
-                        <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                          {selectedWeapon.rc || "-"}
-                        </span>
-                      </div>
-                      <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
-                        <span className="text-zinc-500 dark:text-zinc-400">Ammo</span>
-                        <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                          {selectedWeapon.ammo || "-"}
-                        </span>
-                      </div>
-                      {selectedWeapon.reach !== undefined && (
+              {/* Right Pane: Detail Preview */}
+              <div className="w-1/2 overflow-y-auto p-6">
+                {selectedWeapon ? (
+                  <div className="space-y-4">
+                    {/* Weapon Name */}
+                    <div>
+                      <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                        {selectedWeapon.name}
+                      </h3>
+                      <p className="text-sm text-zinc-500 dark:text-zinc-400 capitalize">
+                        {selectedWeapon.subcategory?.replace("-", " ") || selectedWeapon.category}
+                      </p>
+                    </div>
+
+                    {/* Stats Grid */}
+                    <div className="space-y-3">
+                      <h4 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                        Statistics
+                      </h4>
+                      <div className="grid grid-cols-2 gap-2 text-sm">
                         <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
-                          <span className="text-zinc-500 dark:text-zinc-400">Reach</span>
+                          <span className="text-zinc-500 dark:text-zinc-400">Damage</span>
                           <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                            {selectedWeapon.reach}
+                            {selectedWeapon.damage}
                           </span>
                         </div>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Physical Stats */}
-                  <div className="space-y-3">
-                    <h4 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-                      Physical
-                    </h4>
-                    <div className="grid grid-cols-2 gap-2 text-sm">
-                      <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
-                        <span className="text-zinc-500 dark:text-zinc-400">Conceal</span>
-                        <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                          {conceal >= 0 ? `+${conceal}` : conceal}
-                        </span>
-                      </div>
-                      <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
-                        <span className="text-zinc-500 dark:text-zinc-400">Availability</span>
-                        <span
-                          className={`font-medium ${
-                            selectedWeapon.legality === "forbidden"
-                              ? "text-red-600 dark:text-red-400"
-                              : selectedWeapon.legality === "restricted"
-                                ? "text-amber-600 dark:text-amber-400"
-                                : "text-zinc-900 dark:text-zinc-100"
-                          }`}
-                        >
-                          {getAvailabilityDisplay(
-                            selectedWeapon.availability,
-                            selectedWeapon.legality
-                          )}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Built-in Modifications - only show if weapon has any */}
-                  {selectedWeapon.builtInModifications &&
-                    selectedWeapon.builtInModifications.length > 0 && (
-                      <div className="rounded-lg bg-emerald-50 dark:bg-emerald-900/20 p-3">
-                        <div className="flex items-center gap-2 text-sm font-medium text-emerald-700 dark:text-emerald-300">
-                          <Wrench className="h-4 w-4" />
-                          Built-in Modifications
+                        <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
+                          <span className="text-zinc-500 dark:text-zinc-400">AP</span>
+                          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                            {selectedWeapon.ap}
+                          </span>
                         </div>
-                        <p className="mt-1 text-[10px] text-emerald-600 dark:text-emerald-400">
-                          Included at no extra cost
+                        <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
+                          <span className="text-zinc-500 dark:text-zinc-400">Accuracy</span>
+                          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                            {selectedWeapon.accuracy || "-"}
+                          </span>
+                        </div>
+                        <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
+                          <span className="text-zinc-500 dark:text-zinc-400">Mode</span>
+                          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                            {formatModes(selectedWeapon.mode)}
+                          </span>
+                        </div>
+                        <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
+                          <span className="text-zinc-500 dark:text-zinc-400">RC</span>
+                          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                            {selectedWeapon.rc || "-"}
+                          </span>
+                        </div>
+                        <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
+                          <span className="text-zinc-500 dark:text-zinc-400">Ammo</span>
+                          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                            {selectedWeapon.ammo || "-"}
+                          </span>
+                        </div>
+                        {selectedWeapon.reach !== undefined && (
+                          <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
+                            <span className="text-zinc-500 dark:text-zinc-400">Reach</span>
+                            <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                              {selectedWeapon.reach}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Physical Stats */}
+                    <div className="space-y-3">
+                      <h4 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                        Physical
+                      </h4>
+                      <div className="grid grid-cols-2 gap-2 text-sm">
+                        <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
+                          <span className="text-zinc-500 dark:text-zinc-400">Conceal</span>
+                          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                            {conceal >= 0 ? `+${conceal}` : conceal}
+                          </span>
+                        </div>
+                        <div className="flex justify-between bg-zinc-50 dark:bg-zinc-800 rounded px-3 py-2">
+                          <span className="text-zinc-500 dark:text-zinc-400">Availability</span>
+                          <span
+                            className={`font-medium ${
+                              selectedWeapon.legality === "forbidden"
+                                ? "text-red-600 dark:text-red-400"
+                                : selectedWeapon.legality === "restricted"
+                                  ? "text-amber-600 dark:text-amber-400"
+                                  : "text-zinc-900 dark:text-zinc-100"
+                            }`}
+                          >
+                            {getAvailabilityDisplay(
+                              selectedWeapon.availability,
+                              selectedWeapon.legality
+                            )}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Built-in Modifications - only show if weapon has any */}
+                    {selectedWeapon.builtInModifications &&
+                      selectedWeapon.builtInModifications.length > 0 && (
+                        <div className="rounded-lg bg-emerald-50 dark:bg-emerald-900/20 p-3">
+                          <div className="flex items-center gap-2 text-sm font-medium text-emerald-700 dark:text-emerald-300">
+                            <Wrench className="h-4 w-4" />
+                            Built-in Modifications
+                          </div>
+                          <p className="mt-1 text-[10px] text-emerald-600 dark:text-emerald-400">
+                            Included at no extra cost
+                          </p>
+                          <ul className="mt-2 space-y-1">
+                            {getBuiltInModDetails(selectedWeapon.builtInModifications).map(
+                              (mod) => (
+                                <li
+                                  key={mod.id}
+                                  className="text-xs text-emerald-700 dark:text-emerald-300 flex items-center gap-1"
+                                >
+                                  <span className="w-1 h-1 rounded-full bg-emerald-500" />
+                                  {mod.name}
+                                  {mod.rating && ` (Rating ${mod.rating})`}
+                                  {mod.mount && (
+                                    <span className="text-emerald-500 dark:text-emerald-500 text-[10px]">
+                                      [{mod.mount}]
+                                    </span>
+                                  )}
+                                </li>
+                              )
+                            )}
+                          </ul>
+                        </div>
+                      )}
+
+                    {/* Wireless Bonus - only show if weapon has one */}
+                    {selectedWeapon.wirelessBonus && (
+                      <div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-3">
+                        <div className="flex items-center gap-2 text-sm font-medium text-blue-700 dark:text-blue-300">
+                          <Wifi className="h-4 w-4" />
+                          Wireless Bonus
+                        </div>
+                        <p className="mt-1 text-xs text-blue-600 dark:text-blue-400">
+                          {selectedWeapon.wirelessBonus}
                         </p>
-                        <ul className="mt-2 space-y-1">
-                          {getBuiltInModDetails(selectedWeapon.builtInModifications).map((mod) => (
-                            <li
-                              key={mod.id}
-                              className="text-xs text-emerald-700 dark:text-emerald-300 flex items-center gap-1"
-                            >
-                              <span className="w-1 h-1 rounded-full bg-emerald-500" />
-                              {mod.name}
-                              {mod.rating && ` (Rating ${mod.rating})`}
-                              {mod.mount && (
-                                <span className="text-emerald-500 dark:text-emerald-500 text-[10px]">
-                                  [{mod.mount}]
-                                </span>
-                              )}
-                            </li>
-                          ))}
-                        </ul>
                       </div>
                     )}
 
-                  {/* Wireless Bonus - only show if weapon has one */}
-                  {selectedWeapon.wirelessBonus && (
-                    <div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-3">
-                      <div className="flex items-center gap-2 text-sm font-medium text-blue-700 dark:text-blue-300">
-                        <Wifi className="h-4 w-4" />
-                        Wireless Bonus
-                      </div>
-                      <p className="mt-1 text-xs text-blue-600 dark:text-blue-400">
-                        {selectedWeapon.wirelessBonus}
-                      </p>
-                    </div>
-                  )}
-
-                  {/* Legality Warning */}
-                  {(selectedWeapon.legality === "restricted" ||
-                    selectedWeapon.legality === "forbidden") && (
-                    <div
-                      className={`rounded-lg p-3 ${
-                        selectedWeapon.legality === "forbidden"
-                          ? "bg-red-50 dark:bg-red-900/20"
-                          : "bg-amber-50 dark:bg-amber-900/20"
-                      }`}
-                    >
+                    {/* Legality Warning */}
+                    {(selectedWeapon.legality === "restricted" ||
+                      selectedWeapon.legality === "forbidden") && (
                       <div
-                        className={`flex items-center gap-2 text-sm font-medium ${
+                        className={`rounded-lg p-3 ${
                           selectedWeapon.legality === "forbidden"
-                            ? "text-red-700 dark:text-red-300"
-                            : "text-amber-700 dark:text-amber-300"
+                            ? "bg-red-50 dark:bg-red-900/20"
+                            : "bg-amber-50 dark:bg-amber-900/20"
                         }`}
                       >
-                        <AlertTriangle className="h-4 w-4" />
-                        {selectedWeapon.legality === "forbidden" ? "Forbidden" : "Restricted"}
+                        <div
+                          className={`flex items-center gap-2 text-sm font-medium ${
+                            selectedWeapon.legality === "forbidden"
+                              ? "text-red-700 dark:text-red-300"
+                              : "text-amber-700 dark:text-amber-300"
+                          }`}
+                        >
+                          <AlertTriangle className="h-4 w-4" />
+                          {selectedWeapon.legality === "forbidden" ? "Forbidden" : "Restricted"}
+                        </div>
+                        <p
+                          className={`mt-1 text-xs ${
+                            selectedWeapon.legality === "forbidden"
+                              ? "text-red-600 dark:text-red-400"
+                              : "text-amber-600 dark:text-amber-400"
+                          }`}
+                        >
+                          {selectedWeapon.legality === "forbidden"
+                            ? "Illegal to own. Possession triggers serious legal consequences."
+                            : "Requires a license. May draw law enforcement attention."}
+                        </p>
                       </div>
-                      <p
-                        className={`mt-1 text-xs ${
-                          selectedWeapon.legality === "forbidden"
-                            ? "text-red-600 dark:text-red-400"
-                            : "text-amber-600 dark:text-amber-400"
-                        }`}
-                      >
-                        {selectedWeapon.legality === "forbidden"
-                          ? "Illegal to own. Possession triggers serious legal consequences."
-                          : "Requires a license. May draw law enforcement attention."}
-                      </p>
+                    )}
+
+                    {/* Quantity Selector for stackable items */}
+                    {isStackable && (
+                      <BulkQuantitySelector
+                        packSize={1}
+                        unitLabel={unitLabel}
+                        pricePerPack={selectedWeapon.cost}
+                        remaining={remaining}
+                        selectedPacks={selectedPacks}
+                        onPacksChange={setSelectedPacks}
+                        packLabel="unit"
+                      />
+                    )}
+
+                    {/* Cost Indicator */}
+                    <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                          Cost
+                        </span>
+                        <span
+                          className={`font-semibold ${
+                            canAffordSelected
+                              ? "text-amber-600 dark:text-amber-400"
+                              : "text-red-600 dark:text-red-400"
+                          }`}
+                        >
+                          {formatCurrency(totalCost)}¥
+                        </span>
+                      </div>
                     </div>
-                  )}
-
-                  {/* Quantity Selector for stackable items */}
-                  {isStackable && (
-                    <BulkQuantitySelector
-                      packSize={1}
-                      unitLabel={unitLabel}
-                      pricePerPack={selectedWeapon.cost}
-                      remaining={remaining}
-                      selectedPacks={selectedPacks}
-                      onPacksChange={setSelectedPacks}
-                      packLabel="unit"
-                    />
-                  )}
-
-                  {/* Purchase Button */}
-                  <div className="pt-2">
-                    <button
-                      onClick={handlePurchase}
-                      disabled={!canAffordSelected}
-                      className={`w-full py-3 rounded-lg text-sm font-medium transition-colors ${
-                        canAffordSelected
-                          ? "bg-amber-500 text-white hover:bg-amber-600"
-                          : "bg-zinc-100 text-zinc-400 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500"
-                      }`}
-                    >
-                      {canAffordSelected
-                        ? isStackable
-                          ? `Purchase ${selectedPacks}x - ${formatCurrency(totalCost)}¥`
-                          : `Purchase - ${formatCurrency(selectedWeapon.cost)}¥`
-                        : `Cannot Afford (${formatCurrency(totalCost)}¥)`}
-                    </button>
                   </div>
-                </div>
-              ) : (
-                <div className="flex items-center justify-center h-full text-zinc-400 dark:text-zinc-500">
-                  <p className="text-sm">Select a weapon to see details</p>
-                </div>
-              )}
+                ) : (
+                  <div className="flex h-full flex-col items-center justify-center text-zinc-400">
+                    <Crosshair className="h-12 w-12" />
+                    <p className="mt-4 text-sm">Select a weapon from the list</p>
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
+          </ModalBody>
 
-          {/* Footer */}
-          <div className="px-6 py-3 border-t border-zinc-200 dark:border-zinc-700 flex items-center justify-between">
+          <ModalFooter>
             <div className="text-sm text-zinc-500 dark:text-zinc-400">
-              Budget:{" "}
-              <span className="font-mono font-medium text-emerald-600 dark:text-emerald-400">
-                {formatCurrency(remaining)}¥
-              </span>{" "}
-              remaining
+              {addedThisSession > 0 && (
+                <span className="mr-2 text-emerald-600 dark:text-emerald-400">
+                  {addedThisSession} added
+                </span>
+              )}
+              <span>
+                Budget:{" "}
+                <span className="font-mono font-medium text-zinc-900 dark:text-zinc-100">
+                  {formatCurrency(remaining)}¥
+                </span>
+              </span>
             </div>
-            <button
-              onClick={close}
-              className="px-4 py-2 text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+            <div className="flex gap-3">
+              <button
+                onClick={close}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+              >
+                Done
+              </button>
+              <button
+                onClick={handlePurchase}
+                disabled={!selectedWeapon || !canAffordSelected}
+                className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+                  selectedWeapon && canAffordSelected
+                    ? "bg-amber-500 text-white hover:bg-amber-600"
+                    : "cursor-not-allowed bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
+                }`}
+              >
+                Add Weapon
+              </button>
+            </div>
+          </ModalFooter>
+        </>
       )}
     </BaseModalRoot>
   );


### PR DESCRIPTION
## Summary
- Consolidate WeaponsPanel UI to use single "+ Add Weapon" button instead of per-category buttons
- Update WeaponPurchaseModal with category filtering pills and two-column bulk-add layout
- Update WeaponModificationModal to two-column layout with bulk-add support
- Update AmmunitionModal to two-column layout with bulk quantity selector
- Replace collapsible WeaponCategorySection with flat SpellsCard-style grouped display
- Empty categories are now hidden instead of showing "No weapons" messages

## Test plan
- [ ] Open WeaponsPanel and verify single "+ Add" button in header
- [ ] Click "+ Add" and verify modal opens with "All Weapons" category selected
- [ ] Use category filter pills to browse different weapon types
- [ ] Add weapons from different categories and verify grouped display
- [ ] Verify empty categories are hidden in the grouped list
- [ ] Test weapon modification modal (⚙️ button) - verify two-column layout
- [ ] Test ammunition modal (📦 button) - verify two-column layout with quantity selector
- [ ] Verify weapon removal (✕ button) still works
- [ ] Verify legality warnings appear for restricted/forbidden items

🤖 Generated with [Claude Code](https://claude.com/claude-code)