### PR TITLE
fix(creation): Sync skills and freeSkillDesignations states

### DIFF
--- a/components/creation/SkillsCard.tsx
+++ b/components/creation/SkillsCard.tsx
@@ -40,6 +40,7 @@ import {
   useGroupBreaking,
   useKarmaPurchase,
   getKarmaSpent,
+  removeFromDesignations,
 } from "./skills";
 import { Plus, Users, X, AlertTriangle, Star, RefreshCw } from "lucide-react";
 
@@ -664,6 +665,31 @@ export function SkillsCard({ state, updateState }: SkillsCardProps) {
       const newSpecs = { ...specializations };
       delete newSpecs[skillId];
 
+      // Clean up free skill designations if this skill was designated
+      let newFreeSkillDesignations = freeSkillDesignations;
+      if (designatedSkillIds.has(skillId) && newFreeSkillDesignations) {
+        // Determine which type this skill was designated under and remove it
+        if (newFreeSkillDesignations.magical?.includes(skillId)) {
+          newFreeSkillDesignations = removeFromDesignations(
+            newFreeSkillDesignations,
+            skillId,
+            "magical"
+          );
+        } else if (newFreeSkillDesignations.resonance?.includes(skillId)) {
+          newFreeSkillDesignations = removeFromDesignations(
+            newFreeSkillDesignations,
+            skillId,
+            "resonance"
+          );
+        } else if (newFreeSkillDesignations.active?.includes(skillId)) {
+          newFreeSkillDesignations = removeFromDesignations(
+            newFreeSkillDesignations,
+            skillId,
+            "active"
+          );
+        }
+      }
+
       // Check if karma was spent on this skill and clean it up
       const currentKarmaSpent = (state.selections.skillKarmaSpent as {
         skillRaises: Record<string, number>;
@@ -703,6 +729,7 @@ export function SkillsCard({ state, updateState }: SkillsCardProps) {
             skills: newSkills,
             skillSpecializations: newSpecs,
             skillKarmaSpent: newKarmaSpent,
+            freeSkillDesignations: newFreeSkillDesignations,
           },
         });
       } else {
@@ -711,11 +738,19 @@ export function SkillsCard({ state, updateState }: SkillsCardProps) {
             ...state.selections,
             skills: newSkills,
             skillSpecializations: newSpecs,
+            freeSkillDesignations: newFreeSkillDesignations,
           },
         });
       }
     },
-    [skills, specializations, state.selections, updateState]
+    [
+      skills,
+      specializations,
+      designatedSkillIds,
+      freeSkillDesignations,
+      state.selections,
+      updateState,
+    ]
   );
 
   // Handle removing a skill group

--- a/components/creation/skills/useSkillDesignations.ts
+++ b/components/creation/skills/useSkillDesignations.ts
@@ -196,18 +196,29 @@ export function useSkillDesignations(
   );
 
   // Handle undesignating a skill from the FreeSkillsPanel
+  // Also removes the skill itself to keep states in sync
   const handleUndesignateSkill = useCallback(
     (skillId: string, type: string) => {
       const newDesignations = removeFromDesignations(freeSkillDesignations || {}, skillId, type);
 
+      // Also remove the skill itself
+      const newSkills = { ...skills };
+      delete newSkills[skillId];
+
+      // Remove any specializations for this skill
+      const newSpecs = { ...(state.selections.skillSpecializations as Record<string, string[]>) };
+      delete newSpecs[skillId];
+
       updateState({
         selections: {
           ...state.selections,
+          skills: newSkills,
+          skillSpecializations: newSpecs,
           freeSkillDesignations: newDesignations,
         },
       });
     },
-    [freeSkillDesignations, state.selections, updateState]
+    [freeSkillDesignations, skills, state.selections, updateState]
   );
 
   // Handle designating a skill directly from SkillListItem


### PR DESCRIPTION
## Summary
- Fix synchronization bug where removing a skill from FreeSkillsPanel left it orphaned in main skills list
- Fix synchronization bug where removing a skill from main skills list left it orphaned in free designations
- `handleUndesignateSkill` now also removes the skill and its specializations
- `handleRemoveSkill` now cleans up `freeSkillDesignations` if skill was designated

## Test plan
- [ ] Create a character with magic priority that grants free skills
- [ ] Designate a skill as free in the FreeSkillsPanel
- [ ] Click "Remove" in FreeSkillsPanel → verify skill is removed from BOTH places
- [ ] Add a new skill, designate it as free
- [ ] Click "×" (remove) on the skill in the main list → verify it's removed from BOTH places

🤖 Generated with [Claude Code](https://claude.com/claude-code)