### PR TITLE
fix(creation): Add missing barrel exports for shared components

### DIFF
--- a/components/creation/shared/index.ts
+++ b/components/creation/shared/index.ts
@@ -21,3 +21,7 @@ export { RatingSelector, useRatingSelection } from "./RatingSelector";
 export { LegalityWarnings } from "./LegalityWarnings";
 export type { LegalityWarningItem } from "./LegalityWarnings";
 export { LegalityBadge } from "./LegalityBadge";
+export { BulkQuantitySelector } from "./BulkQuantitySelector";
+export type { BulkQuantitySelectorProps } from "./BulkQuantitySelector";
+export { LifestyleModificationSelector } from "./LifestyleModificationSelector";
+export { LifestyleSubscriptionSelector } from "./LifestyleSubscriptionSelector";


### PR DESCRIPTION
## Summary
- Add 3 missing exports to `components/creation/shared/index.ts`: `BulkQuantitySelector`, `LifestyleModificationSelector`, and `LifestyleSubscriptionSelector`
- Brings consistency with the other 14 exports already in the barrel file

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (300 files, 6736 tests)

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)