### PR TITLE
fix(creation): Add font-mono to numerical stats and standardize nuyen bar colors

### DIFF
--- a/components/creation/AdeptPowersCard.tsx
+++ b/components/creation/AdeptPowersCard.tsx
@@ -416,7 +416,7 @@ export function AdeptPowersCard({ state, updateState }: AdeptPowersCardProps) {
                   Split Magic between spells and powers
                 </div>
               </div>
-              <div className="text-lg font-bold text-amber-600 dark:text-amber-400">
+              <div className="text-lg font-mono font-bold text-amber-600 dark:text-amber-400">
                 {basePowerPointBudget} / {magicRating}
               </div>
             </div>

--- a/components/creation/AttributesCard.tsx
+++ b/components/creation/AttributesCard.tsx
@@ -202,7 +202,7 @@ function InlineAttributeRow({
           </button>
 
           <div
-            className="flex h-7 w-8 items-center justify-center rounded bg-zinc-100 text-sm font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
+            className="flex h-7 w-8 items-center justify-center rounded bg-zinc-100 text-sm font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
             aria-live="polite"
             aria-atomic="true"
           >
@@ -304,7 +304,7 @@ function SpecialAttributeRow({
           </button>
 
           <div
-            className={`flex h-7 w-8 items-center justify-center rounded text-sm font-bold ${config.bgColor} ${config.textColor}`}
+            className={`flex h-7 w-8 items-center justify-center rounded text-sm font-mono font-bold ${config.bgColor} ${config.textColor}`}
             aria-live="polite"
             aria-atomic="true"
           >

--- a/components/creation/AugmentationsCard.tsx
+++ b/components/creation/AugmentationsCard.tsx
@@ -829,14 +829,14 @@ export function AugmentationsCard({ state, updateState }: AugmentationsCardProps
                   </span>
                 )}
               </span>
-              <span className="font-medium text-zinc-900 dark:text-zinc-100">
+              <span className="font-mono font-medium text-zinc-900 dark:text-zinc-100">
                 {formatCurrency(totalSpent)} / {formatCurrency(totalNuyen)}
               </span>
             </div>
             <div className="h-2 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
               <div
                 className={`h-full transition-all ${
-                  remainingNuyen < 0 ? "bg-red-500" : "bg-blue-500"
+                  remainingNuyen < 0 ? "bg-red-500" : "bg-emerald-500"
                 }`}
                 style={{
                   width: `${Math.min(100, (totalSpent / totalNuyen) * 100)}%`,

--- a/components/creation/ComplexFormsCard.tsx
+++ b/components/creation/ComplexFormsCard.tsx
@@ -212,25 +212,25 @@ export function ComplexFormsCard({ state, updateState }: ComplexFormsCardProps) 
           </div>
           <div className="mt-2 grid grid-cols-4 gap-2 text-center text-xs">
             <div>
-              <div className="font-bold text-cyan-900 dark:text-cyan-100">
+              <div className="font-mono font-bold text-cyan-900 dark:text-cyan-100">
                 {livingPersona.attack}
               </div>
               <div className="text-cyan-600 dark:text-cyan-400">ATK</div>
             </div>
             <div>
-              <div className="font-bold text-cyan-900 dark:text-cyan-100">
+              <div className="font-mono font-bold text-cyan-900 dark:text-cyan-100">
                 {livingPersona.sleaze}
               </div>
               <div className="text-cyan-600 dark:text-cyan-400">SLZ</div>
             </div>
             <div>
-              <div className="font-bold text-cyan-900 dark:text-cyan-100">
+              <div className="font-mono font-bold text-cyan-900 dark:text-cyan-100">
                 {livingPersona.dataProcessing}
               </div>
               <div className="text-cyan-600 dark:text-cyan-400">DP</div>
             </div>
             <div>
-              <div className="font-bold text-cyan-900 dark:text-cyan-100">
+              <div className="font-mono font-bold text-cyan-900 dark:text-cyan-100">
                 {livingPersona.firewall}
               </div>
               <div className="text-cyan-600 dark:text-cyan-400">FW</div>

--- a/components/creation/DerivedStatsCard.tsx
+++ b/components/creation/DerivedStatsCard.tsx
@@ -78,7 +78,7 @@ function StatBlock({
       title={tooltip}
     >
       <div className={`text-[10px] font-medium ${labelColorClass}`}>{label}</div>
-      <div className={`font-bold ${textColorClass}`}>{value}</div>
+      <div className={`font-mono font-bold ${textColorClass}`}>{value}</div>
     </div>
   );
 }
@@ -358,7 +358,7 @@ export function DerivedStatsCard({ state }: DerivedStatsCardProps) {
         {augmentationEffects.essenceLoss > 0 && (
           <div className="rounded border border-amber-200 bg-amber-50 p-2 text-center dark:border-amber-800 dark:bg-amber-900/20">
             <div className="text-xs font-medium text-amber-600 dark:text-amber-400">Essence</div>
-            <div className="font-bold text-amber-700 dark:text-amber-300">
+            <div className="font-mono font-bold text-amber-700 dark:text-amber-300">
               {derivedStats.essence.toFixed(2)}
             </div>
             <div className="text-[10px] text-amber-500">

--- a/components/creation/SkillsCard.tsx
+++ b/components/creation/SkillsCard.tsx
@@ -158,7 +158,7 @@ function SkillGroupCard({
 
           {/* Show rating badge for broken groups (read-only) */}
           {isBroken && (
-            <div className="flex h-7 w-8 items-center justify-center rounded bg-zinc-200 text-sm font-bold text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400">
+            <div className="flex h-7 w-8 items-center justify-center rounded bg-zinc-200 text-sm font-mono font-bold text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400">
               {rating}
             </div>
           )}

--- a/components/creation/VehiclesCard.tsx
+++ b/components/creation/VehiclesCard.tsx
@@ -500,7 +500,7 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
             </div>
             <div className="h-2 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
               <div
-                className={`h-full transition-all ${remaining < 0 ? "bg-red-500" : "bg-blue-500"}`}
+                className={`h-full transition-all ${remaining < 0 ? "bg-red-500" : "bg-emerald-500"}`}
                 style={{ width: `${Math.min(100, (totalSpent / totalNuyen) * 100)}%` }}
               />
             </div>

--- a/components/creation/armor/ArmorModificationModal.tsx
+++ b/components/creation/armor/ArmorModificationModal.tsx
@@ -442,7 +442,7 @@ export function ArmorModificationModal({
                         >
                           <Minus className="h-4 w-4" />
                         </button>
-                        <div className="flex h-10 w-12 items-center justify-center rounded bg-zinc-100 text-lg font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+                        <div className="flex h-10 w-12 items-center justify-center rounded bg-zinc-100 text-lg font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
                           {selectedRating}
                         </div>
                         <button

--- a/components/creation/augmentations/AugmentationModal.tsx
+++ b/components/creation/augmentations/AugmentationModal.tsx
@@ -1128,7 +1128,7 @@ export function AugmentationModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Essence</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             hasEssence
                               ? isCyberware
                                 ? "text-cyan-600 dark:text-cyan-400"
@@ -1142,7 +1142,7 @@ export function AugmentationModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Cost</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             canAfford
                               ? "text-zinc-900 dark:text-zinc-100"
                               : "text-red-600 dark:text-red-400"
@@ -1154,7 +1154,7 @@ export function AugmentationModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Availability</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             meetsAvailability
                               ? "text-zinc-900 dark:text-zinc-100"
                               : "text-red-600 dark:text-red-400"

--- a/components/creation/augmentations/CyberlimbAccessoryModal.tsx
+++ b/components/creation/augmentations/CyberlimbAccessoryModal.tsx
@@ -391,7 +391,7 @@ export function CyberlimbAccessoryModal({
                           >
                             <Minus className="h-4 w-4" />
                           </button>
-                          <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+                          <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
                             {rating}
                           </div>
                           <button
@@ -419,7 +419,7 @@ export function CyberlimbAccessoryModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Capacity</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             fitsCapacity
                               ? "text-sky-600 dark:text-sky-400"
                               : "text-red-600 dark:text-red-400"
@@ -431,7 +431,7 @@ export function CyberlimbAccessoryModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Cost</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             canAfford
                               ? "text-zinc-900 dark:text-zinc-100"
                               : "text-red-600 dark:text-red-400"
@@ -443,7 +443,7 @@ export function CyberlimbAccessoryModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Availability</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             meetsAvailability
                               ? "text-zinc-900 dark:text-zinc-100"
                               : "text-red-600 dark:text-red-400"

--- a/components/creation/augmentations/CyberlimbWeaponModal.tsx
+++ b/components/creation/augmentations/CyberlimbWeaponModal.tsx
@@ -358,7 +358,7 @@ export function CyberlimbWeaponModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Capacity</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             fitsCapacity
                               ? "text-red-600 dark:text-red-400"
                               : "text-red-600 dark:text-red-400"
@@ -370,7 +370,7 @@ export function CyberlimbWeaponModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Cost</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             canAfford
                               ? "text-zinc-900 dark:text-zinc-100"
                               : "text-red-600 dark:text-red-400"
@@ -382,7 +382,7 @@ export function CyberlimbWeaponModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Availability</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             meetsAvailability
                               ? "text-zinc-900 dark:text-zinc-100"
                               : "text-amber-600 dark:text-amber-400"

--- a/components/creation/augmentations/CyberwareEnhancementModal.tsx
+++ b/components/creation/augmentations/CyberwareEnhancementModal.tsx
@@ -428,7 +428,7 @@ export function CyberwareEnhancementModal({
                           >
                             <Minus className="h-4 w-4" />
                           </button>
-                          <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+                          <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
                             {rating}
                           </div>
                           <button
@@ -456,7 +456,7 @@ export function CyberwareEnhancementModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Capacity</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             fitsCapacity
                               ? "text-blue-600 dark:text-blue-400"
                               : "text-red-600 dark:text-red-400"
@@ -468,7 +468,7 @@ export function CyberwareEnhancementModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Cost</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             canAfford
                               ? "text-zinc-900 dark:text-zinc-100"
                               : "text-red-600 dark:text-red-400"
@@ -480,7 +480,7 @@ export function CyberwareEnhancementModal({
                       <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
                         <div className="text-xs text-zinc-500 dark:text-zinc-400">Availability</div>
                         <div
-                          className={`mt-1 text-xl font-bold ${
+                          className={`mt-1 text-xl font-mono font-bold ${
                             meetsAvailability
                               ? "text-zinc-900 dark:text-zinc-100"
                               : "text-red-600 dark:text-red-400"

--- a/components/creation/contacts/ContactKarmaConfirmModal.tsx
+++ b/components/creation/contacts/ContactKarmaConfirmModal.tsx
@@ -93,21 +93,21 @@ export function ContactKarmaConfirmModal({
               <div className="flex items-center justify-center gap-4">
                 <div className="flex flex-col items-center">
                   <span className="text-xs text-zinc-500 dark:text-zinc-400">Connection</span>
-                  <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-lg font-bold text-blue-700 dark:bg-blue-900/50 dark:text-blue-300">
+                  <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-lg font-mono font-bold text-blue-700 dark:bg-blue-900/50 dark:text-blue-300">
                     {connection}
                   </div>
                 </div>
                 <span className="text-xl text-zinc-300 dark:text-zinc-600">+</span>
                 <div className="flex flex-col items-center">
                   <span className="text-xs text-zinc-500 dark:text-zinc-400">Loyalty</span>
-                  <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-lg bg-rose-100 text-lg font-bold text-rose-700 dark:bg-rose-900/50 dark:text-rose-300">
+                  <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-lg bg-rose-100 text-lg font-mono font-bold text-rose-700 dark:bg-rose-900/50 dark:text-rose-300">
                     {loyalty}
                   </div>
                 </div>
                 <span className="text-xl text-zinc-300 dark:text-zinc-600">=</span>
                 <div className="flex flex-col items-center">
                   <span className="text-xs text-zinc-500 dark:text-zinc-400">Total</span>
-                  <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-100 text-lg font-bold text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-300">
+                  <div className="mt-1 flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-100 text-lg font-mono font-bold text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-300">
                     {contactKarmaCost}
                   </div>
                 </div>

--- a/components/creation/drugs-toxins/DrugsPurchaseModal.tsx
+++ b/components/creation/drugs-toxins/DrugsPurchaseModal.tsx
@@ -493,7 +493,7 @@ export function DrugsPurchaseModal({
                           <span className="text-xs text-purple-600 dark:text-purple-400">
                             Power
                           </span>
-                          <p className="text-lg font-bold text-purple-800 dark:text-purple-200">
+                          <p className="text-lg font-mono font-bold text-purple-800 dark:text-purple-200">
                             {(selectedItem as ToxinCatalogItemData).power}
                           </p>
                         </div>
@@ -501,7 +501,7 @@ export function DrugsPurchaseModal({
                           <span className="text-xs text-purple-600 dark:text-purple-400">
                             Penetration
                           </span>
-                          <p className="text-lg font-bold text-purple-800 dark:text-purple-200">
+                          <p className="text-lg font-mono font-bold text-purple-800 dark:text-purple-200">
                             {(selectedItem as ToxinCatalogItemData).penetration}
                           </p>
                         </div>

--- a/components/creation/foci/FocusModal.tsx
+++ b/components/creation/foci/FocusModal.tsx
@@ -288,7 +288,7 @@ export function FocusModal({
                     >
                       <Minus className="h-4 w-4" />
                     </button>
-                    <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+                    <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
                       {force}
                     </div>
                     <button
@@ -367,20 +367,20 @@ export function FocusModal({
                   <div className="grid grid-cols-3 gap-4 text-center">
                     <div>
                       <div className="text-xs text-zinc-500 dark:text-zinc-400">Cost</div>
-                      <div className="mt-1 text-lg font-bold text-zinc-900 dark:text-zinc-100">
+                      <div className="mt-1 text-lg font-mono font-bold text-zinc-900 dark:text-zinc-100">
                         {cost.toLocaleString()}¥
                       </div>
                     </div>
                     <div>
                       <div className="text-xs text-zinc-500 dark:text-zinc-400">Bonding</div>
-                      <div className="mt-1 text-lg font-bold text-purple-600 dark:text-purple-400">
+                      <div className="mt-1 text-lg font-mono font-bold text-purple-600 dark:text-purple-400">
                         {karmaToBond} karma
                       </div>
                     </div>
                     <div>
                       <div className="text-xs text-zinc-500 dark:text-zinc-400">Availability</div>
                       <div
-                        className={`mt-1 text-lg font-bold ${
+                        className={`mt-1 text-lg font-mono font-bold ${
                           exceedsAvailability
                             ? "text-red-600 dark:text-red-400"
                             : "text-zinc-900 dark:text-zinc-100"

--- a/components/creation/gear/GearModificationModal.tsx
+++ b/components/creation/gear/GearModificationModal.tsx
@@ -389,7 +389,7 @@ export function GearModificationModal({
                         >
                           <Minus className="h-4 w-4" />
                         </button>
-                        <div className="flex h-10 w-12 items-center justify-center rounded bg-zinc-100 text-lg font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+                        <div className="flex h-10 w-12 items-center justify-center rounded bg-zinc-100 text-lg font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
                           {selectedRating}
                         </div>
                         <button

--- a/components/creation/gear/GearPurchaseModal.tsx
+++ b/components/creation/gear/GearPurchaseModal.tsx
@@ -705,7 +705,7 @@ export function GearPurchaseModal({
                         >
                           <Minus className="h-4 w-4" />
                         </button>
-                        <div className="flex h-10 w-12 items-center justify-center rounded bg-zinc-100 text-lg font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+                        <div className="flex h-10 w-12 items-center justify-center rounded bg-zinc-100 text-lg font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
                           {selectedRating}
                         </div>
                         <button

--- a/components/creation/knowledge-languages/LanguageRow.tsx
+++ b/components/creation/knowledge-languages/LanguageRow.tsx
@@ -27,7 +27,7 @@ export function LanguageRow({ language, onRatingChange, onRemove }: LanguageRowP
       <div className="flex items-center gap-1">
         {isNative ? (
           <>
-            <div className="flex h-7 w-8 items-center justify-center rounded bg-purple-100 text-sm font-bold text-purple-700 dark:bg-purple-900/50 dark:text-purple-300">
+            <div className="flex h-7 w-8 items-center justify-center rounded bg-purple-100 text-sm font-mono font-bold text-purple-700 dark:bg-purple-900/50 dark:text-purple-300">
               N
             </div>
             {/* Separator */}

--- a/components/creation/matrix-gear/MatrixGearCard.tsx
+++ b/components/creation/matrix-gear/MatrixGearCard.tsx
@@ -580,7 +580,7 @@ export function MatrixGearCard({ state, updateState }: MatrixGearCardProps) {
             </div>
             <div className="h-2 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
               <div
-                className={`h-full transition-all ${isOverBudget ? "bg-red-500" : "bg-blue-500"}`}
+                className={`h-full transition-all ${isOverBudget ? "bg-red-500" : "bg-emerald-500"}`}
                 style={{
                   width: `${Math.min(100, (totalSpent / totalNuyen) * 100)}%`,
                 }}

--- a/components/creation/qualities/QualitySelectionModal.tsx
+++ b/components/creation/qualities/QualitySelectionModal.tsx
@@ -723,7 +723,7 @@ export function QualitySelectionModal({
                           Karma {isPositive ? "Cost" : "Gain"}
                         </span>
                         <span
-                          className={`text-2xl font-bold ${
+                          className={`text-2xl font-mono font-bold ${
                             isPositive
                               ? "text-blue-600 dark:text-blue-400"
                               : "text-orange-600 dark:text-orange-400"

--- a/components/creation/shared/BudgetIndicator.tsx
+++ b/components/creation/shared/BudgetIndicator.tsx
@@ -174,7 +174,9 @@ export function BudgetIndicator({
         {/* Header: label and remaining value */}
         <div className="flex items-center justify-between">
           <div className="text-sm font-medium text-zinc-900 dark:text-zinc-100">{label}</div>
-          <div className={`text-lg font-bold ${getCardValueColor()}`}>{formatValue(remaining)}</div>
+          <div className={`text-lg font-mono font-bold ${getCardValueColor()}`}>
+            {formatValue(remaining)}
+          </div>
         </div>
 
         {/* Description */}

--- a/components/creation/shared/Stepper.tsx
+++ b/components/creation/shared/Stepper.tsx
@@ -175,7 +175,7 @@ export function Stepper({
 
         {/* Value display */}
         <div
-          className={`flex h-7 w-8 items-center justify-center rounded text-sm font-bold ${VALUE_DISPLAY_CLASSES[valueColor]}`}
+          className={`flex h-7 w-8 items-center justify-center rounded text-sm font-mono font-bold ${VALUE_DISPLAY_CLASSES[valueColor]}`}
           aria-live="polite"
           aria-atomic="true"
         >

--- a/components/creation/skills/SkillCustomizeModal.tsx
+++ b/components/creation/skills/SkillCustomizeModal.tsx
@@ -218,7 +218,7 @@ export function SkillCustomizeModal({
                     <Minus className="h-4 w-4" />
                   </button>
                   <div className="flex items-baseline gap-2">
-                    <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                    <span className="text-2xl font-mono font-bold text-zinc-900 dark:text-zinc-100">
                       {targetRating}
                     </span>
                     {targetRating > currentRating && (

--- a/components/creation/skills/SkillGroupBreakModal.tsx
+++ b/components/creation/skills/SkillGroupBreakModal.tsx
@@ -159,7 +159,7 @@ export function SkillGroupBreakModal({
                     Karma Cost
                   </span>
                   <span
-                    className={`text-lg font-bold ${
+                    className={`text-lg font-mono font-bold ${
                       isOverBudget
                         ? "text-red-600 dark:text-red-400"
                         : "text-zinc-900 dark:text-zinc-100"

--- a/components/creation/skills/SkillGroupKarmaConfirmModal.tsx
+++ b/components/creation/skills/SkillGroupKarmaConfirmModal.tsx
@@ -88,11 +88,11 @@ export function SkillGroupKarmaConfirmModal({
 
               {/* Rating change display */}
               <div className="flex items-center justify-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-purple-100 text-xl font-bold text-purple-700 dark:bg-purple-900/50 dark:text-purple-300">
+                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-purple-100 text-xl font-mono font-bold text-purple-700 dark:bg-purple-900/50 dark:text-purple-300">
                   {currentRating}
                 </div>
                 <ArrowRight className="h-5 w-5 text-amber-500" />
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-amber-100 text-xl font-bold text-amber-700 dark:bg-amber-900/50 dark:text-amber-300">
+                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-amber-100 text-xl font-mono font-bold text-amber-700 dark:bg-amber-900/50 dark:text-amber-300">
                   {newRating}
                 </div>
               </div>

--- a/components/creation/skills/SkillGroupModal.tsx
+++ b/components/creation/skills/SkillGroupModal.tsx
@@ -363,7 +363,7 @@ export function SkillGroupModal({
                         >
                           <Minus className="h-4 w-4" />
                         </button>
-                        <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+                        <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
                           {rating}
                         </div>
                         <button

--- a/components/creation/skills/SkillKarmaConfirmModal.tsx
+++ b/components/creation/skills/SkillKarmaConfirmModal.tsx
@@ -82,11 +82,11 @@ export function SkillKarmaConfirmModal({
 
               {/* Rating change display */}
               <div className="flex items-center justify-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-zinc-100 text-xl font-bold text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-zinc-100 text-xl font-mono font-bold text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
                   {currentRating}
                 </div>
                 <ArrowRight className="h-5 w-5 text-amber-500" />
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-amber-100 text-xl font-bold text-amber-700 dark:bg-amber-900/50 dark:text-amber-300">
+                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-amber-100 text-xl font-mono font-bold text-amber-700 dark:bg-amber-900/50 dark:text-amber-300">
                   {newRating}
                 </div>
               </div>

--- a/components/creation/skills/SkillListItem.tsx
+++ b/components/creation/skills/SkillListItem.tsx
@@ -175,7 +175,7 @@ export function SkillListItem({
             // Group skill: read-only rating display with customize button
             <>
               <div
-                className={`flex h-7 w-8 items-center justify-center rounded text-sm font-bold ${ratingBgColor}`}
+                className={`flex h-7 w-8 items-center justify-center rounded text-sm font-mono font-bold ${ratingBgColor}`}
               >
                 {rating}
               </div>

--- a/components/creation/skills/SkillModal.tsx
+++ b/components/creation/skills/SkillModal.tsx
@@ -445,7 +445,7 @@ export function SkillModal({
                           <Minus className="h-4 w-4" />
                         </button>
                         <div
-                          className={`flex h-10 w-14 items-center justify-center rounded-lg text-xl font-bold ${
+                          className={`flex h-10 w-14 items-center justify-center rounded-lg text-xl font-mono font-bold ${
                             usingKarma
                               ? "bg-amber-100 text-amber-900 dark:bg-amber-900/50 dark:text-amber-100"
                               : "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"

--- a/components/creation/vehicles/AutosoftModal.tsx
+++ b/components/creation/vehicles/AutosoftModal.tsx
@@ -385,7 +385,7 @@ export function AutosoftModal({
                         >
                           <Minus className="h-4 w-4" />
                         </button>
-                        <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+                        <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
                           {selectedRating}
                         </div>
                         <button

--- a/components/creation/vehicles/RCCModal.tsx
+++ b/components/creation/vehicles/RCCModal.tsx
@@ -316,7 +316,7 @@ export function RCCModal({
                         <div className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
                           Device Rating
                         </div>
-                        <div className="mt-1 text-2xl font-bold text-blue-600 dark:text-blue-400">
+                        <div className="mt-1 text-2xl font-mono font-bold text-blue-600 dark:text-blue-400">
                           {selectedRCC.deviceRating}
                         </div>
                       </div>
@@ -324,7 +324,7 @@ export function RCCModal({
                         <div className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
                           Data Processing
                         </div>
-                        <div className="mt-1 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                        <div className="mt-1 text-2xl font-mono font-bold text-zinc-900 dark:text-zinc-100">
                           {selectedRCC.dataProcessing}
                         </div>
                       </div>
@@ -332,7 +332,7 @@ export function RCCModal({
                         <div className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
                           Firewall
                         </div>
-                        <div className="mt-1 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                        <div className="mt-1 text-2xl font-mono font-bold text-zinc-900 dark:text-zinc-100">
                           {selectedRCC.firewall}
                         </div>
                       </div>

--- a/components/creation/vehicles/VehicleSystemModal.tsx
+++ b/components/creation/vehicles/VehicleSystemModal.tsx
@@ -1011,7 +1011,7 @@ export function VehicleSystemModal({
             <div className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
               Device Rating
             </div>
-            <div className="mt-1 text-2xl font-bold text-purple-600 dark:text-purple-400">
+            <div className="mt-1 text-2xl font-mono font-bold text-purple-600 dark:text-purple-400">
               {rcc.deviceRating}
             </div>
           </div>
@@ -1019,13 +1019,13 @@ export function VehicleSystemModal({
             <div className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
               Data Processing
             </div>
-            <div className="mt-1 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+            <div className="mt-1 text-2xl font-mono font-bold text-zinc-900 dark:text-zinc-100">
               {rcc.dataProcessing}
             </div>
           </div>
           <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
             <div className="text-xs font-medium text-zinc-500 dark:text-zinc-400">Firewall</div>
-            <div className="mt-1 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+            <div className="mt-1 text-2xl font-mono font-bold text-zinc-900 dark:text-zinc-100">
               {rcc.firewall}
             </div>
           </div>
@@ -1088,7 +1088,7 @@ export function VehicleSystemModal({
             >
               <Minus className="h-4 w-4" />
             </button>
-            <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+            <div className="flex h-10 w-14 items-center justify-center rounded-lg bg-zinc-100 text-xl font-mono font-bold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
               {selectedRating}
             </div>
             <button


### PR DESCRIPTION
## Summary

- Add `font-mono` to all numerical game stat displays (attribute values, skill ratings, dice pools, costs, damage codes, essence, availability) across 32 creation components for consistent typography per the Shadowrun aesthetic guide
- Standardize nuyen progress bar colors from `bg-blue-500` to `bg-emerald-500` in VehiclesCard, MatrixGearCard, and AugmentationsCard to match the existing convention in WeaponsPanel, ArmorPanel, GearPanel, and DrugsPanel
- Add `font-mono` to AugmentationsCard nuyen total display

## Test plan

- [ ] Open character creation sheet and verify attribute values display in monospace font
- [ ] Verify derived stats (limits, initiative, condition monitors) display in monospace
- [ ] Verify skill ratings display in monospace across skill list, modals, and karma confirm dialogs
- [ ] Verify all nuyen progress bars use consistent emerald color (weapons, armor, gear, drugs, vehicles, matrix gear, augmentations)
- [ ] Check light mode and dark mode both render correctly
- [ ] `pnpm type-check` passes
- [ ] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)