### PR TITLE
feat(creation): Add SIN rating bounds and license constraint validation (#256)

### DIFF
--- a/components/creation/identities/IdentitiesCard.tsx
+++ b/components/creation/identities/IdentitiesCard.tsx
@@ -507,6 +507,7 @@ export function IdentitiesCard({ state, updateState }: IdentitiesCardProps) {
             onClose={closeModal}
             onSave={(license) => handleAddLicense(editingIdentityIndex!, license)}
             sinType={currentIdentity.sin.type}
+            sinRating={currentIdentity.sin.type === "fake" ? currentIdentity.sin.rating : undefined}
             nuyenRemaining={nuyenRemaining}
           />
 
@@ -520,6 +521,9 @@ export function IdentitiesCard({ state, updateState }: IdentitiesCardProps) {
                 closeModal();
               }}
               sinType={currentIdentity.sin.type}
+              sinRating={
+                currentIdentity.sin.type === "fake" ? currentIdentity.sin.rating : undefined
+              }
               nuyenRemaining={nuyenRemaining}
               isEditMode
               initialData={{

--- a/components/creation/identities/IdentityModal.tsx
+++ b/components/creation/identities/IdentityModal.tsx
@@ -95,7 +95,7 @@ export function IdentityModal({
             >
               <div className="font-medium text-zinc-900 dark:text-zinc-100">Fake SIN</div>
               <div className="mt-0.5 text-sm text-zinc-500 dark:text-zinc-400">
-                Purchased as gear (Rating 1-4)
+                Purchased as gear (Rating 1-6)
               </div>
             </button>
 
@@ -138,7 +138,7 @@ export function IdentityModal({
               onChange={(e) => setFormState({ ...formState, sinRating: parseInt(e.target.value) })}
               className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
             >
-              {[1, 2, 3, 4].map((r) => (
+              {[1, 2, 3, 4, 5, 6].map((r) => (
                 <option key={r} value={r}>
                   Rating {r} ({(r * SIN_COST_PER_RATING).toLocaleString()})
                 </option>

--- a/components/creation/identities/LicenseModal.tsx
+++ b/components/creation/identities/LicenseModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
+import { AlertTriangle } from "lucide-react";
 import { Modal } from "./Modal";
 import { LICENSE_COST_PER_RATING, COMMON_LICENSE_TYPES } from "./constants";
 import type { LicenseModalProps, NewLicenseState } from "./types";
@@ -10,6 +11,7 @@ export function LicenseModal({
   onClose,
   onSave,
   sinType,
+  sinRating,
   nuyenRemaining,
   initialData,
   isEditMode,
@@ -128,16 +130,22 @@ export function LicenseModal({
               onChange={(e) => setFormState({ ...formState, rating: parseInt(e.target.value) })}
               className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800"
             >
-              {[1, 2, 3, 4].map((r) => (
+              {Array.from({ length: sinRating ?? 6 }, (_, i) => i + 1).map((r) => (
                 <option key={r} value={r}>
                   Rating {r} ({(r * LICENSE_COST_PER_RATING).toLocaleString()})
                 </option>
               ))}
             </select>
             <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-              Fake licenses must have a rating between 1-4. Higher ratings are more expensive but
-              harder to detect.
+              Fake licenses must have a rating between 1-{sinRating ?? 6}. Higher ratings are more
+              expensive but harder to detect.
             </p>
+            {sinRating !== undefined && (
+              <div className="mt-1.5 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                <span>License rating cannot exceed the SIN rating ({sinRating})</span>
+              </div>
+            )}
           </div>
         )}
 

--- a/components/creation/identities/types.ts
+++ b/components/creation/identities/types.ts
@@ -47,6 +47,7 @@ export interface LicenseModalProps {
   onClose: () => void;
   onSave: (license: NewLicenseState) => void;
   sinType: "fake" | "real";
+  sinRating?: number;
   nuyenRemaining: number;
   initialData?: NewLicenseState;
   isEditMode?: boolean;

--- a/lib/rules/validation/__tests__/character-validator.test.ts
+++ b/lib/rules/validation/__tests__/character-validator.test.ts
@@ -417,6 +417,159 @@ describe("Character Validator", () => {
         expect.objectContaining({ code: "MISSING_LIFESTYLE" })
       );
     });
+
+    it("should return error when fake SIN rating is below 1", async () => {
+      const character = createMinimalCharacter({
+        identities: [
+          {
+            id: "sin-1",
+            name: "Bad SIN",
+            sin: { type: "fake", rating: 0 },
+            licenses: [],
+          },
+        ],
+      } as Partial<Character>) as Character;
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "SIN_RATING_OUT_OF_RANGE",
+          field: "identities[0].sin.rating",
+        })
+      );
+    });
+
+    it("should return error when fake SIN rating is above 6", async () => {
+      const character = createMinimalCharacter({
+        identities: [
+          {
+            id: "sin-1",
+            name: "Bad SIN",
+            sin: { type: "fake", rating: 7 },
+            licenses: [],
+          },
+        ],
+      } as Partial<Character>) as Character;
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "SIN_RATING_OUT_OF_RANGE",
+          field: "identities[0].sin.rating",
+        })
+      );
+    });
+
+    it("should pass when fake SIN rating is 6", async () => {
+      const character = createMinimalCharacter({
+        identities: [
+          {
+            id: "sin-1",
+            name: "Good SIN",
+            sin: { type: "fake", rating: 6 },
+            licenses: [],
+          },
+        ],
+      } as Partial<Character>) as Character;
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).not.toContainEqual(
+        expect.objectContaining({ code: "SIN_RATING_OUT_OF_RANGE" })
+      );
+    });
+
+    it("should return error when license rating exceeds SIN rating", async () => {
+      const character = createMinimalCharacter({
+        identities: [
+          {
+            id: "sin-1",
+            name: "Test SIN",
+            sin: { type: "fake", rating: 3 },
+            licenses: [{ id: "lic-1", type: "fake", name: "Firearms", rating: 4 }],
+          },
+        ],
+      } as Partial<Character>) as Character;
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "LICENSE_EXCEEDS_SIN_RATING",
+          field: "identities[0].licenses[0].rating",
+        })
+      );
+    });
+
+    it("should pass when license rating equals SIN rating", async () => {
+      const character = createMinimalCharacter({
+        identities: [
+          {
+            id: "sin-1",
+            name: "Test SIN",
+            sin: { type: "fake", rating: 4 },
+            licenses: [{ id: "lic-1", type: "fake", name: "Firearms", rating: 4 }],
+          },
+        ],
+      } as Partial<Character>) as Character;
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).not.toContainEqual(
+        expect.objectContaining({ code: "LICENSE_EXCEEDS_SIN_RATING" })
+      );
+    });
+
+    it("should pass when license rating is less than SIN rating", async () => {
+      const character = createMinimalCharacter({
+        identities: [
+          {
+            id: "sin-1",
+            name: "Test SIN",
+            sin: { type: "fake", rating: 4 },
+            licenses: [{ id: "lic-1", type: "fake", name: "Firearms", rating: 2 }],
+          },
+        ],
+      } as Partial<Character>) as Character;
+      const ruleset = createMinimalRuleset();
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        mode: "finalization",
+      });
+
+      expect(result.errors).not.toContainEqual(
+        expect.objectContaining({ code: "LICENSE_EXCEEDS_SIN_RATING" })
+      );
+    });
   });
 
   // ===========================================================================

--- a/lib/rules/validation/character-validator.ts
+++ b/lib/rules/validation/character-validator.ts
@@ -339,6 +339,39 @@ const identityValidator: ValidatorDefinition = {
       });
     }
 
+    // Validate fake SIN ratings and license constraints
+    if (character.identities) {
+      character.identities.forEach((identity, i) => {
+        const sin = identity.sin;
+        if (sin?.type === "fake") {
+          const sinRating = sin.rating;
+          if (sinRating < 1 || sinRating > 6) {
+            issues.push({
+              code: "SIN_RATING_OUT_OF_RANGE",
+              message: `Fake SIN rating must be between 1 and 6 (got ${sinRating})`,
+              field: `identities[${i}].sin.rating`,
+              severity: "error",
+              suggestion: "Set the fake SIN rating to a value between 1 and 6",
+            });
+          }
+
+          if (identity.licenses) {
+            identity.licenses.forEach((license, j) => {
+              if (license.rating !== undefined && license.rating > sinRating) {
+                issues.push({
+                  code: "LICENSE_EXCEEDS_SIN_RATING",
+                  message: `License rating (${license.rating}) cannot exceed SIN rating (${sinRating})`,
+                  field: `identities[${i}].licenses[${j}].rating`,
+                  severity: "error",
+                  suggestion: "Reduce the license rating to match or be below the SIN rating",
+                });
+              }
+            });
+          }
+        }
+      });
+    }
+
     return issues;
   },
 };

--- a/lib/types/character.ts
+++ b/lib/types/character.ts
@@ -637,7 +637,7 @@ export enum SinnerQuality {
 export type SIN =
   | {
       type: "fake";
-      rating: number; // 1-4 for fake SINs
+      rating: number; // 1-6 for fake SINs
     }
   | {
       type: "real";
@@ -650,7 +650,7 @@ export type SIN =
 export interface License {
   id?: ID;
   type: "fake" | "real";
-  rating?: number; // 1-4 for fake licenses (must match SIN rating if fake)
+  rating?: number; // 1-6 for fake licenses (must not exceed SIN rating)
   name: string; // License name/type (e.g., "Firearms License", "Driver's License")
   sinId?: ID; // Reference to the SIN this license is tied to
   notes?: string;


### PR DESCRIPTION
## Summary
- Add server-side validation for fake SIN rating bounds (1-6) and license rating <= SIN rating constraint
- Expand UI rating range from 1-4 to 1-6 for fake SINs
- Cap license rating options at the parent SIN rating with dynamic dropdown and amber warning
- Add 6 new test cases covering all boundary conditions

## Test plan
- [x] `pnpm test` — all 6,523 tests pass (291 files)
- [x] `pnpm type-check` — no errors
- [x] `pnpm lint` — no new errors
- [ ] Manual: Create character, add fake SIN with rating 5 or 6, confirm it works
- [ ] Manual: Add license to fake SIN identity, confirm rating options capped at SIN rating

🤖 Generated with [Claude Code](https://claude.com/claude-code)