### PR TITLE
feat(creation): Add skill rating validation with Aptitude specification enforcement

### DIFF
--- a/lib/rules/constraint-validation.ts
+++ b/lib/rules/constraint-validation.ts
@@ -372,6 +372,11 @@ function validateAttributeLimit(
 
 /**
  * Validate skill limits
+ *
+ * Rules enforced:
+ * - Base skill rating cap at creation is 6 (configurable via params.max)
+ * - Rating 7 is only allowed with Aptitude quality for that SPECIFIC skill
+ * - Only one skill can reach rating 7 at creation (Aptitude can only be taken once)
  */
 function validateSkillLimit(
   constraint: CreationConstraint,
@@ -383,25 +388,55 @@ function validateSkillLimit(
     maxWithAptitude?: number;
   };
 
-  const hasAptitude = character.positiveQualities?.some(
+  // Find Aptitude quality and its specification
+  const aptitudeQuality = character.positiveQualities?.find(
     (q) => (q.qualityId || q.id) === "aptitude"
   );
-  const campaignSkillCap = context.campaign?.advancementSettings?.skillRatingCap;
-  let maxRating = hasAptitude ? params.maxWithAptitude || 7 : params.max || 6;
+  const aptitudeSkill = aptitudeQuality?.specification?.toLowerCase();
 
-  if (campaignSkillCap !== undefined) {
-    maxRating = Math.min(maxRating, campaignSkillCap);
-  }
+  const campaignSkillCap = context.campaign?.advancementSettings?.skillRatingCap;
+  const baseMax = params.max || 6;
+  const aptitudeMax = params.maxWithAptitude || 7;
+
+  let skillsAtAptitudeMax = 0;
 
   for (const [skillId, rating] of Object.entries(character.skills || {})) {
+    // Determine if this skill is the Aptitude skill
+    const isAptitudeSkill = aptitudeSkill && skillId.toLowerCase() === aptitudeSkill;
+
+    // Calculate max rating for this specific skill
+    let maxRating = isAptitudeSkill ? aptitudeMax : baseMax;
+
+    // Apply campaign cap if defined
+    if (campaignSkillCap !== undefined) {
+      maxRating = Math.min(maxRating, campaignSkillCap);
+    }
+
     if (rating > maxRating) {
       return {
         constraintId: constraint.id,
         field: skillId,
-        message: constraint.errorMessage || `Skill rating cannot exceed ${maxRating} at creation`,
+        message: isAptitudeSkill
+          ? constraint.errorMessage || `Skill rating cannot exceed ${maxRating} at creation`
+          : `Skill "${skillId}" exceeds max of ${maxRating}${aptitudeQuality ? ` (Aptitude is for "${aptitudeQuality.specification}")` : ""}`,
         severity: constraint.severity,
       };
     }
+
+    // Track skills at aptitude max (7+)
+    if (rating >= aptitudeMax) {
+      skillsAtAptitudeMax++;
+    }
+  }
+
+  // Only one skill can reach rating 7 at creation (even with Aptitude)
+  if (skillsAtAptitudeMax > 1) {
+    return {
+      constraintId: constraint.id,
+      field: "skills",
+      message: "Only one skill can reach rating 7 at creation (even with Aptitude)",
+      severity: constraint.severity,
+    };
   }
 
   return null;


### PR DESCRIPTION
## Summary

- Fix critical bug where Aptitude quality allowed ALL skills to reach rating 7 instead of only the specified skill
- Add `skillRatingValidator` to character-validator pipeline for comprehensive skill rating validation
- Add zero-skill warning at finalization to alert players who haven't allocated any active skills

## Changes

### `lib/rules/validation/character-validator.ts`
- Add new `skillRatingValidator` that validates skill ratings against creation limits and Aptitude quality specification
- Checks that only the skill named in Aptitude's specification can reach rating 7
- Errors if multiple skills at rating 7 (Aptitude can only be taken once)
- Issues warning at finalization if no active skills allocated
- Uses case-insensitive matching for skill ID comparison

### `lib/rules/constraint-validation.ts`
- Fix `validateSkillLimit` function to check Aptitude specification per-skill
- Only allows the specific skill named in Aptitude's specification to reach rating 7
- Tracks and rejects multiple skills at rating 7
- Provides better error messages indicating which skill has Aptitude

## Test plan

- [x] Run unit tests: `pnpm test lib/rules/validation/__tests__/character-validator.test.ts` (155 tests pass)
- [x] Run constraint tests: `pnpm test lib/rules/__tests__/constraint-validation.test.ts` (24 tests pass)
- [ ] Manual test: Create character with skill at 7 without Aptitude → expect error
- [ ] Manual test: Create character with Aptitude for "Pistols", put Athletics at 7 → expect error
- [ ] Manual test: Create character with Aptitude for "Pistols", put Pistols at 7 → expect success
- [ ] Manual test: Finalize character with no skills → expect warning (not blocking)

Closes #263

🤖 Generated with [Claude Code](https://claude.ai/code)