### PR TITLE
feat(creation): Add server-side nuyen and karma budget recalculation (#261)

### DIFF
--- a/lib/rules/validation/__tests__/budget-calculator.test.ts
+++ b/lib/rules/validation/__tests__/budget-calculator.test.ts
@@ -1,0 +1,611 @@
+/**
+ * Budget Calculator Tests
+ *
+ * Unit tests for server-side budget calculation functions.
+ * Tests cover all 15 nuyen categories and 8 karma sources.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  calculateNuyenSpent,
+  calculateKarmaSpent,
+  KARMA_TO_NUYEN_LIMIT,
+  SR5_KARMA_BUDGET,
+} from "../budget-calculator";
+import type { CreationSelections } from "@/lib/types/creation-selections";
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+/**
+ * Create selections with type override for testing.
+ * Uses Record<string, unknown> to allow minimal test data.
+ */
+function sel(data: Record<string, unknown> = {}): CreationSelections {
+  return data as CreationSelections;
+}
+
+/**
+ * Create an empty budgets object for testing
+ */
+function createEmptyBudgets(): Record<string, unknown> {
+  return {};
+}
+
+// =============================================================================
+// NUYEN CALCULATION TESTS
+// =============================================================================
+
+describe("calculateNuyenSpent", () => {
+  describe("empty selections", () => {
+    it("returns zero for all categories when selections are empty", () => {
+      const result = calculateNuyenSpent(sel());
+
+      expect(result.total).toBe(0);
+      expect(result.gear).toBe(0);
+      expect(result.weapons).toBe(0);
+      expect(result.armor).toBe(0);
+      expect(result.cyberware).toBe(0);
+      expect(result.bioware).toBe(0);
+      expect(result.foci).toBe(0);
+      expect(result.vehicles).toBe(0);
+      expect(result.drones).toBe(0);
+      expect(result.rccs).toBe(0);
+      expect(result.autosofts).toBe(0);
+      expect(result.lifestyles).toBe(0);
+      expect(result.commlinks).toBe(0);
+      expect(result.cyberdecks).toBe(0);
+      expect(result.software).toBe(0);
+      expect(result.identities).toBe(0);
+    });
+
+    it("returns zero when arrays are empty", () => {
+      const result = calculateNuyenSpent(
+        sel({
+          gear: [],
+          weapons: [],
+          armor: [],
+          cyberware: [],
+          bioware: [],
+          foci: [],
+          vehicles: [],
+          drones: [],
+          rccs: [],
+          autosofts: [],
+          lifestyles: [],
+          commlinks: [],
+          cyberdecks: [],
+          software: [],
+          identities: [],
+        })
+      );
+
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe("gear calculations", () => {
+    it("calculates gear cost with quantity", () => {
+      const result = calculateNuyenSpent(sel({ gear: [{ cost: 100, quantity: 3 }] }));
+
+      expect(result.gear).toBe(300);
+      expect(result.total).toBe(300);
+    });
+
+    it("defaults quantity to 1 if not specified", () => {
+      const result = calculateNuyenSpent(sel({ gear: [{ cost: 250, quantity: 1 }] }));
+
+      expect(result.gear).toBe(250);
+    });
+
+    it("includes gear modifications cost", () => {
+      const result = calculateNuyenSpent(
+        sel({
+          gear: [{ cost: 100, quantity: 1, modifications: [{ cost: 50 }, { cost: 25 }] }],
+        })
+      );
+
+      expect(result.gear).toBe(175); // 100 + 50 + 25
+    });
+
+    it("handles multiple gear items", () => {
+      const result = calculateNuyenSpent(
+        sel({
+          gear: [
+            { cost: 100, quantity: 2 },
+            { cost: 50, quantity: 1 },
+          ],
+        })
+      );
+
+      expect(result.gear).toBe(250); // (100 * 2) + 50
+    });
+  });
+
+  describe("weapons calculations", () => {
+    it("calculates weapon cost with quantity", () => {
+      const result = calculateNuyenSpent(sel({ weapons: [{ cost: 500, quantity: 2 }] }));
+
+      expect(result.weapons).toBe(1000);
+    });
+
+    it("includes weapon modifications", () => {
+      const result = calculateNuyenSpent(
+        sel({
+          weapons: [{ cost: 350, quantity: 1, modifications: [{ cost: 100 }, { cost: 75 }] }],
+        })
+      );
+
+      expect(result.weapons).toBe(525); // 350 + 100 + 75
+    });
+
+    it("includes ammunition cost", () => {
+      const result = calculateNuyenSpent(
+        sel({
+          weapons: [
+            {
+              cost: 200,
+              quantity: 1,
+              purchasedAmmunition: [
+                { cost: 10, quantity: 100 },
+                { cost: 20, quantity: 50 },
+              ],
+            },
+          ],
+        })
+      );
+
+      expect(result.weapons).toBe(2200); // 200 + (10 * 100) + (20 * 50)
+    });
+  });
+
+  describe("armor calculations", () => {
+    it("calculates armor cost with quantity", () => {
+      const result = calculateNuyenSpent(sel({ armor: [{ cost: 500, quantity: 1 }] }));
+
+      expect(result.armor).toBe(500);
+    });
+
+    it("includes armor modifications", () => {
+      const result = calculateNuyenSpent(
+        sel({ armor: [{ cost: 1000, quantity: 1, modifications: [{ cost: 200 }] }] })
+      );
+
+      expect(result.armor).toBe(1200);
+    });
+  });
+
+  describe("cyberware calculations", () => {
+    it("calculates cyberware cost", () => {
+      const result = calculateNuyenSpent(sel({ cyberware: [{ cost: 5000 }] }));
+
+      expect(result.cyberware).toBe(5000);
+    });
+
+    it("includes cyberware enhancements", () => {
+      const result = calculateNuyenSpent(
+        sel({ cyberware: [{ cost: 3000, enhancements: [{ cost: 500 }, { cost: 750 }] }] })
+      );
+
+      expect(result.cyberware).toBe(4250); // 3000 + 500 + 750
+    });
+
+    it("handles missing cost gracefully", () => {
+      const result = calculateNuyenSpent(sel({ cyberware: [{ cost: 0 }] }));
+
+      expect(result.cyberware).toBe(0);
+    });
+  });
+
+  describe("bioware calculations", () => {
+    it("calculates bioware cost", () => {
+      const result = calculateNuyenSpent(sel({ bioware: [{ cost: 2500 }, { cost: 1500 }] }));
+
+      expect(result.bioware).toBe(4000);
+    });
+  });
+
+  describe("foci calculations", () => {
+    it("calculates foci cost", () => {
+      const result = calculateNuyenSpent(sel({ foci: [{ cost: 3000 }, { cost: 6000 }] }));
+
+      expect(result.foci).toBe(9000);
+    });
+  });
+
+  describe("vehicles calculations", () => {
+    it("calculates vehicle cost with quantity", () => {
+      const result = calculateNuyenSpent(sel({ vehicles: [{ cost: 25000, quantity: 1 }] }));
+
+      expect(result.vehicles).toBe(25000);
+    });
+
+    it("includes vehicle modifications", () => {
+      const result = calculateNuyenSpent(
+        sel({
+          vehicles: [{ cost: 15000, quantity: 1, modifications: [{ cost: 2000 }, { cost: 1500 }] }],
+        })
+      );
+
+      expect(result.vehicles).toBe(18500);
+    });
+  });
+
+  describe("drones, RCCs, autosofts calculations", () => {
+    it("calculates drone cost", () => {
+      const result = calculateNuyenSpent(sel({ drones: [{ cost: 5000 }, { cost: 3000 }] }));
+
+      expect(result.drones).toBe(8000);
+    });
+
+    it("calculates RCC cost", () => {
+      const result = calculateNuyenSpent(sel({ rccs: [{ cost: 10000 }] }));
+
+      expect(result.rccs).toBe(10000);
+    });
+
+    it("calculates autosoft cost", () => {
+      const result = calculateNuyenSpent(sel({ autosofts: [{ cost: 500 }, { cost: 750 }] }));
+
+      expect(result.autosofts).toBe(1250);
+    });
+  });
+
+  describe("lifestyle calculations", () => {
+    it("calculates lifestyle cost with prepaid months", () => {
+      const result = calculateNuyenSpent(
+        sel({ lifestyles: [{ monthlyCost: 5000, prepaidMonths: 3 }] })
+      );
+
+      expect(result.lifestyles).toBe(15000);
+    });
+
+    it("defaults to 1 month if prepaidMonths not specified", () => {
+      const result = calculateNuyenSpent(sel({ lifestyles: [{ monthlyCost: 2000 }] }));
+
+      expect(result.lifestyles).toBe(2000);
+    });
+  });
+
+  describe("matrix gear calculations", () => {
+    it("calculates commlink cost", () => {
+      const result = calculateNuyenSpent(sel({ commlinks: [{ cost: 200 }, { cost: 500 }] }));
+
+      expect(result.commlinks).toBe(700);
+    });
+
+    it("calculates cyberdeck cost", () => {
+      const result = calculateNuyenSpent(sel({ cyberdecks: [{ cost: 50000 }] }));
+
+      expect(result.cyberdecks).toBe(50000);
+    });
+
+    it("calculates software cost", () => {
+      const result = calculateNuyenSpent(sel({ software: [{ cost: 250 }, { cost: 500 }] }));
+
+      expect(result.software).toBe(750);
+    });
+  });
+
+  describe("identity calculations", () => {
+    it("calculates fake SIN cost (rating × 2,500¥)", () => {
+      const result = calculateNuyenSpent(
+        sel({ identities: [{ sin: { type: "fake", rating: 4 }, licenses: [] }] })
+      );
+
+      expect(result.identities).toBe(10000); // 4 × 2,500
+    });
+
+    it("calculates fake license cost (rating × 200¥)", () => {
+      const result = calculateNuyenSpent(
+        sel({
+          identities: [
+            {
+              sin: { type: "fake", rating: 2 },
+              licenses: [
+                { type: "fake", rating: 4 },
+                { type: "fake", rating: 3 },
+              ],
+            },
+          ],
+        })
+      );
+
+      // SIN: 2 × 2,500 = 5,000
+      // Licenses: 4 × 200 + 3 × 200 = 800 + 600 = 1,400
+      expect(result.identities).toBe(6400);
+    });
+
+    it("ignores non-fake SINs and licenses", () => {
+      const result = calculateNuyenSpent(
+        sel({
+          identities: [
+            {
+              sin: { type: "real", rating: 6 },
+              licenses: [{ type: "real", rating: 4 }],
+            },
+          ],
+        })
+      );
+
+      expect(result.identities).toBe(0);
+    });
+  });
+
+  describe("total calculations", () => {
+    it("sums all categories correctly", () => {
+      const result = calculateNuyenSpent(
+        sel({
+          gear: [{ cost: 100, quantity: 1 }],
+          weapons: [{ cost: 200, quantity: 1 }],
+          armor: [{ cost: 300, quantity: 1 }],
+          cyberware: [{ cost: 400 }],
+          bioware: [{ cost: 500 }],
+          foci: [{ cost: 600 }],
+          vehicles: [{ cost: 700, quantity: 1 }],
+          drones: [{ cost: 800 }],
+          rccs: [{ cost: 900 }],
+          autosofts: [{ cost: 1000 }],
+          lifestyles: [{ monthlyCost: 1100, prepaidMonths: 1 }],
+          commlinks: [{ cost: 1200 }],
+          cyberdecks: [{ cost: 1300 }],
+          software: [{ cost: 1400 }],
+          identities: [{ sin: { type: "fake", rating: 2 }, licenses: [] }], // 5000
+        })
+      );
+
+      // 100+200+300+400+500+600+700+800+900+1000+1100+1200+1300+1400+5000 = 15500
+      expect(result.total).toBe(15500);
+    });
+  });
+});
+
+// =============================================================================
+// KARMA CALCULATION TESTS
+// =============================================================================
+
+describe("calculateKarmaSpent", () => {
+  describe("empty selections", () => {
+    it("returns zero for all sources when selections and budgets are empty", () => {
+      const result = calculateKarmaSpent(sel(), createEmptyBudgets());
+
+      expect(result.total).toBe(0);
+      expect(result.positiveQualities).toBe(0);
+      expect(result.negativeQualities).toBe(0);
+      expect(result.karmaToNuyen).toBe(0);
+      expect(result.spells).toBe(0);
+      expect(result.powerPoints).toBe(0);
+      expect(result.attributes).toBe(0);
+      expect(result.foci).toBe(0);
+      expect(result.skills).toBe(0);
+      expect(result.contacts).toBe(0);
+    });
+  });
+
+  describe("quality karma calculations", () => {
+    it("calculates positive quality karma from selections with karma field", () => {
+      const result = calculateKarmaSpent(
+        sel({
+          positiveQualities: [
+            { id: "quality1", karma: 10 },
+            { id: "quality2", karma: 15 },
+          ],
+        }),
+        createEmptyBudgets()
+      );
+
+      expect(result.positiveQualities).toBe(25);
+    });
+
+    it("uses originalKarma if karma is undefined", () => {
+      const result = calculateKarmaSpent(
+        sel({ positiveQualities: [{ id: "quality1", originalKarma: 8 }] }),
+        createEmptyBudgets()
+      );
+
+      expect(result.positiveQualities).toBe(8);
+    });
+
+    it("falls back to budgets when qualities lack karma field", () => {
+      const result = calculateKarmaSpent(sel({ positiveQualities: [{ id: "quality1" }] }), {
+        "karma-spent-positive": 20,
+      });
+
+      expect(result.positiveQualities).toBe(20);
+    });
+
+    it("calculates negative quality karma (gives karma back)", () => {
+      const result = calculateKarmaSpent(
+        sel({
+          negativeQualities: [
+            { id: "neg1", karma: 5 },
+            { id: "neg2", karma: 10 },
+          ],
+        }),
+        createEmptyBudgets()
+      );
+
+      expect(result.negativeQualities).toBe(15);
+      // Negative qualities subtract from total
+      expect(result.total).toBe(-15);
+    });
+  });
+
+  describe("karma-to-nuyen conversion", () => {
+    it("gets conversion from budgets", () => {
+      const result = calculateKarmaSpent(sel(), { "karma-spent-gear": 5 });
+
+      expect(result.karmaToNuyen).toBe(5);
+      expect(result.total).toBe(5);
+    });
+  });
+
+  describe("other karma sources", () => {
+    it("gets spells karma from budgets", () => {
+      const result = calculateKarmaSpent(sel(), { "karma-spent-spells": 10 });
+
+      expect(result.spells).toBe(10);
+    });
+
+    it("gets power points karma from budgets", () => {
+      const result = calculateKarmaSpent(sel(), { "karma-spent-power-points": 5 });
+
+      expect(result.powerPoints).toBe(5);
+    });
+
+    it("gets attributes karma from budgets", () => {
+      const result = calculateKarmaSpent(sel(), { "karma-spent-attributes": 25 });
+
+      expect(result.attributes).toBe(25);
+    });
+
+    it("gets foci karma from budgets", () => {
+      const result = calculateKarmaSpent(sel(), { "karma-spent-foci": 8 });
+
+      expect(result.foci).toBe(8);
+    });
+  });
+
+  describe("contact karma calculations", () => {
+    it("calculates contact overflow karma (total cost - CHA×3)", () => {
+      const result = calculateKarmaSpent(
+        sel({
+          attributes: { charisma: 3 }, // Free pool = 9
+          contacts: [
+            { connection: 4, loyalty: 3 }, // 7 points
+            { connection: 3, loyalty: 2 }, // 5 points
+          ],
+        }),
+        createEmptyBudgets()
+      );
+
+      // Total cost: 7 + 5 = 12
+      // Free pool: 3 × 3 = 9
+      // Overflow: 12 - 9 = 3
+      expect(result.contacts).toBe(3);
+    });
+
+    it("returns zero when within free pool", () => {
+      const result = calculateKarmaSpent(
+        sel({
+          attributes: { charisma: 5 }, // Free pool = 15
+          contacts: [{ connection: 3, loyalty: 2 }], // 5 points
+        }),
+        createEmptyBudgets()
+      );
+
+      expect(result.contacts).toBe(0);
+    });
+
+    it("defaults charisma to 1 when not set", () => {
+      const result = calculateKarmaSpent(
+        sel({ contacts: [{ connection: 3, loyalty: 2 }] }), // 5 points
+        createEmptyBudgets()
+      );
+
+      // Free pool: 1 × 3 = 3
+      // Overflow: 5 - 3 = 2
+      expect(result.contacts).toBe(2);
+    });
+  });
+
+  describe("skill karma calculations", () => {
+    it("calculates skill karma from skillKarmaSpent", () => {
+      const result = calculateKarmaSpent(
+        sel({
+          skillKarmaSpent: {
+            skillRaises: { pistols: 10, athletics: 5 },
+            specializations: 7,
+            skillRatingPoints: 0,
+          },
+        }),
+        createEmptyBudgets()
+      );
+
+      expect(result.skills).toBe(22); // 10 + 5 + 7
+    });
+
+    it("includes group raises in skill karma", () => {
+      const result = calculateKarmaSpent(
+        sel({
+          skillKarmaSpent: {
+            skillRaises: { pistols: 5 },
+            specializations: 0,
+            skillRatingPoints: 0,
+            groupRaises: { firearms: 10 },
+          },
+        }),
+        createEmptyBudgets()
+      );
+
+      expect(result.skills).toBe(15); // 5 + 0 + 10
+    });
+
+    it("falls back to budgets when skillKarmaSpent not present", () => {
+      const result = calculateKarmaSpent(sel(), { "karma-spent-skills": 12 });
+
+      expect(result.skills).toBe(12);
+    });
+  });
+
+  describe("total calculations", () => {
+    it("calculates net karma correctly (positive - negative)", () => {
+      const result = calculateKarmaSpent(
+        sel({
+          positiveQualities: [{ id: "pos", karma: 15 }],
+          negativeQualities: [{ id: "neg", karma: 10 }],
+        }),
+        createEmptyBudgets()
+      );
+
+      // Net = 15 (positive) - 10 (negative) = 5
+      expect(result.total).toBe(5);
+    });
+
+    it("sums all karma sources correctly", () => {
+      const result = calculateKarmaSpent(
+        sel({
+          attributes: { charisma: 1 },
+          positiveQualities: [{ id: "pos", karma: 10 }],
+          negativeQualities: [{ id: "neg", karma: 5 }],
+          contacts: [{ connection: 2, loyalty: 2 }], // 4 - 3 = 1 overflow
+          skillKarmaSpent: {
+            skillRaises: { pistols: 3 },
+            specializations: 7,
+            skillRatingPoints: 0,
+          },
+        }),
+        {
+          "karma-spent-gear": 2,
+          "karma-spent-spells": 4,
+          "karma-spent-power-points": 1,
+          "karma-spent-attributes": 5,
+          "karma-spent-foci": 3,
+        }
+      );
+
+      // positiveQualities: 10
+      // negativeQualities: -5
+      // karmaToNuyen: 2
+      // spells: 4
+      // powerPoints: 1
+      // attributes: 5
+      // foci: 3
+      // skills: 3 + 7 = 10
+      // contacts: 1
+      // Total: 10 - 5 + 2 + 4 + 1 + 5 + 3 + 10 + 1 = 31
+      expect(result.total).toBe(31);
+    });
+  });
+
+  describe("constants", () => {
+    it("exports correct karma-to-nuyen limit", () => {
+      expect(KARMA_TO_NUYEN_LIMIT).toBe(10);
+    });
+
+    it("exports correct SR5 karma budget", () => {
+      expect(SR5_KARMA_BUDGET).toBe(25);
+    });
+  });
+});

--- a/lib/rules/validation/__tests__/karma-budget.test.ts
+++ b/lib/rules/validation/__tests__/karma-budget.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Karma Budget Validator Integration Tests
+ *
+ * Tests for server-side karma budget validation during character finalization.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateCharacter } from "../character-validator";
+import type { CharacterValidationContext } from "../types";
+import type { Character } from "@/lib/types/character";
+import type { MergedRuleset } from "@/lib/types";
+import type { CreationState } from "@/lib/types/creation";
+
+// =============================================================================
+// TEST FIXTURES
+// =============================================================================
+
+function createMockRuleset(): MergedRuleset {
+  return {
+    snapshotId: "test-snapshot",
+    editionId: "sr5",
+    editionCode: "sr5",
+    bookIds: ["core-rulebook"],
+    modules: {},
+    createdAt: new Date().toISOString(),
+  } as unknown as MergedRuleset;
+}
+
+function createContext(
+  overrides: Partial<CharacterValidationContext> = {}
+): CharacterValidationContext {
+  return {
+    character: {
+      name: "Test Character",
+      metatype: "human",
+      magicalPath: "mundane",
+      attributes: {
+        body: 3,
+        agility: 3,
+        reaction: 3,
+        strength: 3,
+        willpower: 3,
+        logic: 3,
+        intuition: 3,
+        charisma: 3,
+      },
+      identities: [{ name: "Fake SIN", type: "fake", rating: 4 }],
+      lifestyles: [{ name: "Low", monthlyCost: 2000, type: "low" }],
+    } as unknown as Character,
+    ruleset: createMockRuleset(),
+    mode: "finalization",
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("karmaBudgetValidator", () => {
+  it("passes when karma spent is within 25 karma budget", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          positiveQualities: [{ id: "quality1", karma: 10 }],
+          negativeQualities: [{ id: "quality2", karma: 5 }],
+          attributes: { charisma: 3 },
+          contacts: [], // No overflow
+        },
+        budgets: {
+          "karma-spent-gear": 3, // karma-to-nuyen conversion
+        },
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // 10 (positive) - 5 (negative) + 3 (gear) = 8 karma, under 25
+    expect(result.errors.some((e) => e.code === "KARMA_BUDGET_EXCEEDED")).toBe(false);
+    expect(result.errors.some((e) => e.code === "KARMA_CALCULATION_MISMATCH")).toBe(false);
+  });
+
+  it("reports error when karma spent exceeds 25", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          positiveQualities: [
+            { id: "q1", karma: 15 },
+            { id: "q2", karma: 15 },
+          ], // 30 karma
+          negativeQualities: [],
+          attributes: { charisma: 3 },
+          contacts: [],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KARMA_BUDGET_EXCEEDED")).toBe(true);
+  });
+
+  it("reports error when karma-to-nuyen exceeds 10", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          positiveQualities: [],
+          negativeQualities: [],
+          attributes: { charisma: 3 },
+          contacts: [],
+        },
+        budgets: {
+          "karma-spent-gear": 15, // Exceeds 10 karma limit
+        },
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KARMA_TO_NUYEN_LIMIT_EXCEEDED")).toBe(true);
+  });
+
+  it("allows exactly 10 karma for nuyen conversion", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          positiveQualities: [],
+          negativeQualities: [],
+          attributes: { charisma: 3 },
+          contacts: [],
+        },
+        budgets: {
+          "karma-spent-gear": 10, // Exactly at limit
+        },
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KARMA_TO_NUYEN_LIMIT_EXCEEDED")).toBe(false);
+  });
+
+  it("accounts for negative qualities giving karma back", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          positiveQualities: [{ id: "pos", karma: 20 }],
+          negativeQualities: [{ id: "neg", karma: 10 }], // Gives 10 karma back
+          attributes: { charisma: 3 },
+          contacts: [],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // 20 (positive) - 10 (negative) = 10 net, under 25
+    expect(result.errors.some((e) => e.code === "KARMA_BUDGET_EXCEEDED")).toBe(false);
+  });
+
+  it("includes contact overflow in karma calculation", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          positiveQualities: [{ id: "pos", karma: 20 }],
+          negativeQualities: [],
+          attributes: { charisma: 1 }, // Free pool = 3
+          contacts: [
+            { connection: 3, loyalty: 3 }, // 6 points, 3 overflow karma
+            { connection: 3, loyalty: 3 }, // 6 more, total 12, 9 overflow
+          ],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // 20 (positive) + 9 (contact overflow) = 29, exceeds 25
+    expect(result.errors.some((e) => e.code === "KARMA_BUDGET_EXCEEDED")).toBe(true);
+  });
+
+  it("includes skill karma in calculation", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          positiveQualities: [{ id: "pos", karma: 10 }],
+          negativeQualities: [],
+          attributes: { charisma: 3 },
+          contacts: [],
+          skillKarmaSpent: {
+            skillRaises: { pistols: 10 },
+            specializations: 7, // 7 karma for specialization
+          },
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // 10 (quality) + 17 (skills) = 27, exceeds 25
+    expect(result.errors.some((e) => e.code === "KARMA_BUDGET_EXCEEDED")).toBe(true);
+  });
+
+  it("only runs at finalization mode", async () => {
+    const context = createContext({
+      mode: "creation", // Not finalization
+      creationState: {
+        selections: {
+          positiveQualities: [{ id: "q1", karma: 30 }], // Way over budget
+          negativeQualities: [],
+          attributes: { charisma: 3 },
+          contacts: [],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // Should not report karma budget errors during creation mode
+    expect(result.errors.some((e) => e.code === "KARMA_BUDGET_EXCEEDED")).toBe(false);
+  });
+
+  it("handles missing creationState gracefully", async () => {
+    const context = createContext({
+      creationState: undefined,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "KARMA_BUDGET_EXCEEDED")).toBe(false);
+    expect(result.errors.some((e) => e.code === "KARMA_CALCULATION_MISMATCH")).toBe(false);
+    expect(result.errors.some((e) => e.code === "KARMA_TO_NUYEN_LIMIT_EXCEEDED")).toBe(false);
+  });
+
+  it("sums all karma sources correctly", async () => {
+    const context = createContext({
+      creationState: {
+        selections: {
+          positiveQualities: [{ id: "pos", karma: 5 }],
+          negativeQualities: [{ id: "neg", karma: 3 }],
+          attributes: { charisma: 1 }, // Free pool = 3
+          contacts: [{ connection: 2, loyalty: 2 }], // 4 - 3 = 1 overflow
+          skillKarmaSpent: {
+            skillRaises: { pistols: 5 },
+            specializations: 7,
+            groupRaises: { firearms: 3 },
+          },
+        },
+        budgets: {
+          "karma-spent-gear": 2,
+          "karma-spent-spells": 4,
+          "karma-spent-power-points": 1,
+          "karma-spent-attributes": 3,
+          "karma-spent-foci": 2,
+        },
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // positiveQualities: 5
+    // negativeQualities: -3
+    // karmaToNuyen: 2
+    // spells: 4
+    // powerPoints: 1
+    // attributes: 3
+    // foci: 2
+    // skills: 5+7+3 = 15
+    // contacts: 1
+    // Total: 5 - 3 + 2 + 4 + 1 + 3 + 2 + 15 + 1 = 30 (exceeds 25)
+    expect(result.errors.some((e) => e.code === "KARMA_BUDGET_EXCEEDED")).toBe(true);
+  });
+});

--- a/lib/rules/validation/__tests__/nuyen-budget.test.ts
+++ b/lib/rules/validation/__tests__/nuyen-budget.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Nuyen Budget Validator Integration Tests
+ *
+ * Tests for server-side nuyen budget validation during character finalization.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateCharacter } from "../character-validator";
+import type { CharacterValidationContext } from "../types";
+import type { Character } from "@/lib/types/character";
+import type { MergedRuleset } from "@/lib/types";
+import type { CreationState } from "@/lib/types/creation";
+import type { PriorityTableData } from "@/lib/rules/loader-types";
+
+// =============================================================================
+// TEST FIXTURES
+// =============================================================================
+
+function createMockPriorityTable(resourceNuyen: number): PriorityTableData {
+  return {
+    levels: ["A", "B", "C", "D", "E"],
+    categories: [{ id: "resources", name: "Resources" }],
+    table: {
+      A: { resources: 450000 },
+      B: { resources: 275000 },
+      C: { resources: resourceNuyen },
+      D: { resources: 50000 },
+      E: { resources: 6000 },
+    },
+  } as PriorityTableData;
+}
+
+function createMockRuleset(resourceNuyen = 140000): MergedRuleset {
+  return {
+    snapshotId: "test-snapshot",
+    editionId: "sr5",
+    editionCode: "sr5",
+    bookIds: ["core-rulebook"],
+    modules: {
+      priorities: createMockPriorityTable(resourceNuyen),
+    },
+    createdAt: new Date().toISOString(),
+  } as unknown as MergedRuleset;
+}
+
+function createContext(
+  overrides: Partial<CharacterValidationContext> = {}
+): CharacterValidationContext {
+  return {
+    character: {
+      name: "Test Character",
+      metatype: "human",
+      magicalPath: "mundane",
+      attributes: {
+        body: 3,
+        agility: 3,
+        reaction: 3,
+        strength: 3,
+        willpower: 3,
+        logic: 3,
+        intuition: 3,
+        charisma: 3,
+      },
+      identities: [{ name: "Fake SIN", type: "fake", rating: 4 }],
+      lifestyles: [{ name: "Low", monthlyCost: 2000, type: "low" }],
+    } as unknown as Character,
+    ruleset: createMockRuleset(),
+    mode: "finalization",
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("nuyenBudgetValidator", () => {
+  it("passes when nuyen spent is within budget", async () => {
+    const context = createContext({
+      creationState: {
+        priorities: { resources: "C" }, // 140,000¥
+        selections: {
+          gear: [{ cost: 1000, quantity: 1 }],
+          weapons: [{ cost: 500, quantity: 1 }],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "NUYEN_BUDGET_EXCEEDED")).toBe(false);
+    expect(result.errors.some((e) => e.code === "NUYEN_CALCULATION_MISMATCH")).toBe(false);
+  });
+
+  it("reports error when nuyen spent exceeds budget", async () => {
+    const context = createContext({
+      ruleset: createMockRuleset(10000), // Low budget
+      creationState: {
+        priorities: { resources: "C" }, // 10,000¥ (from mock)
+        selections: {
+          gear: [{ cost: 5000, quantity: 3 }], // 15,000¥ exceeds 10,000¥
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "NUYEN_BUDGET_EXCEEDED")).toBe(true);
+  });
+
+  it("includes karma-to-nuyen conversion in budget", async () => {
+    const context = createContext({
+      ruleset: createMockRuleset(10000), // Base 10,000¥
+      creationState: {
+        priorities: { resources: "C" },
+        selections: {
+          gear: [{ cost: 18000, quantity: 1 }], // 18,000¥ - exceeds base but fits with conversion
+        },
+        budgets: {
+          "karma-spent-gear": 5, // 5 karma × 2,000¥ = 10,000¥ extra
+        },
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // 10,000 base + 10,000 conversion = 20,000 total
+    // 18,000 spent < 20,000 available
+    expect(result.errors.some((e) => e.code === "NUYEN_BUDGET_EXCEEDED")).toBe(false);
+  });
+
+  it("reports error when spending exceeds budget including conversion", async () => {
+    const context = createContext({
+      ruleset: createMockRuleset(10000),
+      creationState: {
+        priorities: { resources: "C" },
+        selections: {
+          gear: [{ cost: 25000, quantity: 1 }], // 25,000¥ exceeds total budget
+        },
+        budgets: {
+          "karma-spent-gear": 5, // +10,000¥ = 20,000 total
+        },
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "NUYEN_BUDGET_EXCEEDED")).toBe(true);
+  });
+
+  it("only runs at finalization mode", async () => {
+    const context = createContext({
+      mode: "creation", // Not finalization
+      ruleset: createMockRuleset(1000),
+      creationState: {
+        priorities: { resources: "C" },
+        selections: {
+          gear: [{ cost: 5000, quantity: 1 }], // Exceeds budget
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // Should not report nuyen budget errors during creation mode
+    expect(result.errors.some((e) => e.code === "NUYEN_BUDGET_EXCEEDED")).toBe(false);
+  });
+
+  it("handles missing priority table gracefully", async () => {
+    const context = createContext({
+      ruleset: {
+        snapshotId: "test",
+        editionId: "sr5",
+        editionCode: "sr5",
+        bookIds: [],
+        modules: {}, // No priorities module
+        createdAt: new Date().toISOString(),
+      } as unknown as MergedRuleset,
+      creationState: {
+        priorities: { resources: "C" },
+        selections: {
+          gear: [{ cost: 5000, quantity: 1 }],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // Should not crash, no nuyen errors since can't validate without table
+    expect(result.errors.some((e) => e.code === "NUYEN_BUDGET_EXCEEDED")).toBe(false);
+  });
+
+  it("handles missing creationState gracefully", async () => {
+    const context = createContext({
+      creationState: undefined,
+    });
+
+    const result = await validateCharacter(context);
+
+    expect(result.errors.some((e) => e.code === "NUYEN_BUDGET_EXCEEDED")).toBe(false);
+    expect(result.errors.some((e) => e.code === "NUYEN_CALCULATION_MISMATCH")).toBe(false);
+  });
+
+  it("handles missing resources priority gracefully", async () => {
+    const context = createContext({
+      creationState: {
+        priorities: {}, // No resources priority assigned
+        selections: {
+          gear: [{ cost: 5000, quantity: 1 }],
+        },
+        budgets: {},
+      } as unknown as CreationState,
+    });
+
+    const result = await validateCharacter(context);
+
+    // Should not crash
+    expect(result.errors.some((e) => e.code === "NUYEN_BUDGET_EXCEEDED")).toBe(false);
+  });
+});

--- a/lib/rules/validation/budget-calculator.ts
+++ b/lib/rules/validation/budget-calculator.ts
@@ -1,0 +1,343 @@
+/**
+ * Budget Calculator Module
+ *
+ * Pure calculation functions for server-side nuyen and karma budget validation.
+ * These functions mirror the client-side calculations in CreationBudgetContext.tsx
+ * to ensure the server never trusts client-calculated values.
+ *
+ * Satisfies:
+ * - Requirement: Server-side recalculation of nuyen/karma budgets
+ * - Guarantee: Server validates all budget calculations independently
+ */
+
+import type { CreationSelections } from "@/lib/types/creation-selections";
+
+// =============================================================================
+// NUYEN CALCULATION
+// =============================================================================
+
+/**
+ * Breakdown of nuyen spending by category (15 categories)
+ */
+export interface NuyenBreakdown {
+  gear: number;
+  weapons: number;
+  armor: number;
+  cyberware: number;
+  bioware: number;
+  foci: number;
+  vehicles: number;
+  drones: number;
+  rccs: number;
+  autosofts: number;
+  lifestyles: number;
+  commlinks: number;
+  cyberdecks: number;
+  software: number;
+  identities: number;
+  total: number;
+}
+
+/** Cost per rating point for fake SINs */
+const SIN_COST_PER_RATING = 2500;
+
+/** Cost per rating point for fake licenses */
+const LICENSE_COST_PER_RATING = 200;
+
+/**
+ * Calculate total nuyen spent from creation selections.
+ *
+ * Extracts spending from 15 categories:
+ * - gear, weapons, armor, cyberware, bioware, foci
+ * - vehicles, drones, rccs, autosofts, lifestyles
+ * - commlinks, cyberdecks, software, identities
+ *
+ * @param selections - Character creation selections
+ * @returns Breakdown of nuyen spending by category plus total
+ */
+export function calculateNuyenSpent(selections: CreationSelections): NuyenBreakdown {
+  // Type definitions for selection arrays (matching CreationBudgetContext.tsx)
+  const gear = (selections.gear || []) as Array<{
+    cost: number;
+    quantity: number;
+    modifications?: Array<{ cost: number }>;
+  }>;
+  const weapons = (selections.weapons || []) as Array<{
+    cost: number;
+    quantity: number;
+    modifications?: Array<{ cost: number }>;
+    purchasedAmmunition?: Array<{ cost: number; quantity: number }>;
+  }>;
+  const armor = (selections.armor || []) as Array<{
+    cost: number;
+    quantity: number;
+    modifications?: Array<{ cost: number }>;
+  }>;
+  const cyberware = (selections.cyberware || []) as Array<{
+    cost: number;
+    enhancements?: Array<{ cost: number }>;
+  }>;
+  const bioware = (selections.bioware || []) as Array<{ cost: number }>;
+  const foci = (selections.foci || []) as Array<{ cost: number }>;
+  const vehicles = (selections.vehicles || []) as Array<{
+    cost: number;
+    quantity: number;
+    modifications?: Array<{ cost: number }>;
+  }>;
+  const drones = (selections.drones || []) as Array<{ cost: number }>;
+  const rccs = (selections.rccs || []) as Array<{ cost: number }>;
+  const autosofts = (selections.autosofts || []) as Array<{ cost: number }>;
+  const commlinks = (selections.commlinks || []) as Array<{ cost: number }>;
+  const cyberdecks = (selections.cyberdecks || []) as Array<{ cost: number }>;
+  const software = (selections.software || []) as Array<{ cost: number }>;
+  const lifestyles = (selections.lifestyles || []) as Array<{
+    monthlyCost: number;
+    prepaidMonths?: number;
+  }>;
+  const identities = (selections.identities || []) as Array<{
+    sin: { type: string; rating: number };
+    licenses?: Array<{ type: string; rating: number }>;
+  }>;
+
+  // Calculate gear spending
+  const gearSpent = gear.reduce((sum, g) => {
+    const baseCost = g.cost * (g.quantity || 1);
+    const modCost = g.modifications?.reduce((m, mod) => m + mod.cost, 0) || 0;
+    return sum + baseCost + modCost;
+  }, 0);
+
+  // Calculate weapons spending
+  const weaponsSpent = weapons.reduce((sum, w) => {
+    const baseCost = w.cost * (w.quantity || 1);
+    const modCost = w.modifications?.reduce((m, mod) => m + mod.cost, 0) || 0;
+    const ammoCost =
+      w.purchasedAmmunition?.reduce((a, ammo) => a + ammo.cost * (ammo.quantity || 1), 0) || 0;
+    return sum + baseCost + modCost + ammoCost;
+  }, 0);
+
+  // Calculate armor spending
+  const armorSpent = armor.reduce((sum, a) => {
+    const baseCost = a.cost * (a.quantity || 1);
+    const modCost = a.modifications?.reduce((m, mod) => m + mod.cost, 0) || 0;
+    return sum + baseCost + modCost;
+  }, 0);
+
+  // Calculate augmentation spending (cyberware + bioware)
+  const cyberwareSpent = cyberware.reduce((sum, c) => {
+    const baseCost = c.cost || 0;
+    const enhCost = c.enhancements?.reduce((e, enh) => e + (enh.cost || 0), 0) || 0;
+    return sum + baseCost + enhCost;
+  }, 0);
+  const biowareSpent = bioware.reduce((sum, b) => sum + (b.cost || 0), 0);
+
+  // Calculate foci spending
+  const fociSpent = foci.reduce((sum, f) => sum + (f.cost || 0), 0);
+
+  // Calculate vehicles spending
+  const vehiclesSpent = vehicles.reduce((sum, v) => {
+    const baseCost = v.cost * (v.quantity || 1);
+    const modCost = v.modifications?.reduce((m, mod) => m + mod.cost, 0) || 0;
+    return sum + baseCost + modCost;
+  }, 0);
+
+  // Calculate drones, RCCs, and autosofts spending
+  const dronesSpent = drones.reduce((sum, d) => sum + (d.cost || 0), 0);
+  const rccsSpent = rccs.reduce((sum, r) => sum + (r.cost || 0), 0);
+  const autosoftsSpent = autosofts.reduce((sum, a) => sum + (a.cost || 0), 0);
+
+  // Calculate lifestyle spending
+  const lifestyleSpent = lifestyles.reduce(
+    (sum, ls) => sum + ls.monthlyCost * (ls.prepaidMonths || 1),
+    0
+  );
+
+  // Calculate matrix gear spending
+  const commlinksSpent = commlinks.reduce((sum, c) => sum + (c.cost || 0), 0);
+  const cyberdecksSpent = cyberdecks.reduce((sum, d) => sum + (d.cost || 0), 0);
+  const softwareSpent = software.reduce((sum, s) => sum + (s.cost || 0), 0);
+
+  // Calculate identity spending (fake SINs and licenses)
+  const identitiesSpent = identities.reduce((sum, identity) => {
+    const sinCost =
+      identity.sin?.type === "fake" ? (identity.sin.rating || 0) * SIN_COST_PER_RATING : 0;
+    const licensesCost =
+      identity.licenses?.reduce((lSum, lic) => {
+        return lSum + (lic.type === "fake" ? (lic.rating || 0) * LICENSE_COST_PER_RATING : 0);
+      }, 0) || 0;
+    return sum + sinCost + licensesCost;
+  }, 0);
+
+  // Total nuyen spent
+  const total =
+    gearSpent +
+    weaponsSpent +
+    armorSpent +
+    cyberwareSpent +
+    biowareSpent +
+    fociSpent +
+    vehiclesSpent +
+    dronesSpent +
+    rccsSpent +
+    autosoftsSpent +
+    lifestyleSpent +
+    commlinksSpent +
+    cyberdecksSpent +
+    softwareSpent +
+    identitiesSpent;
+
+  return {
+    gear: gearSpent,
+    weapons: weaponsSpent,
+    armor: armorSpent,
+    cyberware: cyberwareSpent,
+    bioware: biowareSpent,
+    foci: fociSpent,
+    vehicles: vehiclesSpent,
+    drones: dronesSpent,
+    rccs: rccsSpent,
+    autosofts: autosoftsSpent,
+    lifestyles: lifestyleSpent,
+    commlinks: commlinksSpent,
+    cyberdecks: cyberdecksSpent,
+    software: softwareSpent,
+    identities: identitiesSpent,
+    total,
+  };
+}
+
+// =============================================================================
+// KARMA CALCULATION
+// =============================================================================
+
+/**
+ * Breakdown of karma spending by source (8 sources)
+ */
+export interface KarmaBreakdown {
+  positiveQualities: number;
+  /** Negative qualities give karma back (subtracted from total) */
+  negativeQualities: number;
+  /** Karma spent to convert to nuyen (1 karma = 2,000¥) */
+  karmaToNuyen: number;
+  spells: number;
+  powerPoints: number;
+  attributes: number;
+  foci: number;
+  skills: number;
+  contacts: number;
+  /** Net karma spent (positive sources minus negative quality refund) */
+  total: number;
+}
+
+/** Maximum karma that can be converted to nuyen during creation */
+export const KARMA_TO_NUYEN_LIMIT = 10;
+
+/** Starting karma budget for SR5 character creation */
+export const SR5_KARMA_BUDGET = 25;
+
+/**
+ * Calculate total karma spent from creation selections and budgets.
+ *
+ * Sources of karma spending:
+ * - Positive qualities (cost karma)
+ * - Negative qualities (give karma back)
+ * - Karma-to-nuyen conversion
+ * - Extra spells beyond free allotment
+ * - Extra power points for adepts
+ * - Attribute increases beyond priority allocation
+ * - Foci bonding
+ * - Skills (breaking groups, specializations)
+ * - Contacts (overflow beyond CHA×3 free points)
+ *
+ * @param selections - Character creation selections
+ * @param budgets - State budgets from creation state (contains karma spending values)
+ * @returns Breakdown of karma spending by source plus net total
+ */
+export function calculateKarmaSpent(
+  selections: CreationSelections,
+  budgets: Record<string, unknown>
+): KarmaBreakdown {
+  // Quality karma: derive from selections first, fall back to stateBudgets
+  type QualitySelectionWithKarma = { karma?: number; originalKarma?: number };
+  const positiveQualities = (selections.positiveQualities || []) as QualitySelectionWithKarma[];
+  const negativeQualities = (selections.negativeQualities || []) as QualitySelectionWithKarma[];
+
+  // Check if quality selections have karma values
+  const positiveQualitiesHaveKarma = positiveQualities.some(
+    (q) => q.karma !== undefined || q.originalKarma !== undefined
+  );
+  const negativeQualitiesHaveKarma = negativeQualities.some(
+    (q) => q.karma !== undefined || q.originalKarma !== undefined
+  );
+
+  const karmaSpentPositive = positiveQualitiesHaveKarma
+    ? positiveQualities.reduce((sum, q) => sum + (q.karma ?? q.originalKarma ?? 0), 0)
+    : (budgets["karma-spent-positive"] as number) || 0;
+
+  const karmaGainedNegative = negativeQualitiesHaveKarma
+    ? negativeQualities.reduce((sum, q) => sum + (q.karma ?? q.originalKarma ?? 0), 0)
+    : (budgets["karma-gained-negative"] as number) || 0;
+
+  // Karma-to-nuyen conversion
+  const karmaSpentGear = (budgets["karma-spent-gear"] as number) || 0;
+
+  // Other karma sources from budgets
+  const karmaSpentSpells = (budgets["karma-spent-spells"] as number) || 0;
+  const karmaSpentPowers = (budgets["karma-spent-power-points"] as number) || 0;
+  const karmaSpentAttributes = (budgets["karma-spent-attributes"] as number) || 0;
+  const karmaSpentFoci = (budgets["karma-spent-foci"] as number) || 0;
+
+  // Contact karma - derive from selections
+  // Calculate: total contact cost - free pool (CHA × 3)
+  const contacts = (selections.contacts || []) as Array<{ connection: number; loyalty: number }>;
+  const attributes = selections.attributes as Record<string, number> | undefined;
+  const charisma = attributes?.charisma || 1;
+  const freeContactKarma = charisma * 3;
+  const totalContactCost = contacts.reduce((sum, c) => sum + c.connection + c.loyalty, 0);
+  const karmaSpentContacts = Math.max(0, totalContactCost - freeContactKarma);
+
+  // Skill karma - derive from skillKarmaSpent if present
+  const skillKarmaSpent = selections.skillKarmaSpent as
+    | {
+        skillRaises: Record<string, number>;
+        specializations: number;
+        groupRaises?: Record<string, number>;
+      }
+    | undefined;
+  let karmaSpentSkills = (budgets["karma-spent-skills"] as number) || 0;
+  if (skillKarmaSpent) {
+    const skillRaisesTotal = Object.values(skillKarmaSpent.skillRaises || {}).reduce(
+      (sum, cost) => sum + cost,
+      0
+    );
+    const groupRaisesTotal = Object.values(skillKarmaSpent.groupRaises || {}).reduce(
+      (sum, cost) => sum + cost,
+      0
+    );
+    karmaSpentSkills = skillRaisesTotal + (skillKarmaSpent.specializations || 0) + groupRaisesTotal;
+  }
+
+  // Net karma spent = positive qualities + other spends - negative qualities gained
+  const total =
+    karmaSpentPositive +
+    karmaSpentGear +
+    karmaSpentSpells +
+    karmaSpentPowers +
+    karmaSpentAttributes +
+    karmaSpentFoci +
+    karmaSpentSkills +
+    karmaSpentContacts -
+    karmaGainedNegative;
+
+  return {
+    positiveQualities: karmaSpentPositive,
+    negativeQualities: karmaGainedNegative,
+    karmaToNuyen: karmaSpentGear,
+    spells: karmaSpentSpells,
+    powerPoints: karmaSpentPowers,
+    attributes: karmaSpentAttributes,
+    foci: karmaSpentFoci,
+    skills: karmaSpentSkills,
+    contacts: karmaSpentContacts,
+    total,
+  };
+}

--- a/lib/rules/validation/index.ts
+++ b/lib/rules/validation/index.ts
@@ -25,6 +25,15 @@ export {
   isCharacterValid,
 } from "./character-validator";
 
+// Budget calculator types and functions
+export type { NuyenBreakdown, KarmaBreakdown } from "./budget-calculator";
+export {
+  calculateNuyenSpent,
+  calculateKarmaSpent,
+  KARMA_TO_NUYEN_LIMIT,
+  SR5_KARMA_BUDGET,
+} from "./budget-calculator";
+
 // Re-export from constraint validation module for backwards compatibility
 export {
   type ValidationResult,


### PR DESCRIPTION
## Summary

- Add server-side validators that independently recalculate nuyen and karma budgets from `creationState.selections`
- Ensures the server never trusts client-calculated values during character finalization
- Creates pure calculation functions mirroring `CreationBudgetContext.tsx` logic

## Changes

**New Files:**
- `lib/rules/validation/budget-calculator.ts` - Pure calculation functions:
  - `calculateNuyenSpent()`: 15 spending categories (gear, weapons, armor, cyberware, bioware, foci, vehicles, drones, rccs, autosofts, lifestyles, commlinks, cyberdecks, software, identities)
  - `calculateKarmaSpent()`: 8 karma sources (positive/negative qualities, karma-to-nuyen, spells, power points, attributes, foci, skills, contacts)
  - Exports `NuyenBreakdown` and `KarmaBreakdown` types
  - Exports constants `KARMA_TO_NUYEN_LIMIT` (10) and `SR5_KARMA_BUDGET` (25)

**Modified Files:**
- `lib/rules/validation/character-validator.ts` - Added two new validators:
  - `nuyenBudgetValidator` (priority 11): Validates nuyen spending against priority-based budget + karma conversion
  - `karmaBudgetValidator` (priority 12): Validates karma spending against 25 karma budget and 10 karma conversion limit
- `lib/rules/validation/index.ts` - Exports new types and functions

**Error Codes:**
| Code | Severity | Trigger |
|------|----------|---------|
| `NUYEN_BUDGET_EXCEEDED` | error | Nuyen spent > available |
| `KARMA_BUDGET_EXCEEDED` | error | Karma spent > 25 |
| `KARMA_TO_NUYEN_LIMIT_EXCEEDED` | error | Conversion > 10 |

## Test plan

- [x] 50 unit tests for budget-calculator.ts covering all 15 nuyen and 8 karma categories
- [x] 8 integration tests for nuyen budget validator
- [x] 10 integration tests for karma budget validator
- [x] All 255 validation tests passing
- [x] Type-check passes
- [x] Lint passes

Closes #261

🤖 Generated with [Claude Code](https://claude.ai/code)