### PR TITLE
Sticky the save button

### DIFF
--- a/app/characters/create/sheet/components/SheetCreationLayout.tsx
+++ b/app/characters/create/sheet/components/SheetCreationLayout.tsx
@@ -611,11 +611,9 @@ function ValidationSummary({
   const { canFinalize, isValid, errors } = useCreationBudgets();
 
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
-      <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Finalize Character</h3>
-
-      {/* Save status */}
-      <div className="mt-2 flex items-center gap-2 text-xs">
+    <div className="flex items-center justify-between gap-4 px-4 py-3 sm:px-6">
+      {/* Left: status info */}
+      <div className="flex items-center gap-4 text-xs">
         {saveError ? (
           <div className="flex items-center gap-2 text-red-600 dark:text-red-400">
             <AlertCircle className="h-3 w-3" />
@@ -642,20 +640,26 @@ function ValidationSummary({
             Not yet saved
           </div>
         )}
+
+        {!isValid && errors.length > 0 && (
+          <span className="text-red-600 dark:text-red-400">
+            Fix {errors.length} error{errors.length !== 1 ? "s" : ""} to continue
+          </span>
+        )}
       </div>
 
-      {/* Finalize button */}
+      {/* Right: finalize button */}
       <button
         onClick={onFinalize}
         disabled={!canFinalize || isSaving}
-        className={`mt-4 w-full rounded-lg px-4 py-2.5 text-sm font-medium transition-colors ${
+        className={`shrink-0 rounded-lg px-6 py-2 text-sm font-medium transition-colors ${
           canFinalize && !isSaving
             ? "bg-emerald-600 text-white hover:bg-emerald-700"
             : "cursor-not-allowed bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
         }`}
       >
         {isSaving ? (
-          <span className="flex items-center justify-center gap-2">
+          <span className="flex items-center gap-2">
             <Loader2 className="h-4 w-4 animate-spin" />
             Saving...
           </span>
@@ -665,12 +669,6 @@ function ValidationSummary({
           "Complete All Sections"
         )}
       </button>
-
-      {!isValid && errors.length > 0 && (
-        <p className="mt-2 text-center text-xs text-red-600 dark:text-red-400">
-          Fix {errors.length} error{errors.length !== 1 ? "s" : ""} to continue
-        </p>
-      )}
     </div>
   );
 }
@@ -759,15 +757,6 @@ export function SheetCreationLayout({
 
           {/* Budget Summary */}
           <BudgetSummaryCard creationState={creationState} />
-
-          {/* Finalize */}
-          <ValidationSummary
-            onFinalize={onFinalize}
-            isSaving={isSaving}
-            lastSaved={lastSaved}
-            saveError={saveError}
-            onRetry={onRetry}
-          />
         </div>
 
         {/* Column 2: Stats */}
@@ -831,6 +820,17 @@ export function SheetCreationLayout({
           {/* Identities - Phase 5 */}
           <IdentitiesCard state={creationState} updateState={updateState} />
         </div>
+      </div>
+
+      {/* Sticky Finalize Footer */}
+      <div className="sticky bottom-0 z-10 border-t border-zinc-200 bg-white/95 backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/95">
+        <ValidationSummary
+          onFinalize={onFinalize}
+          isSaving={isSaving}
+          lastSaved={lastSaved}
+          saveError={saveError}
+          onRetry={onRetry}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
  ---
  Summary

  - Moved the ValidationSummary (finalize) component out of Column 1 and into a sticky footer bar pinned to the
  bottom of the viewport
  - Restyled from a stacked card layout to a horizontal bar (save status on left, "Create Character" button on right)
   to minimize vertical footprint

https://github.com/user-attachments/assets/c1e550d2-230f-41be-b591-4597054d2db5

  Test plan

  - Open character creation sheet at /characters/create/sheet
  - Scroll through the page — finalize bar should remain sticky at the bottom
  - Verify save status (not saved / saving / saved / error) displays correctly on the left
  - Verify "Complete All Sections" / "Create Character" button works on the right
  - Check validation error count appears inline next to save status
  - Test responsive behavior: single-column layout on mobile, bar still sticky
  - Verify dark mode styling (semi-transparent background, border color)