### PR TITLE
fix(creation): Auto-select mundane path for Priority E magic

### DIFF
--- a/app/characters/create/sheet/components/SheetCreationLayout.tsx
+++ b/app/characters/create/sheet/components/SheetCreationLayout.tsx
@@ -644,7 +644,8 @@ function ValidationSummary({
 
     if (Object.keys(priorities).length < 5) items.push("Set all 5 priorities");
     if (!selections.metatype) items.push("Select a metatype");
-    if (!selections["magical-path"]) items.push("Select a magic/resonance path");
+    if (!selections["magical-path"] && priorities?.magic !== "E")
+      items.push("Select a magic/resonance path");
 
     // Tradition required for magician, mystic-adept, aspected-mage
     const TRADITION_PATHS = ["magician", "mystic-adept", "aspected-mage"];

--- a/components/creation/magic-path/MagicPathCard.tsx
+++ b/components/creation/magic-path/MagicPathCard.tsx
@@ -15,7 +15,7 @@
  * - Mentor spirit selection (optional quality)
  */
 
-import { useMemo, useCallback, useState } from "react";
+import { useMemo, useCallback, useState, useEffect } from "react";
 import {
   useMagicPaths,
   usePriorityTable,
@@ -278,6 +278,18 @@ export function MagicPathCard({ state, updateState }: MagicPathCardProps) {
   const selectedTraditionData = traditions.find((t) => t.id === selectedTradition);
   const selectedMentorData = mentorSpirits.find((m) => m.id === selectedMentorSpiritId);
 
+  // Mundane only (Priority E) - computed before early returns so the effect hook is always called
+  const isMundaneOnly = availableOptions.length === 0;
+
+  // Auto-select mundane path for Priority E
+  useEffect(() => {
+    if (isMundaneOnly && !selectedPath) {
+      updateState({
+        selections: { ...state.selections, "magical-path": "mundane" },
+      });
+    }
+  }, [isMundaneOnly, selectedPath, state.selections, updateState]);
+
   // Validation status
   const validationStatus = useMemo(() => {
     if (!magicPriority) return "pending";
@@ -299,8 +311,6 @@ export function MagicPathCard({ state, updateState }: MagicPathCardProps) {
     );
   }
 
-  // Mundane only (Priority E)
-  const isMundaneOnly = availableOptions.length === 0;
   if (isMundaneOnly) {
     return (
       <CreationCard


### PR DESCRIPTION
## Summary
- **MagicPathCard** displayed "Mundane (auto)" visually for Priority E but never persisted `selections["magical-path"] = "mundane"` to state, causing a spurious "Select a magic/resonance path" validation warning
- Added a `useEffect` to auto-write the mundane selection when priority E is detected
- Added a belt-and-suspenders guard in `SheetCreationLayout` validation to skip the check for Priority E, preventing a flash before the effect fires

## Test plan
- [ ] `pnpm type-check` passes
- [ ] `pnpm test` — all 6733 tests pass
- [ ] `pnpm lint` — no new warnings
- [ ] Load character with magic priority E — no "Select a magic/resonance path" validation warning
- [ ] Create new character, set magic priority E — card shows "Mundane (auto)", no validation warning
- [ ] Change priority from E to higher — user is prompted to select a path

🤖 Generated with [Claude Code](https://claude.com/claude-code)