### PR TITLE
feat(characters): Add per-character JSON export to characters list

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/rules";
 import { calculateLimit, calculateWoundModifier } from "@/lib/rules/qualities";
 import { ArrowLeft, Download, Pencil, Dice5, Printer, TrendingUp, Users, X } from "lucide-react";
+import { downloadCharacterJson } from "@/lib/utils";
 import { THEMES, DEFAULT_THEME, type Theme, type ThemeId } from "@/lib/themes";
 import { Section } from "./components/Section";
 import { InteractiveConditionMonitor } from "./components/InteractiveConditionMonitor";
@@ -433,16 +434,7 @@ function CharacterSheet({
 
   const initiative = (character.attributes?.reaction || 1) + (character.attributes?.intuition || 1);
 
-  const handleExport = () => {
-    const dataStr =
-      "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(character, null, 2));
-    const downloadAnchorNode = document.createElement("a");
-    downloadAnchorNode.setAttribute("href", dataStr);
-    downloadAnchorNode.setAttribute("download", `${character.name || "character"}.json`);
-    document.body.appendChild(downloadAnchorNode);
-    downloadAnchorNode.click();
-    downloadAnchorNode.remove();
-  };
+  const handleExport = () => downloadCharacterJson(character);
 
   // Dice roller open helper
   const openDiceRoller = (pool: number, context?: string) => {

--- a/app/characters/page.tsx
+++ b/app/characters/page.tsx
@@ -7,7 +7,8 @@ import { useAuth } from "@/lib/auth/AuthProvider";
 import { CharacterImportDialog } from "./components/CharacterImportDialog";
 import { StabilityShield } from "@/components/sync";
 import { BaseModalRoot, ModalBody, ModalFooter } from "@/components/ui";
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle, Download, X } from "lucide-react";
+import { downloadCharacterJson } from "@/lib/utils";
 
 // Extended character type with owner info for admin mode
 interface CharacterWithOwner extends Character {
@@ -343,6 +344,7 @@ type ViewMode = "grid" | "list";
 interface CharacterCardProps {
   character: CharacterWithOwner;
   onDeleteClick: (character: CharacterWithOwner) => void;
+  onExportClick: (character: CharacterWithOwner) => void;
   viewMode?: ViewMode;
   isAdminMode?: boolean;
 }
@@ -350,6 +352,7 @@ interface CharacterCardProps {
 function CharacterCard({
   character,
   onDeleteClick,
+  onExportClick,
   viewMode = "grid",
   isAdminMode = false,
 }: CharacterCardProps) {
@@ -357,6 +360,12 @@ function CharacterCard({
     e.preventDefault();
     e.stopPropagation();
     onDeleteClick(character);
+  };
+
+  const handleExportClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onExportClick(character);
   };
 
   const cardClass = getArchetypeCardClass(character);
@@ -449,11 +458,18 @@ function CharacterCard({
               </div>
             </div>
 
-            {/* Date & Delete */}
+            {/* Date, Export & Delete */}
             <div className="flex items-center gap-3">
               <span className="text-xs text-muted-foreground hidden md:block font-mono">
                 {new Date(character.updatedAt || character.createdAt).toLocaleDateString()}
               </span>
+              <button
+                onClick={handleExportClick}
+                className="p-1.5 rounded text-muted-foreground hover:text-emerald-500 hover:bg-emerald-500/10 transition-colors opacity-0 group-hover:opacity-100"
+                aria-label={`Export ${character.name || "character"}`}
+              >
+                <Download className="w-4 h-4" />
+              </button>
               <button
                 onClick={handleDeleteClick}
                 className="p-1.5 rounded text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors opacity-0 group-hover:opacity-100"
@@ -561,6 +577,13 @@ function CharacterCard({
               <span className="text-xs text-muted-foreground font-mono">
                 {new Date(character.updatedAt || character.createdAt).toLocaleDateString()}
               </span>
+              <button
+                onClick={handleExportClick}
+                className="p-1.5 rounded text-muted-foreground hover:text-emerald-500 hover:bg-emerald-500/10 transition-colors opacity-0 group-hover:opacity-100"
+                aria-label={`Export ${character.name || "character"}`}
+              >
+                <Download className="w-4 h-4" />
+              </button>
               <button
                 onClick={handleDeleteClick}
                 className="p-1.5 rounded text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors opacity-0 group-hover:opacity-100"
@@ -753,6 +776,10 @@ export default function CharactersPage() {
 
   const handleDeleteClick = (character: CharacterWithOwner) => {
     setCharacterToDelete(character);
+  };
+
+  const handleExportClick = (character: CharacterWithOwner) => {
+    downloadCharacterJson(character);
   };
 
   const handleCloseDeleteModal = () => {
@@ -1071,6 +1098,7 @@ export default function CharactersPage() {
                       key={character.id}
                       character={character}
                       onDeleteClick={handleDeleteClick}
+                      onExportClick={handleExportClick}
                       viewMode="grid"
                       isAdminMode={isAdminMode}
                     />
@@ -1083,6 +1111,7 @@ export default function CharactersPage() {
                       key={character.id}
                       character={character}
                       onDeleteClick={handleDeleteClick}
+                      onExportClick={handleExportClick}
                       viewMode="list"
                       isAdminMode={isAdminMode}
                     />

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,18 @@
 export function cn(...classes: (string | undefined | null | false)[]) {
   return classes.filter(Boolean).join(" ");
 }
+
+export function downloadCharacterJson(character: { name?: string }) {
+  const slug = (character.name || "character")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const dataStr =
+    "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(character, null, 2));
+  const a = document.createElement("a");
+  a.setAttribute("href", dataStr);
+  a.setAttribute("download", `shadow-master-${slug}.json`);
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}


### PR DESCRIPTION
## Summary
- Extract `downloadCharacterJson()` utility to `lib/utils.ts` with kebab-case filenames matching the bulk export pattern (`shadow-master-<slug>.json`)
- Add export button (Download icon, emerald hover) to each character card in both grid and list views, alongside the existing delete button
- Refactor character sheet page to use the shared utility instead of inline export logic

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (6927 tests)
- [ ] Manual: hover over a character card in grid view → export button appears → click downloads JSON with kebab-case filename
- [ ] Manual: hover over a character card in list view → same behavior
- [ ] Manual: verify character sheet Export JSON button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)