### PR TITLE
fix(security): Suppress CodeQL false positives for file-access-to-http (CWE-200)

### DIFF
--- a/app/rulesets/components/EditionDetailView.tsx
+++ b/app/rulesets/components/EditionDetailView.tsx
@@ -28,6 +28,7 @@ export default function EditionDetailView({ editionCode, onClose }: EditionDetai
       setLoading(true);
       setError(null);
       try {
+        // codeql-suppress js/file-access-to-http - False positive: editionCode is type-safe enum, not user-controlled path
         const res = await fetch(`/api/editions/${editionCode}`);
         const result = await res.json();
 

--- a/app/users/UserAuditModal.tsx
+++ b/app/users/UserAuditModal.tsx
@@ -29,6 +29,7 @@ export default function UserAuditModal({ user, isOpen, onClose }: UserAuditModal
     setError(null);
 
     try {
+      // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
       const response = await fetch(`/api/users/${user.id}/audit?limit=50&order=desc`);
       const data = await response.json();
 

--- a/app/users/UserTable.tsx
+++ b/app/users/UserTable.tsx
@@ -102,6 +102,7 @@ export default function UserTable({ initialUsers }: UserTableProps) {
     setError(null);
 
     try {
+      // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
       const response = await fetch(`/api/users/${editingUser.id}`, {
         method: "PUT",
         headers: {
@@ -137,6 +138,7 @@ export default function UserTable({ initialUsers }: UserTableProps) {
     setError(null);
 
     try {
+      // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
       const response = await fetch(`/api/users/${userId}`, {
         method: "DELETE",
       });
@@ -223,6 +225,7 @@ export default function UserTable({ initialUsers }: UserTableProps) {
     setError(null);
 
     try {
+      // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
       const response = await fetch(`/api/users/${user.id}/suspend`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -251,6 +254,7 @@ export default function UserTable({ initialUsers }: UserTableProps) {
     setError(null);
 
     try {
+      // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
       const response = await fetch(`/api/users/${user.id}/suspend`, {
         method: "DELETE",
       });
@@ -283,6 +287,7 @@ export default function UserTable({ initialUsers }: UserTableProps) {
     setError(null);
 
     try {
+      // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
       const response = await fetch(`/api/users/${user.id}/lockout`, {
         method: "DELETE",
       });
@@ -307,6 +312,7 @@ export default function UserTable({ initialUsers }: UserTableProps) {
     setError(null);
 
     try {
+      // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
       const response = await fetch(`/api/users/${user.id}/resend-verification`, {
         method: "POST",
       });
@@ -339,6 +345,7 @@ export default function UserTable({ initialUsers }: UserTableProps) {
     setError(null);
 
     try {
+      // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
       const response = await fetch(`/api/users/${user.id}/verify-email`, {
         method: "POST",
       });
@@ -663,6 +670,7 @@ export default function UserTable({ initialUsers }: UserTableProps) {
           onUnlock={async () => {
             await handleUnlock(editingUser);
             // Refresh the editing user data
+            // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
             const response = await fetch(`/api/users/${editingUser.id}`);
             const data = await response.json();
             if (data.success && data.user) {
@@ -675,6 +683,7 @@ export default function UserTable({ initialUsers }: UserTableProps) {
           onManualVerify={async () => {
             await handleManualVerify(editingUser);
             // Refresh the editing user data
+            // codeql-suppress js/file-access-to-http - False positive: only UUID identifier sent, not file data
             const response = await fetch(`/api/users/${editingUser.id}`);
             const data = await response.json();
             if (data.success && data.user) {


### PR DESCRIPTION
## Summary
- Add `codeql-suppress` comments to 11 fetch calls flagged as `js/file-access-to-http` (CWE-200)
- All alerts are false positives - only UUID identifiers or type-safe enum values are sent in API URLs, not sensitive file data
- Files modified: `UserTable.tsx` (9), `UserAuditModal.tsx` (1), `EditionDetailView.tsx` (1)

## Test plan
- [x] TypeScript type-check passes
- [x] All 6,296 unit tests pass
- [ ] Verify CodeQL alerts are suppressed after merge (GitHub rescan)

Closes #223

🤖 Generated with [Claude Code](https://claude.ai/code)