### PR TITLE
feat(sheet): Enhance DerivedStatsDisplay and ComplexFormsDisplay (#333, #334)

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -199,6 +199,13 @@ function CharacterSheet({
     );
   }, [character, ruleset]);
 
+  const armorTotal = useMemo(() => {
+    if (!character.armor || character.armor.length === 0) return 0;
+    return character.armor
+      .filter((a) => a.equipped)
+      .reduce((sum, a) => sum + (a.armorRating || 0), 0);
+  }, [character.armor]);
+
   if (!ready || rulesetLoading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -216,6 +223,15 @@ function CharacterSheet({
   }
 
   const initiative = (character.attributes?.reaction || 1) + (character.attributes?.intuition || 1);
+
+  const composure = (character.attributes?.charisma || 1) + (character.attributes?.willpower || 1);
+  const judgeIntentions =
+    (character.attributes?.charisma || 1) + (character.attributes?.intuition || 1);
+  const memoryPool = (character.attributes?.logic || 1) + (character.attributes?.willpower || 1);
+  const liftCarry = (character.attributes?.body || 1) + (character.attributes?.strength || 1);
+  const walkSpeed = (character.attributes?.agility || 1) * 2;
+  const runSpeed = (character.attributes?.agility || 1) * 4;
+  const overflow = character.attributes?.body || 1;
 
   const handleExport = () => downloadCharacterJson(character);
 
@@ -378,6 +394,16 @@ function CharacterSheet({
               mentalLimit={mentalLimit}
               socialLimit={socialLimit}
               initiative={initiative}
+              physicalMonitorMax={physicalMonitorMax}
+              stunMonitorMax={stunMonitorMax}
+              overflow={overflow}
+              composure={composure}
+              judgeIntentions={judgeIntentions}
+              memory={memoryPool}
+              liftCarry={liftCarry}
+              walkSpeed={walkSpeed}
+              runSpeed={runSpeed}
+              armorTotal={armorTotal}
             />
 
             <ConditionDisplay

--- a/components/character/sheet/ComplexFormsDisplay.tsx
+++ b/components/character/sheet/ComplexFormsDisplay.tsx
@@ -1,29 +1,92 @@
 "use client";
 
+import { useMemo } from "react";
 import { DisplayCard } from "./DisplayCard";
 import { Braces } from "lucide-react";
+import { useComplexForms, type ComplexFormData } from "@/lib/rules";
 
 interface ComplexFormsDisplayProps {
   complexForms: string[];
   onSelect?: (pool: number, label: string) => void;
 }
 
+function ComplexFormItem({
+  formId,
+  catalog,
+  onSelect,
+}: {
+  formId: string;
+  catalog: ComplexFormData[];
+  onSelect?: (pool: number, label: string) => void;
+}) {
+  const form = useMemo(() => catalog.find((f) => f.id === formId), [formId, catalog]);
+
+  // Fallback: no catalog match — render kebab-case display
+  if (!form) {
+    return (
+      <div
+        onClick={() => onSelect?.(6, formId.replace(/-/g, " "))}
+        className="p-3 rounded border border-cyan-500/30 bg-zinc-50 dark:bg-zinc-800/30 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 cursor-pointer transition-colors group"
+      >
+        <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100 capitalize group-hover:text-cyan-500 transition-colors">
+          {formId.replace(/-/g, " ")}
+        </span>
+      </div>
+    );
+  }
+
+  // Rich rendering with catalog metadata
+  return (
+    <div
+      onClick={() => onSelect?.(6, form.name)}
+      className="p-3 rounded transition-all cursor-pointer group bg-zinc-50 dark:bg-zinc-800/30 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 border border-cyan-500/30"
+    >
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <span className="text-sm font-bold text-zinc-700 dark:text-zinc-200 transition-colors group-hover:text-cyan-500 dark:group-hover:text-cyan-400">
+            {form.name}
+          </span>
+          {form.description && (
+            <p className="text-[11px] text-zinc-500 dark:text-zinc-400 line-clamp-2 leading-relaxed">
+              {form.description}
+            </p>
+          )}
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] font-mono mt-1">
+            <div className="flex gap-1.5">
+              <span className="text-zinc-400 dark:text-zinc-500">TARGET</span>
+              <span className="text-blue-500 dark:text-blue-400 uppercase">{form.target}</span>
+            </div>
+            <div className="flex gap-1.5">
+              <span className="text-zinc-400 dark:text-zinc-500">DUR</span>
+              <span className="text-emerald-500 dark:text-emerald-400 uppercase">
+                {form.duration}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          <div className="text-[10px] text-zinc-500 dark:text-zinc-400 uppercase font-mono leading-none mb-1">
+            Fading
+          </div>
+          <div className="text-sm font-mono text-cyan-500 dark:text-cyan-400 font-bold leading-none">
+            {form.fading}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ComplexFormsDisplay({ complexForms, onSelect }: ComplexFormsDisplayProps) {
+  const catalog = useComplexForms();
+
   if (complexForms.length === 0) return null;
 
   return (
-    <DisplayCard title="Complex Forms" icon={<Braces className="h-4 w-4 text-zinc-400" />}>
-      <div className="space-y-2">
+    <DisplayCard title="Complex Forms" icon={<Braces className="h-4 w-4 text-cyan-400" />}>
+      <div className="space-y-3">
         {complexForms.map((formId) => (
-          <div
-            key={formId}
-            onClick={() => onSelect?.(6, formId.replace(/-/g, " "))}
-            className="p-3 rounded border border-cyan-500/30 bg-zinc-50 dark:bg-zinc-800/30 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 cursor-pointer transition-colors group"
-          >
-            <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100 capitalize group-hover:text-cyan-500 transition-colors">
-              {formId.replace(/-/g, " ")}
-            </span>
-          </div>
+          <ComplexFormItem key={formId} formId={formId} catalog={catalog} onSelect={onSelect} />
         ))}
       </div>
     </DisplayCard>

--- a/components/character/sheet/DerivedStatsDisplay.tsx
+++ b/components/character/sheet/DerivedStatsDisplay.tsx
@@ -1,13 +1,56 @@
 "use client";
 
 import { DisplayCard } from "./DisplayCard";
-import { Calculator } from "lucide-react";
+import { Activity, Shield, Heart, Brain, Footprints, ShieldCheck } from "lucide-react";
 
 interface DerivedStatsDisplayProps {
+  // Existing (required)
   physicalLimit: number;
   mentalLimit: number;
   socialLimit: number;
   initiative: number;
+  // Condition Monitors (optional)
+  physicalMonitorMax?: number;
+  stunMonitorMax?: number;
+  overflow?: number;
+  // Secondary Pools (optional)
+  composure?: number;
+  judgeIntentions?: number;
+  memory?: number;
+  liftCarry?: number;
+  // Movement (optional)
+  walkSpeed?: number;
+  runSpeed?: number;
+  // Armor (optional)
+  armorTotal?: number;
+}
+
+function StatBlock({
+  label,
+  value,
+  colorClass = "text-zinc-900 dark:text-zinc-100",
+}: {
+  label: string;
+  value: string | number;
+  colorClass?: string;
+}) {
+  return (
+    <div className="text-center p-3 bg-zinc-50 dark:bg-zinc-800/30 rounded">
+      <span className="block text-xs font-mono text-zinc-500 dark:text-zinc-400 uppercase">
+        {label}
+      </span>
+      <span className={`text-xl font-mono font-bold ${colorClass}`}>{value}</span>
+    </div>
+  );
+}
+
+function SectionHeader({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <div className="mb-1.5 flex items-center gap-1 text-xs font-semibold text-zinc-600 dark:text-zinc-300">
+      {icon}
+      {label}
+    </div>
+  );
 }
 
 export function DerivedStatsDisplay({
@@ -15,34 +58,109 @@ export function DerivedStatsDisplay({
   mentalLimit,
   socialLimit,
   initiative,
+  physicalMonitorMax,
+  stunMonitorMax,
+  overflow,
+  composure,
+  judgeIntentions,
+  memory,
+  liftCarry,
+  walkSpeed,
+  runSpeed,
+  armorTotal,
 }: DerivedStatsDisplayProps) {
+  const hasConditionMonitors =
+    physicalMonitorMax !== undefined || stunMonitorMax !== undefined || overflow !== undefined;
+  const hasPools =
+    composure !== undefined ||
+    judgeIntentions !== undefined ||
+    memory !== undefined ||
+    liftCarry !== undefined;
+  const hasMovement = walkSpeed !== undefined || runSpeed !== undefined;
+  const hasArmor = armorTotal !== undefined;
+
   return (
-    <DisplayCard title="Derived Stats" icon={<Calculator className="h-4 w-4 text-zinc-400" />}>
-      <div className="grid grid-cols-2 gap-4">
-        <div className="text-center p-3 bg-zinc-50 dark:bg-zinc-800/30 rounded">
-          <span className="block text-xs font-mono text-zinc-500 dark:text-zinc-400 uppercase">
-            Physical
-          </span>
-          <span className="text-xl font-mono font-bold text-red-500">{physicalLimit}</span>
+    <DisplayCard title="Derived Stats" icon={<Activity className="h-4 w-4 text-zinc-400" />}>
+      <div className="space-y-4">
+        {/* Initiative */}
+        <div>
+          <SectionHeader icon={<Activity className="h-3.5 w-3.5" />} label="Initiative" />
+          <div className="grid grid-cols-1 gap-2">
+            <StatBlock
+              label="Initiative"
+              value={`${initiative}+1d6`}
+              colorClass="text-emerald-400"
+            />
+          </div>
         </div>
-        <div className="text-center p-3 bg-zinc-50 dark:bg-zinc-800/30 rounded">
-          <span className="block text-xs font-mono text-zinc-500 dark:text-zinc-400 uppercase">
-            Mental
-          </span>
-          <span className="text-xl font-mono font-bold text-blue-400">{mentalLimit}</span>
+
+        {/* Limits */}
+        <div>
+          <SectionHeader icon={<Shield className="h-3.5 w-3.5" />} label="Limits" />
+          <div className="grid grid-cols-3 gap-2">
+            <StatBlock label="Physical" value={physicalLimit} colorClass="text-red-500" />
+            <StatBlock label="Mental" value={mentalLimit} colorClass="text-blue-400" />
+            <StatBlock label="Social" value={socialLimit} colorClass="text-pink-400" />
+          </div>
         </div>
-        <div className="text-center p-3 bg-zinc-50 dark:bg-zinc-800/30 rounded">
-          <span className="block text-xs font-mono text-zinc-500 dark:text-zinc-400 uppercase">
-            Social
-          </span>
-          <span className="text-xl font-mono font-bold text-pink-400">{socialLimit}</span>
-        </div>
-        <div className="text-center p-3 bg-zinc-50 dark:bg-zinc-800/30 rounded">
-          <span className="block text-xs font-mono text-zinc-500 dark:text-zinc-400 uppercase">
-            Initiative
-          </span>
-          <span className="text-xl font-mono font-bold text-emerald-400">{initiative}+1d6</span>
-        </div>
+
+        {/* Condition Monitors */}
+        {hasConditionMonitors && (
+          <div>
+            <SectionHeader icon={<Heart className="h-3.5 w-3.5" />} label="Condition Monitors" />
+            <div className="grid grid-cols-3 gap-2">
+              {physicalMonitorMax !== undefined && (
+                <StatBlock
+                  label="Physical CM"
+                  value={physicalMonitorMax}
+                  colorClass="text-red-500"
+                />
+              )}
+              {stunMonitorMax !== undefined && (
+                <StatBlock label="Stun CM" value={stunMonitorMax} colorClass="text-amber-400" />
+              )}
+              {overflow !== undefined && <StatBlock label="Overflow" value={overflow} />}
+            </div>
+          </div>
+        )}
+
+        {/* Pools */}
+        {hasPools && (
+          <div>
+            <SectionHeader icon={<Brain className="h-3.5 w-3.5" />} label="Pools" />
+            <div className="grid grid-cols-2 gap-2">
+              {composure !== undefined && <StatBlock label="Composure" value={composure} />}
+              {judgeIntentions !== undefined && (
+                <StatBlock label="Judge Intentions" value={judgeIntentions} />
+              )}
+              {memory !== undefined && <StatBlock label="Memory" value={memory} />}
+              {liftCarry !== undefined && (
+                <StatBlock label="Lift/Carry" value={`${liftCarry} kg`} />
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Movement */}
+        {hasMovement && (
+          <div>
+            <SectionHeader icon={<Footprints className="h-3.5 w-3.5" />} label="Movement" />
+            <div className="grid grid-cols-2 gap-2">
+              {walkSpeed !== undefined && <StatBlock label="Walk" value={`${walkSpeed}m`} />}
+              {runSpeed !== undefined && <StatBlock label="Run" value={`${runSpeed}m`} />}
+            </div>
+          </div>
+        )}
+
+        {/* Armor */}
+        {hasArmor && (
+          <div>
+            <SectionHeader icon={<ShieldCheck className="h-3.5 w-3.5" />} label="Armor" />
+            <div className="grid grid-cols-1 gap-2">
+              <StatBlock label="Total" value={armorTotal} />
+            </div>
+          </div>
+        )}
       </div>
     </DisplayCard>
   );


### PR DESCRIPTION
## Summary
- **DerivedStatsDisplay** (#333): Expanded from 4 stats to full SR5 derived stats organized into sectioned groups (Initiative, Limits, Condition Monitors, Pools, Movement, Armor) with StatBlock/SectionHeader helpers. All new props are optional for backward compatibility.
- **ComplexFormsDisplay** (#334): Now resolves catalog metadata via `useComplexForms` hook, showing name, description, target, duration, and fading value with cyan-themed styling. Falls back to kebab-case display when no catalog match is found.
- **page.tsx**: Added derived stat calculations (composure, judge intentions, memory, lift/carry, walk/run speed, overflow, armor total) and wired them to `DerivedStatsDisplay`.

Closes #333, closes #334

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (no new errors)
- [x] `pnpm test` passes (308 files, 6927 tests)
- [ ] Manual: load character sheet, verify all derived stat sections render
- [ ] Manual: load technomancer character, verify complex form metadata (target, duration, fading)
- [ ] Manual: verify backward compatibility — components render correctly with only required props

🤖 Generated with [Claude Code](https://claude.com/claude-code)