### PR TITLE
fix(creation): Complete subdirectory barrel exports for consistency

### DIFF
--- a/components/creation/contacts/index.ts
+++ b/components/creation/contacts/index.ts
@@ -1,2 +1,3 @@
 export { ContactsCard } from "./ContactsCard";
 export { ContactKarmaConfirmModal } from "./ContactKarmaConfirmModal";
+export { ContactModal } from "./ContactModal";

--- a/components/creation/drugs-toxins/index.ts
+++ b/components/creation/drugs-toxins/index.ts
@@ -1,1 +1,4 @@
 export { DrugsPanel } from "./DrugsPanel";
+export { DrugRow } from "./DrugRow";
+export { ToxinRow } from "./ToxinRow";
+export { DrugsPurchaseModal } from "./DrugsPurchaseModal";

--- a/components/creation/identities/index.ts
+++ b/components/creation/identities/index.ts
@@ -1,1 +1,6 @@
 export { IdentitiesCard } from "./IdentitiesCard";
+export { IdentityCard } from "./IdentityCard";
+export { IdentityModal } from "./IdentityModal";
+export { LicenseModal } from "./LicenseModal";
+export { LifestyleModal } from "./LifestyleModal";
+export { Modal } from "./Modal";

--- a/components/creation/knowledge-languages/index.ts
+++ b/components/creation/knowledge-languages/index.ts
@@ -1,2 +1,5 @@
 export { KnowledgeLanguagesCard } from "./KnowledgeLanguagesCard";
 export { KnowledgeSkillSpecModal } from "./KnowledgeSkillSpecModal";
+export { KnowledgeLanguageModal } from "./KnowledgeLanguageModal";
+export { KnowledgeSkillRow } from "./KnowledgeSkillRow";
+export { LanguageRow } from "./LanguageRow";

--- a/components/creation/magic-path/index.ts
+++ b/components/creation/magic-path/index.ts
@@ -1,1 +1,2 @@
 export { MagicPathCard } from "./MagicPathCard";
+export { MagicPathModal } from "./MagicPathModal";

--- a/components/creation/metatype/index.ts
+++ b/components/creation/metatype/index.ts
@@ -1,1 +1,2 @@
 export { MetatypeCard } from "./MetatypeCard";
+export { MetatypeModal } from "./MetatypeModal";

--- a/components/creation/qualities/index.ts
+++ b/components/creation/qualities/index.ts
@@ -1,1 +1,3 @@
 export { QualitiesCard } from "./QualitiesCard";
+export { QualitySelectionModal } from "./QualitySelectionModal";
+export { SelectedQualityCard } from "./SelectedQualityCard";


### PR DESCRIPTION
## Summary
- Add missing component exports to 7 creation subdirectory `index.ts` files (contacts, drugs-toxins, identities, knowledge-languages, magic-path, metatype, qualities)
- Brings consistency with well-organized directories like `armor/` and `skills/` that already export all their `.tsx` components
- Adds exports for modals, rows, and helper components that were previously only accessible via direct file imports

Closes #299

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (300 files, 6736 tests)
- [x] Pre-commit hooks pass (lint, format, type-check)
- [x] Pre-push hooks pass (knip, CLAUDE.md validation)
- [x] No circular import issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)