### PR TITLE
feat(creation): Require tradition selection at finalization

### DIFF
--- a/app/characters/create/sheet/components/SheetCreationLayout.tsx
+++ b/app/characters/create/sheet/components/SheetCreationLayout.tsx
@@ -644,6 +644,13 @@ function ValidationSummary({
     if (Object.keys(priorities).length < 5) items.push("Set all 5 priorities");
     if (!selections.metatype) items.push("Select a metatype");
     if (!selections["magical-path"]) items.push("Select a magic/resonance path");
+
+    // Tradition required for magician, mystic-adept, aspected-mage
+    const TRADITION_PATHS = ["magician", "mystic-adept", "aspected-mage"];
+    const magicPathSel = selections["magical-path"] as string | undefined;
+    if (magicPathSel && TRADITION_PATHS.includes(magicPathSel) && !selections["tradition"])
+      items.push("Select a tradition");
+
     if (!selections.identities || selections.identities.length === 0)
       items.push("Add at least one identity (SIN)");
     if (!selections.lifestyles || selections.lifestyles.length === 0)

--- a/lib/rules/validation/__tests__/character-validator.test.ts
+++ b/lib/rules/validation/__tests__/character-validator.test.ts
@@ -439,7 +439,7 @@ describe("Character Validator", () => {
       );
     });
 
-    it("should return warning when full-mage has no tradition", async () => {
+    it("should return warning when full-mage has no tradition in creation mode", async () => {
       const character = createMinimalCharacter({
         magicalPath: "full-mage",
         tradition: undefined,
@@ -456,7 +456,173 @@ describe("Character Validator", () => {
         expect.objectContaining({
           code: "MISSING_TRADITION",
           field: "tradition",
+          severity: "warning",
         })
+      );
+    });
+
+    it("should return error when full-mage has no tradition at finalization", async () => {
+      const character = createMinimalCharacter({
+        magicalPath: "full-mage",
+        tradition: undefined,
+      });
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "MISSING_TRADITION",
+          field: "tradition",
+          severity: "error",
+        })
+      );
+    });
+
+    it("should return error when mystic-adept has no tradition at finalization", async () => {
+      const character = createMinimalCharacter({
+        magicalPath: "mystic-adept",
+        tradition: undefined,
+      });
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "MISSING_TRADITION",
+          field: "tradition",
+          severity: "error",
+        })
+      );
+    });
+
+    it("should return error when aspected-mage has no tradition at finalization", async () => {
+      const character = createMinimalCharacter({
+        magicalPath: "aspected-mage",
+        tradition: undefined,
+      });
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "MISSING_TRADITION",
+          field: "tradition",
+          severity: "error",
+        })
+      );
+    });
+
+    it("should not return MISSING_TRADITION when tradition is set", async () => {
+      const character = createMinimalCharacter({
+        magicalPath: "full-mage",
+        tradition: "hermetic",
+      });
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).not.toContainEqual(
+        expect.objectContaining({ code: "MISSING_TRADITION" })
+      );
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "MISSING_TRADITION" })
+      );
+    });
+
+    it("should resolve MISSING_TRADITION via creationState selections", async () => {
+      // During creation, character.magicalPath may not be set — use creationState
+      const character = createMinimalCharacter({
+        magicalPath: "mundane", // Not yet mapped from selections
+        tradition: undefined,
+      });
+      const ruleset = createMinimalRuleset();
+      const creationState = createMinimalCreationState({
+        selections: {
+          "magical-path": "magician", // selection value, maps to "full-mage"
+        } as CreationState["selections"],
+      });
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        creationState,
+        mode: "finalization",
+      });
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "MISSING_TRADITION",
+          field: "tradition",
+          severity: "error",
+        })
+      );
+    });
+
+    it("should not return MISSING_TRADITION when tradition is in creationState", async () => {
+      const character = createMinimalCharacter({
+        magicalPath: "mundane",
+        tradition: undefined,
+      });
+      const ruleset = createMinimalRuleset();
+      const creationState = createMinimalCreationState({
+        selections: {
+          "magical-path": "magician",
+          tradition: "hermetic",
+        } as CreationState["selections"],
+      });
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        creationState,
+        mode: "finalization",
+      });
+
+      expect(result.errors).not.toContainEqual(
+        expect.objectContaining({ code: "MISSING_TRADITION" })
+      );
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "MISSING_TRADITION" })
+      );
+    });
+
+    it("should not return MISSING_TRADITION for adept at finalization", async () => {
+      const character = createMinimalCharacter({
+        magicalPath: "adept",
+        tradition: undefined,
+      });
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).not.toContainEqual(
+        expect.objectContaining({ code: "MISSING_TRADITION" })
+      );
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ code: "MISSING_TRADITION" })
       );
     });
 


### PR DESCRIPTION
## Summary
- Upgrade `MISSING_TRADITION` validation from warning to **error** at finalization for magicians, mystic adepts, and aspected mages — tradition determines drain attribute, spirit types, and spell access per SR5 rules
- Add creationState fallback so the magic validator correctly reads `magical-path` and `tradition` from selections during creation drafts (where `character.magicalPath`/`character.tradition` are not yet mapped)
- Add "Select a tradition" to the completion checklist in the sticky footer when applicable

## Changes
| File | What |
|---|---|
| `lib/rules/validation/character-validator.ts` | Read tradition/path from creationState fallback; normalize `"magician"` → `"full-mage"`; upgrade severity to error at finalization; add `aspected-mage` to tradition-required paths; use `normalizedPath` throughout validator |
| `app/characters/create/sheet/components/SheetCreationLayout.tsx` | Add tradition check to completion checklist |
| `lib/rules/validation/__tests__/character-validator.test.ts` | Add 8 new tests for finalization-mode tradition validation, creationState fallback, and path-specific behavior |

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (6460 tests, 290 files)
- [x] Manual: Create magician without tradition → footer shows "Select a tradition"
- [x] Manual: Select tradition → checklist item disappears
- [x] Manual: Attempt finalize without tradition → server returns MISSING_TRADITION error
- [x] Manual: Aspected mage without tradition → same blocking behavior
- [x] Manual: Adept without tradition → no error (adepts don't need tradition)

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)