### PR TITLE
fix(docker): Revert to node:22-alpine from non-existent node:25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Optimized for production deployment with minimal image size
 
 # Stage 1: Dependencies
-FROM node:25-alpine AS deps
+FROM node:22-alpine AS deps
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
@@ -13,7 +13,7 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod=false
 
 # Stage 2: Builder
-FROM node:25-alpine AS builder
+FROM node:22-alpine AS builder
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
@@ -36,7 +36,7 @@ ENV NEXT_PUBLIC_GIT_SHA=${NEXT_PUBLIC_GIT_SHA}
 RUN pnpm build
 
 # Stage 3: Runner (Production)
-FROM node:25-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 # Set production environment


### PR DESCRIPTION
## Summary
- Reverts the invalid Dependabot bump from `node:20-alpine` to `node:25-alpine`
- Node.js 25 doesn't exist - current versions are 18, 20, 21, 22, 23
- Uses `node:22-alpine` (current LTS with support through April 2027)

## Test plan
- [ ] Docker build succeeds
- [ ] Container starts and serves application

🤖 Generated with [Claude Code](https://claude.com/claude-code)