### PR TITLE
fix(security): Prevent remote property injection vulnerabilities (CWE-94)

### DIFF
--- a/app/api/grunt-teams/[teamId]/damage/bulk/route.ts
+++ b/app/api/grunt-teams/[teamId]/damage/bulk/route.ts
@@ -83,11 +83,23 @@ export async function POST(
     const monitorSize = team.baseGrunts.conditionMonitorSize;
     const useSimplified = team.options?.useSimplifiedRules ?? false;
 
+    // Build allowlist of valid grunt IDs to prevent property injection attacks
+    const validGruntIds = new Set<string>([
+      ...Object.keys(individualGrunts.grunts),
+      ...(individualGrunts.lieutenant ? [individualGrunts.lieutenant.id] : []),
+      ...(individualGrunts.specialists ? Object.keys(individualGrunts.specialists) : []),
+    ]);
+
     const results: DamageResult[] = [];
     let newDeaths = 0;
 
     // Process each grunt
     for (const gruntId of body.gruntIds) {
+      // Validate gruntId against allowlist to prevent property injection
+      if (!validGruntIds.has(gruntId)) {
+        continue;
+      }
+
       // Find grunt in grunts, lieutenant, or specialists
       let grunt = individualGrunts.grunts[gruntId];
       let gruntLocation: "grunts" | "lieutenant" | "specialists" = "grunts";

--- a/lib/storage/locations.ts
+++ b/lib/storage/locations.ts
@@ -735,7 +735,8 @@ export async function exportLocations(campaignId: ID): Promise<Location[]> {
  */
 export async function importLocations(campaignId: ID, locations: Location[]): Promise<Location[]> {
   const now = new Date().toISOString();
-  const idMap: Record<string, string> = {};
+  // Use Object.create(null) for prototype-less object to prevent property injection
+  const idMap: Record<string, string> = Object.create(null);
   const newLocations: Location[] = [];
 
   // 1. Generate new IDs for all imported locations


### PR DESCRIPTION
## Summary

- Add allowlist validation in bulk damage API to prevent prototype pollution when using user-supplied `gruntIds` as object keys
- Use `Object.create(null)` for `idMap` in locations import to eliminate prototype chain access

## Details

**Bulk Damage Route** (`app/api/grunt-teams/[teamId]/damage/bulk/route.ts`):
- Build a `Set<string>` of valid grunt IDs from existing data structures before processing
- Validate each `gruntId` from request body against allowlist before using as object key
- Prevents attackers from passing `"__proto__"` or `"constructor"` as gruntId

**Locations Import** (`lib/storage/locations.ts`):
- Changed `const idMap = {}` to `const idMap = Object.create(null)`
- Creates prototype-less object, eliminating theoretical prototype property access

## Test plan

- [x] Type-check passes
- [x] All 6,296 unit tests pass
- [x] Code review confirms fix is correct and effective

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)