### PR TITLE
refactor(sheet): Extract remaining inline sections into DisplayCard components

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -2,27 +2,16 @@
 
 import { useEffect, useState, use, useMemo, useCallback } from "react";
 import { Link, Button, Modal, ModalOverlay, Dialog, Heading } from "react-aria-components";
-import type { Character, AdeptPower, Vehicle, CharacterDrone, CharacterRCC } from "@/lib/types";
+import type { Character } from "@/lib/types";
 
 import { DiceRoller } from "@/components";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import AdminActionsPanel from "../components/AdminActionsPanel";
-import {
-  RulesetProvider,
-  useRuleset,
-  useMergedRuleset,
-  useRulesetStatus,
-  useSpells,
-  type SpellData,
-  type SpellsCatalogData,
-} from "@/lib/rules";
+import { RulesetProvider, useRuleset, useMergedRuleset, useRulesetStatus } from "@/lib/rules";
 import { calculateLimit, calculateWoundModifier } from "@/lib/rules/qualities";
 import { ArrowLeft, Download, Pencil, Dice5, Printer, TrendingUp, Users, X } from "lucide-react";
 import { downloadCharacterJson } from "@/lib/utils";
 import { THEMES, DEFAULT_THEME, type Theme, type ThemeId } from "@/lib/themes";
-import { Section } from "./components/Section";
-import { InteractiveConditionMonitor } from "./components/InteractiveConditionMonitor";
-import { CombatQuickReference } from "./components/CombatQuickReference";
 import { ActionPanel } from "./components/ActionPanel";
 import { QuickCombatControls } from "./components/QuickCombatControls";
 import { QuickNPCPanel } from "./components/QuickNPCPanel";
@@ -32,232 +21,28 @@ import { CombatSessionProvider } from "@/lib/combat";
 
 import {
   ATTRIBUTE_DISPLAY,
+  AdeptPowersDisplay,
   AttributesDisplay,
-  SkillsDisplay,
-  DerivedStatsDisplay,
-  KnowledgeLanguagesDisplay,
-  WeaponsDisplay,
-  ArmorDisplay,
-  GearDisplay,
-  AugmentationsDisplay,
+  CombatDisplay,
+  ComplexFormsDisplay,
+  ConditionDisplay,
   ContactsDisplay,
+  DerivedStatsDisplay,
+  DrugsDisplay,
+  FociDisplay,
+  GearDisplay,
   IdentitiesDisplay,
   CharacterInfoDisplay,
+  KnowledgeLanguagesDisplay,
+  LifestylesDisplay,
   QualitiesDisplay,
-  FociDisplay,
-  ComplexFormsDisplay,
+  SkillsDisplay,
+  SpellsDisplay,
+  VehiclesDisplay,
+  WeaponsDisplay,
+  ArmorDisplay,
+  AugmentationsDisplay,
 } from "@/components/character/sheet";
-
-// =============================================================================
-// SPELL CARD COMPONENT (uses theme + spellsCatalog — migrates in Phase 4)
-// =============================================================================
-
-interface SpellCardProps {
-  spellId: string;
-  spellsCatalog: SpellsCatalogData | null;
-  onSelect?: (pool: number, label: string) => void;
-  theme?: Theme;
-}
-
-function SpellCard({ spellId, spellsCatalog, onSelect, theme }: SpellCardProps) {
-  const t = theme || THEMES[DEFAULT_THEME];
-  const spell = useMemo(() => {
-    if (!spellsCatalog) return null;
-    for (const cat in spellsCatalog) {
-      const categorySpells = spellsCatalog[cat as keyof typeof spellsCatalog] as SpellData[];
-      const found = categorySpells.find((s) => s.id === spellId);
-      if (found) return found;
-    }
-    return null;
-  }, [spellId, spellsCatalog]);
-
-  if (!spell) return null;
-
-  return (
-    <div
-      onClick={() => onSelect?.(6, spell.name)}
-      className={`p-3 rounded transition-all cursor-pointer group ${t.components.card.wrapper} ${t.components.card.hover} ${t.id === "modern-card" ? t.components.card.border : "border-violet-500/50"}`}
-    >
-      <div className="flex items-start justify-between">
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <span
-              className={`text-sm font-bold text-foreground transition-colors ${t.id === "modern-card" ? "group-hover:text-foreground" : "group-hover:text-violet-400"}`}
-            >
-              {spell.name}
-            </span>
-            <span className="text-[10px] font-mono text-muted-foreground uppercase tracking-tighter px-1.5 py-0.5 border border-border rounded">
-              {spell.category}
-            </span>
-          </div>
-          <p className="text-[11px] text-muted-foreground line-clamp-2 leading-relaxed">
-            {spell.description}
-          </p>
-          <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] font-mono mt-1">
-            <div className="flex gap-1.5">
-              <span className="text-muted-foreground opacity-70">TYPE</span>
-              <span className="text-blue-400 uppercase">{spell.type}</span>
-            </div>
-            <div className="flex gap-1.5">
-              <span className="text-muted-foreground opacity-70">RANGE</span>
-              <span className="text-emerald-400 uppercase">{spell.range}</span>
-            </div>
-            <div className="flex gap-1.5">
-              <span className="text-muted-foreground opacity-70">DUR</span>
-              <span className="text-amber-400 uppercase">{spell.duration}</span>
-            </div>
-          </div>
-        </div>
-        <div className="text-right shrink-0">
-          <div className="text-[10px] text-muted-foreground uppercase font-mono leading-none mb-1">
-            Drain
-          </div>
-          <div className="text-sm font-mono text-violet-400 font-bold leading-none">
-            {spell.drain}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// =============================================================================
-// ADEPT POWER CARD COMPONENT (uses theme — migrates in Phase 4)
-// =============================================================================
-
-function AdeptPowerCard({ power, theme }: { power: AdeptPower; theme?: Theme }) {
-  const t = theme || THEMES[DEFAULT_THEME];
-  return (
-    <div
-      className={`p-3 rounded transition-all group ${t.components.card.wrapper} ${t.components.card.hover} ${t.id === "modern-card" ? t.components.card.border : "border-amber-500/50"}`}
-    >
-      <div className="flex items-start justify-between">
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <span
-              className={`text-sm font-bold text-foreground transition-colors ${t.id === "modern-card" ? "group-hover:text-foreground" : "group-hover:text-amber-400"}`}
-            >
-              {power.name}
-            </span>
-            {power.rating && (
-              <span className="text-[10px] font-mono text-amber-500 uppercase tracking-tighter px-1.5 py-0.5 border border-amber-500/30 rounded bg-amber-500/5">
-                Level {power.rating}
-              </span>
-            )}
-          </div>
-          {power.specification && (
-            <p className="text-[11px] text-muted-foreground font-mono italic">
-              Spec: {power.specification}
-            </p>
-          )}
-        </div>
-        <div className="text-right shrink-0">
-          <div className="text-[10px] text-muted-foreground uppercase font-mono leading-none mb-1">
-            Cost
-          </div>
-          <div className="text-sm font-mono text-amber-500 dark:text-amber-400 font-bold leading-none">
-            {power.powerPointCost} PP
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// =============================================================================
-// VEHICLE CARD COMPONENT (uses theme — migrates in Phase 4)
-// =============================================================================
-
-function VehicleCard({
-  vehicle,
-  theme,
-}: {
-  vehicle: Vehicle | CharacterDrone | CharacterRCC;
-  theme?: Theme;
-}) {
-  const isRCC = "deviceRating" in vehicle;
-  const isDrone = "size" in vehicle;
-  const t = theme || THEMES[DEFAULT_THEME];
-
-  return (
-    <div
-      className={`p-3 rounded transition-all group ${t.components.card.wrapper} ${t.components.card.hover} ${t.id === "modern-card" ? t.components.card.border : isRCC ? "border-orange-500/50" : "border-border/50"}`}
-    >
-      <div className="flex items-start justify-between mb-2">
-        <div>
-          <div
-            className={`font-bold text-foreground transition-colors ${t.id === "modern-card" ? "" : "group-hover:text-amber-400"}`}
-          >
-            {vehicle.name}
-          </div>
-          <div className="text-[10px] text-muted-foreground uppercase font-mono">
-            {isRCC ? "RCC" : isDrone ? `${(vehicle as CharacterDrone).size} Drone` : "Vehicle"}
-          </div>
-        </div>
-        {isRCC && (
-          <div className="text-right">
-            <div className="text-[10px] text-muted-foreground uppercase font-mono">Rating</div>
-            <div className="text-lg font-bold font-mono text-orange-400">
-              {(vehicle as CharacterRCC).deviceRating}
-            </div>
-          </div>
-        )}
-      </div>
-
-      {!isRCC && (
-        <div className="grid grid-cols-4 gap-2 text-center border-t border-border/50 pt-2">
-          <div className="space-y-0.5">
-            <div className="text-[9px] text-muted-foreground opacity-70 uppercase font-mono">
-              Hand
-            </div>
-            <div className="text-xs font-mono text-foreground/80">
-              {(vehicle as Vehicle).handling}
-            </div>
-          </div>
-          <div className="space-y-0.5">
-            <div className="text-[9px] text-muted-foreground opacity-70 uppercase font-mono">
-              Spd
-            </div>
-            <div className="text-xs font-mono text-foreground/80">{(vehicle as Vehicle).speed}</div>
-          </div>
-          <div className="space-y-0.5">
-            <div className="text-[9px] text-muted-foreground opacity-70 uppercase font-mono">
-              Body
-            </div>
-            <div className="text-xs font-mono text-foreground/80">{(vehicle as Vehicle).body}</div>
-          </div>
-          <div className="space-y-0.5">
-            <div className="text-[9px] text-muted-foreground opacity-70 uppercase font-mono">
-              Armor
-            </div>
-            <div className="text-xs font-mono text-foreground/80">{(vehicle as Vehicle).armor}</div>
-          </div>
-        </div>
-      )}
-
-      {isRCC && (
-        <div className="grid grid-cols-2 gap-4 text-center border-t border-border/50 pt-2">
-          <div className="space-y-0.5">
-            <div className="text-[9px] text-muted-foreground opacity-70 uppercase font-mono">
-              Data Proc
-            </div>
-            <div className="text-xs font-mono text-foreground/80">
-              {(vehicle as CharacterRCC).dataProcessing}
-            </div>
-          </div>
-          <div className="space-y-0.5">
-            <div className="text-[9px] text-muted-foreground opacity-70 uppercase font-mono">
-              Firewall
-            </div>
-            <div className="text-xs font-mono text-foreground/80">
-              {(vehicle as CharacterRCC).firewall}
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
 
 // =============================================================================
 // THEME SELECTOR
@@ -321,8 +106,6 @@ function CharacterSheet({
 }) {
   const { loadRuleset } = useRuleset();
   const { ready, loading: rulesetLoading } = useRulesetStatus();
-  const spellsCatalog = useSpells();
-
   const ruleset = useMergedRuleset();
 
   // Theme State
@@ -597,63 +380,23 @@ function CharacterSheet({
               initiative={initiative}
             />
 
-            {/* Condition Monitors (uses theme + InteractiveConditionMonitor — Phase 4) */}
-            <Section theme={theme} title="Condition">
-              <div className="space-y-6">
-                {woundModifier !== 0 && (
-                  <div
-                    className={`p-2 rounded text-center ${
-                      theme.id === "modern-card"
-                        ? "bg-amber-50 border border-amber-200 text-amber-700"
-                        : "bg-amber-500/10 border border-amber-500/30 text-amber-400"
-                    }`}
-                  >
-                    <span className="text-xs font-mono uppercase">Total Wound Modifier: </span>
-                    <span className="font-mono font-bold">{woundModifier}</span>
-                  </div>
-                )}
-                <div className="grid grid-cols-2 gap-4">
-                  <InteractiveConditionMonitor
-                    characterId={character.id}
-                    type="physical"
-                    current={character.condition?.physicalDamage ?? 0}
-                    max={physicalMonitorMax}
-                    theme={theme}
-                    readonly={character.status !== "draft" && character.status !== "active"}
-                    onDamageApplied={(newValue) => handleDamageApplied("physical", newValue)}
-                  />
-                  <InteractiveConditionMonitor
-                    characterId={character.id}
-                    type="stun"
-                    current={character.condition?.stunDamage ?? 0}
-                    max={stunMonitorMax}
-                    theme={theme}
-                    readonly={character.status !== "draft" && character.status !== "active"}
-                    onDamageApplied={(newValue) => handleDamageApplied("stun", newValue)}
-                  />
-                </div>
-                <InteractiveConditionMonitor
-                  characterId={character.id}
-                  type="overflow"
-                  current={character.condition?.overflowDamage ?? 0}
-                  max={character.attributes?.body || 3}
-                  theme={theme}
-                  readonly={character.status !== "draft" && character.status !== "active"}
-                  onDamageApplied={(newValue) => handleDamageApplied("overflow", newValue)}
-                />
-              </div>
-            </Section>
+            <ConditionDisplay
+              character={character}
+              woundModifier={woundModifier}
+              physicalMonitorMax={physicalMonitorMax}
+              stunMonitorMax={stunMonitorMax}
+              theme={theme}
+              readonly={character.status !== "draft" && character.status !== "active"}
+              onDamageApplied={handleDamageApplied}
+            />
 
-            {/* Combat Quick Reference */}
-            <Section theme={theme} title="Combat">
-              <CombatQuickReference
-                character={character}
-                woundModifier={woundModifier}
-                physicalLimit={physicalLimit}
-                theme={theme}
-                onPoolSelect={(pool, context) => openDiceRoller(pool, context)}
-              />
-            </Section>
+            <CombatDisplay
+              character={character}
+              woundModifier={woundModifier}
+              physicalLimit={physicalLimit}
+              theme={theme}
+              onPoolSelect={(pool, context) => openDiceRoller(pool, context)}
+            />
 
             {/* Action Panel */}
             <ActionPanel
@@ -689,49 +432,16 @@ function CharacterSheet({
               }}
             />
 
-            {/* Spells & Adept Powers (uses theme + spellsCatalog — Phase 4) */}
-            {(character.spells?.length || 0) > 0 || (character.adeptPowers?.length || 0) > 0 ? (
-              <Section theme={theme} title="Magic & Resonance">
-                <div className="space-y-4">
-                  {character.spells && character.spells.length > 0 && (
-                    <div>
-                      <span className="text-xs font-mono text-violet-500 uppercase mb-2 block">
-                        Spells
-                      </span>
-                      <div className="space-y-3">
-                        {character.spells.map((spellEntry, idx) => {
-                          const spellId =
-                            typeof spellEntry === "string"
-                              ? spellEntry
-                              : (spellEntry as { id: string }).id;
-                          return (
-                            <SpellCard
-                              theme={theme}
-                              key={spellId || idx}
-                              spellId={spellId}
-                              spellsCatalog={spellsCatalog}
-                              onSelect={(pool, label) => openDiceRoller(pool, label)}
-                            />
-                          );
-                        })}
-                      </div>
-                    </div>
-                  )}
-                  {character.adeptPowers && character.adeptPowers.length > 0 && (
-                    <div>
-                      <span className="text-xs font-mono text-amber-500 uppercase mb-2 block">
-                        Adept Powers
-                      </span>
-                      <div className="space-y-3">
-                        {character.adeptPowers.map((power, idx) => (
-                          <AdeptPowerCard theme={theme} key={idx} power={power} />
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </Section>
-            ) : null}
+            {character.spells && character.spells.length > 0 && (
+              <SpellsDisplay
+                spells={character.spells}
+                onSelect={(pool, label) => openDiceRoller(pool, label)}
+              />
+            )}
+
+            {character.adeptPowers && character.adeptPowers.length > 0 && (
+              <AdeptPowersDisplay adeptPowers={character.adeptPowers} />
+            )}
 
             {/* Complex Forms */}
             {character.complexForms && character.complexForms.length > 0 && (
@@ -764,22 +474,11 @@ function CharacterSheet({
 
             <AugmentationsDisplay character={character} />
 
-            {/* Vehicles & Assets (uses theme — Phase 4) */}
-            {character.vehicles?.length || character.drones?.length || character.rccs?.length ? (
-              <Section theme={theme} title="Gear & Assets">
-                <div className="space-y-3">
-                  {character.rccs?.map((rcc, idx) => (
-                    <VehicleCard theme={theme} key={`rcc-${idx}`} vehicle={rcc} />
-                  ))}
-                  {character.vehicles?.map((v, idx) => (
-                    <VehicleCard theme={theme} key={`veh-${idx}`} vehicle={v} />
-                  ))}
-                  {character.drones?.map((d, idx) => (
-                    <VehicleCard theme={theme} key={`drone-${idx}`} vehicle={d} />
-                  ))}
-                </div>
-              </Section>
-            ) : null}
+            <VehiclesDisplay
+              vehicles={character.vehicles}
+              drones={character.drones}
+              rccs={character.rccs}
+            />
 
             {/* Inventory Management Panel */}
             <InventoryPanel
@@ -795,51 +494,20 @@ function CharacterSheet({
               onUpdate={(updated) => setCharacter(updated)}
             />
 
-            <GearDisplay gear={character.gear || []} />
+            <GearDisplay gear={(character.gear || []).filter((item) => item.category !== "drug")} />
+
+            <DrugsDisplay
+              drugs={(character.gear || []).filter((item) => item.category === "drug")}
+            />
 
             <ContactsDisplay character={character} />
 
             <IdentitiesDisplay character={character} />
 
-            {/* Lifestyles (uses theme — Phase 4) */}
-            {character.lifestyles && character.lifestyles.length > 0 && (
-              <Section theme={theme} title="Lifestyles">
-                <div className="space-y-3">
-                  {character.lifestyles.map((lifestyle, index) => {
-                    const isPrimary = character.primaryLifestyleId === lifestyle.id;
-                    return (
-                      <div
-                        key={`lifestyle-${index}`}
-                        className={`p-3 rounded border-l-2 transition-colors ${
-                          isPrimary
-                            ? "bg-emerald-500/10 border-emerald-500/50"
-                            : "bg-muted/30 border-border"
-                        }`}
-                      >
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            <span className="text-sm font-medium text-foreground/90 capitalize">
-                              {lifestyle.type}
-                            </span>
-                            {isPrimary && (
-                              <span className="text-[10px] bg-emerald-500 text-white px-1.5 py-0.5 rounded uppercase font-mono tracking-tighter">
-                                Primary
-                              </span>
-                            )}
-                          </div>
-                          <span className="text-xs font-mono text-emerald-400">
-                            ¥{lifestyle.monthlyCost.toLocaleString()}/mo
-                          </span>
-                        </div>
-                        {lifestyle.location && (
-                          <p className="text-xs text-muted-foreground mt-1">{lifestyle.location}</p>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              </Section>
-            )}
+            <LifestylesDisplay
+              lifestyles={character.lifestyles || []}
+              primaryLifestyleId={character.primaryLifestyleId}
+            />
           </div>
         </div>
 

--- a/components/character/sheet/AdeptPowersDisplay.tsx
+++ b/components/character/sheet/AdeptPowersDisplay.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { DisplayCard } from "./DisplayCard";
+import { Zap } from "lucide-react";
+import type { AdeptPower } from "@/lib/types";
+
+interface AdeptPowersDisplayProps {
+  adeptPowers: AdeptPower[];
+}
+
+export function AdeptPowersDisplay({ adeptPowers }: AdeptPowersDisplayProps) {
+  if (!adeptPowers || adeptPowers.length === 0) return null;
+
+  return (
+    <DisplayCard title="Adept Powers" icon={<Zap className="h-4 w-4 text-amber-400" />}>
+      <div className="space-y-3">
+        {adeptPowers.map((power, idx) => (
+          <div
+            key={power.id || idx}
+            className="p-3 rounded transition-all group bg-zinc-50 dark:bg-zinc-800/30 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 border border-amber-500/30"
+          >
+            <div className="flex items-start justify-between">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-bold text-zinc-700 dark:text-zinc-200 transition-colors group-hover:text-amber-500 dark:group-hover:text-amber-400">
+                    {power.name}
+                  </span>
+                  {power.rating && (
+                    <span className="text-[10px] font-mono text-amber-500 uppercase tracking-tighter px-1.5 py-0.5 border border-amber-500/30 rounded bg-amber-500/5">
+                      Level {power.rating}
+                    </span>
+                  )}
+                </div>
+                {power.specification && (
+                  <p className="text-[11px] text-zinc-500 dark:text-zinc-400 font-mono italic">
+                    Spec: {power.specification}
+                  </p>
+                )}
+              </div>
+              <div className="text-right shrink-0">
+                <div className="text-[10px] text-zinc-500 dark:text-zinc-400 uppercase font-mono leading-none mb-1">
+                  Cost
+                </div>
+                <div className="text-sm font-mono text-amber-500 dark:text-amber-400 font-bold leading-none">
+                  {power.powerPointCost} PP
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/CombatDisplay.tsx
+++ b/components/character/sheet/CombatDisplay.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { DisplayCard } from "./DisplayCard";
+import { Swords } from "lucide-react";
+import { CombatQuickReference } from "@/app/characters/[id]/components/CombatQuickReference";
+import type { Character } from "@/lib/types";
+import type { Theme } from "@/lib/themes";
+
+interface CombatDisplayProps {
+  character: Character;
+  woundModifier: number;
+  physicalLimit: number;
+  theme: Theme;
+  onPoolSelect: (pool: number, context: string) => void;
+}
+
+export function CombatDisplay({
+  character,
+  woundModifier,
+  physicalLimit,
+  theme,
+  onPoolSelect,
+}: CombatDisplayProps) {
+  return (
+    <DisplayCard title="Combat" icon={<Swords className="h-4 w-4 text-zinc-400" />}>
+      <CombatQuickReference
+        character={character}
+        woundModifier={woundModifier}
+        physicalLimit={physicalLimit}
+        theme={theme}
+        onPoolSelect={onPoolSelect}
+      />
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/ConditionDisplay.tsx
+++ b/components/character/sheet/ConditionDisplay.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { DisplayCard } from "./DisplayCard";
+import { Heart } from "lucide-react";
+import { InteractiveConditionMonitor } from "@/app/characters/[id]/components/InteractiveConditionMonitor";
+import type { Character } from "@/lib/types";
+import type { Theme } from "@/lib/themes";
+
+interface ConditionDisplayProps {
+  character: Character;
+  woundModifier: number;
+  physicalMonitorMax: number;
+  stunMonitorMax: number;
+  theme: Theme;
+  readonly: boolean;
+  onDamageApplied: (type: "physical" | "stun" | "overflow", newValue: number) => void;
+}
+
+export function ConditionDisplay({
+  character,
+  woundModifier,
+  physicalMonitorMax,
+  stunMonitorMax,
+  theme,
+  readonly,
+  onDamageApplied,
+}: ConditionDisplayProps) {
+  return (
+    <DisplayCard title="Condition" icon={<Heart className="h-4 w-4 text-zinc-400" />}>
+      <div className="space-y-6">
+        {woundModifier !== 0 && (
+          <div className="p-2 rounded text-center bg-amber-50 dark:bg-amber-500/10 border border-amber-300 dark:border-amber-500/30 text-amber-700 dark:text-amber-400">
+            <span className="text-xs font-mono uppercase">Total Wound Modifier: </span>
+            <span className="font-mono font-bold">{woundModifier}</span>
+          </div>
+        )}
+        <div className="grid grid-cols-2 gap-4">
+          <InteractiveConditionMonitor
+            characterId={character.id}
+            type="physical"
+            current={character.condition?.physicalDamage ?? 0}
+            max={physicalMonitorMax}
+            theme={theme}
+            readonly={readonly}
+            onDamageApplied={(newValue) => onDamageApplied("physical", newValue)}
+          />
+          <InteractiveConditionMonitor
+            characterId={character.id}
+            type="stun"
+            current={character.condition?.stunDamage ?? 0}
+            max={stunMonitorMax}
+            theme={theme}
+            readonly={readonly}
+            onDamageApplied={(newValue) => onDamageApplied("stun", newValue)}
+          />
+        </div>
+        <InteractiveConditionMonitor
+          characterId={character.id}
+          type="overflow"
+          current={character.condition?.overflowDamage ?? 0}
+          max={character.attributes?.body || 3}
+          theme={theme}
+          readonly={readonly}
+          onDamageApplied={(newValue) => onDamageApplied("overflow", newValue)}
+        />
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/LifestylesDisplay.tsx
+++ b/components/character/sheet/LifestylesDisplay.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { DisplayCard } from "./DisplayCard";
+import { Home } from "lucide-react";
+import type { Lifestyle } from "@/lib/types";
+
+interface LifestylesDisplayProps {
+  lifestyles: Lifestyle[];
+  primaryLifestyleId?: string;
+}
+
+export function LifestylesDisplay({ lifestyles, primaryLifestyleId }: LifestylesDisplayProps) {
+  if (!lifestyles || lifestyles.length === 0) return null;
+
+  return (
+    <DisplayCard title="Lifestyles" icon={<Home className="h-4 w-4 text-zinc-400" />}>
+      <div className="space-y-3">
+        {lifestyles.map((lifestyle, index) => {
+          const isPrimary = primaryLifestyleId === lifestyle.id;
+          return (
+            <div
+              key={`lifestyle-${index}`}
+              className={`p-3 rounded border-l-2 transition-colors ${
+                isPrimary
+                  ? "bg-emerald-50 dark:bg-emerald-500/10 border-emerald-500/50"
+                  : "bg-zinc-50 dark:bg-zinc-800/30 border-zinc-300 dark:border-zinc-600"
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-zinc-700 dark:text-zinc-200 capitalize">
+                    {lifestyle.type}
+                  </span>
+                  {isPrimary && (
+                    <span className="text-[10px] bg-emerald-500 text-white px-1.5 py-0.5 rounded uppercase font-mono tracking-tighter">
+                      Primary
+                    </span>
+                  )}
+                </div>
+                <span className="text-xs font-mono text-emerald-500 dark:text-emerald-400">
+                  ¥{lifestyle.monthlyCost.toLocaleString()}/mo
+                </span>
+              </div>
+              {lifestyle.location && (
+                <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1">
+                  {lifestyle.location}
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/SpellsDisplay.tsx
+++ b/components/character/sheet/SpellsDisplay.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useMemo } from "react";
+import { DisplayCard } from "./DisplayCard";
+import { Sparkles } from "lucide-react";
+import { useSpells, type SpellData, type SpellsCatalogData } from "@/lib/rules";
+
+interface SpellsDisplayProps {
+  spells: Array<string | { id: string }>;
+  onSelect?: (pool: number, label: string) => void;
+}
+
+function SpellItem({
+  spellId,
+  spellsCatalog,
+  onSelect,
+}: {
+  spellId: string;
+  spellsCatalog: SpellsCatalogData | null;
+  onSelect?: (pool: number, label: string) => void;
+}) {
+  const spell = useMemo(() => {
+    if (!spellsCatalog) return null;
+    for (const cat in spellsCatalog) {
+      const categorySpells = spellsCatalog[cat as keyof typeof spellsCatalog] as SpellData[];
+      const found = categorySpells.find((s) => s.id === spellId);
+      if (found) return found;
+    }
+    return null;
+  }, [spellId, spellsCatalog]);
+
+  if (!spell) return null;
+
+  return (
+    <div
+      onClick={() => onSelect?.(6, spell.name)}
+      className="p-3 rounded transition-all cursor-pointer group bg-zinc-50 dark:bg-zinc-800/30 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 border border-violet-500/30"
+    >
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-bold text-zinc-700 dark:text-zinc-200 transition-colors group-hover:text-violet-500 dark:group-hover:text-violet-400">
+              {spell.name}
+            </span>
+            <span className="text-[10px] font-mono text-zinc-500 dark:text-zinc-400 uppercase tracking-tighter px-1.5 py-0.5 border border-zinc-300 dark:border-zinc-600 rounded">
+              {spell.category}
+            </span>
+          </div>
+          {spell.description && (
+            <p className="text-[11px] text-zinc-500 dark:text-zinc-400 line-clamp-2 leading-relaxed">
+              {spell.description}
+            </p>
+          )}
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] font-mono mt-1">
+            <div className="flex gap-1.5">
+              <span className="text-zinc-400 dark:text-zinc-500">TYPE</span>
+              <span className="text-blue-500 dark:text-blue-400 uppercase">{spell.type}</span>
+            </div>
+            <div className="flex gap-1.5">
+              <span className="text-zinc-400 dark:text-zinc-500">RANGE</span>
+              <span className="text-emerald-500 dark:text-emerald-400 uppercase">
+                {spell.range}
+              </span>
+            </div>
+            <div className="flex gap-1.5">
+              <span className="text-zinc-400 dark:text-zinc-500">DUR</span>
+              <span className="text-amber-500 dark:text-amber-400 uppercase">{spell.duration}</span>
+            </div>
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          <div className="text-[10px] text-zinc-500 dark:text-zinc-400 uppercase font-mono leading-none mb-1">
+            Drain
+          </div>
+          <div className="text-sm font-mono text-violet-500 dark:text-violet-400 font-bold leading-none">
+            {spell.drain}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SpellsDisplay({ spells, onSelect }: SpellsDisplayProps) {
+  const spellsCatalog = useSpells();
+
+  if (!spells || spells.length === 0) return null;
+
+  return (
+    <DisplayCard title="Spells" icon={<Sparkles className="h-4 w-4 text-violet-400" />}>
+      <div className="space-y-3">
+        {spells.map((spellEntry, idx) => {
+          const spellId =
+            typeof spellEntry === "string" ? spellEntry : (spellEntry as { id: string }).id;
+          return (
+            <SpellItem
+              key={spellId || idx}
+              spellId={spellId}
+              spellsCatalog={spellsCatalog}
+              onSelect={onSelect}
+            />
+          );
+        })}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/VehiclesDisplay.tsx
+++ b/components/character/sheet/VehiclesDisplay.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { DisplayCard } from "./DisplayCard";
+import { Car } from "lucide-react";
+import type { Vehicle, CharacterDrone, CharacterRCC } from "@/lib/types";
+
+interface VehiclesDisplayProps {
+  vehicles?: Vehicle[];
+  drones?: CharacterDrone[];
+  rccs?: CharacterRCC[];
+}
+
+function VehicleItem({ vehicle }: { vehicle: Vehicle | CharacterDrone | CharacterRCC }) {
+  const isRCC = "deviceRating" in vehicle;
+  const isDrone = "size" in vehicle;
+
+  return (
+    <div className="p-3 rounded transition-all group bg-zinc-50 dark:bg-zinc-800/30 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 border border-zinc-300/50 dark:border-zinc-700/50">
+      <div className="flex items-start justify-between mb-2">
+        <div>
+          <div className="font-bold text-zinc-700 dark:text-zinc-200 transition-colors group-hover:text-emerald-500 dark:group-hover:text-emerald-400">
+            {vehicle.name}
+          </div>
+          <div className="text-[10px] text-zinc-500 dark:text-zinc-400 uppercase font-mono">
+            {isRCC ? "RCC" : isDrone ? `${(vehicle as CharacterDrone).size} Drone` : "Vehicle"}
+          </div>
+        </div>
+        {isRCC && (
+          <div className="text-right">
+            <div className="text-[10px] text-zinc-500 dark:text-zinc-400 uppercase font-mono">
+              Rating
+            </div>
+            <div className="text-lg font-bold font-mono text-orange-500 dark:text-orange-400">
+              {(vehicle as CharacterRCC).deviceRating}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {!isRCC && (
+        <div className="grid grid-cols-4 gap-2 text-center border-t border-zinc-200 dark:border-zinc-700/50 pt-2">
+          <div className="space-y-0.5">
+            <div className="text-[9px] text-zinc-400 dark:text-zinc-500 uppercase font-mono">
+              Hand
+            </div>
+            <div className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
+              {(vehicle as Vehicle).handling}
+            </div>
+          </div>
+          <div className="space-y-0.5">
+            <div className="text-[9px] text-zinc-400 dark:text-zinc-500 uppercase font-mono">
+              Spd
+            </div>
+            <div className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
+              {(vehicle as Vehicle).speed}
+            </div>
+          </div>
+          <div className="space-y-0.5">
+            <div className="text-[9px] text-zinc-400 dark:text-zinc-500 uppercase font-mono">
+              Body
+            </div>
+            <div className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
+              {(vehicle as Vehicle).body}
+            </div>
+          </div>
+          <div className="space-y-0.5">
+            <div className="text-[9px] text-zinc-400 dark:text-zinc-500 uppercase font-mono">
+              Armor
+            </div>
+            <div className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
+              {(vehicle as Vehicle).armor}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {isRCC && (
+        <div className="grid grid-cols-2 gap-4 text-center border-t border-zinc-200 dark:border-zinc-700/50 pt-2">
+          <div className="space-y-0.5">
+            <div className="text-[9px] text-zinc-400 dark:text-zinc-500 uppercase font-mono">
+              Data Proc
+            </div>
+            <div className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
+              {(vehicle as CharacterRCC).dataProcessing}
+            </div>
+          </div>
+          <div className="space-y-0.5">
+            <div className="text-[9px] text-zinc-400 dark:text-zinc-500 uppercase font-mono">
+              Firewall
+            </div>
+            <div className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
+              {(vehicle as CharacterRCC).firewall}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function VehiclesDisplay({ vehicles, drones, rccs }: VehiclesDisplayProps) {
+  const hasContent =
+    (rccs && rccs.length > 0) || (vehicles && vehicles.length > 0) || (drones && drones.length > 0);
+
+  if (!hasContent) return null;
+
+  return (
+    <DisplayCard title="Vehicles & Drones" icon={<Car className="h-4 w-4 text-zinc-400" />}>
+      <div className="space-y-3">
+        {rccs?.map((rcc, idx) => (
+          <VehicleItem key={`rcc-${idx}`} vehicle={rcc} />
+        ))}
+        {vehicles?.map((v, idx) => (
+          <VehicleItem key={`veh-${idx}`} vehicle={v} />
+        ))}
+        {drones?.map((d, idx) => (
+          <VehicleItem key={`drone-${idx}`} vehicle={d} />
+        ))}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/index.ts
+++ b/components/character/sheet/index.ts
@@ -2,11 +2,14 @@ export { DisplayCard } from "./DisplayCard";
 export { ATTRIBUTE_DISPLAY, getAttributeBonus, isMeleeWeapon } from "./constants";
 
 // Display components
+export { AdeptPowersDisplay } from "./AdeptPowersDisplay";
 export { ArmorDisplay } from "./ArmorDisplay";
 export { AttributesDisplay } from "./AttributesDisplay";
 export { AugmentationsDisplay } from "./AugmentationsDisplay";
 export { CharacterInfoDisplay } from "./CharacterInfoDisplay";
+export { CombatDisplay } from "./CombatDisplay";
 export { ComplexFormsDisplay } from "./ComplexFormsDisplay";
+export { ConditionDisplay } from "./ConditionDisplay";
 export { ContactsDisplay } from "./ContactsDisplay";
 export { DerivedStatsDisplay } from "./DerivedStatsDisplay";
 export { DrugsDisplay } from "./DrugsDisplay";
@@ -14,6 +17,9 @@ export { FociDisplay } from "./FociDisplay";
 export { GearDisplay } from "./GearDisplay";
 export { IdentitiesDisplay } from "./IdentitiesDisplay";
 export { KnowledgeLanguagesDisplay } from "./KnowledgeLanguagesDisplay";
+export { LifestylesDisplay } from "./LifestylesDisplay";
 export { QualitiesDisplay } from "./QualitiesDisplay";
 export { SkillsDisplay } from "./SkillsDisplay";
+export { SpellsDisplay } from "./SpellsDisplay";
+export { VehiclesDisplay } from "./VehiclesDisplay";
 export { WeaponsDisplay } from "./WeaponsDisplay";


### PR DESCRIPTION
## Summary

- Extract all 5 remaining `<Section>`-wrapped inline blocks and 3 inline card subcomponents from `page.tsx` into 6 new DisplayCard-based components
- Separate drugs from general gear into dedicated `DrugsDisplay` component
- Reduce `page.tsx` from 974 → 645 lines (~34% reduction)
- Eliminate all legacy `Section` usage from the character sheet page

Closes #329, #330, #331, #332, #337

## New Components

| Component | Description |
|-----------|-------------|
| `SpellsDisplay` | Spell catalog lookup via `useSpells()`, violet accent, click-to-roll |
| `AdeptPowersDisplay` | Power name, rating badge, PP cost, amber accent |
| `VehiclesDisplay` | Vehicle/Drone/RCC union type handling with stats grids |
| `LifestylesDisplay` | Primary lifestyle highlighting with emerald accent |
| `ConditionDisplay` | Transitional wrapper for InteractiveConditionMonitor (passes theme) |
| `CombatDisplay` | Transitional wrapper for CombatQuickReference (passes theme) |

## Test plan

- [x] `pnpm type-check` — zero errors
- [x] `pnpm test` — 308 files, 6927 tests, all passing
- [x] Pre-commit hooks (lint, prettier, type-check) passed
- [ ] Manual: load character sheet, verify all sections render
- [ ] Manual: verify empty states (character without spells/vehicles/etc hides those sections)
- [ ] Manual: verify dice roller integration (click spell → opens roller)
- [ ] Manual: verify drugs shown separately from general gear
- [ ] Manual: verify condition monitors still interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)