### PR TITLE
fix(security): Prevent log injection vulnerabilities (CWE-117)

### DIFF
--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { getCampaignsByUserId, createCampaign } from "@/lib/storage/campaigns";
 import type { CreateCampaignRequest, CampaignsListResponse, CampaignResponse } from "@/lib/types";
+import { apiLogger } from "@/lib/logging";
 
 /**
  * GET /api/campaigns - List all campaigns the user is involved in
@@ -116,7 +117,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<CampaignR
       userRole: "gm",
     });
   } catch (error) {
-    console.error("Create campaign error:", error);
+    apiLogger.error({ error }, "Create campaign error");
     const errorMessage = error instanceof Error ? error.message : "An error occurred";
     return NextResponse.json({ success: false, error: errorMessage }, { status: 500 });
   }

--- a/app/api/characters/[characterId]/edge/route.ts
+++ b/app/api/characters/[characterId]/edge/route.ts
@@ -19,6 +19,7 @@ import {
   getMaxEdge,
 } from "@/lib/storage/characters";
 import type { EdgeRequest } from "@/lib/types";
+import { apiLogger } from "@/lib/logging";
 
 /**
  * GET /api/characters/[characterId]/edge
@@ -164,7 +165,8 @@ export async function POST(
       { status: 400 }
     );
   } catch (error) {
-    console.error("Error managing Edge:", error);
+    const { characterId } = await params;
+    apiLogger.error({ error, characterId }, "Error managing Edge");
     return NextResponse.json(
       {
         success: false,

--- a/app/api/characters/[characterId]/gameplay/route.ts
+++ b/app/api/characters/[characterId]/gameplay/route.ts
@@ -15,6 +15,7 @@ import {
   retireCharacter,
   killCharacter,
 } from "@/lib/storage/characters";
+import { apiLogger } from "@/lib/logging";
 
 type GameplayAction =
   | { action: "damage"; physical: number; stun: number }
@@ -102,7 +103,8 @@ export async function POST(
       character,
     });
   } catch (error) {
-    console.error("Failed to apply gameplay action:", error);
+    const { characterId } = await params;
+    apiLogger.error({ error, characterId }, "Failed to apply gameplay action");
     const message = error instanceof Error ? error.message : "Failed to apply action";
     return NextResponse.json({ success: false, error: message }, { status: 500 });
   }

--- a/app/api/grunt-teams/[teamId]/spend-edge/route.ts
+++ b/app/api/grunt-teams/[teamId]/spend-edge/route.ts
@@ -12,6 +12,7 @@ import { authorizeCampaign } from "@/lib/auth/campaign";
 import { getGruntTeam, spendGroupEdge } from "@/lib/storage/grunts";
 import { canSpendEdge } from "@/lib/rules/grunts";
 import type { GruntTeamResponse, SpendEdgeRequest } from "@/lib/types/grunts";
+import { apiLogger } from "@/lib/logging";
 
 /**
  * POST /api/grunt-teams/[teamId]/spend-edge
@@ -76,7 +77,8 @@ export async function POST(
       team: updatedTeam,
     });
   } catch (error) {
-    console.error("Spend Edge error:", error);
+    const { teamId } = await params;
+    apiLogger.error({ error, teamId }, "Spend Edge error");
     const errorMessage = error instanceof Error ? error.message : "An error occurred";
     return NextResponse.json({ success: false, error: errorMessage }, { status: 500 });
   }

--- a/lib/logging/__tests__/sanitize.test.ts
+++ b/lib/logging/__tests__/sanitize.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeLogValue } from "../sanitize";
+
+describe("sanitizeLogValue", () => {
+  describe("safe values pass through unchanged", () => {
+    it("returns normal strings unchanged", () => {
+      expect(sanitizeLogValue("hello world")).toBe("hello world");
+    });
+
+    it("returns alphanumeric strings unchanged", () => {
+      expect(sanitizeLogValue("user123")).toBe("user123");
+    });
+
+    it("returns paths unchanged", () => {
+      expect(sanitizeLogValue("/api/characters/abc-123")).toBe("/api/characters/abc-123");
+    });
+
+    it("returns emails unchanged", () => {
+      expect(sanitizeLogValue("user@example.com")).toBe("user@example.com");
+    });
+
+    it("preserves unicode characters", () => {
+      expect(sanitizeLogValue("日本語テスト")).toBe("日本語テスト");
+      expect(sanitizeLogValue("émojis 🎮")).toBe("émojis 🎮");
+    });
+  });
+
+  describe("handles null and undefined", () => {
+    it("converts null to string", () => {
+      expect(sanitizeLogValue(null)).toBe("null");
+    });
+
+    it("converts undefined to string", () => {
+      expect(sanitizeLogValue(undefined)).toBe("undefined");
+    });
+  });
+
+  describe("handles non-string values", () => {
+    it("converts numbers to string", () => {
+      expect(sanitizeLogValue(42)).toBe("42");
+      expect(sanitizeLogValue(3.14)).toBe("3.14");
+    });
+
+    it("converts booleans to string", () => {
+      expect(sanitizeLogValue(true)).toBe("true");
+      expect(sanitizeLogValue(false)).toBe("false");
+    });
+
+    it("converts objects to string", () => {
+      expect(sanitizeLogValue({ key: "value" })).toBe("[object Object]");
+    });
+  });
+
+  describe("escapes newlines (CWE-117 primary vector)", () => {
+    it("escapes LF (\\n)", () => {
+      expect(sanitizeLogValue("line1\nline2")).toBe("line1\\nline2");
+    });
+
+    it("escapes CR (\\r)", () => {
+      expect(sanitizeLogValue("line1\rline2")).toBe("line1\\rline2");
+    });
+
+    it("escapes CRLF (\\r\\n)", () => {
+      expect(sanitizeLogValue("line1\r\nline2")).toBe("line1\\r\\nline2");
+    });
+
+    it("escapes multiple newlines", () => {
+      expect(sanitizeLogValue("a\nb\nc")).toBe("a\\nb\\nc");
+    });
+  });
+
+  describe("escapes other control characters", () => {
+    it("escapes tab (\\t)", () => {
+      expect(sanitizeLogValue("col1\tcol2")).toBe("col1\\tcol2");
+    });
+
+    it("escapes null byte (\\0)", () => {
+      expect(sanitizeLogValue("before\x00after")).toBe("before\\0after");
+    });
+
+    it("escapes ESC as hex", () => {
+      expect(sanitizeLogValue("test\x1bcolor")).toBe("test\\x1bcolor");
+    });
+
+    it("escapes backspace as hex", () => {
+      expect(sanitizeLogValue("test\x08back")).toBe("test\\x08back");
+    });
+
+    it("escapes form feed as hex", () => {
+      expect(sanitizeLogValue("page\x0cnew")).toBe("page\\x0cnew");
+    });
+
+    it("escapes vertical tab as hex", () => {
+      expect(sanitizeLogValue("line\x0bdown")).toBe("line\\x0bdown");
+    });
+
+    it("escapes DEL (0x7F) as hex", () => {
+      expect(sanitizeLogValue("test\x7fdel")).toBe("test\\x7fdel");
+    });
+  });
+
+  describe("neutralizes log injection attack payloads", () => {
+    it("prevents fake log entry injection", () => {
+      const malicious = "attacker\n[INFO] User admin logged in successfully";
+      const sanitized = sanitizeLogValue(malicious);
+      expect(sanitized).toBe("attacker\\n[INFO] User admin logged in successfully");
+      expect(sanitized).not.toContain("\n");
+    });
+
+    it("prevents multiline injection with CRLF", () => {
+      const malicious = "value\r\n[CRITICAL] System compromised\r\n[INFO] Normal";
+      const sanitized = sanitizeLogValue(malicious);
+      expect(sanitized).toBe("value\\r\\n[CRITICAL] System compromised\\r\\n[INFO] Normal");
+      expect(sanitized).not.toContain("\r");
+      expect(sanitized).not.toContain("\n");
+    });
+
+    it("prevents ANSI escape sequence injection", () => {
+      const malicious = "normal\x1b[31mRED_TEXT\x1b[0m";
+      const sanitized = sanitizeLogValue(malicious);
+      expect(sanitized).toBe("normal\\x1b[31mRED_TEXT\\x1b[0m");
+      expect(sanitized).not.toContain("\x1b");
+    });
+
+    it("prevents null byte injection", () => {
+      const malicious = "visible\x00hidden";
+      const sanitized = sanitizeLogValue(malicious);
+      expect(sanitized).toBe("visible\\0hidden");
+      expect(sanitized).not.toContain("\x00");
+    });
+  });
+});

--- a/lib/logging/index.ts
+++ b/lib/logging/index.ts
@@ -43,6 +43,9 @@ export {
   apiLogger,
 } from "./child-loggers";
 
+// Sanitization utilities
+export { sanitizeLogValue } from "./sanitize";
+
 // Types
 export type { LogLevel, LogContext, LoggerConfig } from "./types";
 export { REDACTED_FIELDS } from "./types";

--- a/lib/logging/sanitize.ts
+++ b/lib/logging/sanitize.ts
@@ -1,0 +1,55 @@
+/**
+ * Log Sanitization Utilities
+ *
+ * Prevents log injection attacks (CWE-117) by escaping control characters
+ * that could be used to forge log entries or corrupt log output.
+ *
+ * Primary defense: Use structured logging (Pino) with data as object fields.
+ * This module provides additional sanitization for edge cases.
+ */
+
+/**
+ * Regex matching control characters that enable log injection attacks.
+ * Includes:
+ * - C0 controls (0x00-0x1F): newlines, tabs, null, etc.
+ * - DEL (0x7F)
+ * - C1 controls (0x80-0x9F): rarely used but potentially dangerous
+ */
+const CONTROL_CHAR_REGEX = /[\x00-\x1F\x7F\x80-\x9F]/g;
+
+/**
+ * Human-readable escape sequences for common control characters.
+ */
+const ESCAPE_MAP: Record<string, string> = {
+  "\n": "\\n",
+  "\r": "\\r",
+  "\t": "\\t",
+  "\x00": "\\0",
+};
+
+/**
+ * Sanitize a value for safe log inclusion.
+ *
+ * Escapes control characters to prevent log injection (CWE-117).
+ * Common characters get readable escapes (\n, \r, \t, \0).
+ * Other control chars get hex escapes (\x1b for ESC, etc.).
+ *
+ * @param value - Any value to sanitize
+ * @returns Sanitized string safe for log output
+ *
+ * @example
+ * sanitizeLogValue("normal text") // "normal text"
+ * sanitizeLogValue("line1\nline2") // "line1\\nline2"
+ * sanitizeLogValue("fake entry\n[INFO] Injected log") // "fake entry\\n[INFO] Injected log"
+ */
+export function sanitizeLogValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+
+  const str = typeof value === "string" ? value : String(value);
+
+  return str.replace(CONTROL_CHAR_REGEX, (char) => {
+    return ESCAPE_MAP[char] ?? `\\x${char.charCodeAt(0).toString(16).padStart(2, "0")}`;
+  });
+}

--- a/lib/rules/loader.ts
+++ b/lib/rules/loader.ts
@@ -31,6 +31,7 @@ import {
   getCreationMethod,
   getAllCreationMethods,
 } from "../storage/editions";
+import { rulesetLogger } from "../logging";
 
 // =============================================================================
 // LOADER FUNCTIONS
@@ -82,7 +83,7 @@ export async function loadRuleset(config: RulesetLoadConfig): Promise<LoadResult
         };
       }
       // Other books are optional - log warning but continue
-      console.warn(`Book '${bookId}' not found for edition '${editionCode}'`);
+      rulesetLogger.warn({ bookId, editionCode }, "Optional book not found, skipping");
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes 5 CodeQL-identified log injection vulnerabilities where user-controlled data was written to logs without sanitization, enabling attackers to inject fake log entries.

- Add `sanitizeLogValue()` utility for escaping control characters in log output
- Replace `console.warn` in loader.ts with structured `rulesetLogger.warn`
- Replace `console.error` in 4 API routes with structured `apiLogger.error`
- Add 25 unit tests for sanitization covering attack payloads

## Test plan

- [x] Unit tests pass (`pnpm test lib/logging/__tests__/sanitize.test.ts`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [ ] CodeQL no longer flags these 5 alerts

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)