### PR TITLE
feat(creation): Add 4 validators to block finalization of invalid characters

### DIFF
--- a/lib/contexts/CreationBudgetContext.tsx
+++ b/lib/contexts/CreationBudgetContext.tsx
@@ -445,9 +445,12 @@ function extractSpentValues(
   spent["skill-group-points"] = totalGroupRatings - karmaGroupRatingPoints - freeSkillGroupPoints;
 
   // Calculate knowledge points spent from selections (languages + knowledge skills)
-  const languages = (selections.languages || []) as Array<{ rating: number }>;
+  // Native languages are free and do not count toward the knowledge point budget (SR5 Core)
+  const languages = (selections.languages || []) as Array<{ rating: number; isNative?: boolean }>;
   const knowledgeSkills = (selections.knowledgeSkills || []) as Array<{ rating: number }>;
-  const languagePointsSpent = languages.reduce((sum, lang) => sum + (lang.rating || 0), 0);
+  const languagePointsSpent = languages
+    .filter((lang) => !lang.isNative)
+    .reduce((sum, lang) => sum + (lang.rating || 0), 0);
   const knowledgePointsSpent = knowledgeSkills.reduce((sum, skill) => sum + (skill.rating || 0), 0);
   spent["knowledge-points"] = languagePointsSpent + knowledgePointsSpent;
 

--- a/lib/rules/magic/__tests__/complex-form-validator.test.ts
+++ b/lib/rules/magic/__tests__/complex-form-validator.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Complex Form Validator Tests
+ *
+ * Tests for complex form allocation validation for technomancers.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateComplexFormAllocation,
+  canUseComplexForms,
+  getComplexFormDefinition,
+  getAllComplexForms,
+} from "../complex-form-validator";
+import type { Character } from "@/lib/types/character";
+import type { LoadedRuleset, ComplexFormData } from "../../loader-types";
+import type { BookPayload } from "@/lib/types/edition";
+
+// =============================================================================
+// TEST FIXTURES
+// =============================================================================
+
+function createMockComplexForm(overrides: Partial<ComplexFormData> = {}): ComplexFormData {
+  return {
+    id: "cleaner",
+    name: "Cleaner",
+    target: "persona",
+    duration: "permanent",
+    fading: "L+1",
+    description: "Test complex form",
+    ...overrides,
+  };
+}
+
+function createMockRuleset(complexForms?: ComplexFormData[]): LoadedRuleset {
+  return {
+    edition: {} as LoadedRuleset["edition"],
+    books: [
+      {
+        id: "core-rulebook",
+        title: "Core Rulebook",
+        isCore: true,
+        loadOrder: 0,
+        payload: {
+          meta: {
+            id: "core-rulebook",
+            editionCode: "sr5",
+            name: "Core Rulebook",
+            category: "core",
+            releaseYear: 2013,
+          },
+          modules: {
+            magic: complexForms
+              ? {
+                  mergeStrategy: "override" as const,
+                  payload: { complexForms },
+                }
+              : undefined,
+          },
+        } as unknown as BookPayload,
+      },
+    ],
+    modules: {},
+  } as unknown as LoadedRuleset;
+}
+
+function createMockCharacter(overrides: Partial<Character> = {}): Partial<Character> {
+  return {
+    magicalPath: "technomancer",
+    specialAttributes: { resonance: 4, edge: 2, essence: 6 },
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// TESTS: canUseComplexForms
+// =============================================================================
+
+describe("canUseComplexForms", () => {
+  it("returns true for technomancers", () => {
+    expect(canUseComplexForms({ magicalPath: "technomancer" })).toBe(true);
+  });
+
+  it("returns false for mundane characters", () => {
+    expect(canUseComplexForms({ magicalPath: "mundane" })).toBe(false);
+  });
+
+  it("returns false for full mages", () => {
+    expect(canUseComplexForms({ magicalPath: "full-mage" })).toBe(false);
+  });
+
+  it("returns false for adepts", () => {
+    expect(canUseComplexForms({ magicalPath: "adept" })).toBe(false);
+  });
+
+  it("returns false for mystic adepts", () => {
+    expect(canUseComplexForms({ magicalPath: "mystic-adept" })).toBe(false);
+  });
+
+  it("returns false when magicalPath is undefined", () => {
+    expect(canUseComplexForms({})).toBe(false);
+  });
+});
+
+// =============================================================================
+// TESTS: validateComplexFormAllocation
+// =============================================================================
+
+describe("validateComplexFormAllocation", () => {
+  const form1 = createMockComplexForm({ id: "cleaner", name: "Cleaner" });
+  const form2 = createMockComplexForm({ id: "editor", name: "Editor" });
+  const form3 = createMockComplexForm({ id: "resonance-spike", name: "Resonance Spike" });
+
+  it("validates valid allocation", () => {
+    const character = createMockCharacter();
+    const ruleset = createMockRuleset([form1, form2, form3]);
+
+    const result = validateComplexFormAllocation(character, ["cleaner", "editor"], 5, ruleset);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.budgetRemaining).toBe(3);
+    expect(result.budgetTotal).toBe(5);
+  });
+
+  it("rejects non-technomancer characters", () => {
+    const character = createMockCharacter({ magicalPath: "full-mage" });
+    const ruleset = createMockRuleset([form1]);
+
+    const result = validateComplexFormAllocation(character, ["cleaner"], 5, ruleset);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(expect.objectContaining({ code: "CF_CANNOT_USE" }));
+    expect(result.budgetRemaining).toBe(0);
+    expect(result.budgetTotal).toBe(0);
+  });
+
+  it("detects form limit exceeded", () => {
+    const character = createMockCharacter();
+    const ruleset = createMockRuleset([form1, form2, form3]);
+
+    const result = validateComplexFormAllocation(
+      character,
+      ["cleaner", "editor", "resonance-spike"],
+      2,
+      ruleset
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(expect.objectContaining({ code: "CF_LIMIT_EXCEEDED" }));
+  });
+
+  it("detects forms not found in catalog", () => {
+    const character = createMockCharacter();
+    const ruleset = createMockRuleset([form1]);
+
+    const result = validateComplexFormAllocation(
+      character,
+      ["cleaner", "nonexistent-form"],
+      5,
+      ruleset
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(expect.objectContaining({ code: "CF_NOT_FOUND" }));
+  });
+
+  it("detects duplicate forms", () => {
+    const character = createMockCharacter();
+    const ruleset = createMockRuleset([form1, form2]);
+
+    const result = validateComplexFormAllocation(character, ["cleaner", "cleaner"], 5, ruleset);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(expect.objectContaining({ code: "CF_DUPLICATE" }));
+  });
+
+  it("handles empty form list", () => {
+    const character = createMockCharacter();
+    const ruleset = createMockRuleset([form1]);
+
+    const result = validateComplexFormAllocation(character, [], 5, ruleset);
+
+    expect(result.valid).toBe(true);
+    expect(result.budgetRemaining).toBe(5);
+  });
+
+  it("handles empty catalog", () => {
+    const character = createMockCharacter();
+    const ruleset = createMockRuleset([]);
+
+    const result = validateComplexFormAllocation(character, ["cleaner"], 5, ruleset);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(expect.objectContaining({ code: "CF_NOT_FOUND" }));
+  });
+
+  it("calculates budget remaining correctly with duplicates", () => {
+    const character = createMockCharacter();
+    const ruleset = createMockRuleset([form1, form2]);
+
+    const result = validateComplexFormAllocation(
+      character,
+      ["cleaner", "cleaner", "editor"],
+      5,
+      ruleset
+    );
+
+    // Budget remaining is based on unique count (2), not total (3)
+    expect(result.budgetRemaining).toBe(3);
+  });
+});
+
+// =============================================================================
+// TESTS: getComplexFormDefinition
+// =============================================================================
+
+describe("getComplexFormDefinition", () => {
+  it("returns form when found", () => {
+    const form = createMockComplexForm({ id: "cleaner", name: "Cleaner" });
+    const ruleset = createMockRuleset([form]);
+
+    const result = getComplexFormDefinition("cleaner", ruleset);
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("cleaner");
+    expect(result!.name).toBe("Cleaner");
+  });
+
+  it("returns null when not found", () => {
+    const ruleset = createMockRuleset([]);
+
+    const result = getComplexFormDefinition("nonexistent", ruleset);
+
+    expect(result).toBeNull();
+  });
+});
+
+// =============================================================================
+// TESTS: getAllComplexForms
+// =============================================================================
+
+describe("getAllComplexForms", () => {
+  it("returns all forms from ruleset", () => {
+    const form1 = createMockComplexForm({ id: "cleaner" });
+    const form2 = createMockComplexForm({ id: "editor" });
+    const ruleset = createMockRuleset([form1, form2]);
+
+    const result = getAllComplexForms(ruleset);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns empty array when no magic module", () => {
+    const ruleset = createMockRuleset();
+
+    const result = getAllComplexForms(ruleset);
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/lib/rules/magic/complex-form-validator.ts
+++ b/lib/rules/magic/complex-form-validator.ts
@@ -1,0 +1,143 @@
+/**
+ * Complex Form Validation Service
+ *
+ * Provides validation for complex form allocation for technomancer characters.
+ * Mirrors the spell-validator.ts pattern.
+ */
+
+import type { Character } from "@/lib/types/character";
+import type {
+  SpellValidationResult,
+  MagicValidationError,
+  MagicValidationWarning,
+} from "@/lib/types/magic";
+import type { LoadedRuleset, ComplexFormData } from "../loader-types";
+import { extractComplexForms } from "../loader";
+
+// =============================================================================
+// COMPLEX FORM VALIDATION
+// =============================================================================
+
+/**
+ * Check if a character can use complex forms (must be a technomancer).
+ *
+ * @param character - The character to check
+ * @returns True if character can use complex forms
+ */
+export function canUseComplexForms(character: Partial<Character>): boolean {
+  return character.magicalPath === "technomancer";
+}
+
+/**
+ * Validate complex form allocation against character's form budget.
+ *
+ * @param character - The character to validate
+ * @param formIds - Array of complex form IDs to validate
+ * @param formLimit - Maximum number of complex forms allowed
+ * @param ruleset - The loaded ruleset containing complex form data
+ * @returns Validation result
+ */
+export function validateComplexFormAllocation(
+  character: Partial<Character>,
+  formIds: string[],
+  formLimit: number,
+  ruleset: LoadedRuleset
+): SpellValidationResult {
+  const errors: MagicValidationError[] = [];
+  const warnings: MagicValidationWarning[] = [];
+
+  // Check character can use complex forms
+  if (!canUseComplexForms(character)) {
+    errors.push({
+      code: "CF_CANNOT_USE",
+      message: "Character's magical path does not allow complex forms (must be technomancer)",
+      field: "magicalPath",
+    });
+    return {
+      valid: false,
+      errors,
+      warnings,
+      budgetRemaining: 0,
+      budgetTotal: 0,
+    };
+  }
+
+  // Check form limit
+  if (formIds.length > formLimit) {
+    errors.push({
+      code: "CF_LIMIT_EXCEEDED",
+      message: `Cannot select more than ${formLimit} complex forms (selected: ${formIds.length})`,
+      field: "complexForms",
+    });
+  }
+
+  // Validate each form exists in ruleset
+  const formsCatalog = extractComplexForms(ruleset);
+  const invalidForms: string[] = [];
+  const duplicateForms: string[] = [];
+  const seenForms = new Set<string>();
+
+  for (const formId of formIds) {
+    // Check for duplicates
+    if (seenForms.has(formId)) {
+      duplicateForms.push(formId);
+    } else {
+      seenForms.add(formId);
+    }
+
+    // Check form exists in catalog
+    const form = formsCatalog.find((f) => f.id === formId);
+    if (!form) {
+      invalidForms.push(formId);
+    }
+  }
+
+  if (invalidForms.length > 0) {
+    errors.push({
+      code: "CF_NOT_FOUND",
+      message: `Complex forms not found in ruleset: ${invalidForms.join(", ")}`,
+      field: "complexForms",
+    });
+  }
+
+  if (duplicateForms.length > 0) {
+    errors.push({
+      code: "CF_DUPLICATE",
+      message: `Duplicate complex forms selected: ${duplicateForms.join(", ")}`,
+      field: "complexForms",
+    });
+  }
+
+  const uniqueFormCount = seenForms.size;
+  const budgetRemaining = Math.max(0, formLimit - uniqueFormCount);
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    budgetRemaining,
+    budgetTotal: formLimit,
+  };
+}
+
+/**
+ * Get complex form definition from ruleset.
+ *
+ * @param formId - The form ID to look up
+ * @param ruleset - The loaded ruleset
+ * @returns Complex form data or null if not found
+ */
+export function getComplexFormDefinition(
+  formId: string,
+  ruleset: LoadedRuleset
+): ComplexFormData | null {
+  const formsCatalog = extractComplexForms(ruleset);
+  return formsCatalog.find((f) => f.id === formId) ?? null;
+}
+
+/**
+ * Get all complex forms from the ruleset.
+ */
+export function getAllComplexForms(ruleset: LoadedRuleset): ComplexFormData[] {
+  return extractComplexForms(ruleset);
+}

--- a/lib/rules/validation/__tests__/contact-budget.test.ts
+++ b/lib/rules/validation/__tests__/contact-budget.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Contact Budget Validator Tests
+ *
+ * Tests for contact point budget enforcement during character creation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateCharacter } from "../character-validator";
+import type { CharacterValidationContext } from "../types";
+import type { Character } from "@/lib/types/character";
+import type { MergedRuleset } from "@/lib/types";
+import type { CreationState } from "@/lib/types/creation";
+
+// =============================================================================
+// TEST FIXTURES
+// =============================================================================
+
+function createMockRuleset(): MergedRuleset {
+  return {
+    snapshotId: "test-snapshot",
+    editionId: "sr5",
+    editionCode: "sr5",
+    bookIds: ["core-rulebook"],
+    modules: {},
+    createdAt: new Date().toISOString(),
+  } as unknown as MergedRuleset;
+}
+
+function createContext(
+  overrides: Partial<CharacterValidationContext> = {}
+): CharacterValidationContext {
+  return {
+    character: {
+      name: "Test Runner",
+      metatype: "human",
+      magicalPath: "mundane",
+      attributes: {
+        body: 3,
+        agility: 3,
+        reaction: 3,
+        strength: 3,
+        willpower: 3,
+        logic: 3,
+        intuition: 3,
+        charisma: 4,
+      },
+      identities: [{ name: "Fake SIN", type: "fake", rating: 4 }],
+      lifestyles: [{ name: "Low", monthlyCost: 2000, type: "low" }],
+    } as unknown as Character,
+    ruleset: createMockRuleset(),
+    mode: "creation",
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("contactBudgetValidator", () => {
+  it("passes with valid contacts within budget", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          contacts: [
+            { name: "Fixer Joe", connection: 3, loyalty: 2 },
+            { name: "Street Doc", connection: 2, loyalty: 3 },
+          ],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "CONTACT_INVALID_CONNECTION")).toBe(false);
+    expect(result.errors.some((e) => e.code === "CONTACT_INVALID_LOYALTY")).toBe(false);
+  });
+
+  it("reports info when contacts exceed free pool", async () => {
+    // CHA 4 → free pool = 12
+    const context = createContext({
+      creationState: {
+        selections: {
+          contacts: [
+            { name: "Mr. Big", connection: 6, loyalty: 6 }, // 12 points
+            { name: "Another", connection: 1, loyalty: 1 }, // 2 more → total 14 > 12
+          ],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    const infoIssues = [...result.errors, ...result.warnings].filter(
+      (i) => i.code === "CONTACT_KARMA_OVERFLOW"
+    );
+    expect(infoIssues).toHaveLength(1);
+    expect(infoIssues[0].severity).toBe("info");
+  });
+
+  it("reports error for connection below minimum", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          contacts: [{ name: "Bad Contact", connection: 0, loyalty: 2 }],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "CONTACT_INVALID_CONNECTION")).toBe(true);
+  });
+
+  it("reports error for loyalty below minimum", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          contacts: [{ name: "Disloyal Contact", connection: 2, loyalty: 0 }],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "CONTACT_INVALID_LOYALTY")).toBe(true);
+  });
+
+  it("warns when no contacts at finalization", async () => {
+    const context = createContext({
+      mode: "finalization",
+      creationState: {
+        selections: {
+          contacts: [],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.warnings.some((w) => w.code === "CONTACT_NONE_SELECTED")).toBe(true);
+  });
+
+  it("does not warn about no contacts during creation mode", async () => {
+    const context = createContext({
+      mode: "creation",
+      creationState: {
+        selections: {
+          contacts: [],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.warnings.some((w) => w.code === "CONTACT_NONE_SELECTED")).toBe(false);
+  });
+
+  it("handles missing creationState gracefully", async () => {
+    const context = createContext({
+      creationState: undefined,
+    });
+
+    const result = await validateCharacter(context);
+
+    // Should not crash, no contact-related errors
+    expect(result.errors.some((e) => e.code === "CONTACT_INVALID_CONNECTION")).toBe(false);
+    expect(result.errors.some((e) => e.code === "CONTACT_INVALID_LOYALTY")).toBe(false);
+  });
+
+  it("calculates overflow correctly with charisma", async () => {
+    // CHA 2 → free pool = 6
+    const context = createContext({
+      character: {
+        name: "Low CHA",
+        metatype: "human",
+        magicalPath: "mundane",
+        attributes: {
+          body: 3,
+          agility: 3,
+          reaction: 3,
+          strength: 3,
+          willpower: 3,
+          logic: 3,
+          intuition: 3,
+          charisma: 2,
+        },
+        identities: [{ name: "SIN", type: "fake", rating: 4 }],
+        lifestyles: [{ name: "Low", monthlyCost: 2000, type: "low" }],
+      } as unknown as Character,
+      creationState: {
+        selections: {
+          contacts: [
+            { name: "Contact 1", connection: 3, loyalty: 3 }, // 6 points
+            { name: "Contact 2", connection: 2, loyalty: 2 }, // 4 more → total 10, overflow 4
+          ],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    const overflow = [...result.errors, ...result.warnings].find(
+      (i) => i.code === "CONTACT_KARMA_OVERFLOW"
+    );
+    expect(overflow).toBeDefined();
+    expect(overflow!.message).toContain("4"); // overflow amount
+  });
+});

--- a/lib/rules/validation/__tests__/knowledge-budget.test.ts
+++ b/lib/rules/validation/__tests__/knowledge-budget.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Knowledge Budget Validator Tests
+ *
+ * Tests for knowledge point budget enforcement during character creation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateCharacter } from "../character-validator";
+import type { CharacterValidationContext } from "../types";
+import type { Character } from "@/lib/types/character";
+import type { MergedRuleset } from "@/lib/types";
+import type { CreationState } from "@/lib/types/creation";
+
+// =============================================================================
+// TEST FIXTURES
+// =============================================================================
+
+function createMockRuleset(): MergedRuleset {
+  return {
+    snapshotId: "test-snapshot",
+    editionId: "sr5",
+    editionCode: "sr5",
+    bookIds: ["core-rulebook"],
+    modules: {},
+    createdAt: new Date().toISOString(),
+  } as unknown as MergedRuleset;
+}
+
+function createContext(
+  overrides: Partial<CharacterValidationContext> = {}
+): CharacterValidationContext {
+  return {
+    character: {
+      name: "Test Runner",
+      metatype: "human",
+      magicalPath: "mundane",
+      // INT 4 + LOG 5 = 9, budget = 18
+      attributes: {
+        body: 3,
+        agility: 3,
+        reaction: 3,
+        strength: 3,
+        willpower: 3,
+        logic: 5,
+        intuition: 4,
+        charisma: 3,
+      },
+      identities: [{ name: "Fake SIN", type: "fake", rating: 4 }],
+      lifestyles: [{ name: "Low", monthlyCost: 2000, type: "low" }],
+    } as unknown as Character,
+    ruleset: createMockRuleset(),
+    mode: "creation",
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("knowledgeBudgetValidator", () => {
+  it("passes when knowledge spending is within budget", async () => {
+    // Budget: (4 + 5) × 2 = 18
+    const context = createContext({
+      creationState: {
+        selections: {
+          languages: [
+            { name: "English", rating: 6, isNative: true },
+            { name: "Japanese", rating: 3 },
+          ],
+          knowledgeSkills: [
+            { name: "Shadowrun History", category: "academic", rating: 4 },
+            { name: "Seattle Gangs", category: "street", rating: 3 },
+          ],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KNOWLEDGE_BUDGET_EXCEEDED")).toBe(false);
+  });
+
+  it("reports error when knowledge spending exceeds budget", async () => {
+    // Budget: (4 + 5) × 2 = 18
+    const context = createContext({
+      creationState: {
+        selections: {
+          languages: [
+            { name: "English", rating: 6, isNative: true }, // Free (native)
+            { name: "Japanese", rating: 5 }, // 5 points
+            { name: "Mandarin", rating: 4 }, // 4 points
+          ],
+          knowledgeSkills: [
+            { name: "Matrix Security", category: "professional", rating: 5 }, // 5
+            { name: "Seattle History", category: "academic", rating: 5 }, // 5 → total 19 > 18
+          ],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KNOWLEDGE_BUDGET_EXCEEDED")).toBe(true);
+  });
+
+  it("excludes native languages from budget calculation", async () => {
+    // Budget: (4 + 5) × 2 = 18
+    // Without native exclusion, total would be 6 + 3 + 10 = 19 (over budget)
+    // With native exclusion, total is 3 + 10 = 13 (within budget)
+    const context = createContext({
+      creationState: {
+        selections: {
+          languages: [
+            { name: "English", rating: 6, isNative: true }, // Excluded
+            { name: "Japanese", rating: 3 }, // 3 points
+          ],
+          knowledgeSkills: [
+            { name: "Matrix Security", category: "professional", rating: 5 }, // 5
+            { name: "Seattle History", category: "academic", rating: 5 }, // 5 → total 13
+          ],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KNOWLEDGE_BUDGET_EXCEEDED")).toBe(false);
+  });
+
+  it("warns about no native language at finalization", async () => {
+    const context = createContext({
+      mode: "finalization",
+      creationState: {
+        selections: {
+          languages: [{ name: "Japanese", rating: 3 }],
+          knowledgeSkills: [],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.warnings.some((w) => w.code === "KNOWLEDGE_NO_NATIVE_LANGUAGE")).toBe(true);
+  });
+
+  it("does not warn about no native language during creation", async () => {
+    const context = createContext({
+      mode: "creation",
+      creationState: {
+        selections: {
+          languages: [{ name: "Japanese", rating: 3 }],
+          knowledgeSkills: [],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.warnings.some((w) => w.code === "KNOWLEDGE_NO_NATIVE_LANGUAGE")).toBe(false);
+  });
+
+  it("warns about unspent points at finalization", async () => {
+    // Budget: 18, spending: 3 → 15 remaining
+    const context = createContext({
+      mode: "finalization",
+      creationState: {
+        selections: {
+          languages: [
+            { name: "English", rating: 6, isNative: true },
+            { name: "Japanese", rating: 3 },
+          ],
+          knowledgeSkills: [],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.warnings.some((w) => w.code === "KNOWLEDGE_POINTS_REMAINING")).toBe(true);
+  });
+
+  it("does not warn about unspent points when fully spent", async () => {
+    // Budget: 18, spending exactly 18
+    const context = createContext({
+      mode: "finalization",
+      creationState: {
+        selections: {
+          languages: [
+            { name: "English", rating: 6, isNative: true },
+            { name: "Japanese", rating: 5 }, // 5
+            { name: "Spanish", rating: 4 }, // 4
+          ],
+          knowledgeSkills: [
+            { name: "History", category: "academic", rating: 5 }, // 5
+            { name: "Street Gangs", category: "street", rating: 4 }, // 4 → total 18
+          ],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.warnings.some((w) => w.code === "KNOWLEDGE_POINTS_REMAINING")).toBe(false);
+  });
+
+  it("handles empty selections gracefully", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {},
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KNOWLEDGE_BUDGET_EXCEEDED")).toBe(false);
+  });
+
+  it("handles missing creationState gracefully", async () => {
+    const context = createContext({
+      creationState: undefined,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KNOWLEDGE_BUDGET_EXCEEDED")).toBe(false);
+  });
+
+  it("calculates budget correctly with different attribute values", async () => {
+    // INT 2 + LOG 3 = 5, budget = 10
+    const context = createContext({
+      character: {
+        name: "Low Mental",
+        metatype: "ork",
+        magicalPath: "mundane",
+        attributes: {
+          body: 5,
+          agility: 3,
+          reaction: 3,
+          strength: 5,
+          willpower: 3,
+          logic: 3,
+          intuition: 2,
+          charisma: 2,
+        },
+        identities: [{ name: "SIN", type: "fake", rating: 4 }],
+        lifestyles: [{ name: "Low", monthlyCost: 2000, type: "low" }],
+      } as unknown as Character,
+      creationState: {
+        selections: {
+          languages: [
+            { name: "Or'zet", rating: 6, isNative: true },
+            { name: "English", rating: 4 }, // 4
+          ],
+          knowledgeSkills: [
+            { name: "Brawling Tactics", category: "street", rating: 4 }, // 4
+            { name: "Ork Underground", category: "interests", rating: 3 }, // 3 → total 11 > 10
+          ],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KNOWLEDGE_BUDGET_EXCEEDED")).toBe(true);
+  });
+});

--- a/lib/rules/validation/__tests__/skill-group-constraints.test.ts
+++ b/lib/rules/validation/__tests__/skill-group-constraints.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Skill Group Constraint Validator Tests
+ *
+ * Tests that individual skill points cannot be allocated to skills
+ * in an active (non-broken) group during character creation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateCharacter } from "../character-validator";
+import type { CharacterValidationContext } from "../types";
+import type { Character } from "@/lib/types/character";
+import type { MergedRuleset } from "@/lib/types";
+import type { CreationState } from "@/lib/types/creation";
+import type { SkillGroupData } from "../../loader-types";
+
+// =============================================================================
+// TEST FIXTURES
+// =============================================================================
+
+function createMockRuleset(skillGroups: SkillGroupData[] = []): MergedRuleset {
+  return {
+    snapshotId: "test-snapshot",
+    editionId: "sr5",
+    editionCode: "sr5",
+    bookIds: ["core-rulebook"],
+    modules: {
+      skills: {
+        skillGroups,
+      },
+    },
+    createdAt: new Date().toISOString(),
+  } as unknown as MergedRuleset;
+}
+
+function createContext(
+  overrides: Partial<CharacterValidationContext> = {}
+): CharacterValidationContext {
+  return {
+    character: {
+      name: "Test Runner",
+      metatype: "human",
+      magicalPath: "mundane",
+      attributes: {
+        body: 3,
+        agility: 3,
+        reaction: 3,
+        strength: 3,
+        willpower: 3,
+        logic: 3,
+        intuition: 3,
+        charisma: 3,
+      },
+      identities: [{ name: "Fake SIN", type: "fake", rating: 4 }],
+      lifestyles: [{ name: "Low", monthlyCost: 2000, type: "low" }],
+    } as unknown as Character,
+    ruleset: createMockRuleset(),
+    mode: "creation",
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("skillGroupConstraintValidator", () => {
+  const firearmGroupDef: SkillGroupData = {
+    id: "firearms",
+    name: "Firearms",
+    skills: ["automatics", "longarms", "pistols"],
+  };
+
+  it("reports error when individual skill has points in an active group (no karma)", async () => {
+    const ruleset = createMockRuleset([firearmGroupDef]);
+    const context = createContext({
+      ruleset,
+      mode: "creation",
+      creationState: {
+        selections: {
+          skillGroups: { firearms: 3 }, // Active, not broken
+          skills: { automatics: 5 }, // Individual points in group member
+          skillKarmaSpent: { skillRaises: {}, skillRatingPoints: 0, specializations: 0 },
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "SG_INDIVIDUAL_SKILL_IN_GROUP")).toBe(true);
+  });
+
+  it("allows individual skill raise with karma in active group", async () => {
+    const ruleset = createMockRuleset([firearmGroupDef]);
+    const context = createContext({
+      ruleset,
+      mode: "creation",
+      creationState: {
+        selections: {
+          skillGroups: { firearms: 3 },
+          skills: { automatics: 5 },
+          skillKarmaSpent: {
+            skillRaises: { automatics: 20 }, // Karma spent to raise
+            skillRatingPoints: 2,
+            specializations: 0,
+          },
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "SG_INDIVIDUAL_SKILL_IN_GROUP")).toBe(false);
+  });
+
+  it("allows individual skill allocation in broken group", async () => {
+    const ruleset = createMockRuleset([firearmGroupDef]);
+    const context = createContext({
+      ruleset,
+      mode: "creation",
+      creationState: {
+        selections: {
+          skillGroups: { firearms: { rating: 3, isBroken: true } },
+          skills: { automatics: 5, longarms: 4 },
+          skillKarmaSpent: { skillRaises: {}, skillRatingPoints: 0, specializations: 0 },
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "SG_INDIVIDUAL_SKILL_IN_GROUP")).toBe(false);
+  });
+
+  it("passes when no skill groups are selected", async () => {
+    const ruleset = createMockRuleset([firearmGroupDef]);
+    const context = createContext({
+      ruleset,
+      mode: "creation",
+      creationState: {
+        selections: {
+          skillGroups: {},
+          skills: { automatics: 5 },
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "SG_INDIVIDUAL_SKILL_IN_GROUP")).toBe(false);
+  });
+
+  it("passes when active group has no individual member skills", async () => {
+    const ruleset = createMockRuleset([firearmGroupDef]);
+    const context = createContext({
+      ruleset,
+      mode: "creation",
+      creationState: {
+        selections: {
+          skillGroups: { firearms: 3 },
+          skills: { computer: 4 }, // Not a member of firearms group
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "SG_INDIVIDUAL_SKILL_IN_GROUP")).toBe(false);
+  });
+
+  it("skips groups with rating 0", async () => {
+    const ruleset = createMockRuleset([firearmGroupDef]);
+    const context = createContext({
+      ruleset,
+      mode: "creation",
+      creationState: {
+        selections: {
+          skillGroups: { firearms: 0 },
+          skills: { automatics: 5 },
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "SG_INDIVIDUAL_SKILL_IN_GROUP")).toBe(false);
+  });
+
+  it("reports errors for multiple members in the same group", async () => {
+    const ruleset = createMockRuleset([firearmGroupDef]);
+    const context = createContext({
+      ruleset,
+      mode: "creation",
+      creationState: {
+        selections: {
+          skillGroups: { firearms: 3 },
+          skills: { automatics: 5, longarms: 4 }, // Two members with individual points
+          skillKarmaSpent: { skillRaises: {}, skillRatingPoints: 0, specializations: 0 },
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    const sgErrors = result.errors.filter((e) => e.code === "SG_INDIVIDUAL_SKILL_IN_GROUP");
+    expect(sgErrors).toHaveLength(2);
+  });
+
+  it("runs in finalization mode", async () => {
+    const ruleset = createMockRuleset([firearmGroupDef]);
+    const context = createContext({
+      ruleset,
+      mode: "finalization",
+      creationState: {
+        selections: {
+          skillGroups: { firearms: 3 },
+          skills: { automatics: 5 },
+          skillKarmaSpent: { skillRaises: {}, skillRatingPoints: 0, specializations: 0 },
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "SG_INDIVIDUAL_SKILL_IN_GROUP")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add **complex form validator** (priority 6): enforces form limit, catalog existence, and duplicate detection for technomancers; upgrades `NO_COMPLEX_FORMS` to error at finalization
- Add **skill group constraint validator** (priority 7): prevents individual skill points in active (non-broken) groups during creation; karma raises still allowed
- Add **contact budget validator** (priority 8): enforces min connection/loyalty ratings, reports karma overflow as info, warns if no contacts at finalization
- Add **knowledge budget validator** (priority 9): enforces `(INT+LOG)×2` budget excluding native languages, warns about unspent points and missing native language
- **Fix native language bug** in `CreationBudgetContext` where native language ratings were incorrectly counted toward knowledge-points spent

Closes #243

## Test plan
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 290 test files, 6413 tests all passing (44 new tests across 4 test files)
- [x] `pnpm lint` — 0 errors
- [x] Pre-commit hooks pass (lint-staged, type-check, test coverage check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)