### PR TITLE
feat(creation): Add vehicle availability and legality validation

### DIFF
--- a/app/api/rigging/validate/__tests__/route.test.ts
+++ b/app/api/rigging/validate/__tests__/route.test.ts
@@ -126,6 +126,7 @@ function createMockCharacter(overrides?: Partial<Character>): Character {
 function createMockVehicle(overrides?: Partial<Vehicle>): Vehicle {
   return {
     id: TEST_VEHICLE_ID,
+    catalogId: "westwind-3000",
     name: "Westwind 3000",
     type: "ground",
     handling: 5,
@@ -135,6 +136,8 @@ function createMockVehicle(overrides?: Partial<Vehicle>): Vehicle {
     armor: 6,
     pilot: 2,
     sensor: 3,
+    cost: 150000,
+    availability: 12,
     ...overrides,
   };
 }

--- a/components/creation/VehiclesCard.tsx
+++ b/components/creation/VehiclesCard.tsx
@@ -26,7 +26,10 @@ import {
   SummaryFooter,
   KarmaConversionModal,
   useKarmaConversionPrompt,
+  LegalityWarnings,
+  LegalityBadge,
 } from "./shared";
+import type { LegalityWarningItem } from "./shared";
 import {
   VehicleSystemModal,
   type VehicleSystemSelection,
@@ -419,6 +422,23 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
     [selectedAutosofts, state.selections, updateState]
   );
 
+  // Legality items for warnings (combine vehicles, drones, RCCs)
+  const legalityItems: LegalityWarningItem[] = useMemo(() => {
+    const items: LegalityWarningItem[] = [];
+
+    for (const v of selectedVehicles) {
+      items.push({ name: v.name, legality: v.legality, availability: v.availability });
+    }
+    for (const d of selectedDrones) {
+      items.push({ name: d.name, legality: d.legality, availability: d.availability });
+    }
+    for (const r of selectedRCCs) {
+      items.push({ name: r.name, legality: r.legality, availability: r.availability });
+    }
+
+    return items;
+  }, [selectedVehicles, selectedDrones, selectedRCCs]);
+
   // Validation status
   const validationStatus = useMemo(() => {
     if (remaining < 0) return "error";
@@ -486,6 +506,9 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
             </div>
           </div>
 
+          {/* Legality Warnings */}
+          <LegalityWarnings items={legalityItems} />
+
           {/* Empty state */}
           {totalItems === 0 && (
             <div className="rounded-lg border-2 border-dashed border-zinc-200 p-3 text-center dark:border-zinc-700">
@@ -514,9 +537,12 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
                       <div className="my-1.5 border-t border-zinc-100 dark:border-zinc-800" />
                     )}
                     <div className="flex items-center justify-between py-1">
-                      <span className="truncate text-sm text-zinc-900 dark:text-zinc-100">
-                        {v.name}
-                      </span>
+                      <div className="flex items-center gap-1.5 truncate">
+                        <span className="truncate text-sm text-zinc-900 dark:text-zinc-100">
+                          {v.name}
+                        </span>
+                        <LegalityBadge legality={v.legality} availability={v.availability} />
+                      </div>
                       <div className="flex items-center gap-1">
                         <span className="shrink-0 text-sm font-medium text-zinc-900 dark:text-zinc-100">
                           ¥{formatCurrency(v.cost)}
@@ -556,9 +582,12 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
                       <div className="my-1.5 border-t border-zinc-100 dark:border-zinc-800" />
                     )}
                     <div className="flex items-center justify-between py-1">
-                      <span className="truncate text-sm text-zinc-900 dark:text-zinc-100">
-                        {d.name}
-                      </span>
+                      <div className="flex items-center gap-1.5 truncate">
+                        <span className="truncate text-sm text-zinc-900 dark:text-zinc-100">
+                          {d.name}
+                        </span>
+                        <LegalityBadge legality={d.legality} availability={d.availability} />
+                      </div>
                       <div className="flex items-center gap-1">
                         <span className="shrink-0 text-sm font-medium text-zinc-900 dark:text-zinc-100">
                           ¥{formatCurrency(d.cost)}
@@ -598,9 +627,12 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
                       <div className="my-1.5 border-t border-zinc-100 dark:border-zinc-800" />
                     )}
                     <div className="flex items-center justify-between py-1">
-                      <span className="truncate text-sm text-zinc-900 dark:text-zinc-100">
-                        {r.name}
-                      </span>
+                      <div className="flex items-center gap-1.5 truncate">
+                        <span className="truncate text-sm text-zinc-900 dark:text-zinc-100">
+                          {r.name}
+                        </span>
+                        <LegalityBadge legality={r.legality} availability={r.availability} />
+                      </div>
                       <div className="flex items-center gap-1">
                         <span className="shrink-0 text-sm font-medium text-zinc-900 dark:text-zinc-100">
                           ¥{formatCurrency(r.cost)}

--- a/components/creation/vehicles/VehicleSystemModal.tsx
+++ b/components/creation/vehicles/VehicleSystemModal.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/rules/RulesetContext";
 import type { ItemLegality } from "@/lib/types";
 import { BaseModalRoot, ModalHeader, ModalBody, ModalFooter } from "@/components/ui";
+import { LegalityBadge } from "../shared/LegalityBadge";
 import {
   Search,
   Car,
@@ -683,6 +684,17 @@ export function VehicleSystemModal({
     canAfford = displayCost <= remainingNuyen;
     const isDisabled = isOwned;
 
+    // Get legality and availability for the badge (autosofts don't have legality)
+    const itemLegality =
+      activeType === "autosoft"
+        ? undefined
+        : (item as VehicleCatalogItemData | DroneCatalogItemData | RCCCatalogItemData).legality;
+    // Autosofts have availabilityPerRating, other items have availability
+    const itemAvailability =
+      activeType === "autosoft"
+        ? (item as AutosoftCatalogItemData).availabilityPerRating
+        : (item as VehicleCatalogItemData | DroneCatalogItemData | RCCCatalogItemData).availability;
+
     return (
       <button
         key={item.id}
@@ -700,6 +712,7 @@ export function VehicleSystemModal({
       >
         <div className="flex items-center gap-2">
           <span className={isOwned ? "line-through" : ""}>{item.name}</span>
+          <LegalityBadge legality={itemLegality} availability={itemAvailability} />
           {activeType === "drone" && (item as DroneCatalogItemData).canFly && (
             <span title="Can fly">
               <Plane className="h-3 w-3 text-sky-400" />

--- a/lib/rules/gear/__tests__/validation.test.ts
+++ b/lib/rules/gear/__tests__/validation.test.ts
@@ -756,6 +756,177 @@ describe("validateAllGear - Autosofts", () => {
 });
 
 // =============================================================================
+// VEHICLE VALIDATION TESTS
+// =============================================================================
+
+describe("validateAllGear - Vehicles", () => {
+  it("should pass for vehicles with availability <= 12", () => {
+    const character = createTestCharacter({
+      vehicles: [
+        {
+          catalogId: "dodge-scoot",
+          name: "Dodge Scoot",
+          type: "ground",
+          handling: 4,
+          speed: 3,
+          acceleration: 1,
+          body: 4,
+          armor: 4,
+          pilot: 1,
+          sensor: 1,
+          seats: 1,
+          cost: 3000,
+          availability: 0,
+        },
+      ],
+    });
+
+    const result = validateAllGear(character);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should fail for vehicles with availability > 12 at creation", () => {
+    const character = createTestCharacter({
+      vehicles: [
+        {
+          catalogId: "ares-roadmaster",
+          name: "Ares Roadmaster",
+          type: "ground",
+          handling: 3,
+          speed: 3,
+          acceleration: 1,
+          body: 18,
+          armor: 14,
+          pilot: 1,
+          sensor: 2,
+          seats: 8,
+          cost: 52000,
+          availability: 14,
+        },
+      ],
+    });
+
+    const result = validateAllGear(character);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].code).toBe("AVAILABILITY_EXCEEDED");
+    expect(result.errors[0].itemType).toBe("vehicle");
+    expect(result.errors[0].itemName).toBe("Ares Roadmaster");
+  });
+
+  it("should fail for vehicles with restricted legality at creation", () => {
+    const character = createTestCharacter({
+      vehicles: [
+        {
+          catalogId: "gmc-bulldog-stepvan",
+          name: "GMC Bulldog Step-Van",
+          type: "ground",
+          handling: 4,
+          speed: 3,
+          acceleration: 2,
+          body: 16,
+          armor: 12,
+          pilot: 1,
+          sensor: 2,
+          seats: 4,
+          cost: 35000,
+          availability: 8,
+          legality: "restricted",
+        },
+      ],
+    });
+
+    const result = validateAllGear(character);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].code).toBe("AVAILABILITY_RESTRICTED");
+    expect(result.errors[0].itemType).toBe("vehicle");
+  });
+
+  it("should fail for vehicles with forbidden legality at creation", () => {
+    const character = createTestCharacter({
+      vehicles: [
+        {
+          catalogId: "ares-citymaster",
+          name: "Ares Citymaster",
+          type: "ground",
+          handling: 2,
+          speed: 2,
+          acceleration: 1,
+          body: 20,
+          armor: 20,
+          pilot: 1,
+          sensor: 3,
+          seats: 6,
+          cost: 330000,
+          availability: 10,
+          legality: "forbidden",
+        },
+      ],
+    });
+
+    const result = validateAllGear(character);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].code).toBe("AVAILABILITY_FORBIDDEN");
+    expect(result.errors[0].itemType).toBe("vehicle");
+  });
+
+  it("should pass for active character with high availability vehicles", () => {
+    const character = createTestCharacter({
+      status: "active",
+      vehicles: [
+        {
+          catalogId: "ares-roadmaster",
+          name: "Ares Roadmaster",
+          type: "ground",
+          handling: 3,
+          speed: 3,
+          acceleration: 1,
+          body: 18,
+          armor: 14,
+          pilot: 1,
+          sensor: 2,
+          seats: 8,
+          cost: 52000,
+          availability: 14,
+        },
+      ],
+    });
+
+    const result = validateAllGear(character);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should pass for active character with restricted vehicles", () => {
+    const character = createTestCharacter({
+      status: "active",
+      vehicles: [
+        {
+          catalogId: "gmc-bulldog-stepvan",
+          name: "GMC Bulldog Step-Van",
+          type: "ground",
+          handling: 4,
+          speed: 3,
+          acceleration: 2,
+          body: 16,
+          armor: 12,
+          pilot: 1,
+          sensor: 2,
+          seats: 4,
+          cost: 35000,
+          availability: 8,
+          legality: "restricted",
+        },
+      ],
+    });
+
+    const result = validateAllGear(character);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+// =============================================================================
 // CONSTANTS TESTS
 // =============================================================================
 

--- a/lib/types/character.ts
+++ b/lib/types/character.ts
@@ -1138,6 +1138,8 @@ export interface EssenceHole {
 
 export interface Vehicle {
   id?: ID;
+  /** Reference to catalog vehicle ID */
+  catalogId: string;
   name: string;
   type: "ground" | "water" | "air" | "drone";
   handling: number;
@@ -1148,6 +1150,12 @@ export interface Vehicle {
   pilot: number;
   sensor: number;
   seats?: number;
+  /** Purchase cost in nuyen */
+  cost: number;
+  /** Availability rating */
+  availability: number;
+  /** Legality status (restricted/forbidden) */
+  legality?: ItemLegality;
   notes?: string;
 }
 


### PR DESCRIPTION
## Summary
- Add availability (max 12) and legality (R/F restriction) validation for vehicles during character creation
- Update `Vehicle` type with `catalogId`, `cost`, `availability`, `legality` fields
- Add `validateVehicles()` function to gear validation engine
- Add `LegalityWarnings` banner and `LegalityBadge` to VehiclesCard
- Add `LegalityBadge` indicators to VehicleSystemModal item list

## Test plan
- [x] Type check passes (`pnpm type-check`)
- [x] All gear validation tests pass (`pnpm test lib/rules/gear`)
- [x] 6 new vehicle validation test cases added
- [ ] Manual test: Add vehicle with availability > 12 → should show warning badge
- [ ] Manual test: Add restricted vehicle → should show "R" badge and warning banner
- [ ] Manual test: Try to finalize character with restricted vehicle → should fail validation

Closes #259

🤖 Generated with [Claude Code](https://claude.ai/code)