### PR TITLE
feat(email): add admin notification emails for key events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,3 +187,12 @@ SMTP_SECURE=false
 # File Transport Configuration
 # Directory where emails are saved when using file transport
 # EMAIL_OUTPUT_DIR=data/emails
+
+# ===================
+# Admin Notifications
+# ===================
+
+# Admin email addresses for notifications (comma-separated for multiple recipients)
+# Receives notifications for: new user registration, account lockout, password reset
+# ADMIN_NOTIFICATION_EMAIL=admin@example.com
+# ADMIN_NOTIFICATION_EMAIL=admin1@example.com,admin2@example.com

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -5,6 +5,7 @@ import { createSession } from "@/lib/auth/session";
 import { toPublicUser } from "@/lib/auth/middleware";
 import { isValidEmail, isStrongPassword, getPasswordStrengthError } from "@/lib/auth/validation";
 import { sendVerificationEmail } from "@/lib/auth/email-verification";
+import { sendAdminNewUserNotification } from "@/lib/email";
 import { RateLimiter } from "@/lib/security/rate-limit";
 import { AuditLogger } from "@/lib/security/audit-logger";
 import type { SignupRequest, AuthResponse } from "@/lib/types/user";
@@ -88,6 +89,11 @@ export async function POST(request: NextRequest): Promise<NextResponse<AuthRespo
 
     sendVerificationEmail(user.id, user.email, user.username, baseUrl).catch((err) => {
       console.error("Failed to send verification email:", err);
+    });
+
+    // Send admin notification (non-blocking)
+    sendAdminNewUserNotification(user.id, user.email, user.username, new Date()).catch((err) => {
+      console.error("Admin notification failed:", err);
     });
 
     return response;

--- a/lib/auth/password-reset.ts
+++ b/lib/auth/password-reset.ts
@@ -25,6 +25,7 @@ import { sendEmail, renderTemplate } from "@/lib/email";
 import { PasswordResetEmailTemplate } from "@/lib/email/templates/password-reset-email";
 import { AuditLogger } from "@/lib/security/audit-logger";
 import { sendPasswordChangedEmail } from "@/lib/email/security-alerts";
+import { sendAdminPasswordResetNotification } from "@/lib/email/admin-notifications";
 import { isStrongPassword } from "./validation";
 
 /** Token size in bytes (32 bytes = 256 bits of entropy) */
@@ -197,6 +198,11 @@ export async function requestPasswordReset(
   if (user) {
     // Send reset email (errors are logged but not returned)
     await sendPasswordResetEmail(user.id, user.email, user.username, baseUrl);
+
+    // Send admin notification (fire-and-forget)
+    sendAdminPasswordResetNotification(user.id, user.email, user.username, new Date(), ip).catch(
+      (err) => console.error("Admin notification failed:", err)
+    );
   }
 
   // Always return success to prevent email enumeration

--- a/lib/email/__tests__/admin-notifications.test.ts
+++ b/lib/email/__tests__/admin-notifications.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Admin Notification Email Tests
+ *
+ * Tests for admin notification email templates and send functions.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render } from "@react-email/components";
+import { AdminNotificationEmailTemplate, getAdminNotificationSubject } from "../templates";
+import { EmailService } from "../email-service";
+import { MockTransport, clearMockTransport } from "../transports/mock";
+import { clearConfigCache } from "../config";
+import type { EmailConfig } from "../types";
+
+// Mock the audit logger
+vi.mock("@/lib/security/audit-logger", () => ({
+  AuditLogger: {
+    log: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+describe("Admin Notification Email Templates", () => {
+  describe("getAdminNotificationSubject", () => {
+    it("returns correct subject for new user", () => {
+      expect(getAdminNotificationSubject("new_user")).toBe("Shadow Master: New User Registration");
+    });
+
+    it("returns correct subject for lockout", () => {
+      expect(getAdminNotificationSubject("lockout")).toBe("Shadow Master: Account Lockout Alert");
+    });
+
+    it("returns correct subject for password reset", () => {
+      expect(getAdminNotificationSubject("password_reset")).toBe(
+        "Shadow Master: Password Reset Requested"
+      );
+    });
+  });
+
+  describe("AdminNotificationEmailTemplate - new_user", () => {
+    it("renders with correct content", async () => {
+      const props = {
+        type: "new_user" as const,
+        userEmail: "newuser@example.com",
+        username: "NewRunner",
+        eventTime: "Monday, January 15, 2024 at 3:30 PM EST",
+      };
+
+      const html = await render(AdminNotificationEmailTemplate(props));
+
+      expect(html).toContain("New User Registration");
+      expect(html).toContain("NewRunner");
+      expect(html).toContain("newuser@example.com");
+      expect(html).toContain("3:30 PM");
+      expect(html).toContain("new user has registered");
+    });
+  });
+
+  describe("AdminNotificationEmailTemplate - lockout", () => {
+    it("renders with correct content", async () => {
+      const props = {
+        type: "lockout" as const,
+        userEmail: "lockeduser@example.com",
+        username: "LockedRunner",
+        eventTime: "Monday, January 15, 2024 at 3:30 PM EST",
+        failedAttempts: 5,
+      };
+
+      const html = await render(AdminNotificationEmailTemplate(props));
+
+      expect(html).toContain("Account Lockout");
+      expect(html).toContain("LockedRunner");
+      expect(html).toContain("lockeduser@example.com");
+      // React Email adds HTML comments in interpolations
+      expect(html).toMatch(/Failed Attempts:.*5/);
+      expect(html).toContain("brute-force");
+    });
+
+    it("shows N/A when failedAttempts not provided", async () => {
+      const props = {
+        type: "lockout" as const,
+        userEmail: "user@example.com",
+        username: "User",
+        eventTime: "Now",
+      };
+
+      const html = await render(AdminNotificationEmailTemplate(props));
+
+      // React Email adds HTML comments in interpolations
+      expect(html).toMatch(/Failed Attempts:.*N\/A/);
+    });
+  });
+
+  describe("AdminNotificationEmailTemplate - password_reset", () => {
+    it("renders with correct content", async () => {
+      const props = {
+        type: "password_reset" as const,
+        userEmail: "resetuser@example.com",
+        username: "ResetRunner",
+        eventTime: "Monday, January 15, 2024 at 3:30 PM EST",
+        ipAddress: "192.168.1.100",
+      };
+
+      const html = await render(AdminNotificationEmailTemplate(props));
+
+      expect(html).toContain("Password Reset Requested");
+      expect(html).toContain("ResetRunner");
+      expect(html).toContain("resetuser@example.com");
+      expect(html).toContain("3:30 PM");
+      expect(html).toContain("192.168.1.100");
+    });
+
+    it("omits IP when not provided", async () => {
+      const props = {
+        type: "password_reset" as const,
+        userEmail: "user@example.com",
+        username: "User",
+        eventTime: "Now",
+      };
+
+      const html = await render(AdminNotificationEmailTemplate(props));
+
+      expect(html).not.toContain("IP Address");
+    });
+  });
+});
+
+describe("Admin Notification Config Functions", () => {
+  const originalEnv = process.env.ADMIN_NOTIFICATION_EMAIL;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ADMIN_NOTIFICATION_EMAIL;
+    } else {
+      process.env.ADMIN_NOTIFICATION_EMAIL = originalEnv;
+    }
+  });
+
+  describe("getAdminEmails", () => {
+    it("returns empty array when not configured", async () => {
+      delete process.env.ADMIN_NOTIFICATION_EMAIL;
+      const { getAdminEmails } = await import("../admin-notifications");
+      expect(getAdminEmails()).toEqual([]);
+    });
+
+    it("returns empty array for empty string", async () => {
+      process.env.ADMIN_NOTIFICATION_EMAIL = "";
+      const { getAdminEmails } = await import("../admin-notifications");
+      expect(getAdminEmails()).toEqual([]);
+    });
+
+    it("returns single email", async () => {
+      process.env.ADMIN_NOTIFICATION_EMAIL = "admin@example.com";
+      const { getAdminEmails } = await import("../admin-notifications");
+      expect(getAdminEmails()).toEqual(["admin@example.com"]);
+    });
+
+    it("returns multiple emails from comma-separated list", async () => {
+      process.env.ADMIN_NOTIFICATION_EMAIL = "admin1@example.com,admin2@example.com";
+      const { getAdminEmails } = await import("../admin-notifications");
+      expect(getAdminEmails()).toEqual(["admin1@example.com", "admin2@example.com"]);
+    });
+
+    it("trims whitespace from emails", async () => {
+      process.env.ADMIN_NOTIFICATION_EMAIL = " admin1@example.com , admin2@example.com ";
+      const { getAdminEmails } = await import("../admin-notifications");
+      expect(getAdminEmails()).toEqual(["admin1@example.com", "admin2@example.com"]);
+    });
+
+    it("filters out empty entries", async () => {
+      process.env.ADMIN_NOTIFICATION_EMAIL = "admin@example.com,,other@example.com";
+      const { getAdminEmails } = await import("../admin-notifications");
+      expect(getAdminEmails()).toEqual(["admin@example.com", "other@example.com"]);
+    });
+  });
+
+  describe("isAdminNotificationEnabled", () => {
+    it("returns false when not configured", async () => {
+      delete process.env.ADMIN_NOTIFICATION_EMAIL;
+      const { isAdminNotificationEnabled } = await import("../admin-notifications");
+      expect(isAdminNotificationEnabled()).toBe(false);
+    });
+
+    it("returns true when configured", async () => {
+      process.env.ADMIN_NOTIFICATION_EMAIL = "admin@example.com";
+      const { isAdminNotificationEnabled } = await import("../admin-notifications");
+      expect(isAdminNotificationEnabled()).toBe(true);
+    });
+  });
+});
+
+describe("Admin Notification Send Functions", () => {
+  const mockConfig: EmailConfig = {
+    transport: "mock",
+    from: { email: "noreply@test.com", name: "Shadow Master" },
+  };
+
+  const originalEnv = process.env.ADMIN_NOTIFICATION_EMAIL;
+
+  beforeEach(() => {
+    EmailService.resetInstance();
+    clearConfigCache();
+    clearMockTransport();
+    vi.clearAllMocks();
+    process.env.ADMIN_NOTIFICATION_EMAIL = "admin@example.com";
+  });
+
+  afterEach(() => {
+    EmailService.resetInstance();
+    clearMockTransport();
+    if (originalEnv === undefined) {
+      delete process.env.ADMIN_NOTIFICATION_EMAIL;
+    } else {
+      process.env.ADMIN_NOTIFICATION_EMAIL = originalEnv;
+    }
+  });
+
+  describe("sendAdminNewUserNotification", () => {
+    it("sends notification to admin email", async () => {
+      const service = EmailService.getInstance(mockConfig);
+      const transport = service.getTransport() as MockTransport;
+
+      const { sendAdminNewUserNotification } = await import("../admin-notifications");
+
+      await sendAdminNewUserNotification(
+        "user-123",
+        "newuser@example.com",
+        "NewUser",
+        new Date("2024-01-15T15:30:00Z")
+      );
+
+      const emails = transport.getSentEmails();
+      expect(emails).toHaveLength(1);
+      expect(emails[0].message.to).toEqual({ email: "admin@example.com" });
+      expect(emails[0].message.subject).toBe("Shadow Master: New User Registration");
+    });
+
+    it("sends to multiple admin emails", async () => {
+      process.env.ADMIN_NOTIFICATION_EMAIL = "admin1@example.com,admin2@example.com";
+      const service = EmailService.getInstance(mockConfig);
+      const transport = service.getTransport() as MockTransport;
+
+      const { sendAdminNewUserNotification } = await import("../admin-notifications");
+
+      await sendAdminNewUserNotification("user-123", "newuser@example.com", "NewUser", new Date());
+
+      const emails = transport.getSentEmails();
+      expect(emails).toHaveLength(2);
+    });
+
+    it("logs audit event on success", async () => {
+      EmailService.getInstance(mockConfig);
+      const { AuditLogger } = await import("@/lib/security/audit-logger");
+      const { sendAdminNewUserNotification } = await import("../admin-notifications");
+
+      await sendAdminNewUserNotification("user-123", "newuser@example.com", "NewUser", new Date());
+
+      expect(AuditLogger.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "admin_notification.new_user_sent",
+          userId: "user-123",
+          email: "newuser@example.com",
+        })
+      );
+    });
+
+    it("does nothing when admin email not configured", async () => {
+      delete process.env.ADMIN_NOTIFICATION_EMAIL;
+      const service = EmailService.getInstance(mockConfig);
+      const transport = service.getTransport() as MockTransport;
+
+      const { sendAdminNewUserNotification } = await import("../admin-notifications");
+
+      await sendAdminNewUserNotification("user-123", "newuser@example.com", "NewUser", new Date());
+
+      expect(transport.getSentEmails()).toHaveLength(0);
+    });
+
+    it("handles errors gracefully without throwing", async () => {
+      const service = EmailService.getInstance(mockConfig);
+      const transport = service.getTransport() as MockTransport;
+      transport.simulateFailure("Test failure");
+
+      const { sendAdminNewUserNotification } = await import("../admin-notifications");
+
+      // Should not throw
+      await expect(
+        sendAdminNewUserNotification("user-123", "newuser@example.com", "NewUser", new Date())
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("sendAdminLockoutNotification", () => {
+    it("sends notification with failed attempts", async () => {
+      const service = EmailService.getInstance(mockConfig);
+      const transport = service.getTransport() as MockTransport;
+
+      const { sendAdminLockoutNotification } = await import("../admin-notifications");
+
+      await sendAdminLockoutNotification(
+        "user-123",
+        "locked@example.com",
+        "LockedUser",
+        new Date(),
+        5
+      );
+
+      const emails = transport.getSentEmails();
+      expect(emails).toHaveLength(1);
+      expect(emails[0].message.subject).toBe("Shadow Master: Account Lockout Alert");
+      // React Email adds HTML comments in interpolations
+      expect(emails[0].message.html).toMatch(/Failed Attempts:.*5/);
+    });
+
+    it("logs audit event with failed attempts", async () => {
+      EmailService.getInstance(mockConfig);
+      const { AuditLogger } = await import("@/lib/security/audit-logger");
+      const { sendAdminLockoutNotification } = await import("../admin-notifications");
+
+      await sendAdminLockoutNotification(
+        "user-123",
+        "locked@example.com",
+        "LockedUser",
+        new Date(),
+        5
+      );
+
+      expect(AuditLogger.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "admin_notification.lockout_sent",
+          metadata: expect.objectContaining({
+            failedAttempts: 5,
+          }),
+        })
+      );
+    });
+  });
+
+  describe("sendAdminPasswordResetNotification", () => {
+    it("sends notification with IP address", async () => {
+      const service = EmailService.getInstance(mockConfig);
+      const transport = service.getTransport() as MockTransport;
+
+      const { sendAdminPasswordResetNotification } = await import("../admin-notifications");
+
+      await sendAdminPasswordResetNotification(
+        "user-123",
+        "reset@example.com",
+        "ResetUser",
+        new Date(),
+        "192.168.1.100"
+      );
+
+      const emails = transport.getSentEmails();
+      expect(emails).toHaveLength(1);
+      expect(emails[0].message.subject).toBe("Shadow Master: Password Reset Requested");
+      expect(emails[0].message.html).toContain("192.168.1.100");
+    });
+
+    it("logs audit event with IP address", async () => {
+      EmailService.getInstance(mockConfig);
+      const { AuditLogger } = await import("@/lib/security/audit-logger");
+      const { sendAdminPasswordResetNotification } = await import("../admin-notifications");
+
+      await sendAdminPasswordResetNotification(
+        "user-123",
+        "reset@example.com",
+        "ResetUser",
+        new Date(),
+        "192.168.1.100"
+      );
+
+      expect(AuditLogger.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "admin_notification.password_reset_sent",
+          ip: "192.168.1.100",
+        })
+      );
+    });
+
+    it("works without IP address", async () => {
+      const service = EmailService.getInstance(mockConfig);
+      const transport = service.getTransport() as MockTransport;
+
+      const { sendAdminPasswordResetNotification } = await import("../admin-notifications");
+
+      await sendAdminPasswordResetNotification(
+        "user-123",
+        "reset@example.com",
+        "ResetUser",
+        new Date()
+      );
+
+      const emails = transport.getSentEmails();
+      expect(emails).toHaveLength(1);
+    });
+  });
+});

--- a/lib/email/admin-notifications.ts
+++ b/lib/email/admin-notifications.ts
@@ -1,0 +1,299 @@
+/**
+ * Admin Notification Email Service
+ *
+ * Sends notification emails to administrators for key events:
+ * - New user registration
+ * - Account lockout
+ * - Password reset requested
+ *
+ * All functions use fire-and-forget pattern: errors are logged but not thrown.
+ * Application functionality should never be blocked by admin notification failures.
+ *
+ * Configuration:
+ * - ADMIN_NOTIFICATION_EMAIL: Comma-separated list of admin email addresses
+ */
+
+import { sendEmail, renderTemplate } from "@/lib/email";
+import { AdminNotificationEmailTemplate, getAdminNotificationSubject } from "@/lib/email/templates";
+import { AuditLogger } from "@/lib/security/audit-logger";
+
+/**
+ * Format a date for display in emails
+ */
+function formatDateTime(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+/**
+ * Parse admin email addresses from environment variable
+ *
+ * @returns Array of admin email addresses (empty if not configured)
+ */
+export function getAdminEmails(): string[] {
+  const envValue = process.env.ADMIN_NOTIFICATION_EMAIL;
+  if (!envValue || envValue.trim() === "") {
+    return [];
+  }
+
+  return envValue
+    .split(",")
+    .map((email) => email.trim())
+    .filter((email) => email.length > 0);
+}
+
+/**
+ * Check if admin notifications are enabled
+ *
+ * @returns true if ADMIN_NOTIFICATION_EMAIL is configured with at least one email
+ */
+export function isAdminNotificationEnabled(): boolean {
+  return getAdminEmails().length > 0;
+}
+
+/**
+ * Send admin notification for new user registration
+ *
+ * Notifies administrators when a new user signs up.
+ * Uses fire-and-forget pattern - errors are logged but not thrown.
+ *
+ * @param userId - The new user's ID
+ * @param email - The new user's email address
+ * @param username - The new user's display name
+ * @param registrationTime - When the user registered
+ */
+export async function sendAdminNewUserNotification(
+  userId: string,
+  email: string,
+  username: string,
+  registrationTime: Date | string
+): Promise<void> {
+  const adminEmails = getAdminEmails();
+  if (adminEmails.length === 0) {
+    return;
+  }
+
+  try {
+    const { html, text } = await renderTemplate(
+      AdminNotificationEmailTemplate({
+        type: "new_user",
+        userEmail: email,
+        username,
+        eventTime: formatDateTime(registrationTime),
+      })
+    );
+
+    const subject = getAdminNotificationSubject("new_user");
+
+    // Send to all configured admin emails
+    const sendPromises = adminEmails.map((adminEmail) =>
+      sendEmail({
+        to: { email: adminEmail },
+        subject,
+        html,
+        text,
+      })
+    );
+
+    const results = await Promise.allSettled(sendPromises);
+    const successCount = results.filter((r) => r.status === "fulfilled" && r.value.success).length;
+
+    if (successCount > 0) {
+      await AuditLogger.log({
+        event: "admin_notification.new_user_sent",
+        userId,
+        email,
+        metadata: {
+          recipientCount: successCount,
+          totalRecipients: adminEmails.length,
+        },
+      });
+    }
+
+    // Log any failures
+    results.forEach((result, index) => {
+      if (result.status === "rejected") {
+        console.error(`Failed to send admin notification to ${adminEmails[index]}:`, result.reason);
+      } else if (!result.value.success) {
+        console.error(
+          `Failed to send admin notification to ${adminEmails[index]}:`,
+          result.value.error
+        );
+      }
+    });
+  } catch (error) {
+    console.error("Error sending admin new user notification:", error);
+  }
+}
+
+/**
+ * Send admin notification for account lockout
+ *
+ * Notifies administrators when an account is locked due to failed login attempts.
+ * Uses fire-and-forget pattern - errors are logged but not thrown.
+ *
+ * @param userId - The locked user's ID
+ * @param email - The locked user's email address
+ * @param username - The locked user's display name
+ * @param lockoutTime - When the lockout was triggered
+ * @param failedAttempts - Number of failed login attempts
+ */
+export async function sendAdminLockoutNotification(
+  userId: string,
+  email: string,
+  username: string,
+  lockoutTime: Date | string,
+  failedAttempts: number
+): Promise<void> {
+  const adminEmails = getAdminEmails();
+  if (adminEmails.length === 0) {
+    return;
+  }
+
+  try {
+    const { html, text } = await renderTemplate(
+      AdminNotificationEmailTemplate({
+        type: "lockout",
+        userEmail: email,
+        username,
+        eventTime: formatDateTime(lockoutTime),
+        failedAttempts,
+      })
+    );
+
+    const subject = getAdminNotificationSubject("lockout");
+
+    // Send to all configured admin emails
+    const sendPromises = adminEmails.map((adminEmail) =>
+      sendEmail({
+        to: { email: adminEmail },
+        subject,
+        html,
+        text,
+      })
+    );
+
+    const results = await Promise.allSettled(sendPromises);
+    const successCount = results.filter((r) => r.status === "fulfilled" && r.value.success).length;
+
+    if (successCount > 0) {
+      await AuditLogger.log({
+        event: "admin_notification.lockout_sent",
+        userId,
+        email,
+        metadata: {
+          failedAttempts,
+          recipientCount: successCount,
+          totalRecipients: adminEmails.length,
+        },
+      });
+    }
+
+    // Log any failures
+    results.forEach((result, index) => {
+      if (result.status === "rejected") {
+        console.error(
+          `Failed to send admin lockout notification to ${adminEmails[index]}:`,
+          result.reason
+        );
+      } else if (!result.value.success) {
+        console.error(
+          `Failed to send admin lockout notification to ${adminEmails[index]}:`,
+          result.value.error
+        );
+      }
+    });
+  } catch (error) {
+    console.error("Error sending admin lockout notification:", error);
+  }
+}
+
+/**
+ * Send admin notification for password reset request
+ *
+ * Notifies administrators when a password reset is requested.
+ * Uses fire-and-forget pattern - errors are logged but not thrown.
+ *
+ * @param userId - The user's ID
+ * @param email - The user's email address
+ * @param username - The user's display name
+ * @param requestTime - When the reset was requested
+ * @param ip - The requester's IP address (optional)
+ */
+export async function sendAdminPasswordResetNotification(
+  userId: string,
+  email: string,
+  username: string,
+  requestTime: Date | string,
+  ip?: string
+): Promise<void> {
+  const adminEmails = getAdminEmails();
+  if (adminEmails.length === 0) {
+    return;
+  }
+
+  try {
+    const { html, text } = await renderTemplate(
+      AdminNotificationEmailTemplate({
+        type: "password_reset",
+        userEmail: email,
+        username,
+        eventTime: formatDateTime(requestTime),
+        ipAddress: ip,
+      })
+    );
+
+    const subject = getAdminNotificationSubject("password_reset");
+
+    // Send to all configured admin emails
+    const sendPromises = adminEmails.map((adminEmail) =>
+      sendEmail({
+        to: { email: adminEmail },
+        subject,
+        html,
+        text,
+      })
+    );
+
+    const results = await Promise.allSettled(sendPromises);
+    const successCount = results.filter((r) => r.status === "fulfilled" && r.value.success).length;
+
+    if (successCount > 0) {
+      await AuditLogger.log({
+        event: "admin_notification.password_reset_sent",
+        userId,
+        email,
+        ip,
+        metadata: {
+          recipientCount: successCount,
+          totalRecipients: adminEmails.length,
+        },
+      });
+    }
+
+    // Log any failures
+    results.forEach((result, index) => {
+      if (result.status === "rejected") {
+        console.error(
+          `Failed to send admin reset notification to ${adminEmails[index]}:`,
+          result.reason
+        );
+      } else if (!result.value.success) {
+        console.error(
+          `Failed to send admin reset notification to ${adminEmails[index]}:`,
+          result.value.error
+        );
+      }
+    });
+  } catch (error) {
+    console.error("Error sending admin password reset notification:", error);
+  }
+}

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -62,3 +62,12 @@ export {
   sendPasswordChangedEmail,
   sendEmailChangedEmail,
 } from "./security-alerts";
+
+// Admin Notifications
+export {
+  getAdminEmails,
+  isAdminNotificationEnabled,
+  sendAdminNewUserNotification,
+  sendAdminLockoutNotification,
+  sendAdminPasswordResetNotification,
+} from "./admin-notifications";

--- a/lib/email/templates/admin-notification.tsx
+++ b/lib/email/templates/admin-notification.tsx
@@ -1,0 +1,260 @@
+/**
+ * Admin Notification Email Template
+ *
+ * Sent to administrators for key events during early-stage testing:
+ * - New user registration
+ * - Account lockout
+ * - Password reset requested
+ */
+
+import * as React from "react";
+import { Text } from "@react-email/components";
+import { BaseEmailLayout, EmailText, EmailInfoBox } from "./base";
+
+/**
+ * Notification types supported by this template
+ */
+export type AdminNotificationType = "new_user" | "lockout" | "password_reset";
+
+/**
+ * Props for the admin notification email template
+ */
+export interface AdminNotificationProps {
+  /** Type of notification */
+  type: AdminNotificationType;
+  /** User's email address */
+  userEmail: string;
+  /** User's display name */
+  username: string;
+  /** When the event occurred (formatted string) */
+  eventTime: string;
+  /** Number of failed attempts (for lockout notifications) */
+  failedAttempts?: number;
+  /** IP address (for password reset notifications) */
+  ipAddress?: string;
+}
+
+/**
+ * Get subject line based on notification type
+ */
+export function getAdminNotificationSubject(type: AdminNotificationType): string {
+  switch (type) {
+    case "new_user":
+      return "Shadow Master: New User Registration";
+    case "lockout":
+      return "Shadow Master: Account Lockout Alert";
+    case "password_reset":
+      return "Shadow Master: Password Reset Requested";
+  }
+}
+
+/**
+ * Admin notification email template
+ *
+ * Notifies administrators of security-relevant events.
+ */
+export function AdminNotificationEmailTemplate({
+  type,
+  userEmail,
+  username,
+  eventTime,
+  failedAttempts,
+  ipAddress,
+}: AdminNotificationProps) {
+  return (
+    <BaseEmailLayout preview={getAdminNotificationSubject(type)} heading={getHeading(type)}>
+      <EmailText>Admin notification for Shadow Master:</EmailText>
+
+      {type === "new_user" && (
+        <>
+          <EmailText>A new user has registered on Shadow Master.</EmailText>
+          <EmailInfoBox>
+            <Text
+              style={{
+                color: "#22c55e",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 8px 0",
+                fontWeight: 600,
+              }}
+            >
+              New User Details
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 4px 0",
+              }}
+            >
+              Username: {username}
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 4px 0",
+              }}
+            >
+              Email: {userEmail}
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: 0,
+              }}
+            >
+              Registered: {eventTime}
+            </Text>
+          </EmailInfoBox>
+        </>
+      )}
+
+      {type === "lockout" && (
+        <>
+          <EmailText>An account has been locked due to multiple failed login attempts.</EmailText>
+          <EmailInfoBox>
+            <Text
+              style={{
+                color: "#fbbf24",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 8px 0",
+                fontWeight: 600,
+              }}
+            >
+              Lockout Details
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 4px 0",
+              }}
+            >
+              Username: {username}
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 4px 0",
+              }}
+            >
+              Email: {userEmail}
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 4px 0",
+              }}
+            >
+              Failed Attempts: {failedAttempts ?? "N/A"}
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: 0,
+              }}
+            >
+              Locked at: {eventTime}
+            </Text>
+          </EmailInfoBox>
+          <EmailText style={{ fontSize: "13px", color: "#fbbf24" }}>
+            This may indicate a brute-force attack attempt. Consider monitoring this account.
+          </EmailText>
+        </>
+      )}
+
+      {type === "password_reset" && (
+        <>
+          <EmailText>A password reset has been requested for an account.</EmailText>
+          <EmailInfoBox>
+            <Text
+              style={{
+                color: "#60a5fa",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 8px 0",
+                fontWeight: 600,
+              }}
+            >
+              Password Reset Details
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 4px 0",
+              }}
+            >
+              Username: {username}
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 4px 0",
+              }}
+            >
+              Email: {userEmail}
+            </Text>
+            <Text
+              style={{
+                color: "#f5f5f5",
+                fontSize: "13px",
+                lineHeight: "20px",
+                margin: "0 0 4px 0",
+              }}
+            >
+              Requested at: {eventTime}
+            </Text>
+            {ipAddress && (
+              <Text
+                style={{
+                  color: "#f5f5f5",
+                  fontSize: "13px",
+                  lineHeight: "20px",
+                  margin: 0,
+                }}
+              >
+                IP Address: {ipAddress}
+              </Text>
+            )}
+          </EmailInfoBox>
+        </>
+      )}
+
+      <EmailText style={{ fontSize: "13px", color: "#737373" }}>
+        This is an automated admin notification. You are receiving this because you are configured
+        as an admin recipient.
+      </EmailText>
+    </BaseEmailLayout>
+  );
+}
+
+/**
+ * Get heading based on notification type
+ */
+function getHeading(type: AdminNotificationType): string {
+  switch (type) {
+    case "new_user":
+      return "New User Registration";
+    case "lockout":
+      return "Account Lockout";
+    case "password_reset":
+      return "Password Reset Requested";
+  }
+}

--- a/lib/email/templates/index.ts
+++ b/lib/email/templates/index.ts
@@ -33,6 +33,10 @@ export type { PasswordChangedEmailTemplateProps } from "./password-changed";
 export { EmailChangedEmailTemplate, maskEmail } from "./email-changed";
 export type { EmailChangedEmailTemplateProps } from "./email-changed";
 
+// Export admin notification email template
+export { AdminNotificationEmailTemplate, getAdminNotificationSubject } from "./admin-notification";
+export type { AdminNotificationProps, AdminNotificationType } from "./admin-notification";
+
 /**
  * Rendered template output
  */

--- a/lib/security/audit-logger.ts
+++ b/lib/security/audit-logger.ts
@@ -34,7 +34,10 @@ export type SecurityEvent =
   | "email.delivery_failed"
   | "security_email.lockout_sent"
   | "security_email.password_changed_sent"
-  | "security_email.email_changed_sent";
+  | "security_email.email_changed_sent"
+  | "admin_notification.new_user_sent"
+  | "admin_notification.lockout_sent"
+  | "admin_notification.password_reset_sent";
 
 export interface SecurityRecord {
   timestamp: string;

--- a/lib/storage/users.ts
+++ b/lib/storage/users.ts
@@ -361,6 +361,13 @@ export async function incrementFailedAttempts(userId: string): Promise<User> {
           )
         )
         .catch((err) => console.error("Failed to send lockout alert email:", err));
+
+      // Send admin notification for lockout (fire-and-forget)
+      import("@/lib/email/admin-notifications")
+        .then(({ sendAdminLockoutNotification }) =>
+          sendAdminLockoutNotification(userId, user.email, user.username, lockoutTime, newAttempts)
+        )
+        .catch((err) => console.error("Admin lockout notification failed:", err));
     }
   }
 


### PR DESCRIPTION
Add admin notification system to alert administrators of security-relevant events during early-stage testing:
- New user registration
- Account lockout (with failed attempt count)
- Password reset requests (with IP address)

Supports comma-separated ADMIN_NOTIFICATION_EMAIL env var for multiple recipients. Uses fire-and-forget pattern to never block user actions.