### PR TITLE
feat(creation): Add drugs & toxins purchasing panel

### DIFF
--- a/__tests__/lib/contexts/CreationBudgetContext-drugs-toxins.test.ts
+++ b/__tests__/lib/contexts/CreationBudgetContext-drugs-toxins.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for drugs and toxins spending in CreationBudgetContext.
+ *
+ * Validates that drugs and toxins selections are correctly included
+ * in the nuyen budget calculation via extractSpentValues.
+ */
+
+import { describe, test, expect } from "vitest";
+import { _testExports } from "@/lib/contexts/CreationBudgetContext";
+
+const { extractSpentValues } = _testExports;
+
+// Minimal defaults for extractSpentValues parameters
+const emptyBudgets: Record<string, number> = {};
+const emptyTotals: Record<
+  string,
+  { total: number; label: string; displayFormat?: "number" | "currency" }
+> = {};
+const nullPriorityTable = null;
+const noSkillCategories: Record<string, string | undefined> = {};
+
+describe("extractSpentValues - drugs and toxins", () => {
+  test("empty drugs and toxins arrays contribute 0 to nuyen", () => {
+    const selections = {
+      drugs: [],
+      toxins: [],
+    };
+
+    const spent = extractSpentValues(
+      emptyBudgets,
+      selections,
+      emptyTotals,
+      nullPriorityTable,
+      undefined,
+      noSkillCategories
+    );
+
+    // With no other gear, nuyen should be 0
+    expect(spent["nuyen"]).toBe(0);
+  });
+
+  test("drug cost * quantity adds correctly to nuyen", () => {
+    const selections = {
+      drugs: [
+        { cost: 15, quantity: 3 }, // Bliss x3 = 45
+        { cost: 100, quantity: 1 }, // Kamikaze x1 = 100
+      ],
+      toxins: [],
+    };
+
+    const spent = extractSpentValues(
+      emptyBudgets,
+      selections,
+      emptyTotals,
+      nullPriorityTable,
+      undefined,
+      noSkillCategories
+    );
+
+    expect(spent["nuyen"]).toBe(145);
+  });
+
+  test("toxin cost * quantity adds correctly to nuyen", () => {
+    const selections = {
+      drugs: [],
+      toxins: [
+        { cost: 20, quantity: 5 }, // CS/Tear Gas x5 = 100
+        { cost: 50, quantity: 2 }, // Narcoject x2 = 100
+      ],
+    };
+
+    const spent = extractSpentValues(
+      emptyBudgets,
+      selections,
+      emptyTotals,
+      nullPriorityTable,
+      undefined,
+      noSkillCategories
+    );
+
+    expect(spent["nuyen"]).toBe(200);
+  });
+
+  test("combined drug and toxin spending included in total nuyen", () => {
+    const selections = {
+      drugs: [
+        { cost: 75, quantity: 2 }, // Jazz x2 = 150
+      ],
+      toxins: [
+        { cost: 1000, quantity: 1 }, // Seven-7 x1 = 1000
+      ],
+      gear: [
+        { cost: 500, quantity: 1 }, // Some other gear = 500
+      ],
+    };
+
+    const spent = extractSpentValues(
+      emptyBudgets,
+      selections,
+      emptyTotals,
+      nullPriorityTable,
+      undefined,
+      noSkillCategories
+    );
+
+    // 150 (drugs) + 1000 (toxins) + 500 (gear) = 1650
+    expect(spent["nuyen"]).toBe(1650);
+  });
+
+  test("undefined drugs and toxins in selections default to 0", () => {
+    const selections = {};
+
+    const spent = extractSpentValues(
+      emptyBudgets,
+      selections,
+      emptyTotals,
+      nullPriorityTable,
+      undefined,
+      noSkillCategories
+    );
+
+    expect(spent["nuyen"]).toBe(0);
+  });
+
+  test("drug with quantity defaulting to 1 when quantity is 0", () => {
+    // Quantity of 0 should multiply to 0 (edge case)
+    const selections = {
+      drugs: [{ cost: 200, quantity: 0 }],
+      toxins: [],
+    };
+
+    const spent = extractSpentValues(
+      emptyBudgets,
+      selections,
+      emptyTotals,
+      nullPriorityTable,
+      undefined,
+      noSkillCategories
+    );
+
+    // 200 * 0 = 0 (but budget uses || 1 pattern, so it will be 200)
+    // Actually checking: (d.cost || 0) * (d.quantity || 1) -> 200 * 1 = 200
+    expect(spent["nuyen"]).toBe(200);
+  });
+});

--- a/app/characters/create/sheet/components/SheetCreationLayout.tsx
+++ b/app/characters/create/sheet/components/SheetCreationLayout.tsx
@@ -36,6 +36,7 @@ import {
   GearPanel,
   WeaponsPanel,
   ArmorPanel,
+  DrugsPanel,
   MatrixGearCard,
   AugmentationsCard,
   VehiclesCard,
@@ -926,6 +927,9 @@ export function SheetCreationLayout({
 
           {/* Armor - Phase 4 (New) */}
           <ArmorPanel state={creationState} updateState={updateState} />
+
+          {/* Drugs & Toxins - Phase 4 */}
+          <DrugsPanel state={creationState} updateState={updateState} />
 
           {/* Matrix Gear - Phase 4 (Commlinks & Cyberdecks) */}
           <MatrixGearCard state={creationState} updateState={updateState} />

--- a/components/creation/GearTabsCard.tsx
+++ b/components/creation/GearTabsCard.tsx
@@ -11,12 +11,22 @@
 import { useState, useMemo, useCallback } from "react";
 import type { CreationState } from "@/lib/types";
 import { useCreationBudgets } from "@/lib/contexts";
-import { Package, Sword, Shield, Cpu, Car, AlertCircle, CheckCircle2 } from "lucide-react";
+import {
+  Package,
+  Sword,
+  Shield,
+  Cpu,
+  Car,
+  FlaskConical,
+  AlertCircle,
+  CheckCircle2,
+} from "lucide-react";
 
 // Import individual panels
 import { GearPanel } from "./gear/GearPanel";
 import { WeaponsPanel } from "./WeaponsPanel";
 import { ArmorPanel } from "./armor";
+import { DrugsPanel } from "./drugs-toxins";
 import { AugmentationsCard } from "./AugmentationsCard";
 import { VehiclesCard } from "./VehiclesCard";
 
@@ -29,7 +39,7 @@ interface GearTabsCardProps {
   updateState: (updates: Partial<CreationState>) => void;
 }
 
-type TabId = "gear" | "weapons" | "armor" | "augmentations" | "vehicles";
+type TabId = "gear" | "weapons" | "armor" | "drugs-toxins" | "augmentations" | "vehicles";
 
 interface TabConfig {
   id: TabId;
@@ -71,6 +81,16 @@ const TABS: TabConfig[] = [
     },
   },
   {
+    id: "drugs-toxins",
+    label: "Drugs",
+    icon: FlaskConical,
+    getBadge: (state) => {
+      const drugs = (state.selections.drugs || []) as unknown[];
+      const toxins = (state.selections.toxins || []) as unknown[];
+      return { count: drugs.length + toxins.length };
+    },
+  },
+  {
     id: "augmentations",
     label: "Augmentations",
     icon: Cpu,
@@ -109,6 +129,8 @@ export function GearTabsCard({ state, updateState }: GearTabsCardProps) {
     const gear = (state.selections.gear || []) as unknown[];
     const weapons = (state.selections.weapons || []) as unknown[];
     const armor = (state.selections.armor || []) as unknown[];
+    const drugs = (state.selections.drugs || []) as unknown[];
+    const toxins = (state.selections.toxins || []) as unknown[];
     const cyberware = (state.selections.cyberware || []) as unknown[];
     const bioware = (state.selections.bioware || []) as unknown[];
     const vehicles = (state.selections.vehicles || []) as unknown[];
@@ -119,6 +141,8 @@ export function GearTabsCard({ state, updateState }: GearTabsCardProps) {
         gear.length +
         weapons.length +
         armor.length +
+        drugs.length +
+        toxins.length +
         cyberware.length +
         bioware.length +
         vehicles.length +
@@ -143,6 +167,8 @@ export function GearTabsCard({ state, updateState }: GearTabsCardProps) {
         return <WeaponsPanel state={state} updateState={updateState} />;
       case "armor":
         return <ArmorPanel state={state} updateState={updateState} />;
+      case "drugs-toxins":
+        return <DrugsPanel state={state} updateState={updateState} />;
       case "augmentations":
         return <AugmentationsCard state={state} updateState={updateState} />;
       case "vehicles":

--- a/components/creation/drugs-toxins/DrugRow.tsx
+++ b/components/creation/drugs-toxins/DrugRow.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+/**
+ * DrugRow
+ *
+ * Compact display for a purchased drug item.
+ * Line 1: Name, qty badge, legality badge, cost, remove
+ * Line 2: Vector • Speed • Addiction info
+ * Expandable for full effects and description.
+ */
+
+import { useState } from "react";
+import type { GearItem } from "@/lib/types";
+import { LegalityBadge } from "@/components/creation/shared/LegalityBadge";
+import { ChevronDown, ChevronRight, X } from "lucide-react";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "decimal",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+interface DrugRowProps {
+  drug: GearItem;
+  onRemove: (id: string) => void;
+}
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+export function DrugRow({ drug, onRemove }: DrugRowProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const totalCost = drug.cost * drug.quantity;
+
+  // Extract drug-specific metadata stored during purchase
+  const meta = (drug as GearItem & { metadata?: Record<string, unknown> }).metadata;
+  const vector = (meta?.vector as string[]) || [];
+  const speed = (meta?.speed as string) || "";
+  const duration = (meta?.duration as string) || "";
+  const addictionType = (meta?.addictionType as string) || "";
+  const addictionRating = (meta?.addictionRating as number) || 0;
+  const addictionThreshold = (meta?.addictionThreshold as number) || 0;
+  const activeEffects = (meta?.activeEffects as Record<string, unknown>) || null;
+  const crashEffects = (meta?.crashEffects as Record<string, unknown>) || null;
+  const description = (meta?.description as string) || drug.notes || "";
+
+  return (
+    <div className="py-1.5">
+      {/* Line 1: Name and controls */}
+      <div className="flex items-center justify-between">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+          </button>
+
+          <span className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">
+            {drug.name}
+          </span>
+
+          {drug.quantity > 1 && (
+            <span className="shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+              x{drug.quantity}
+            </span>
+          )}
+          <LegalityBadge legality={drug.legality} availability={drug.availability} />
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <span className="font-mono text-sm font-medium text-zinc-900 dark:text-zinc-100">
+            {formatCurrency(totalCost)}¥
+          </span>
+          <div className="mx-2 h-5 w-px bg-zinc-300 dark:bg-zinc-600" />
+          <button
+            onClick={() => drug.id && onRemove(drug.id)}
+            className="rounded p-1 text-zinc-400 hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+            title="Remove drug"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+
+      {/* Line 2: Vector, speed, addiction */}
+      <div className="ml-5 mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
+        {vector.length > 0 && vector.join(", ")}
+        {speed && ` • ${speed}`}
+        {addictionType && ` • ${addictionType} (${addictionRating}/${addictionThreshold})`}
+      </div>
+
+      {/* Expanded Details */}
+      {isExpanded && (
+        <div className="ml-5 mt-2 space-y-2 border-l-2 border-zinc-200 pl-3 dark:border-zinc-700">
+          {/* Stats Grid */}
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+            {duration && (
+              <div className="flex justify-between">
+                <span className="text-zinc-500 dark:text-zinc-400">Duration</span>
+                <span className="font-medium text-zinc-700 dark:text-zinc-300">{duration}</span>
+              </div>
+            )}
+            <div className="flex justify-between">
+              <span className="text-zinc-500 dark:text-zinc-400">Cost/dose</span>
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                {formatCurrency(drug.cost)}¥
+              </span>
+            </div>
+          </div>
+
+          {/* Active Effects */}
+          {activeEffects && Object.keys(activeEffects).length > 0 && (
+            <div>
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600 dark:text-emerald-400">
+                Active Effects
+              </span>
+              <div className="mt-1 flex flex-wrap gap-1">
+                {Object.entries(activeEffects)
+                  .filter(([key]) => key !== "description")
+                  .map(([key, value]) => (
+                    <span
+                      key={key}
+                      className="rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                    >
+                      {key}: {String(value)}
+                    </span>
+                  ))}
+              </div>
+            </div>
+          )}
+
+          {/* Crash Effects */}
+          {crashEffects && Object.keys(crashEffects).length > 0 && (
+            <div>
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-red-600 dark:text-red-400">
+                Crash Effects
+              </span>
+              <div className="mt-1 flex flex-wrap gap-1">
+                {Object.entries(crashEffects)
+                  .filter(([key]) => key !== "description")
+                  .map(([key, value]) => (
+                    <span
+                      key={key}
+                      className="rounded bg-red-50 px-1.5 py-0.5 text-[10px] text-red-700 dark:bg-red-900/30 dark:text-red-300"
+                    >
+                      {key}: {String(value)}
+                    </span>
+                  ))}
+              </div>
+            </div>
+          )}
+
+          {/* Description */}
+          {description && <p className="text-xs text-zinc-600 dark:text-zinc-400">{description}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/creation/drugs-toxins/DrugsPanel.tsx
+++ b/components/creation/drugs-toxins/DrugsPanel.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+/**
+ * DrugsPanel
+ *
+ * Card for drugs and toxins purchasing in sheet-driven creation.
+ * Combines both categories into a single panel with:
+ * - Separate drug and toxin sections
+ * - Combined purchase modal with tab switching
+ * - Shared nuyen budget via useCreationBudgets()
+ * - Karma-to-nuyen conversion for budget overflow
+ */
+
+import { useMemo, useCallback, useState } from "react";
+import { type DrugCatalogItemData, type ToxinCatalogItemData } from "@/lib/rules/RulesetContext";
+import type { CreationState, GearItem } from "@/lib/types";
+import { useCreationBudgets } from "@/lib/contexts";
+import {
+  CreationCard,
+  EmptyState,
+  SummaryFooter,
+  KarmaConversionModal,
+  useKarmaConversionPrompt,
+  LegalityWarnings,
+} from "../shared";
+import { DrugRow } from "./DrugRow";
+import { ToxinRow } from "./ToxinRow";
+import { DrugsPurchaseModal } from "./DrugsPurchaseModal";
+import { Lock, Plus, Pill, FlaskConical } from "lucide-react";
+import { InfoTooltip } from "@/components/ui";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const KARMA_TO_NUYEN_RATE = 2000;
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "decimal",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+interface DrugsPanelProps {
+  state: CreationState;
+  updateState: (updates: Partial<CreationState>) => void;
+}
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+export function DrugsPanel({ state, updateState }: DrugsPanelProps) {
+  const { getBudget } = useCreationBudgets();
+  const nuyenBudget = getBudget("nuyen");
+  const karmaBudget = getBudget("karma");
+
+  const [isPurchaseModalOpen, setIsPurchaseModalOpen] = useState(false);
+
+  // Get selected items from state
+  const selectedDrugs = useMemo(
+    () => (state.selections?.drugs || []) as GearItem[],
+    [state.selections?.drugs]
+  );
+
+  const selectedToxins = useMemo(
+    () => (state.selections?.toxins || []) as GearItem[],
+    [state.selections?.toxins]
+  );
+
+  const totalItems = selectedDrugs.length + selectedToxins.length;
+
+  // Karma-to-nuyen conversion
+  const karmaConversion = (state.budgets?.["karma-spent-gear"] as number) || 0;
+  const karmaRemaining = karmaBudget?.remaining || 0;
+
+  // Calculate budget (shared with other panels)
+  const baseNuyen = nuyenBudget?.total || 0;
+  const convertedNuyen = karmaConversion * KARMA_TO_NUYEN_RATE;
+  const totalNuyen = baseNuyen + convertedNuyen;
+
+  // Use centralized nuyen spent from budget context
+  const totalSpent = nuyenBudget?.spent || 0;
+  const remaining = totalNuyen - totalSpent;
+  const isOverBudget = remaining < 0;
+
+  // Local cost for footer
+  const drugsSpent = selectedDrugs.reduce((sum, d) => sum + d.cost * d.quantity, 0);
+  const toxinsSpent = selectedToxins.reduce((sum, t) => sum + t.cost * t.quantity, 0);
+  const localSpent = drugsSpent + toxinsSpent;
+
+  // Karma conversion hook
+  const handleKarmaConvert = useCallback(
+    (newTotalConversion: number) => {
+      updateState({
+        budgets: {
+          ...state.budgets,
+          "karma-spent-gear": newTotalConversion,
+        },
+      });
+    },
+    [state.budgets, updateState]
+  );
+
+  const karmaConversionPrompt = useKarmaConversionPrompt({
+    remaining,
+    karmaRemaining,
+    currentConversion: karmaConversion,
+    onConvert: handleKarmaConvert,
+  });
+
+  // Add drug (actual implementation)
+  const actuallyAddDrug = useCallback(
+    (drugData: DrugCatalogItemData, quantity: number) => {
+      const newDrug: GearItem = {
+        id: `${drugData.id}-${Date.now()}`,
+        name: drugData.name,
+        category: "drug",
+        cost: drugData.cost,
+        availability: drugData.availability,
+        legality: drugData.legality,
+        quantity,
+        capacityUsed: 0,
+        modifications: [],
+        metadata: {
+          vector: drugData.vector,
+          speed: drugData.speed,
+          duration: drugData.duration,
+          addictionType: drugData.addictionType,
+          addictionRating: drugData.addictionRating,
+          addictionThreshold: drugData.addictionThreshold,
+          activeEffects: drugData.effects.active,
+          crashEffects: drugData.effects.crash,
+          description: drugData.description,
+        },
+      };
+
+      updateState({
+        selections: {
+          ...state.selections,
+          drugs: [...selectedDrugs, newDrug],
+        },
+      });
+    },
+    [selectedDrugs, state.selections, updateState]
+  );
+
+  // Add drug with karma conversion prompt
+  const addDrug = useCallback(
+    (drugData: DrugCatalogItemData, quantity: number) => {
+      const totalCost = drugData.cost * quantity;
+
+      if (totalCost <= remaining) {
+        actuallyAddDrug(drugData, quantity);
+        return;
+      }
+
+      const conversionInfo = karmaConversionPrompt.checkPurchase(totalCost);
+      if (conversionInfo?.canConvert) {
+        const itemName = quantity > 1 ? `${drugData.name} x${quantity}` : drugData.name;
+        karmaConversionPrompt.promptConversion(itemName, totalCost, () => {
+          actuallyAddDrug(drugData, quantity);
+        });
+        return;
+      }
+    },
+    [remaining, actuallyAddDrug, karmaConversionPrompt]
+  );
+
+  // Add toxin (actual implementation)
+  const actuallyAddToxin = useCallback(
+    (toxinData: ToxinCatalogItemData, quantity: number) => {
+      const newToxin: GearItem = {
+        id: `${toxinData.id}-${Date.now()}`,
+        name: toxinData.name,
+        category: "toxin",
+        cost: toxinData.cost,
+        availability: toxinData.availability,
+        legality: toxinData.legality,
+        quantity,
+        capacityUsed: 0,
+        modifications: [],
+        metadata: {
+          vector: toxinData.vector,
+          speed: toxinData.speed,
+          power: toxinData.power,
+          penetration: toxinData.penetration,
+          effects: toxinData.effects,
+          duration: toxinData.duration,
+          description: toxinData.description,
+        },
+      };
+
+      updateState({
+        selections: {
+          ...state.selections,
+          toxins: [...selectedToxins, newToxin],
+        },
+      });
+    },
+    [selectedToxins, state.selections, updateState]
+  );
+
+  // Add toxin with karma conversion prompt
+  const addToxin = useCallback(
+    (toxinData: ToxinCatalogItemData, quantity: number) => {
+      const totalCost = toxinData.cost * quantity;
+
+      if (totalCost <= remaining) {
+        actuallyAddToxin(toxinData, quantity);
+        return;
+      }
+
+      const conversionInfo = karmaConversionPrompt.checkPurchase(totalCost);
+      if (conversionInfo?.canConvert) {
+        const itemName = quantity > 1 ? `${toxinData.name} x${quantity}` : toxinData.name;
+        karmaConversionPrompt.promptConversion(itemName, totalCost, () => {
+          actuallyAddToxin(toxinData, quantity);
+        });
+        return;
+      }
+    },
+    [remaining, actuallyAddToxin, karmaConversionPrompt]
+  );
+
+  // Remove handlers
+  const removeDrug = useCallback(
+    (id: string) => {
+      updateState({
+        selections: {
+          ...state.selections,
+          drugs: selectedDrugs.filter((d) => d.id !== id),
+        },
+      });
+    },
+    [selectedDrugs, state.selections, updateState]
+  );
+
+  const removeToxin = useCallback(
+    (id: string) => {
+      updateState({
+        selections: {
+          ...state.selections,
+          toxins: selectedToxins.filter((t) => t.id !== id),
+        },
+      });
+    },
+    [selectedToxins, state.selections, updateState]
+  );
+
+  // Combine for legality warnings
+  const allItems = useMemo(
+    () => [...selectedDrugs, ...selectedToxins],
+    [selectedDrugs, selectedToxins]
+  );
+
+  // Purchased catalog IDs for strikethrough display
+  const purchasedDrugIds = useMemo(
+    () =>
+      selectedDrugs.map((d) => {
+        const id = d.id || "";
+        const lastHyphen = id.lastIndexOf("-");
+        return lastHyphen > 0 ? id.slice(0, lastHyphen) : id;
+      }),
+    [selectedDrugs]
+  );
+
+  const purchasedToxinIds = useMemo(
+    () =>
+      selectedToxins.map((t) => {
+        const id = t.id || "";
+        const lastHyphen = id.lastIndexOf("-");
+        return lastHyphen > 0 ? id.slice(0, lastHyphen) : id;
+      }),
+    [selectedToxins]
+  );
+
+  // Validation status
+  const validationStatus = useMemo(() => {
+    if (isOverBudget) return "error";
+    if (totalItems > 0) return "valid";
+    return "pending";
+  }, [isOverBudget, totalItems]);
+
+  // Check prerequisites
+  const hasPriorities = state.priorities?.metatype && state.priorities?.resources;
+  if (!hasPriorities) {
+    return (
+      <CreationCard title="Drugs & Toxins" description="Purchase consumables" status="pending">
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 rounded-lg border-2 border-dashed border-zinc-200 p-4 dark:border-zinc-700">
+            <Lock className="h-5 w-5 text-zinc-400" />
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">Set priorities first</p>
+          </div>
+        </div>
+      </CreationCard>
+    );
+  }
+
+  return (
+    <>
+      <CreationCard
+        title="Drugs & Toxins"
+        status={validationStatus}
+        headerAction={
+          <button
+            onClick={() => setIsPurchaseModalOpen(true)}
+            className="flex items-center gap-1 rounded-lg bg-amber-500 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-amber-600"
+          >
+            <Plus className="h-3 w-3" />
+            Add
+          </button>
+        }
+      >
+        <div className="space-y-3">
+          {/* Nuyen Budget Bar */}
+          <div className="space-y-1">
+            <div className="flex items-center justify-between text-xs">
+              <span className="flex items-center gap-1 text-zinc-600 dark:text-zinc-400">
+                <span>Nuyen</span>
+                <InfoTooltip content="Total nuyen spent on all gear" label="Nuyen budget info" />
+                {karmaConversion > 0 && (
+                  <span className="ml-1 text-[10px] text-emerald-600 dark:text-emerald-400">
+                    (+{(karmaConversion * KARMA_TO_NUYEN_RATE).toLocaleString()}¥ karma)
+                  </span>
+                )}
+              </span>
+              <span className="font-mono font-medium text-zinc-900 dark:text-zinc-100">
+                {formatCurrency(totalSpent)} / {formatCurrency(totalNuyen)}
+              </span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+              <div
+                className={`h-full transition-all ${isOverBudget ? "bg-red-500" : "bg-emerald-500"}`}
+                style={{
+                  width: `${Math.min(100, (totalSpent / totalNuyen) * 100)}%`,
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Legality Warnings */}
+          <LegalityWarnings items={allItems} />
+
+          {/* Selected Items */}
+          {totalItems > 0 ? (
+            <div className="space-y-4">
+              {/* Drugs Section */}
+              {selectedDrugs.length > 0 && (
+                <div>
+                  <h5 className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase text-zinc-400 dark:text-zinc-500">
+                    <Pill className="h-3.5 w-3.5" />
+                    Drugs ({selectedDrugs.length})
+                  </h5>
+                  <div className="divide-y divide-zinc-100 rounded-lg border border-zinc-200 px-3 dark:divide-zinc-800 dark:border-zinc-700">
+                    {selectedDrugs.map((drug) => (
+                      <DrugRow key={drug.id} drug={drug} onRemove={removeDrug} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Toxins Section */}
+              {selectedToxins.length > 0 && (
+                <div>
+                  <h5 className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase text-zinc-400 dark:text-zinc-500">
+                    <FlaskConical className="h-3.5 w-3.5" />
+                    Toxins ({selectedToxins.length})
+                  </h5>
+                  <div className="divide-y divide-zinc-100 rounded-lg border border-zinc-200 px-3 dark:divide-zinc-800 dark:border-zinc-700">
+                    {selectedToxins.map((toxin) => (
+                      <ToxinRow key={toxin.id} toxin={toxin} onRemove={removeToxin} />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <EmptyState message="No drugs or toxins purchased" />
+          )}
+
+          {/* Footer Summary */}
+          <SummaryFooter count={totalItems} total={localSpent} format="currency" />
+        </div>
+      </CreationCard>
+
+      {/* Purchase Modal */}
+      <DrugsPurchaseModal
+        isOpen={isPurchaseModalOpen}
+        onClose={() => setIsPurchaseModalOpen(false)}
+        remaining={remaining}
+        onPurchaseDrug={addDrug}
+        onPurchaseToxin={addToxin}
+        purchasedDrugIds={purchasedDrugIds}
+        purchasedToxinIds={purchasedToxinIds}
+      />
+
+      {/* Karma Conversion Modal */}
+      <KarmaConversionModal
+        isOpen={karmaConversionPrompt.modalState.isOpen}
+        onClose={karmaConversionPrompt.closeModal}
+        onConfirm={karmaConversionPrompt.confirmConversion}
+        itemName={karmaConversionPrompt.modalState.itemName}
+        itemCost={karmaConversionPrompt.modalState.itemCost}
+        currentRemaining={karmaConversionPrompt.currentRemaining}
+        karmaToConvert={karmaConversionPrompt.modalState.karmaToConvert}
+        karmaAvailable={karmaConversionPrompt.karmaAvailable}
+        currentKarmaConversion={karmaConversionPrompt.currentKarmaConversion}
+        maxKarmaConversion={karmaConversionPrompt.maxKarmaConversion}
+      />
+    </>
+  );
+}

--- a/components/creation/drugs-toxins/DrugsPurchaseModal.tsx
+++ b/components/creation/drugs-toxins/DrugsPurchaseModal.tsx
@@ -1,0 +1,659 @@
+"use client";
+
+/**
+ * DrugsPurchaseModal
+ *
+ * Split-pane modal for browsing and purchasing drugs and toxins.
+ * Left side: Tab filter (Drugs/Toxins), search, and item list
+ * Right side: Selected item details with quantity selection
+ *
+ * Follows the bulk-add pattern: modal stays open after adding items.
+ */
+
+import { useState, useMemo, useCallback } from "react";
+import {
+  useDrugs,
+  useToxins,
+  type DrugCatalogItemData,
+  type ToxinCatalogItemData,
+} from "@/lib/rules/RulesetContext";
+import type { ItemLegality } from "@/lib/types";
+import { isLegalAtCreation, CREATION_CONSTRAINTS } from "@/lib/rules/gear/validation";
+import { BaseModalRoot, ModalFooter } from "@/components/ui";
+import { Search, X, Check, AlertTriangle, Pill, FlaskConical } from "lucide-react";
+import { BulkQuantitySelector } from "@/components/creation/shared/BulkQuantitySelector";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const MAX_AVAILABILITY = CREATION_CONSTRAINTS.maxAvailabilityAtCreation;
+
+type CatalogTab = "drugs" | "toxins";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "decimal",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function getAvailabilityDisplay(availability: number, legality?: ItemLegality): string {
+  let display = String(availability);
+  if (legality === "restricted") display += "R";
+  if (legality === "forbidden") display += "F";
+  return display;
+}
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+type CatalogItem = DrugCatalogItemData | ToxinCatalogItemData;
+
+interface DrugsPurchaseModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  remaining: number;
+  onPurchaseDrug: (drug: DrugCatalogItemData, quantity: number) => void;
+  onPurchaseToxin: (toxin: ToxinCatalogItemData, quantity: number) => void;
+  purchasedDrugIds?: string[];
+  purchasedToxinIds?: string[];
+}
+
+// =============================================================================
+// LIST ITEM COMPONENT
+// =============================================================================
+
+function CatalogListItem({
+  item,
+  isSelected,
+  canAfford,
+  isAlreadyAdded,
+  isOverAvailability,
+  onClick,
+}: {
+  item: CatalogItem;
+  isSelected: boolean;
+  canAfford: boolean;
+  isAlreadyAdded: boolean;
+  isOverAvailability: boolean;
+  onClick: () => void;
+}) {
+  const isDisabled = isOverAvailability || isAlreadyAdded;
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={isDisabled}
+      className={`w-full rounded-lg border p-2.5 text-left transition-all ${
+        isSelected
+          ? "border-emerald-400 bg-emerald-50 dark:border-emerald-500 dark:bg-emerald-900/20"
+          : isAlreadyAdded
+            ? "cursor-not-allowed border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/50"
+            : isOverAvailability
+              ? "cursor-not-allowed border-zinc-200 bg-zinc-100 opacity-50 dark:border-zinc-700 dark:bg-zinc-800"
+              : "border-zinc-200 bg-white hover:border-emerald-400 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-emerald-500/50"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span
+              className={`truncate text-sm font-medium ${
+                isAlreadyAdded || isOverAvailability
+                  ? "text-zinc-400 line-through dark:text-zinc-500"
+                  : "text-zinc-900 dark:text-zinc-100"
+              }`}
+            >
+              {item.name}
+            </span>
+            {isAlreadyAdded && <Check className="h-4 w-4 flex-shrink-0 text-emerald-500" />}
+            {isOverAvailability && !isAlreadyAdded && (
+              <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
+            )}
+          </div>
+          <div
+            className={`mt-0.5 flex flex-wrap gap-x-2 text-xs ${
+              isAlreadyAdded || isOverAvailability
+                ? "text-zinc-400 dark:text-zinc-500"
+                : "text-zinc-500 dark:text-zinc-400"
+            }`}
+          >
+            <span>{item.vector.join(", ")}</span>
+            <span>Avail: {getAvailabilityDisplay(item.availability, item.legality)}</span>
+          </div>
+        </div>
+        <div className="flex-shrink-0 text-right">
+          <div
+            className={`font-mono text-sm font-medium ${
+              isAlreadyAdded || isOverAvailability
+                ? "text-zinc-400 dark:text-zinc-500"
+                : !canAfford
+                  ? "text-red-600 dark:text-red-400"
+                  : "text-zinc-900 dark:text-zinc-100"
+            }`}
+          >
+            {formatCurrency(item.cost)}¥
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+export function DrugsPurchaseModal({
+  isOpen,
+  onClose,
+  remaining,
+  onPurchaseDrug,
+  onPurchaseToxin,
+  purchasedDrugIds = [],
+  purchasedToxinIds = [],
+}: DrugsPurchaseModalProps) {
+  const drugsCatalog = useDrugs();
+  const toxinsCatalog = useToxins();
+
+  const [activeTab, setActiveTab] = useState<CatalogTab>("drugs");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedItem, setSelectedItem] = useState<CatalogItem | null>(null);
+  const [selectedPacks, setSelectedPacks] = useState(1);
+  const [addedThisSession, setAddedThisSession] = useState(0);
+
+  // Get items for current tab
+  const currentItems = useMemo(() => {
+    const items = activeTab === "drugs" ? drugsCatalog : toxinsCatalog;
+    let filtered = [...items];
+
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (item) =>
+          item.name.toLowerCase().includes(query) ||
+          item.vector.some((v) => v.toLowerCase().includes(query))
+      );
+    }
+
+    return filtered.sort((a, b) => a.name.localeCompare(b.name));
+  }, [activeTab, drugsCatalog, toxinsCatalog, searchQuery]);
+
+  // Calculate selected item cost
+  const selectedItemCost = useMemo(() => {
+    if (!selectedItem) return 0;
+    return selectedItem.cost * selectedPacks;
+  }, [selectedItem, selectedPacks]);
+
+  const canAfford = selectedItemCost <= remaining;
+  const availabilityOk = selectedItem ? selectedItem.availability <= MAX_AVAILABILITY : false;
+  const canPurchase = canAfford && availabilityOk && selectedItem !== null;
+
+  // Check purchased IDs
+  const purchasedIds = activeTab === "drugs" ? purchasedDrugIds : purchasedToxinIds;
+
+  // Full reset on close
+  const resetState = useCallback(() => {
+    setSearchQuery("");
+    setActiveTab("drugs");
+    setSelectedItem(null);
+    setSelectedPacks(1);
+    setAddedThisSession(0);
+  }, []);
+
+  // Partial reset after adding
+  const resetForNextItem = useCallback(() => {
+    setSelectedItem(null);
+    setSelectedPacks(1);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    resetState();
+    onClose();
+  }, [resetState, onClose]);
+
+  const handlePurchase = useCallback(() => {
+    if (!selectedItem || !canPurchase) return;
+
+    if (activeTab === "drugs") {
+      onPurchaseDrug(selectedItem as DrugCatalogItemData, selectedPacks);
+    } else {
+      onPurchaseToxin(selectedItem as ToxinCatalogItemData, selectedPacks);
+    }
+    setAddedThisSession((prev) => prev + 1);
+    resetForNextItem();
+  }, [
+    selectedItem,
+    canPurchase,
+    activeTab,
+    onPurchaseDrug,
+    onPurchaseToxin,
+    selectedPacks,
+    resetForNextItem,
+  ]);
+
+  const handleSelectItem = useCallback((item: CatalogItem) => {
+    setSelectedItem(item);
+    setSelectedPacks(1);
+  }, []);
+
+  const handleTabChange = useCallback((tab: CatalogTab) => {
+    setActiveTab(tab);
+    setSelectedItem(null);
+    setSelectedPacks(1);
+  }, []);
+
+  // Drug-specific detail rendering
+  const isDrug = (item: CatalogItem): item is DrugCatalogItemData => {
+    return "addictionType" in item;
+  };
+
+  return (
+    <BaseModalRoot isOpen={isOpen} onClose={handleClose} size="2xl">
+      {({ close }) => (
+        <div className="flex max-h-[85vh] flex-col overflow-hidden">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
+            <div>
+              <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                Purchase Drugs & Toxins
+              </h2>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                <span className="font-mono text-emerald-600 dark:text-emerald-400">
+                  {formatCurrency(remaining)}¥
+                </span>{" "}
+                available
+              </p>
+            </div>
+            <button
+              onClick={close}
+              className="rounded-lg p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          {/* Tab Filters */}
+          <div className="flex gap-1.5 border-b border-zinc-100 px-6 py-3 dark:border-zinc-800">
+            <button
+              onClick={() => handleTabChange("drugs")}
+              className={`flex items-center gap-1.5 rounded-full px-4 py-1.5 text-xs font-medium transition-colors ${
+                activeTab === "drugs"
+                  ? "bg-emerald-600 text-white"
+                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+              }`}
+            >
+              <Pill className="h-3.5 w-3.5" />
+              Drugs
+              <span
+                className={
+                  activeTab === "drugs" ? "text-emerald-100" : "text-zinc-400 dark:text-zinc-500"
+                }
+              >
+                ({drugsCatalog.length})
+              </span>
+            </button>
+            <button
+              onClick={() => handleTabChange("toxins")}
+              className={`flex items-center gap-1.5 rounded-full px-4 py-1.5 text-xs font-medium transition-colors ${
+                activeTab === "toxins"
+                  ? "bg-emerald-600 text-white"
+                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+              }`}
+            >
+              <FlaskConical className="h-3.5 w-3.5" />
+              Toxins
+              <span
+                className={
+                  activeTab === "toxins" ? "text-emerald-100" : "text-zinc-400 dark:text-zinc-500"
+                }
+              >
+                ({toxinsCatalog.length})
+              </span>
+            </button>
+          </div>
+
+          {/* Search */}
+          <div className="border-b border-zinc-100 px-6 py-3 dark:border-zinc-800">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+              <input
+                type="text"
+                placeholder={`Search ${activeTab}...`}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full rounded-lg border border-zinc-200 bg-white py-2 pl-10 pr-4 text-sm text-zinc-900 placeholder-zinc-400 focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+              />
+            </div>
+          </div>
+
+          {/* Content - Split Pane */}
+          <div className="flex flex-1 overflow-hidden">
+            {/* Left: Item List */}
+            <div className="w-1/2 space-y-2 overflow-y-auto border-r border-zinc-100 p-4 dark:border-zinc-800">
+              {currentItems.length === 0 ? (
+                <p className="py-8 text-center text-sm text-zinc-500">No {activeTab} found</p>
+              ) : (
+                currentItems.map((item) => {
+                  const isAlreadyAdded = purchasedIds.includes(item.id);
+                  const isOverAvailability = item.availability > MAX_AVAILABILITY;
+                  return (
+                    <CatalogListItem
+                      key={item.id}
+                      item={item}
+                      isSelected={selectedItem?.id === item.id}
+                      canAfford={item.cost <= remaining}
+                      isAlreadyAdded={isAlreadyAdded}
+                      isOverAvailability={isOverAvailability}
+                      onClick={() => handleSelectItem(item)}
+                    />
+                  );
+                })
+              )}
+            </div>
+
+            {/* Right: Detail Preview */}
+            <div className="w-1/2 overflow-y-auto p-4">
+              {selectedItem ? (
+                <div className="space-y-4">
+                  {/* Item Name */}
+                  <div>
+                    <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                      {selectedItem.name}
+                    </h3>
+                    <p className="text-sm capitalize text-zinc-500 dark:text-zinc-400">
+                      {selectedItem.category}
+                    </p>
+                  </div>
+
+                  {/* Description */}
+                  {selectedItem.description && (
+                    <p className="text-sm text-zinc-600 dark:text-zinc-400">
+                      {selectedItem.description}
+                    </p>
+                  )}
+
+                  {/* Vector Badges */}
+                  <div className="flex flex-wrap gap-1.5">
+                    {selectedItem.vector.map((v) => (
+                      <span
+                        key={v}
+                        className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+                      >
+                        {v}
+                      </span>
+                    ))}
+                  </div>
+
+                  {/* Drug-specific Details */}
+                  {isDrug(selectedItem) && (
+                    <>
+                      {/* Addiction Info */}
+                      <div className="rounded-lg bg-amber-50 p-3 dark:bg-amber-900/20">
+                        <span className="text-xs font-semibold uppercase tracking-wider text-amber-700 dark:text-amber-300">
+                          Addiction
+                        </span>
+                        <div className="mt-1 grid grid-cols-3 gap-2 text-xs">
+                          <div>
+                            <span className="text-amber-600 dark:text-amber-400">Type</span>
+                            <p className="font-medium capitalize text-amber-800 dark:text-amber-200">
+                              {selectedItem.addictionType}
+                            </p>
+                          </div>
+                          <div>
+                            <span className="text-amber-600 dark:text-amber-400">Rating</span>
+                            <p className="font-medium text-amber-800 dark:text-amber-200">
+                              {selectedItem.addictionRating}
+                            </p>
+                          </div>
+                          <div>
+                            <span className="text-amber-600 dark:text-amber-400">Threshold</span>
+                            <p className="font-medium text-amber-800 dark:text-amber-200">
+                              {selectedItem.addictionThreshold}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Active Effects */}
+                      {selectedItem.effects.active && (
+                        <div>
+                          <span className="text-xs font-semibold uppercase tracking-wider text-emerald-600 dark:text-emerald-400">
+                            Active Effects
+                          </span>
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {Object.entries(selectedItem.effects.active)
+                              .filter(([key]) => key !== "description")
+                              .map(([key, value]) => (
+                                <span
+                                  key={key}
+                                  className="rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                                >
+                                  {key}: {String(value)}
+                                </span>
+                              ))}
+                          </div>
+                          {Boolean(
+                            (selectedItem.effects.active as Record<string, unknown>).description
+                          ) && (
+                            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                              {String(
+                                (selectedItem.effects.active as Record<string, unknown>).description
+                              )}
+                            </p>
+                          )}
+                        </div>
+                      )}
+
+                      {/* Crash Effects */}
+                      {selectedItem.effects.crash && (
+                        <div>
+                          <span className="text-xs font-semibold uppercase tracking-wider text-red-600 dark:text-red-400">
+                            Crash Effects
+                          </span>
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {Object.entries(selectedItem.effects.crash)
+                              .filter(([key]) => key !== "description")
+                              .map(([key, value]) => (
+                                <span
+                                  key={key}
+                                  className="rounded bg-red-50 px-1.5 py-0.5 text-[10px] text-red-700 dark:bg-red-900/30 dark:text-red-300"
+                                >
+                                  {key}: {String(value)}
+                                </span>
+                              ))}
+                          </div>
+                          {Boolean(
+                            (selectedItem.effects.crash as Record<string, unknown>).description
+                          ) && (
+                            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                              {String(
+                                (selectedItem.effects.crash as Record<string, unknown>).description
+                              )}
+                            </p>
+                          )}
+                        </div>
+                      )}
+                    </>
+                  )}
+
+                  {/* Toxin-specific Details */}
+                  {!isDrug(selectedItem) && (
+                    <>
+                      {/* Power & Penetration */}
+                      <div className="grid grid-cols-2 gap-3">
+                        <div className="rounded-lg bg-purple-50 p-3 dark:bg-purple-900/20">
+                          <span className="text-xs text-purple-600 dark:text-purple-400">
+                            Power
+                          </span>
+                          <p className="text-lg font-bold text-purple-800 dark:text-purple-200">
+                            {(selectedItem as ToxinCatalogItemData).power}
+                          </p>
+                        </div>
+                        <div className="rounded-lg bg-purple-50 p-3 dark:bg-purple-900/20">
+                          <span className="text-xs text-purple-600 dark:text-purple-400">
+                            Penetration
+                          </span>
+                          <p className="text-lg font-bold text-purple-800 dark:text-purple-200">
+                            {(selectedItem as ToxinCatalogItemData).penetration}
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Effects */}
+                      {(selectedItem as ToxinCatalogItemData).effects.length > 0 && (
+                        <div>
+                          <span className="text-xs font-semibold uppercase tracking-wider text-purple-600 dark:text-purple-400">
+                            Effects
+                          </span>
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {(selectedItem as ToxinCatalogItemData).effects.map((effect) => (
+                              <span
+                                key={effect}
+                                className="rounded bg-purple-50 px-1.5 py-0.5 text-[10px] text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+                              >
+                                {effect.replace(/-/g, " ")}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  )}
+
+                  {/* Common Stats */}
+                  <div className="space-y-2">
+                    <span className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                      Statistics
+                    </span>
+                    <div className="flex justify-between rounded bg-zinc-50 px-3 py-2 text-sm dark:bg-zinc-800">
+                      <span className="text-zinc-500 dark:text-zinc-400">Speed</span>
+                      <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                        {selectedItem.speed}
+                      </span>
+                    </div>
+                    {"duration" in selectedItem && selectedItem.duration && (
+                      <div className="flex justify-between rounded bg-zinc-50 px-3 py-2 text-sm dark:bg-zinc-800">
+                        <span className="text-zinc-500 dark:text-zinc-400">Duration</span>
+                        <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                          {selectedItem.duration}
+                        </span>
+                      </div>
+                    )}
+                    <div className="flex justify-between rounded bg-zinc-50 px-3 py-2 text-sm dark:bg-zinc-800">
+                      <span className="text-zinc-500 dark:text-zinc-400">Availability</span>
+                      <span
+                        className={`font-medium ${
+                          selectedItem.legality === "forbidden"
+                            ? "text-red-600 dark:text-red-400"
+                            : selectedItem.legality === "restricted"
+                              ? "text-amber-600 dark:text-amber-400"
+                              : "text-zinc-900 dark:text-zinc-100"
+                        }`}
+                      >
+                        {getAvailabilityDisplay(selectedItem.availability, selectedItem.legality)}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Quantity Selector */}
+                  <BulkQuantitySelector
+                    packSize={1}
+                    unitLabel="doses"
+                    pricePerPack={selectedItem.cost}
+                    remaining={remaining}
+                    selectedPacks={selectedPacks}
+                    onPacksChange={setSelectedPacks}
+                    packLabel="dose"
+                  />
+
+                  {/* Legality Warning */}
+                  {(selectedItem.legality === "restricted" ||
+                    selectedItem.legality === "forbidden") && (
+                    <div
+                      className={`rounded-lg p-3 ${
+                        selectedItem.legality === "forbidden"
+                          ? "bg-red-50 dark:bg-red-900/20"
+                          : "bg-amber-50 dark:bg-amber-900/20"
+                      }`}
+                    >
+                      <div
+                        className={`flex items-center gap-2 text-sm font-medium ${
+                          selectedItem.legality === "forbidden"
+                            ? "text-red-700 dark:text-red-300"
+                            : "text-amber-700 dark:text-amber-300"
+                        }`}
+                      >
+                        <AlertTriangle className="h-4 w-4" />
+                        {selectedItem.legality === "forbidden" ? "Forbidden" : "Restricted"}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Availability Warning */}
+                  {!availabilityOk && (
+                    <div className="rounded-lg bg-red-50 p-3 dark:bg-red-900/20">
+                      <div className="flex items-center gap-2 text-sm font-medium text-red-700 dark:text-red-300">
+                        <AlertTriangle className="h-4 w-4" />
+                        Availability exceeds {MAX_AVAILABILITY} for character creation
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="flex h-full items-center justify-center text-zinc-400 dark:text-zinc-500">
+                  <p className="text-sm">
+                    Select {activeTab === "drugs" ? "a drug" : "a toxin"} to see details
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <ModalFooter>
+            <div className="text-sm text-zinc-500 dark:text-zinc-400">
+              {addedThisSession > 0 && (
+                <span className="mr-2 text-emerald-600 dark:text-emerald-400">
+                  {addedThisSession} added
+                </span>
+              )}
+              <span className="font-mono font-medium text-zinc-900 dark:text-zinc-100">
+                {formatCurrency(remaining)}¥
+              </span>{" "}
+              remaining
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={close}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+              >
+                Done
+              </button>
+              <button
+                onClick={handlePurchase}
+                disabled={!canPurchase}
+                className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+                  canPurchase
+                    ? "bg-amber-500 text-white hover:bg-amber-600"
+                    : "cursor-not-allowed bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
+                }`}
+              >
+                {canPurchase && selectedItem
+                  ? `Add ${selectedPacks > 1 ? `${selectedPacks} doses` : "1 dose"} (${formatCurrency(selectedItemCost)}¥)`
+                  : `Add ${activeTab === "drugs" ? "Drug" : "Toxin"}`}
+              </button>
+            </div>
+          </ModalFooter>
+        </div>
+      )}
+    </BaseModalRoot>
+  );
+}

--- a/components/creation/drugs-toxins/ToxinRow.tsx
+++ b/components/creation/drugs-toxins/ToxinRow.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+/**
+ * ToxinRow
+ *
+ * Compact display for a purchased toxin item.
+ * Line 1: Name, qty badge, legality badge, cost, remove
+ * Line 2: Vector • Power • Penetration
+ * Expandable for full effects and description.
+ */
+
+import { useState } from "react";
+import type { GearItem } from "@/lib/types";
+import { LegalityBadge } from "@/components/creation/shared/LegalityBadge";
+import { ChevronDown, ChevronRight, X } from "lucide-react";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "decimal",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+interface ToxinRowProps {
+  toxin: GearItem;
+  onRemove: (id: string) => void;
+}
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+export function ToxinRow({ toxin, onRemove }: ToxinRowProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const totalCost = toxin.cost * toxin.quantity;
+
+  // Extract toxin-specific metadata stored during purchase
+  const meta = (toxin as GearItem & { metadata?: Record<string, unknown> }).metadata;
+  const vector = (meta?.vector as string[]) || [];
+  const speed = (meta?.speed as string) || "";
+  const power = (meta?.power as number) ?? 0;
+  const penetration = (meta?.penetration as number) ?? 0;
+  const effects = (meta?.effects as string[]) || [];
+  const duration = (meta?.duration as string) || "";
+  const description = (meta?.description as string) || toxin.notes || "";
+
+  return (
+    <div className="py-1.5">
+      {/* Line 1: Name and controls */}
+      <div className="flex items-center justify-between">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+          </button>
+
+          <span className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">
+            {toxin.name}
+          </span>
+
+          {toxin.quantity > 1 && (
+            <span className="shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+              x{toxin.quantity}
+            </span>
+          )}
+          <LegalityBadge legality={toxin.legality} availability={toxin.availability} />
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <span className="font-mono text-sm font-medium text-zinc-900 dark:text-zinc-100">
+            {formatCurrency(totalCost)}¥
+          </span>
+          <div className="mx-2 h-5 w-px bg-zinc-300 dark:bg-zinc-600" />
+          <button
+            onClick={() => toxin.id && onRemove(toxin.id)}
+            className="rounded p-1 text-zinc-400 hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+            title="Remove toxin"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+
+      {/* Line 2: Vector, power, penetration */}
+      <div className="ml-5 mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
+        {vector.length > 0 && vector.join(", ")}
+        {power > 0 && ` • Power ${power}`}
+        {penetration !== 0 && ` • Pen ${penetration}`}
+      </div>
+
+      {/* Expanded Details */}
+      {isExpanded && (
+        <div className="ml-5 mt-2 space-y-2 border-l-2 border-zinc-200 pl-3 dark:border-zinc-700">
+          {/* Stats Grid */}
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+            {speed && (
+              <div className="flex justify-between">
+                <span className="text-zinc-500 dark:text-zinc-400">Speed</span>
+                <span className="font-medium text-zinc-700 dark:text-zinc-300">{speed}</span>
+              </div>
+            )}
+            {duration && (
+              <div className="flex justify-between">
+                <span className="text-zinc-500 dark:text-zinc-400">Duration</span>
+                <span className="font-medium text-zinc-700 dark:text-zinc-300">{duration}</span>
+              </div>
+            )}
+            <div className="flex justify-between">
+              <span className="text-zinc-500 dark:text-zinc-400">Cost/dose</span>
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                {formatCurrency(toxin.cost)}¥
+              </span>
+            </div>
+          </div>
+
+          {/* Effects */}
+          {effects.length > 0 && (
+            <div>
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-purple-600 dark:text-purple-400">
+                Effects
+              </span>
+              <div className="mt-1 flex flex-wrap gap-1">
+                {effects.map((effect) => (
+                  <span
+                    key={effect}
+                    className="rounded bg-purple-50 px-1.5 py-0.5 text-[10px] text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+                  >
+                    {effect.replace(/-/g, " ")}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Description */}
+          {description && <p className="text-xs text-zinc-600 dark:text-zinc-400">{description}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/creation/drugs-toxins/__tests__/DrugsPanel.test.tsx
+++ b/components/creation/drugs-toxins/__tests__/DrugsPanel.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * DrugsPanel Component Tests
+ *
+ * Tests the drugs & toxins purchasing card in character creation.
+ * Covers: locked state, empty state, rendering with items, and footer totals.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DrugsPanel } from "../DrugsPanel";
+
+// Mock the hooks used by DrugsPanel
+vi.mock("@/lib/rules/RulesetContext", () => ({
+  useDrugs: vi.fn(),
+  useToxins: vi.fn(),
+}));
+
+vi.mock("@/lib/contexts", () => ({
+  useCreationBudgets: vi.fn(),
+}));
+
+// Mock lucide-react icons
+vi.mock("lucide-react", () => ({
+  Lock: () => <span data-testid="lock-icon" />,
+  Plus: () => <span data-testid="plus-icon" />,
+  Pill: () => <span data-testid="pill-icon" />,
+  FlaskConical: () => <span data-testid="flask-icon" />,
+  ChevronDown: () => <span data-testid="chevron-down" />,
+  ChevronRight: () => <span data-testid="chevron-right" />,
+  X: () => <span data-testid="x-icon" />,
+  Search: () => <span data-testid="search-icon" />,
+  Check: () => <span data-testid="check-icon" />,
+  AlertTriangle: () => <span data-testid="alert-icon" />,
+  Package: () => <span data-testid="package-icon" />,
+  Info: () => <span data-testid="info-icon" />,
+}));
+
+// Mock the shared components
+vi.mock("@/components/creation/shared", () => ({
+  CreationCard: ({
+    children,
+    title,
+    status,
+    headerAction,
+  }: {
+    children: React.ReactNode;
+    title: string;
+    description?: string;
+    status?: string;
+    headerAction?: React.ReactNode;
+  }) => (
+    <div data-testid="creation-card" data-status={status}>
+      <h3>{title}</h3>
+      {headerAction}
+      {children}
+    </div>
+  ),
+  EmptyState: ({ message }: { message: string }) => <div data-testid="empty-state">{message}</div>,
+  SummaryFooter: ({ count, total }: { count: number; total: number; format?: string }) => (
+    <div data-testid="summary-footer">
+      {count} items • {total}¥
+    </div>
+  ),
+  KarmaConversionModal: () => null,
+  useKarmaConversionPrompt: () => ({
+    modalState: { isOpen: false, itemName: "", itemCost: 0, karmaToConvert: 0 },
+    closeModal: vi.fn(),
+    confirmConversion: vi.fn(),
+    checkPurchase: vi.fn(),
+    promptConversion: vi.fn(),
+    currentRemaining: 0,
+    karmaAvailable: 0,
+    currentKarmaConversion: 0,
+    maxKarmaConversion: 0,
+  }),
+  LegalityWarnings: () => null,
+}));
+
+// Mock UI components
+vi.mock("@/components/ui", () => ({
+  InfoTooltip: () => null,
+  BaseModalRoot: () => null,
+  ModalFooter: () => null,
+}));
+
+// Mock child components that have their own hook dependencies
+vi.mock("../DrugsPurchaseModal", () => ({
+  DrugsPurchaseModal: () => null,
+}));
+
+vi.mock("../DrugRow", () => ({
+  DrugRow: ({ drug }: { drug: { name: string } }) => <div data-testid="drug-row">{drug.name}</div>,
+}));
+
+vi.mock("../ToxinRow", () => ({
+  ToxinRow: ({ toxin }: { toxin: { name: string } }) => (
+    <div data-testid="toxin-row">{toxin.name}</div>
+  ),
+}));
+
+import { useCreationBudgets } from "@/lib/contexts";
+import type { CreationState } from "@/lib/types";
+
+// =============================================================================
+// TEST DATA
+// =============================================================================
+
+const mockBudgets = {
+  getBudget: (id: string) => {
+    if (id === "nuyen") return { total: 50000, spent: 10000, remaining: 40000 };
+    if (id === "karma") return { total: 25, spent: 0, remaining: 25 };
+    return undefined;
+  },
+  budgets: {
+    nuyen: { total: 50000, spent: 10000, remaining: 40000 },
+    karma: { total: 25, spent: 0, remaining: 25 },
+  },
+};
+
+function makeState(overrides: Partial<CreationState> = {}): CreationState {
+  return {
+    editionCode: "sr5",
+    method: "priority",
+    step: "sheet",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    selections: {},
+    priorities: {
+      metatype: "A",
+      attributes: "B",
+      magic: "C",
+      skills: "D",
+      resources: "E",
+    },
+    budgets: {},
+    ...overrides,
+  } as CreationState;
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("DrugsPanel", () => {
+  beforeEach(() => {
+    (useCreationBudgets as Mock).mockReturnValue(mockBudgets);
+  });
+
+  it("shows locked state when priorities not set", () => {
+    const state = makeState({ priorities: undefined });
+    const updateState = vi.fn();
+
+    render(<DrugsPanel state={state} updateState={updateState} />);
+
+    expect(screen.getByText("Set priorities first")).toBeDefined();
+  });
+
+  it("shows empty state with no items", () => {
+    const state = makeState();
+    const updateState = vi.fn();
+
+    render(<DrugsPanel state={state} updateState={updateState} />);
+
+    expect(screen.getByTestId("empty-state")).toBeDefined();
+    expect(screen.getByText("No drugs or toxins purchased")).toBeDefined();
+  });
+
+  it("renders drug rows when drugs are selected", () => {
+    const state = makeState({
+      selections: {
+        drugs: [
+          {
+            id: "bliss-123",
+            name: "Bliss",
+            category: "drug",
+            cost: 15,
+            quantity: 3,
+            availability: 3,
+            legality: "forbidden" as const,
+          },
+          {
+            id: "jazz-456",
+            name: "Jazz",
+            category: "drug",
+            cost: 75,
+            quantity: 1,
+            availability: 2,
+            legality: "restricted" as const,
+          },
+        ],
+      },
+    });
+    const updateState = vi.fn();
+
+    render(<DrugsPanel state={state} updateState={updateState} />);
+
+    expect(screen.getByText("Bliss")).toBeDefined();
+    expect(screen.getByText("Jazz")).toBeDefined();
+    expect(screen.getByText(/Drugs \(2\)/)).toBeDefined();
+  });
+
+  it("renders toxin rows when toxins are selected", () => {
+    const state = makeState({
+      selections: {
+        toxins: [
+          {
+            id: "narcoject-789",
+            name: "Narcoject",
+            category: "toxin",
+            cost: 50,
+            quantity: 2,
+            availability: 8,
+            legality: "restricted" as const,
+          },
+        ],
+      },
+    });
+    const updateState = vi.fn();
+
+    render(<DrugsPanel state={state} updateState={updateState} />);
+
+    expect(screen.getByText("Narcoject")).toBeDefined();
+    expect(screen.getByText(/Toxins \(1\)/)).toBeDefined();
+  });
+
+  it("shows correct totals in footer", () => {
+    const state = makeState({
+      selections: {
+        drugs: [{ id: "bliss-1", name: "Bliss", category: "drug", cost: 15, quantity: 5 }],
+        toxins: [
+          { id: "narcoject-1", name: "Narcoject", category: "toxin", cost: 50, quantity: 2 },
+        ],
+      },
+    });
+    const updateState = vi.fn();
+
+    render(<DrugsPanel state={state} updateState={updateState} />);
+
+    // 2 items total (1 drug + 1 toxin), cost = 75 + 100 = 175
+    expect(screen.getByTestId("summary-footer")).toBeDefined();
+    expect(screen.getByText("2 items • 175¥")).toBeDefined();
+  });
+
+  it("has Add button in header when priorities are set", () => {
+    const state = makeState();
+    const updateState = vi.fn();
+
+    render(<DrugsPanel state={state} updateState={updateState} />);
+
+    expect(screen.getByText("Add")).toBeDefined();
+  });
+});

--- a/components/creation/drugs-toxins/index.ts
+++ b/components/creation/drugs-toxins/index.ts
@@ -1,0 +1,1 @@
+export { DrugsPanel } from "./DrugsPanel";

--- a/components/creation/index.ts
+++ b/components/creation/index.ts
@@ -17,6 +17,7 @@ export { FociCard } from "./foci";
 export { GearPanel } from "./gear";
 export { WeaponsPanel } from "./WeaponsPanel";
 export { ArmorPanel } from "./armor";
+export { DrugsPanel } from "./drugs-toxins";
 export { MatrixGearCard } from "./matrix-gear";
 export { AugmentationsCard } from "./AugmentationsCard";
 export { VehiclesCard } from "./VehiclesCard";

--- a/lib/contexts/CreationBudgetContext.tsx
+++ b/lib/contexts/CreationBudgetContext.tsx
@@ -488,6 +488,8 @@ function extractSpentValues(
   const commlinks = (selections.commlinks || []) as Array<{ cost: number }>;
   const cyberdecks = (selections.cyberdecks || []) as Array<{ cost: number }>;
   const software = (selections.software || []) as Array<{ cost: number }>;
+  const drugs = (selections.drugs || []) as Array<{ cost: number; quantity: number }>;
+  const toxins = (selections.toxins || []) as Array<{ cost: number; quantity: number }>;
   const identities = (selections.identities || []) as Array<{
     sin: { type: string; rating: number };
     licenses?: Array<{ type: string; rating: number }>;
@@ -554,6 +556,12 @@ function extractSpentValues(
   const cyberdecksSpent = cyberdecks.reduce((sum, d) => sum + (d.cost || 0), 0);
   const softwareSpent = software.reduce((sum, s) => sum + (s.cost || 0), 0);
 
+  // Calculate drugs spending
+  const drugsSpent = drugs.reduce((sum, d) => sum + d.cost * (d.quantity || 1), 0);
+
+  // Calculate toxins spending
+  const toxinsSpent = toxins.reduce((sum, t) => sum + t.cost * (t.quantity || 1), 0);
+
   // Calculate identity spending (fake SINs and licenses)
   // Fake SIN: Rating × 2,500¥, Fake License: Rating × 200¥
   const SIN_COST_PER_RATING = 2500;
@@ -584,6 +592,8 @@ function extractSpentValues(
     commlinksSpent +
     cyberdecksSpent +
     softwareSpent +
+    drugsSpent +
+    toxinsSpent +
     identitiesSpent;
 
   // ============================================================================

--- a/lib/rules/RulesetContext.tsx
+++ b/lib/rules/RulesetContext.tsx
@@ -50,6 +50,8 @@ import type {
   ActionsCatalogData,
   DataSoftwareCatalogData,
   DataSoftwareCatalogItemData,
+  DrugCatalogItemData,
+  ToxinCatalogItemData,
 } from "./loader-types";
 export type {
   QualityData,
@@ -81,6 +83,8 @@ export type {
   ActionsCatalogData,
   DataSoftwareCatalogData,
   DataSoftwareCatalogItemData,
+  DrugCatalogItemData,
+  ToxinCatalogItemData,
 };
 
 // =============================================================================
@@ -317,6 +321,8 @@ export interface GearCatalogData {
   industrialChemicals: GearItemData[];
   visionEnhancements?: GearItemData[];
   audioEnhancements?: GearItemData[];
+  drugs?: DrugCatalogItemData[];
+  toxins?: ToxinCatalogItemData[];
 }
 
 export interface SpellData {
@@ -981,6 +987,22 @@ export function useRulesetStatus(): {
 export function useGear(): GearCatalogData | null {
   const { data } = useRuleset();
   return data.gear;
+}
+
+/**
+ * Hook to get drugs catalog from gear module
+ */
+export function useDrugs(): DrugCatalogItemData[] {
+  const { data } = useRuleset();
+  return data.gear?.drugs || [];
+}
+
+/**
+ * Hook to get toxins catalog from gear module
+ */
+export function useToxins(): ToxinCatalogItemData[] {
+  const { data } = useRuleset();
+  return data.gear?.toxins || [];
 }
 
 /**

--- a/lib/rules/loader-types.ts
+++ b/lib/rules/loader-types.ts
@@ -432,6 +432,56 @@ export interface SensorsCatalogData {
 }
 
 /**
+ * Drug catalog item data structure
+ */
+export interface DrugCatalogItemData {
+  id: string;
+  name: string;
+  category: string;
+  vector: string[];
+  speed: string;
+  duration: string;
+  addictionType: string;
+  addictionRating: number;
+  addictionThreshold: number;
+  effects: {
+    active: Record<string, unknown> | null;
+    crash: Record<string, unknown> | null;
+  };
+  cost: number;
+  availability: number;
+  legality?: ItemLegality;
+  stackable?: boolean;
+  consumable?: boolean;
+  description?: string;
+  page?: number;
+  source?: string;
+}
+
+/**
+ * Toxin catalog item data structure
+ */
+export interface ToxinCatalogItemData {
+  id: string;
+  name: string;
+  category: string;
+  vector: string[];
+  speed: string;
+  penetration: number;
+  power: number;
+  effects: string[];
+  duration?: string;
+  cost: number;
+  availability: number;
+  legality?: ItemLegality;
+  stackable?: boolean;
+  consumable?: boolean;
+  description?: string;
+  page?: number;
+  source?: string;
+}
+
+/**
  * Gear catalog data structure
  */
 export interface GearCatalogData {
@@ -465,6 +515,8 @@ export interface GearCatalogData {
   security: GearItemData[];
   miscellaneous: GearItemData[];
   ammunition: GearItemData[];
+  drugs?: DrugCatalogItemData[];
+  toxins?: ToxinCatalogItemData[];
 }
 
 // =============================================================================

--- a/lib/types/creation-selections.ts
+++ b/lib/types/creation-selections.ts
@@ -250,6 +250,8 @@ export interface GearSelections {
   commlinks?: CharacterCommlink[];
   cyberdecks?: CharacterCyberdeck[];
   software?: CharacterDataSoftware[];
+  drugs?: GearItem[];
+  toxins?: GearItem[];
 }
 
 /**
@@ -405,7 +407,9 @@ export function hasGearSelections(selections: CreationSelections): boolean {
   const hasGear = Array.isArray(selections.gear) && selections.gear.length > 0;
   const hasWeapons = Array.isArray(selections.weapons) && selections.weapons.length > 0;
   const hasArmor = Array.isArray(selections.armor) && selections.armor.length > 0;
-  return hasGear || hasWeapons || hasArmor;
+  const hasDrugs = Array.isArray(selections.drugs) && selections.drugs.length > 0;
+  const hasToxins = Array.isArray(selections.toxins) && selections.toxins.length > 0;
+  return hasGear || hasWeapons || hasArmor || hasDrugs || hasToxins;
 }
 
 /**
@@ -584,6 +588,20 @@ export function getBioware(selections: CreationSelections): BiowareItem[] {
  */
 export function getGear(selections: CreationSelections): GearItem[] {
   return (selections.gear || []) as GearItem[];
+}
+
+/**
+ * Safely get drugs
+ */
+export function getDrugs(selections: CreationSelections): GearItem[] {
+  return (selections.drugs || []) as GearItem[];
+}
+
+/**
+ * Safely get toxins
+ */
+export function getToxins(selections: CreationSelections): GearItem[] {
+  return (selections.toxins || []) as GearItem[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a combined Drugs & Toxins panel to character creation for browsing and purchasing drugs (10 items) and toxins (9 items) from the SR5 core rulebook catalog
- Includes split-pane purchase modal with Drug/Toxin tabs, quantity selection, availability enforcement (max 12), legality badges, and nuyen budget tracking with karma conversion support
- Adds `DrugCatalogItemData` and `ToxinCatalogItemData` types, `useDrugs()`/`useToxins()` hooks, budget calculation integration, and layout integration in both SheetCreationLayout and GearTabsCard

## Test plan
- [x] `pnpm type-check` passes with no errors
- [x] `pnpm test` — all 300 test files pass (6733 tests), including 12 new tests
- [x] `pnpm lint` — 0 errors (only pre-existing warnings)
- [ ] Manual: Open character creation sheet, verify DrugsPanel renders after Armor
- [ ] Manual: Open purchase modal, browse drugs/toxins catalog, add items with quantities
- [ ] Manual: Verify nuyen budget decreases correctly after purchases
- [ ] Manual: Verify availability restrictions (e.g., Seven-7 shown grayed out at avail 20F)
- [ ] Manual: Verify legality badges on restricted/forbidden items
- [ ] Manual: Verify karma conversion prompt triggers when over budget

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)