### PR TITLE
test: add tests for password reset API routes and creation components

### DIFF
--- a/app/api/auth/forgot-password/__tests__/route.test.ts
+++ b/app/api/auth/forgot-password/__tests__/route.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for /api/auth/forgot-password endpoint
+ *
+ * Tests the password reset request flow including validation,
+ * rate limiting, and email enumeration prevention.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Define mocks using vi.hoisted so they're available before vi.mock runs
+const { mockRateLimiterInstance, mockAuditLogger } = vi.hoisted(() => ({
+  mockRateLimiterInstance: {
+    isRateLimited: vi.fn().mockReturnValue(false),
+    getRemaining: vi.fn().mockReturnValue(3),
+    reset: vi.fn(),
+  },
+  mockAuditLogger: {
+    log: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock dependencies
+vi.mock("@/lib/auth/password-reset");
+vi.mock("@/lib/auth/validation");
+vi.mock("@/lib/security/rate-limit", () => ({
+  RateLimiter: {
+    get: vi.fn(() => mockRateLimiterInstance),
+  },
+}));
+vi.mock("@/lib/security/audit-logger", () => ({
+  AuditLogger: mockAuditLogger,
+}));
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue({
+    get: vi.fn().mockReturnValue("127.0.0.1"),
+  }),
+}));
+
+// Import after mocks are set up
+import { POST } from "../route";
+import * as passwordResetModule from "@/lib/auth/password-reset";
+import * as validationModule from "@/lib/auth/validation";
+
+// Helper to create a NextRequest with JSON body
+function createMockRequest(url: string, body?: unknown, method = "POST"): NextRequest {
+  const headers = new Headers();
+  if (body) {
+    headers.set("Content-Type", "application/json");
+  }
+  headers.set("host", "localhost:3000");
+  headers.set("x-forwarded-proto", "http");
+
+  const request = new NextRequest(url, {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers,
+  });
+
+  // Mock json() method if body is provided
+  if (body) {
+    (request as { json: () => Promise<unknown> }).json = async () => body;
+  }
+
+  return request;
+}
+
+describe("POST /api/auth/forgot-password", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Reset mock implementations
+    mockRateLimiterInstance.isRateLimited.mockReturnValue(false);
+    mockRateLimiterInstance.getRemaining.mockReturnValue(3);
+
+    vi.mocked(validationModule.isValidEmail).mockReturnValue(true);
+    vi.mocked(passwordResetModule.requestPasswordReset).mockResolvedValue({ success: true });
+  });
+
+  it("should return success for valid email", async () => {
+    const requestBody = { email: "test@example.com" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/forgot-password",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.message).toBe(
+      "If an account exists with this email, you will receive a password reset link."
+    );
+    expect(passwordResetModule.requestPasswordReset).toHaveBeenCalledWith(
+      "test@example.com",
+      "http://localhost:3000",
+      "127.0.0.1"
+    );
+  });
+
+  it("should return 400 when email is missing", async () => {
+    const requestBody = {};
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/forgot-password",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Email is required");
+    expect(passwordResetModule.requestPasswordReset).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 when email is not a string", async () => {
+    const requestBody = { email: 12345 };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/forgot-password",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Email is required");
+  });
+
+  it("should return 400 for invalid email format", async () => {
+    vi.mocked(validationModule.isValidEmail).mockReturnValue(false);
+
+    const requestBody = { email: "invalid-email" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/forgot-password",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Invalid email format");
+    expect(passwordResetModule.requestPasswordReset).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 for invalid JSON body", async () => {
+    const request = new NextRequest("http://localhost:3000/api/auth/forgot-password", {
+      method: "POST",
+      headers: new Headers({
+        "Content-Type": "application/json",
+        host: "localhost:3000",
+      }),
+    });
+    (request as { json: () => Promise<unknown> }).json = async () => {
+      throw new Error("Invalid JSON");
+    };
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Invalid request body");
+  });
+
+  it("should still return success when rate limited (prevents email enumeration)", async () => {
+    mockRateLimiterInstance.isRateLimited.mockReturnValue(true);
+
+    const requestBody = { email: "test@example.com" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/forgot-password",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    // Still returns success to prevent email enumeration
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.message).toBe(
+      "If an account exists with this email, you will receive a password reset link."
+    );
+    // But the actual reset request is NOT made
+    expect(passwordResetModule.requestPasswordReset).not.toHaveBeenCalled();
+  });
+
+  it("should log rate limit events", async () => {
+    mockRateLimiterInstance.isRateLimited.mockReturnValue(true);
+    mockRateLimiterInstance.getRemaining.mockReturnValue(0);
+
+    const requestBody = { email: "test@example.com" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/forgot-password",
+      requestBody
+    );
+
+    await POST(request);
+
+    expect(mockAuditLogger.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "password_reset.rate_limited",
+        email: "test@example.com",
+        ip: "127.0.0.1",
+      })
+    );
+  });
+
+  it("should normalize email to lowercase for rate limiting", async () => {
+    const requestBody = { email: "TEST@EXAMPLE.COM" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/forgot-password",
+      requestBody
+    );
+
+    await POST(request);
+
+    // Rate limiter should check with lowercase email
+    expect(mockRateLimiterInstance.isRateLimited).toHaveBeenCalledWith(
+      "password-reset:test@example.com"
+    );
+  });
+
+  it("should still return success when requestPasswordReset throws (prevents information leakage)", async () => {
+    // Suppress console.error output for this test
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.mocked(passwordResetModule.requestPasswordReset).mockRejectedValue(
+      new Error("Database error")
+    );
+
+    const requestBody = { email: "test@example.com" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/forgot-password",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    // Still returns success to prevent information leakage
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.message).toBe(
+      "If an account exists with this email, you will receive a password reset link."
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should build correct base URL from request headers", async () => {
+    const request = createMockRequest("http://localhost:3000/api/auth/forgot-password", {
+      email: "test@example.com",
+    });
+    // Override headers for custom host/protocol
+    Object.defineProperty(request.headers, "get", {
+      value: (name: string) => {
+        if (name === "x-forwarded-proto") return "https";
+        if (name === "host") return "example.com";
+        return null;
+      },
+    });
+
+    await POST(request);
+
+    expect(passwordResetModule.requestPasswordReset).toHaveBeenCalledWith(
+      "test@example.com",
+      "https://example.com",
+      "127.0.0.1"
+    );
+  });
+});

--- a/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/app/api/auth/reset-password/__tests__/route.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for /api/auth/reset-password endpoint
+ *
+ * Tests the password reset execution flow including token validation,
+ * password strength requirements, and error handling.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+import * as passwordResetModule from "@/lib/auth/password-reset";
+import * as validationModule from "@/lib/auth/validation";
+
+// Mock dependencies
+vi.mock("@/lib/auth/password-reset");
+vi.mock("@/lib/auth/validation");
+
+// Helper to create a NextRequest with JSON body
+function createMockRequest(url: string, body?: unknown, method = "POST"): NextRequest {
+  const headers = new Headers();
+  if (body) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const request = new NextRequest(url, {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers,
+  });
+
+  // Mock json() method if body is provided
+  if (body) {
+    (request as { json: () => Promise<unknown> }).json = async () => body;
+  }
+
+  return request;
+}
+
+describe("POST /api/auth/reset-password", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mocks
+    vi.mocked(validationModule.isStrongPassword).mockReturnValue(true);
+    vi.mocked(validationModule.getPasswordStrengthError).mockReturnValue(null);
+    vi.mocked(passwordResetModule.resetPassword).mockResolvedValue({
+      success: true,
+      userId: "user-123",
+    });
+  });
+
+  it("should reset password successfully with valid token and password", async () => {
+    const requestBody = {
+      token: "valid-reset-token-abc123",
+      password: "NewSecurePass123!",
+    };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(passwordResetModule.resetPassword).toHaveBeenCalledWith(
+      "valid-reset-token-abc123",
+      "NewSecurePass123!"
+    );
+  });
+
+  it("should return 400 when token is missing", async () => {
+    const requestBody = { password: "NewSecurePass123!" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Reset token is required");
+    expect(passwordResetModule.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 when token is not a string", async () => {
+    const requestBody = { token: 12345, password: "NewSecurePass123!" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Reset token is required");
+  });
+
+  it("should return 400 when password is missing", async () => {
+    const requestBody = { token: "valid-token" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Password is required");
+    expect(passwordResetModule.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 when password is not a string", async () => {
+    const requestBody = { token: "valid-token", password: null };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Password is required");
+  });
+
+  it("should return 400 when password does not meet strength requirements", async () => {
+    vi.mocked(validationModule.isStrongPassword).mockReturnValue(false);
+    vi.mocked(validationModule.getPasswordStrengthError).mockReturnValue(
+      "Password must be at least 8 characters"
+    );
+
+    const requestBody = { token: "valid-token", password: "weak" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Password must be at least 8 characters");
+    expect(passwordResetModule.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("should return default error message when password strength error is null", async () => {
+    vi.mocked(validationModule.isStrongPassword).mockReturnValue(false);
+    vi.mocked(validationModule.getPasswordStrengthError).mockReturnValue(null);
+
+    const requestBody = { token: "valid-token", password: "weak" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Password does not meet strength requirements");
+  });
+
+  it("should return 400 for invalid JSON body", async () => {
+    const request = new NextRequest("http://localhost:3000/api/auth/reset-password", {
+      method: "POST",
+      headers: new Headers({
+        "Content-Type": "application/json",
+      }),
+    });
+    (request as { json: () => Promise<unknown> }).json = async () => {
+      throw new Error("Invalid JSON");
+    };
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Invalid request body");
+  });
+
+  it("should return 400 with user-friendly message for expired token", async () => {
+    vi.mocked(passwordResetModule.resetPassword).mockResolvedValue({
+      success: false,
+      error: "expired_token",
+      userId: "user-123",
+    });
+
+    const requestBody = { token: "expired-token", password: "NewSecurePass123!" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("This password reset link has expired. Please request a new one.");
+  });
+
+  it("should return 400 with user-friendly message for invalid token", async () => {
+    vi.mocked(passwordResetModule.resetPassword).mockResolvedValue({
+      success: false,
+      error: "invalid_token",
+    });
+
+    const requestBody = { token: "invalid-token", password: "NewSecurePass123!" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("This password reset link is invalid or has already been used.");
+  });
+
+  it("should return 400 with generic message for user_not_found error", async () => {
+    vi.mocked(passwordResetModule.resetPassword).mockResolvedValue({
+      success: false,
+      error: "user_not_found",
+    });
+
+    const requestBody = { token: "valid-token", password: "NewSecurePass123!" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Unable to reset password. Please try again.");
+  });
+
+  it("should return 500 with generic message for unknown error", async () => {
+    vi.mocked(passwordResetModule.resetPassword).mockResolvedValue({
+      success: false,
+      error: "unknown_error" as "invalid_token",
+    });
+
+    const requestBody = { token: "valid-token", password: "NewSecurePass123!" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("An error occurred while resetting your password. Please try again.");
+  });
+
+  it("should return 500 when resetPassword throws an error", async () => {
+    // Suppress console.error output for this test
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.mocked(passwordResetModule.resetPassword).mockRejectedValue(new Error("Database error"));
+
+    const requestBody = { token: "valid-token", password: "NewSecurePass123!" };
+    const request = createMockRequest("http://localhost:3000/api/auth/reset-password", requestBody);
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("An error occurred while resetting your password");
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/app/api/auth/reset-password/validate/__tests__/route.test.ts
+++ b/app/api/auth/reset-password/validate/__tests__/route.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for /api/auth/reset-password/validate endpoint
+ *
+ * Tests token validation without consuming the token.
+ * Used to check if a token is valid before showing the reset form.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+import * as passwordResetModule from "@/lib/auth/password-reset";
+
+// Mock dependencies
+vi.mock("@/lib/auth/password-reset");
+
+// Helper to create a NextRequest with JSON body
+function createMockRequest(url: string, body?: unknown, method = "POST"): NextRequest {
+  const headers = new Headers();
+  if (body) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const request = new NextRequest(url, {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers,
+  });
+
+  // Mock json() method if body is provided
+  if (body) {
+    (request as { json: () => Promise<unknown> }).json = async () => body;
+  }
+
+  return request;
+}
+
+describe("POST /api/auth/reset-password/validate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return valid: true for a valid token", async () => {
+    vi.mocked(passwordResetModule.validateResetToken).mockResolvedValue({
+      valid: true,
+      userId: "user-123",
+    });
+
+    const requestBody = { token: "valid-reset-token" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.reason).toBeUndefined();
+    expect(passwordResetModule.validateResetToken).toHaveBeenCalledWith("valid-reset-token");
+  });
+
+  it("should return valid: false with reason 'invalid' for invalid token", async () => {
+    vi.mocked(passwordResetModule.validateResetToken).mockResolvedValue({
+      valid: false,
+      reason: "invalid",
+    });
+
+    const requestBody = { token: "invalid-token" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.valid).toBe(false);
+    expect(data.reason).toBe("invalid");
+  });
+
+  it("should return valid: false with reason 'expired' for expired token", async () => {
+    vi.mocked(passwordResetModule.validateResetToken).mockResolvedValue({
+      valid: false,
+      reason: "expired",
+      userId: "user-123",
+    });
+
+    const requestBody = { token: "expired-token" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.valid).toBe(false);
+    expect(data.reason).toBe("expired");
+  });
+
+  it("should return 400 with invalid reason when token is missing", async () => {
+    const requestBody = {};
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.valid).toBe(false);
+    expect(data.reason).toBe("invalid");
+    expect(passwordResetModule.validateResetToken).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 with invalid reason when token is not a string", async () => {
+    const requestBody = { token: 12345 };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.valid).toBe(false);
+    expect(data.reason).toBe("invalid");
+    expect(passwordResetModule.validateResetToken).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 with invalid reason when token is null", async () => {
+    const requestBody = { token: null };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.valid).toBe(false);
+    expect(data.reason).toBe("invalid");
+  });
+
+  it("should return 400 with invalid reason when token is empty string", async () => {
+    const requestBody = { token: "" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.valid).toBe(false);
+    expect(data.reason).toBe("invalid");
+    expect(passwordResetModule.validateResetToken).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 with invalid reason for invalid JSON body", async () => {
+    const request = new NextRequest("http://localhost:3000/api/auth/reset-password/validate", {
+      method: "POST",
+      headers: new Headers({
+        "Content-Type": "application/json",
+      }),
+    });
+    (request as { json: () => Promise<unknown> }).json = async () => {
+      throw new Error("Invalid JSON");
+    };
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.valid).toBe(false);
+    expect(data.reason).toBe("invalid");
+  });
+
+  it("should return 500 with invalid reason when validateResetToken throws", async () => {
+    // Suppress console.error output for this test
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.mocked(passwordResetModule.validateResetToken).mockRejectedValue(
+      new Error("Database error")
+    );
+
+    const requestBody = { token: "valid-token" };
+    const request = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.valid).toBe(false);
+    expect(data.reason).toBe("invalid");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should not consume the token (can be validated multiple times)", async () => {
+    vi.mocked(passwordResetModule.validateResetToken).mockResolvedValue({
+      valid: true,
+      userId: "user-123",
+    });
+
+    const requestBody = { token: "valid-token" };
+
+    // Validate the same token multiple times
+    const request1 = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+    const request2 = createMockRequest(
+      "http://localhost:3000/api/auth/reset-password/validate",
+      requestBody
+    );
+
+    const response1 = await POST(request1);
+    const response2 = await POST(request2);
+
+    const data1 = await response1.json();
+    const data2 = await response2.json();
+
+    // Both validations should succeed (token not consumed)
+    expect(data1.valid).toBe(true);
+    expect(data2.valid).toBe(true);
+    expect(passwordResetModule.validateResetToken).toHaveBeenCalledTimes(2);
+  });
+});

--- a/components/creation/__tests__/AttributesCard.test.tsx
+++ b/components/creation/__tests__/AttributesCard.test.tsx
@@ -1,0 +1,505 @@
+/**
+ * AttributesCard Component Tests
+ *
+ * Tests the attribute allocation card in character creation.
+ * Tests include rendering, attribute adjustments, budget tracking,
+ * and metatype-specific limits.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AttributesCard } from "../AttributesCard";
+
+// Mock the hooks used by AttributesCard
+vi.mock("@/lib/rules", () => ({
+  useMetatypes: vi.fn(),
+  usePriorityTable: vi.fn(),
+  useMagicPaths: vi.fn(),
+}));
+
+vi.mock("@/lib/contexts", () => ({
+  useCreationBudgets: vi.fn(),
+}));
+
+import { useMetatypes, usePriorityTable, useMagicPaths } from "@/lib/rules";
+import { useCreationBudgets } from "@/lib/contexts";
+
+// Sample data for tests - simplified for mocking purposes
+const mockMetatypes = [
+  {
+    id: "human",
+    name: "Human",
+    attributes: {
+      body: { min: 1, max: 6 },
+      agility: { min: 1, max: 6 },
+      reaction: { min: 1, max: 6 },
+      strength: { min: 1, max: 6 },
+      willpower: { min: 1, max: 6 },
+      logic: { min: 1, max: 6 },
+      intuition: { min: 1, max: 6 },
+      charisma: { min: 1, max: 6 },
+      edge: { min: 2, max: 7 },
+    },
+  },
+  {
+    id: "elf",
+    name: "Elf",
+    attributes: {
+      body: { min: 1, max: 6 },
+      agility: { min: 2, max: 7 },
+      reaction: { min: 1, max: 6 },
+      strength: { min: 1, max: 6 },
+      willpower: { min: 1, max: 6 },
+      logic: { min: 1, max: 6 },
+      intuition: { min: 1, max: 6 },
+      charisma: { min: 3, max: 8 },
+      edge: { min: 1, max: 6 },
+    },
+  },
+  {
+    id: "troll",
+    name: "Troll",
+    attributes: {
+      body: { min: 5, max: 10 },
+      agility: { min: 1, max: 5 },
+      reaction: { min: 1, max: 6 },
+      strength: { min: 5, max: 10 },
+      willpower: { min: 1, max: 6 },
+      logic: { min: 1, max: 5 },
+      intuition: { min: 1, max: 5 },
+      charisma: { min: 1, max: 4 },
+      edge: { min: 1, max: 6 },
+    },
+  },
+];
+
+const mockPriorityTable = {
+  table: {
+    A: {
+      metatype: { specialAttributePoints: 6 },
+      attributes: 24,
+      magic: {
+        options: [
+          { path: "magician", magicRating: 6 },
+          { path: "adept", magicRating: 6 },
+        ],
+      },
+    },
+    B: {
+      metatype: { specialAttributePoints: 4 },
+      attributes: 20,
+      magic: {
+        options: [
+          { path: "magician", magicRating: 4 },
+          { path: "technomancer", resonanceRating: 4 },
+        ],
+      },
+    },
+    C: {
+      metatype: { specialAttributePoints: 3 },
+      attributes: 16,
+      magic: { options: [] },
+    },
+    D: {
+      metatype: { specialAttributePoints: 2 },
+      attributes: 14,
+      magic: { options: [] },
+    },
+    E: {
+      metatype: { specialAttributePoints: 1 },
+      attributes: 12,
+      magic: { options: [] },
+    },
+  },
+};
+
+const mockMagicPaths = [
+  { id: "magician", name: "Magician", hasMagic: true, hasResonance: false },
+  { id: "adept", name: "Adept", hasMagic: true, hasResonance: false },
+  { id: "technomancer", name: "Technomancer", hasMagic: false, hasResonance: true },
+  { id: "mundane", name: "Mundane", hasMagic: false, hasResonance: false },
+];
+
+const createMockBudget = (total: number, spent: number = 0) => ({
+  total,
+  spent,
+  remaining: total - spent,
+  label: "Test Budget",
+});
+
+// Factory to create test state - using 'any' to allow flexible test data
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createBaseState = (overrides: Record<string, any> = {}): any => ({
+  currentStep: 2,
+  priorities: {
+    metatype: "C",
+    attributes: "B",
+    magic: "E",
+    skills: "D",
+    resources: "A",
+  },
+  selections: {
+    metatype: "human",
+    attributes: {},
+    specialAttributes: {},
+    ...overrides.selections,
+  },
+  budgets: {},
+  validation: { errors: [], warnings: [] },
+  ...overrides,
+});
+
+describe("AttributesCard", () => {
+  let mockUpdateState: Mock;
+  let mockGetBudget: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUpdateState = vi.fn();
+    mockGetBudget = vi.fn((budgetId: string) => {
+      if (budgetId === "attribute-points") return createMockBudget(20, 0);
+      if (budgetId === "special-attribute-points") return createMockBudget(3, 0);
+      return null;
+    });
+
+    vi.mocked(useMetatypes).mockReturnValue(mockMetatypes as ReturnType<typeof useMetatypes>);
+    vi.mocked(usePriorityTable).mockReturnValue(
+      mockPriorityTable as unknown as ReturnType<typeof usePriorityTable>
+    );
+    vi.mocked(useMagicPaths).mockReturnValue(mockMagicPaths as ReturnType<typeof useMagicPaths>);
+    vi.mocked(useCreationBudgets).mockReturnValue({
+      getBudget: mockGetBudget,
+      budgets: {},
+      updateSpent: vi.fn(),
+      errors: [],
+      warnings: [],
+      isComplete: false,
+    } as unknown as ReturnType<typeof useCreationBudgets>);
+  });
+
+  describe("rendering", () => {
+    it("renders locked state when no priority is set", () => {
+      const state = createBaseState({
+        priorities: undefined,
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Set priorities to unlock attributes")).toBeInTheDocument();
+    });
+
+    it("renders awaiting metatype state when metatype not selected", () => {
+      const state = createBaseState({
+        selections: { metatype: undefined },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(
+        screen.getByText("Select a metatype to see adjusted attribute ranges")
+      ).toBeInTheDocument();
+    });
+
+    it("renders physical attributes section", () => {
+      const state = createBaseState();
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Physical")).toBeInTheDocument();
+      expect(screen.getByText("Body")).toBeInTheDocument();
+      expect(screen.getByText("Agility")).toBeInTheDocument();
+      expect(screen.getByText("Reaction")).toBeInTheDocument();
+      expect(screen.getByText("Strength")).toBeInTheDocument();
+    });
+
+    it("renders mental attributes section", () => {
+      const state = createBaseState();
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Mental")).toBeInTheDocument();
+      expect(screen.getByText("Willpower")).toBeInTheDocument();
+      expect(screen.getByText("Logic")).toBeInTheDocument();
+      expect(screen.getByText("Intuition")).toBeInTheDocument();
+      expect(screen.getByText("Charisma")).toBeInTheDocument();
+    });
+
+    it("renders special attributes section with Edge", () => {
+      const state = createBaseState();
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Special")).toBeInTheDocument();
+      expect(screen.getByText("Edge")).toBeInTheDocument();
+    });
+
+    it("renders Magic attribute for magic users", () => {
+      const state = createBaseState({
+        priorities: {
+          metatype: "C",
+          attributes: "B",
+          magic: "A",
+          skills: "D",
+          resources: "E",
+        },
+        selections: {
+          metatype: "human",
+          "magical-path": "magician",
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Magic")).toBeInTheDocument();
+    });
+
+    it("renders Resonance attribute for technomancers", () => {
+      const state = createBaseState({
+        priorities: {
+          metatype: "C",
+          attributes: "B",
+          magic: "B",
+          skills: "D",
+          resources: "E",
+        },
+        selections: {
+          metatype: "human",
+          "magical-path": "technomancer",
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Resonance")).toBeInTheDocument();
+    });
+
+    it("shows budget indicator with correct totals", () => {
+      const state = createBaseState();
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Attribute Points")).toBeInTheDocument();
+    });
+  });
+
+  describe("metatype-specific limits", () => {
+    it("shows correct attribute ranges for Human metatype", () => {
+      const state = createBaseState({
+        selections: { metatype: "human" },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      // Human Body range is 1-6
+      const bodyRanges = screen.getAllByText("1-6");
+      expect(bodyRanges.length).toBeGreaterThan(0);
+    });
+
+    it("shows correct attribute ranges for Elf metatype", () => {
+      const state = createBaseState({
+        selections: { metatype: "elf" },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      // Elf Agility range is 2-7
+      expect(screen.getByText("2-7")).toBeInTheDocument();
+      // Elf Charisma range is 3-8
+      expect(screen.getByText("3-8")).toBeInTheDocument();
+    });
+
+    it("shows correct attribute ranges for Troll metatype", () => {
+      const state = createBaseState({
+        selections: { metatype: "troll" },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      // Troll Body and Strength both have range 5-10
+      const highRanges = screen.getAllByText("5-10");
+      expect(highRanges.length).toBe(2); // Body and Strength
+      // Troll Charisma range is 1-4
+      expect(screen.getByText("1-4")).toBeInTheDocument();
+    });
+  });
+
+  describe("attribute adjustment", () => {
+    it("increases attribute when + button clicked", () => {
+      const state = createBaseState({
+        selections: {
+          metatype: "human",
+          attributes: { body: 1 },
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      const increaseButton = screen.getByRole("button", { name: "Increase Body" });
+      fireEvent.click(increaseButton);
+
+      expect(mockUpdateState).toHaveBeenCalled();
+      const updateCall = mockUpdateState.mock.calls[0][0];
+      expect(updateCall.selections.attributes.body).toBe(2);
+    });
+
+    it("decreases attribute when - button clicked", () => {
+      const state = createBaseState({
+        selections: {
+          metatype: "human",
+          attributes: { body: 3 },
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      const decreaseButton = screen.getByRole("button", { name: "Decrease Body" });
+      fireEvent.click(decreaseButton);
+
+      expect(mockUpdateState).toHaveBeenCalled();
+      const updateCall = mockUpdateState.mock.calls[0][0];
+      expect(updateCall.selections.attributes.body).toBe(2);
+    });
+
+    it("prevents decreasing below minimum", () => {
+      const state = createBaseState({
+        selections: {
+          metatype: "human",
+          attributes: { body: 1 }, // At minimum for Human
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      const decreaseButton = screen.getByRole("button", { name: "Decrease Body" });
+      expect(decreaseButton).toHaveAttribute("disabled");
+    });
+
+    it("shows MAX badge when attribute is at maximum", () => {
+      const state = createBaseState({
+        selections: {
+          metatype: "human",
+          attributes: { body: 6 }, // At maximum for Human
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("MAX")).toBeInTheDocument();
+    });
+
+    it("tracks attribute points spent correctly", () => {
+      mockGetBudget.mockImplementation((budgetId: string) => {
+        if (budgetId === "attribute-points") return createMockBudget(20, 5);
+        if (budgetId === "special-attribute-points") return createMockBudget(3, 0);
+        return null;
+      });
+
+      const state = createBaseState({
+        selections: {
+          metatype: "human",
+          attributes: { body: 3, agility: 3 }, // 2 + 2 = 4 points spent (from base 1)
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      // Budget indicator should be visible
+      expect(screen.getByText("Attribute Points")).toBeInTheDocument();
+    });
+  });
+
+  describe("special attribute adjustment", () => {
+    it("adjusts Edge attribute", () => {
+      mockGetBudget.mockImplementation((budgetId: string) => {
+        if (budgetId === "attribute-points") return createMockBudget(20, 0);
+        if (budgetId === "special-attribute-points") return createMockBudget(3, 0);
+        return null;
+      });
+
+      const state = createBaseState({
+        selections: {
+          metatype: "human",
+          specialAttributes: { edge: 0 },
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      const increaseEdgeButton = screen.getByRole("button", { name: "Increase Edge" });
+      fireEvent.click(increaseEdgeButton);
+
+      expect(mockUpdateState).toHaveBeenCalled();
+      const updateCall = mockUpdateState.mock.calls[0][0];
+      expect(updateCall.selections.specialAttributes.edge).toBe(1);
+    });
+  });
+
+  describe("keyboard navigation", () => {
+    it("supports arrow key navigation on attribute controls", () => {
+      const state = createBaseState({
+        selections: {
+          metatype: "human",
+          attributes: { body: 3 },
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      const bodyControls = screen.getByRole("group", { name: "Body controls" });
+
+      // Arrow up should increase
+      fireEvent.keyDown(bodyControls, { key: "ArrowUp" });
+      expect(mockUpdateState).toHaveBeenCalled();
+    });
+  });
+
+  describe("validation status", () => {
+    it("shows pending status when no points spent", () => {
+      const state = createBaseState({
+        selections: {
+          metatype: "human",
+          attributes: {},
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      // Card should render without error
+      expect(screen.getByText("Attributes")).toBeInTheDocument();
+    });
+
+    it("shows warning status when points partially spent", () => {
+      mockGetBudget.mockImplementation((budgetId: string) => {
+        if (budgetId === "attribute-points") return createMockBudget(20, 10);
+        if (budgetId === "special-attribute-points") return createMockBudget(3, 1);
+        return null;
+      });
+
+      const state = createBaseState({
+        selections: {
+          metatype: "human",
+          attributes: { body: 3, agility: 3 },
+        },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      // Component should render with budget tracking
+      expect(screen.getByText("Attribute Points")).toBeInTheDocument();
+    });
+  });
+
+  describe("footer summary", () => {
+    it("shows metatype and priority info in footer", () => {
+      const state = createBaseState({
+        selections: { metatype: "human" },
+      });
+
+      render(<AttributesCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText(/Human/)).toBeInTheDocument();
+      expect(screen.getByText(/Priority B Attributes/)).toBeInTheDocument();
+    });
+  });
+});

--- a/components/creation/__tests__/SkillsCard.test.tsx
+++ b/components/creation/__tests__/SkillsCard.test.tsx
@@ -1,0 +1,566 @@
+/**
+ * SkillsCard Component Tests
+ *
+ * Tests the skill allocation card in character creation.
+ * Tests include rendering, skill/group selection, budget tracking,
+ * specializations, and karma purchases.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SkillsCard } from "../SkillsCard";
+
+// Mock the hooks used by SkillsCard
+vi.mock("@/lib/rules", () => ({
+  useSkills: vi.fn(),
+  usePriorityTable: vi.fn(),
+}));
+
+vi.mock("@/lib/contexts", () => ({
+  useCreationBudgets: vi.fn(),
+}));
+
+// Mock the sub-components that use modals (to simplify testing)
+vi.mock("../skills", () => ({
+  SkillModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="skill-modal">Skill Modal</div> : null,
+  SkillGroupModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="skill-group-modal">Skill Group Modal</div> : null,
+  SkillListItem: ({
+    skillName,
+    rating,
+    onRemove,
+    isGroupSkill,
+  }: {
+    skillName: string;
+    rating: number;
+    onRemove?: () => void;
+    isGroupSkill: boolean;
+  }) => (
+    <div data-testid={`skill-item-${skillName.toLowerCase().replace(/\s+/g, "-")}`}>
+      <span>{skillName}</span>
+      <span data-testid="skill-rating">{rating}</span>
+      {!isGroupSkill && onRemove && (
+        <button onClick={onRemove} data-testid={`remove-${skillName.toLowerCase()}`}>
+          Remove
+        </button>
+      )}
+    </div>
+  ),
+  SkillCustomizeModal: () => null,
+  SkillGroupBreakModal: () => null,
+  SkillKarmaConfirmModal: () => null,
+  SkillGroupKarmaConfirmModal: () => null,
+  SkillSpecModal: () => null,
+}));
+
+vi.mock("../skills/FreeSkillsPanel", () => ({
+  FreeSkillsPanel: () => null,
+}));
+
+vi.mock("../skills/FreeSkillDesignationModal", () => ({
+  FreeSkillDesignationModal: () => null,
+}));
+
+vi.mock("@/lib/rules/skills/group-utils", () => ({
+  getGroupRating: (value: number | { rating: number; isBroken?: boolean }) =>
+    typeof value === "number" ? value : value.rating,
+  isGroupBroken: (value: number | { rating: number; isBroken?: boolean }) =>
+    typeof value === "object" && value.isBroken === true,
+  createBrokenGroup: (value: number | { rating: number }) => ({
+    rating: typeof value === "number" ? value : value.rating,
+    isBroken: true,
+  }),
+  createRestoredGroup: (rating: number) => rating,
+  normalizeGroupValue: (value: number | { rating: number; isBroken?: boolean }) =>
+    typeof value === "number" ? { rating: value, isBroken: false } : value,
+  canRestoreGroup: () => ({ canRestore: false }),
+  calculateSkillRaiseKarmaCost: (from: number, to: number) => (from + to) * 2,
+  calculateSkillGroupRaiseKarmaCost: (from: number, to: number) => (from + to) * 5,
+}));
+
+vi.mock("@/lib/rules/skills/free-skills", () => ({
+  getFreeSkillsFromMagicPriority: () => [],
+  getSkillsWithFreeAllocation: () => new Set(),
+  getFreeSkillAllocationStatus: () => [],
+  getDesignatedFreeSkills: () => new Set(),
+  getDesignatedSkillFreeRating: () => undefined,
+  canDesignateForFreeSkill: () => ({ canDesignate: false }),
+}));
+
+import { useSkills, usePriorityTable } from "@/lib/rules";
+import { useCreationBudgets } from "@/lib/contexts";
+
+// Sample data for tests
+const mockActiveSkills = [
+  { id: "archery", name: "Archery", linkedAttribute: "AGI", category: "combat" },
+  { id: "automatics", name: "Automatics", linkedAttribute: "AGI", category: "combat" },
+  { id: "blades", name: "Blades", linkedAttribute: "AGI", category: "combat" },
+  { id: "clubs", name: "Clubs", linkedAttribute: "AGI", category: "combat" },
+  { id: "computer", name: "Computer", linkedAttribute: "LOG", category: "technical" },
+  { id: "cybercombat", name: "Cybercombat", linkedAttribute: "LOG", category: "technical" },
+  { id: "hacking", name: "Hacking", linkedAttribute: "LOG", category: "technical" },
+  { id: "spellcasting", name: "Spellcasting", linkedAttribute: "MAG", category: "magical" },
+  { id: "summoning", name: "Summoning", linkedAttribute: "MAG", category: "magical" },
+  { id: "counterspelling", name: "Counterspelling", linkedAttribute: "MAG", category: "magical" },
+  { id: "perception", name: "Perception", linkedAttribute: "INT", category: "general" },
+  { id: "sneaking", name: "Sneaking", linkedAttribute: "AGI", category: "general" },
+];
+
+const mockSkillGroups = [
+  {
+    id: "firearms",
+    name: "Firearms",
+    skills: ["archery", "automatics", "longarms", "pistols"],
+  },
+  {
+    id: "close-combat",
+    name: "Close Combat",
+    skills: ["blades", "clubs", "unarmed-combat"],
+  },
+  {
+    id: "sorcery",
+    name: "Sorcery",
+    skills: ["spellcasting", "counterspelling", "ritual-spellcasting"],
+  },
+  {
+    id: "electronics",
+    name: "Electronics",
+    skills: ["computer", "cybercombat", "hacking", "software"],
+  },
+];
+
+const mockPriorityTable = {
+  table: {
+    A: { skills: { skillPoints: 46, groupPoints: 10 } },
+    B: { skills: { skillPoints: 36, groupPoints: 5 } },
+    C: { skills: { skillPoints: 28, groupPoints: 2 } },
+    D: { skills: { skillPoints: 22, groupPoints: 0 } },
+    E: { skills: { skillPoints: 18, groupPoints: 0 } },
+  },
+};
+
+const createMockBudget = (total: number, spent: number = 0) => ({
+  total,
+  spent,
+  remaining: total - spent,
+  label: "Test Budget",
+});
+
+// Factory to create test state - using 'any' to allow flexible test data
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createBaseState = (overrides: Record<string, any> = {}): any => ({
+  currentStep: 3,
+  priorities: {
+    metatype: "C",
+    attributes: "B",
+    magic: "E",
+    skills: "A",
+    resources: "D",
+  },
+  selections: {
+    skills: {},
+    skillGroups: {},
+    skillSpecializations: {},
+    ...overrides.selections,
+  },
+  budgets: {},
+  validation: { errors: [], warnings: [] },
+  ...overrides,
+});
+
+describe("SkillsCard", () => {
+  let mockUpdateState: Mock;
+  let mockGetBudget: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUpdateState = vi.fn();
+    mockGetBudget = vi.fn((budgetId: string) => {
+      if (budgetId === "skill-points") return createMockBudget(46, 0);
+      if (budgetId === "skill-group-points") return createMockBudget(10, 0);
+      if (budgetId === "karma") return createMockBudget(25, 0);
+      return null;
+    });
+
+    vi.mocked(useSkills).mockReturnValue({
+      activeSkills: mockActiveSkills,
+      skillGroups: mockSkillGroups,
+    } as unknown as ReturnType<typeof useSkills>);
+    vi.mocked(usePriorityTable).mockReturnValue(
+      mockPriorityTable as unknown as ReturnType<typeof usePriorityTable>
+    );
+    vi.mocked(useCreationBudgets).mockReturnValue({
+      getBudget: mockGetBudget,
+      budgets: {},
+      updateSpent: vi.fn(),
+      errors: [],
+      warnings: [],
+      isComplete: false,
+    } as unknown as ReturnType<typeof useCreationBudgets>);
+  });
+
+  describe("rendering", () => {
+    it("renders locked state when no skill priority is set", () => {
+      const state = createBaseState({
+        priorities: undefined,
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(
+        screen.getByText("Skills locked until priorities are configured.")
+      ).toBeInTheDocument();
+    });
+
+    it("renders skill points budget indicator", () => {
+      const state = createBaseState();
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Skill Points")).toBeInTheDocument();
+    });
+
+    it("renders group points budget indicator when group points > 0", () => {
+      const state = createBaseState();
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Group Points")).toBeInTheDocument();
+    });
+
+    it("renders empty skills state when no skills selected", () => {
+      const state = createBaseState();
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("No skills added")).toBeInTheDocument();
+    });
+
+    it("renders empty skill groups state when no groups selected", () => {
+      const state = createBaseState();
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("No skill groups added")).toBeInTheDocument();
+    });
+
+    it("renders Add Skill button", () => {
+      const state = createBaseState();
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      const skillButton = screen.getAllByRole("button", { name: /Skill/i })[0];
+      expect(skillButton).toBeInTheDocument();
+    });
+
+    it("renders Add Group button", () => {
+      const state = createBaseState();
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      // Use getAllBy since there are multiple buttons with "Group" in name (info buttons + add button)
+      const groupButtons = screen.getAllByRole("button", { name: /Group/i });
+      // Find the Add Group button specifically (it should have text containing just "Group")
+      const addGroupButton = groupButtons.find(
+        (btn) => btn.textContent?.includes("Group") && btn.classList.contains("bg-amber-500")
+      );
+      expect(addGroupButton).toBeInTheDocument();
+    });
+  });
+
+  describe("skill display", () => {
+    it("renders selected individual skills", () => {
+      const state = createBaseState({
+        selections: {
+          skills: { perception: 4, sneaking: 3 },
+          skillGroups: {},
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Perception")).toBeInTheDocument();
+      expect(screen.getByText("Sneaking")).toBeInTheDocument();
+    });
+
+    it("renders skills from selected groups", () => {
+      const state = createBaseState({
+        selections: {
+          skills: {},
+          skillGroups: { sorcery: 4 },
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      // Check that skills from the Sorcery group are displayed
+      expect(screen.getByText("Spellcasting")).toBeInTheDocument();
+      expect(screen.getByText("Counterspelling")).toBeInTheDocument();
+    });
+
+    it("sorts skills alphabetically", () => {
+      const state = createBaseState({
+        selections: {
+          skills: { sneaking: 3, perception: 4, computer: 2 },
+          skillGroups: {},
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      const skillItems = screen.getAllByTestId(/^skill-item-/);
+      const skillNames = skillItems.map((item) => item.textContent?.split(/\d/)[0]);
+
+      // Computer comes before Perception which comes before Sneaking
+      expect(skillNames[0]).toContain("Computer");
+      expect(skillNames[1]).toContain("Perception");
+      expect(skillNames[2]).toContain("Sneaking");
+    });
+  });
+
+  describe("skill groups display", () => {
+    it("renders selected skill groups", () => {
+      const state = createBaseState({
+        selections: {
+          skills: {},
+          skillGroups: { sorcery: 4 },
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Sorcery")).toBeInTheDocument();
+    });
+
+    it("shows group skills in the group card", () => {
+      const state = createBaseState({
+        selections: {
+          skills: {},
+          skillGroups: { sorcery: 4 },
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      // Group skills should be listed (may appear multiple times in different contexts)
+      const spellcastingElements = screen.getAllByText(/Spellcasting/);
+      expect(spellcastingElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("modal interactions", () => {
+    it("opens skill modal when Add Skill button clicked", () => {
+      const state = createBaseState();
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      // Find the amber-colored Add Skill button
+      const buttons = screen.getAllByRole("button");
+      const addButton = buttons.find(
+        (btn) => btn.textContent?.includes("Skill") && btn.classList.contains("bg-amber-500")
+      );
+      expect(addButton).toBeDefined();
+      fireEvent.click(addButton!);
+
+      expect(screen.getByTestId("skill-modal")).toBeInTheDocument();
+    });
+
+    it("opens group modal when Add Group button clicked", () => {
+      const state = createBaseState();
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      // Find the amber-colored Add Group button
+      const buttons = screen.getAllByRole("button");
+      const addButton = buttons.find(
+        (btn) => btn.textContent?.includes("Group") && btn.classList.contains("bg-amber-500")
+      );
+      expect(addButton).toBeDefined();
+      fireEvent.click(addButton!);
+
+      expect(screen.getByTestId("skill-group-modal")).toBeInTheDocument();
+    });
+  });
+
+  describe("skill removal", () => {
+    it("removes individual skill when remove button clicked", () => {
+      const state = createBaseState({
+        selections: {
+          skills: { perception: 4 },
+          skillGroups: {},
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      const removeButton = screen.getByTestId("remove-perception");
+      fireEvent.click(removeButton);
+
+      expect(mockUpdateState).toHaveBeenCalled();
+      const updateCall = mockUpdateState.mock.calls[0][0];
+      expect(updateCall.selections.skills.perception).toBeUndefined();
+    });
+  });
+
+  describe("budget tracking", () => {
+    it("shows correct skill points spent", () => {
+      mockGetBudget.mockImplementation((budgetId: string) => {
+        if (budgetId === "skill-points") return createMockBudget(46, 10);
+        if (budgetId === "skill-group-points") return createMockBudget(10, 0);
+        if (budgetId === "karma") return createMockBudget(25, 0);
+        return null;
+      });
+
+      const state = createBaseState({
+        selections: {
+          skills: { perception: 4, sneaking: 3, computer: 3 }, // 10 points
+          skillGroups: {},
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Skill Points")).toBeInTheDocument();
+    });
+
+    it("shows correct group points spent", () => {
+      mockGetBudget.mockImplementation((budgetId: string) => {
+        if (budgetId === "skill-points") return createMockBudget(46, 0);
+        if (budgetId === "skill-group-points") return createMockBudget(10, 4);
+        if (budgetId === "karma") return createMockBudget(25, 0);
+        return null;
+      });
+
+      const state = createBaseState({
+        selections: {
+          skills: {},
+          skillGroups: { sorcery: 4 },
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Group Points")).toBeInTheDocument();
+    });
+  });
+
+  describe("priority D/E handling", () => {
+    it("hides group section when no group points available", () => {
+      mockGetBudget.mockImplementation((budgetId: string) => {
+        if (budgetId === "skill-points") return createMockBudget(22, 0); // Priority D
+        if (budgetId === "skill-group-points") return createMockBudget(0, 0);
+        if (budgetId === "karma") return createMockBudget(25, 0);
+        return null;
+      });
+
+      const state = createBaseState({
+        priorities: {
+          metatype: "C",
+          attributes: "B",
+          magic: "E",
+          skills: "D",
+          resources: "A",
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      // Group Points should not be shown
+      expect(screen.queryByText("Group Points")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("specialization display", () => {
+    it("shows specialization count in footer when specs exist", () => {
+      const state = createBaseState({
+        selections: {
+          skills: { perception: 4 },
+          skillGroups: {},
+          skillSpecializations: { perception: ["Visual"] },
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText(/1 specialization/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("footer summary", () => {
+    it("shows correct totals in footer", () => {
+      const state = createBaseState({
+        selections: {
+          skills: { perception: 4, sneaking: 3 },
+          skillGroups: { sorcery: 4 },
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      // Should show count of groups and skills
+      expect(screen.getByText(/Total:/)).toBeInTheDocument();
+    });
+  });
+
+  describe("validation status", () => {
+    it("shows pending status when no points spent", () => {
+      const state = createBaseState({
+        selections: {
+          skills: {},
+          skillGroups: {},
+          skillSpecializations: {},
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      // Card should render without error - look for the card title heading
+      const skillsHeadings = screen.getAllByText("Skills");
+      expect(skillsHeadings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("magical path integration", () => {
+    it("handles magician path correctly", () => {
+      const state = createBaseState({
+        selections: {
+          skills: { spellcasting: 4 },
+          skillGroups: {},
+          skillSpecializations: {},
+          "magical-path": "magician",
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Spellcasting")).toBeInTheDocument();
+    });
+
+    it("handles technomancer path correctly", () => {
+      const state = createBaseState({
+        selections: {
+          skills: { computer: 4, hacking: 3 },
+          skillGroups: {},
+          skillSpecializations: {},
+          "magical-path": "technomancer",
+        },
+      });
+
+      render(<SkillsCard state={state} updateState={mockUpdateState} />);
+
+      expect(screen.getByText("Computer")).toBeInTheDocument();
+      expect(screen.getByText("Hacking")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Add comprehensive test coverage for:
- /api/auth/forgot-password - 10 tests covering validation, rate limiting,
  email enumeration prevention
- /api/auth/reset-password - 13 tests covering token validation, password
  strength, error handling
- /api/auth/reset-password/validate - 10 tests covering token validation
- AttributesCard component - 21 tests covering rendering, metatype limits,
  attribute adjustment, budget tracking
- SkillsCard component - 23 tests covering rendering, skill/group selection,
  modal interactions, budget tracking

Total: 77 new tests

https://claude.ai/code/session_011s7sLKq7fGwyDTUXPSoj2R