### PR TITLE
feat(creation): Add knowledge skill and language duplicate detection (#260)

### DIFF
--- a/lib/rules/validation/character-validator.ts
+++ b/lib/rules/validation/character-validator.ts
@@ -887,6 +887,48 @@ const knowledgeLanguageValidator: ValidatorDefinition = {
     const knowledgeSkills: KnowledgeSkill[] =
       (creationState.selections.knowledgeSkills as KnowledgeSkill[] | undefined) ?? [];
 
+    // Duplicate language detection (case-insensitive)
+    const seenLanguages = new Set<string>();
+    const duplicateLanguages: string[] = [];
+    for (const lang of languages) {
+      const key = lang.name.toLowerCase().trim();
+      if (seenLanguages.has(key)) {
+        duplicateLanguages.push(lang.name);
+      } else {
+        seenLanguages.add(key);
+      }
+    }
+    if (duplicateLanguages.length > 0) {
+      issues.push({
+        code: "LANGUAGE_DUPLICATE",
+        message: `Duplicate languages selected: ${duplicateLanguages.join(", ")}`,
+        field: "languages",
+        severity: "error",
+        suggestion: "Remove duplicate language entries",
+      });
+    }
+
+    // Duplicate knowledge skill detection (case-insensitive)
+    const seenKnowledgeSkills = new Set<string>();
+    const duplicateKnowledgeSkills: string[] = [];
+    for (const skill of knowledgeSkills) {
+      const key = skill.name.toLowerCase().trim();
+      if (seenKnowledgeSkills.has(key)) {
+        duplicateKnowledgeSkills.push(skill.name);
+      } else {
+        seenKnowledgeSkills.add(key);
+      }
+    }
+    if (duplicateKnowledgeSkills.length > 0) {
+      issues.push({
+        code: "KNOWLEDGE_SKILL_DUPLICATE",
+        message: `Duplicate knowledge skills selected: ${duplicateKnowledgeSkills.join(", ")}`,
+        field: "knowledgeSkills",
+        severity: "error",
+        suggestion: "Remove duplicate knowledge skill entries",
+      });
+    }
+
     // Determine if character has the bilingual quality
     const positiveQualities =
       (creationState.selections.positiveQualities as Array<string | { id: string }> | undefined) ??


### PR DESCRIPTION
## Summary
- Add case-insensitive duplicate detection to the `knowledgeLanguageValidator`
- Prevents characters from having duplicate language or knowledge skill entries
- Provides server-side defense-in-depth for imported/corrupted data

## Changes
| File | Change |
|------|--------|
| `lib/rules/validation/character-validator.ts` | Add duplicate detection logic |
| `lib/rules/validation/__tests__/character-validator.test.ts` | Add 7 test cases |

## New Error Codes
| Code | Message | Severity |
|------|---------|----------|
| `LANGUAGE_DUPLICATE` | Duplicate languages selected: {names} | error |
| `KNOWLEDGE_SKILL_DUPLICATE` | Duplicate knowledge skills selected: {names} | error |

## Test Plan
- [x] Run unit tests: `pnpm test lib/rules/validation/__tests__/character-validator.test.ts`
- [x] Type check passes
- [x] All 145 validator tests pass

Closes #260

🤖 Generated with [Claude Code](https://claude.ai/code)