### PR TITLE
refactor(sheet): Remove legacy theme system from character sheet page

### DIFF
--- a/app/characters/[id]/components/ActionPanel.tsx
+++ b/app/characters/[id]/components/ActionPanel.tsx
@@ -34,7 +34,7 @@ import type { ActionPool, EdgeActionType, ActionContext } from "@/lib/types";
 import { useAvailableActions, type ActionAvailabilityResult } from "@/lib/rules/RulesetContext";
 import { TargetSelector } from "./TargetSelector";
 import type { Character, ActionDefinition } from "@/lib/types";
-import type { Theme } from "@/lib/themes";
+import { THEMES, DEFAULT_THEME, type Theme } from "@/lib/themes";
 
 interface ActionPanelProps {
   /** Character data */
@@ -54,7 +54,7 @@ interface ActionPanelProps {
   /** Callback to open dice roller with a pool */
   onOpenDiceRoller: (pool: number, context: string) => void;
   /** Current theme */
-  theme: Theme;
+  theme?: Theme;
 }
 
 interface QuickRollButtonProps {
@@ -62,10 +62,17 @@ interface QuickRollButtonProps {
   pool: number;
   context: string;
   onClick: (pool: number, context: string) => void;
-  theme: Theme;
+  theme?: Theme;
 }
 
-function QuickRollButton({ label, pool, context, onClick, theme }: QuickRollButtonProps) {
+function QuickRollButton({
+  label,
+  pool,
+  context,
+  onClick,
+  theme: themeProp,
+}: QuickRollButtonProps) {
+  const theme = themeProp || THEMES[DEFAULT_THEME];
   return (
     <Button
       onPress={() => onClick(pool, context)}
@@ -96,7 +103,7 @@ interface CombatActionButtonProps {
   isAvailable: boolean;
   isInCombat: boolean;
   isLoading?: boolean;
-  theme: Theme;
+  theme?: Theme;
 }
 
 /**
@@ -156,8 +163,9 @@ function CombatActionButton({
   isAvailable,
   isInCombat,
   isLoading,
-  theme,
+  theme: themeProp,
 }: CombatActionButtonProps) {
+  const theme = themeProp || THEMES[DEFAULT_THEME];
   const typeColors = {
     free: "bg-emerald-500/20 border-emerald-500/30 text-emerald-500",
     simple: "bg-blue-500/20 border-blue-500/30 text-blue-500",
@@ -214,6 +222,7 @@ export function ActionPanel({
   onOpenDiceRoller,
   theme,
 }: ActionPanelProps) {
+  const t = theme || THEMES[DEFAULT_THEME];
   // Combat session context
   const { isInCombat, isMyTurn, executeAction, isLoading: combatLoading } = useCombatSession();
   const actionEconomy = useActionEconomy();
@@ -455,27 +464,25 @@ export function ActionPanel({
   };
 
   return (
-    <div className={`rounded-lg overflow-hidden ${theme.components.section.wrapper}`}>
+    <div className={`rounded-lg overflow-hidden ${t.components.section.wrapper}`}>
       {/* Header - Always visible */}
       <button
         onClick={onToggleExpand}
         className={`
           w-full flex items-center justify-between p-3
-          ${theme.components.section.header}
+          ${t.components.section.header}
           hover:opacity-80 transition-opacity
         `}
       >
         <div className="flex items-center gap-3">
-          <Dice1 className={`w-5 h-5 ${theme.colors.accent}`} />
-          <span className={`font-medium ${theme.colors.heading}`}>Action Panel</span>
+          <Dice1 className={`w-5 h-5 ${t.colors.accent}`} />
+          <span className={`font-medium ${t.colors.heading}`}>Action Panel</span>
         </div>
         <div className="flex items-center gap-3">
           {/* Edge Quick Display */}
           <div className="flex items-center gap-1.5">
             <Zap className="w-4 h-4 text-rose-500 dark:text-rose-400" />
-            <span
-              className={`${theme.fonts.mono} text-sm font-bold text-rose-500 dark:text-rose-400`}
-            >
+            <span className={`${t.fonts.mono} text-sm font-bold text-rose-500 dark:text-rose-400`}>
               {edgeCurrent}/{edgeMaximum}
             </span>
           </div>
@@ -483,24 +490,24 @@ export function ActionPanel({
           {woundModifier !== 0 && (
             <span
               className={`
-              text-xs ${theme.fonts.mono} px-2 py-0.5 rounded border
-              ${theme.components.badge.negative}
+              text-xs ${t.fonts.mono} px-2 py-0.5 rounded border
+              ${t.components.badge.negative}
             `}
             >
               {woundModifier}
             </span>
           )}
           {isExpanded ? (
-            <ChevronUp className={`w-4 h-4 ${theme.colors.muted}`} />
+            <ChevronUp className={`w-4 h-4 ${t.colors.muted}`} />
           ) : (
-            <ChevronDown className={`w-4 h-4 ${theme.colors.muted}`} />
+            <ChevronDown className={`w-4 h-4 ${t.colors.muted}`} />
           )}
         </div>
       </button>
 
       {/* Expanded Content */}
       {isExpanded && (
-        <div className={`p-4 space-y-4 border-t ${theme.colors.border}`}>
+        <div className={`p-4 space-y-4 border-t ${t.colors.border}`}>
           {/* Edge Tracker - Using standalone EdgeTracker component */}
           <EdgeTracker
             current={edgeCurrent}
@@ -515,29 +522,29 @@ export function ActionPanel({
 
           {/* Limits */}
           <div
-            className={`grid grid-cols-3 gap-2 p-3 rounded ${theme.components.card.wrapper} ${theme.components.card.border}`}
+            className={`grid grid-cols-3 gap-2 p-3 rounded ${t.components.card.wrapper} ${t.components.card.border}`}
           >
             <div className="text-center">
-              <div className={`text-[10px] uppercase ${theme.fonts.mono} ${theme.colors.muted}`}>
+              <div className={`text-[10px] uppercase ${t.fonts.mono} ${t.colors.muted}`}>
                 Physical
               </div>
-              <div className={`${theme.fonts.mono} font-bold text-red-500 dark:text-red-400`}>
+              <div className={`${t.fonts.mono} font-bold text-red-500 dark:text-red-400`}>
                 {physicalLimit}
               </div>
             </div>
             <div className="text-center">
-              <div className={`text-[10px] uppercase ${theme.fonts.mono} ${theme.colors.muted}`}>
+              <div className={`text-[10px] uppercase ${t.fonts.mono} ${t.colors.muted}`}>
                 Mental
               </div>
-              <div className={`${theme.fonts.mono} font-bold text-blue-500 dark:text-blue-400`}>
+              <div className={`${t.fonts.mono} font-bold text-blue-500 dark:text-blue-400`}>
                 {mentalLimit}
               </div>
             </div>
             <div className="text-center">
-              <div className={`text-[10px] uppercase ${theme.fonts.mono} ${theme.colors.muted}`}>
+              <div className={`text-[10px] uppercase ${t.fonts.mono} ${t.colors.muted}`}>
                 Social
               </div>
-              <div className={`${theme.fonts.mono} font-bold text-pink-500 dark:text-pink-400`}>
+              <div className={`${t.fonts.mono} font-bold text-pink-500 dark:text-pink-400`}>
                 {socialLimit}
               </div>
             </div>
@@ -551,8 +558,8 @@ export function ActionPanel({
                 flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium transition-colors
                 ${
                   activeTab === "quick"
-                    ? `${theme.colors.accent} bg-background shadow-sm`
-                    : `${theme.colors.muted} hover:text-foreground`
+                    ? `${t.colors.accent} bg-background shadow-sm`
+                    : `${t.colors.muted} hover:text-foreground`
                 }
               `}
             >
@@ -565,8 +572,8 @@ export function ActionPanel({
                 flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium transition-colors
                 ${
                   activeTab === "combat"
-                    ? `${theme.colors.accent} bg-background shadow-sm`
-                    : `${theme.colors.muted} hover:text-foreground`
+                    ? `${t.colors.accent} bg-background shadow-sm`
+                    : `${t.colors.muted} hover:text-foreground`
                 }
                 ${isInCombat ? "ring-1 ring-amber-500/50" : ""}
               `}
@@ -583,8 +590,8 @@ export function ActionPanel({
                 flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium transition-colors
                 ${
                   activeTab === "advanced"
-                    ? `${theme.colors.accent} bg-background shadow-sm`
-                    : `${theme.colors.muted} hover:text-foreground`
+                    ? `${t.colors.accent} bg-background shadow-sm`
+                    : `${t.colors.muted} hover:text-foreground`
                 }
               `}
             >
@@ -597,15 +604,15 @@ export function ActionPanel({
                 flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium transition-colors
                 ${
                   activeTab === "history"
-                    ? `${theme.colors.accent} bg-background shadow-sm`
-                    : `${theme.colors.muted} hover:text-foreground`
+                    ? `${t.colors.accent} bg-background shadow-sm`
+                    : `${t.colors.muted} hover:text-foreground`
                 }
               `}
             >
               <History className="w-3 h-3" />
               History
               {combinedHistory.length > 0 && (
-                <span className={`text-[10px] ${theme.fonts.mono} px-1 rounded bg-muted`}>
+                <span className={`text-[10px] ${t.fonts.mono} px-1 rounded bg-muted`}>
                   {combinedHistory.length}
                 </span>
               )}
@@ -615,7 +622,7 @@ export function ActionPanel({
           {/* Quick Rolls Tab */}
           {activeTab === "quick" && (
             <div className="space-y-2">
-              <div className={`text-xs uppercase ${theme.fonts.mono} ${theme.colors.muted}`}>
+              <div className={`text-xs uppercase ${t.fonts.mono} ${t.colors.muted}`}>
                 Common Tests
               </div>
               <div className="grid grid-cols-2 gap-2">
@@ -624,42 +631,42 @@ export function ActionPanel({
                   pool={pools.initiative}
                   context="Initiative (REA + INT)"
                   onClick={onOpenDiceRoller}
-                  theme={theme}
+                  theme={t}
                 />
                 <QuickRollButton
                   label="Perception"
                   pool={pools.perception}
                   context="Perception (INT + Perception)"
                   onClick={onOpenDiceRoller}
-                  theme={theme}
+                  theme={t}
                 />
                 <QuickRollButton
                   label="Composure"
                   pool={pools.composure}
                   context="Composure (CHA + WIL)"
                   onClick={onOpenDiceRoller}
-                  theme={theme}
+                  theme={t}
                 />
                 <QuickRollButton
                   label="Judge Intent"
                   pool={pools.judgeIntentions}
                   context="Judge Intentions (CHA + INT)"
                   onClick={onOpenDiceRoller}
-                  theme={theme}
+                  theme={t}
                 />
                 <QuickRollButton
                   label="Memory"
                   pool={pools.memory}
                   context="Memory (LOG + WIL)"
                   onClick={onOpenDiceRoller}
-                  theme={theme}
+                  theme={t}
                 />
                 <QuickRollButton
                   label="Lift/Carry"
                   pool={pools.liftCarry}
                   context="Lift/Carry (BOD + STR)"
                   onClick={onOpenDiceRoller}
-                  theme={theme}
+                  theme={t}
                 />
               </div>
             </div>
@@ -671,18 +678,16 @@ export function ActionPanel({
               {/* Action Economy Display (when in combat) */}
               {isInCombat && actionEconomy && (
                 <div
-                  className={`p-2 rounded ${theme.components.card.wrapper} ${theme.components.card.border}`}
+                  className={`p-2 rounded ${t.components.card.wrapper} ${t.components.card.border}`}
                 >
-                  <div
-                    className={`text-[10px] uppercase ${theme.fonts.mono} ${theme.colors.muted} mb-2`}
-                  >
+                  <div className={`text-[10px] uppercase ${t.fonts.mono} ${t.colors.muted} mb-2`}>
                     Actions Remaining
                   </div>
                   <div className="flex items-center gap-3">
                     <div className="flex items-center gap-1" title="Free Actions">
                       <span className="text-xs text-muted-foreground">F</span>
                       <span
-                        className={`px-2 py-0.5 rounded text-xs font-bold ${theme.fonts.mono} ${
+                        className={`px-2 py-0.5 rounded text-xs font-bold ${t.fonts.mono} ${
                           actionEconomy.free > 0
                             ? "bg-emerald-500/20 text-emerald-500"
                             : "bg-muted text-muted-foreground"
@@ -694,7 +699,7 @@ export function ActionPanel({
                     <div className="flex items-center gap-1" title="Simple Actions">
                       <span className="text-xs text-muted-foreground">S</span>
                       <span
-                        className={`px-2 py-0.5 rounded text-xs font-bold ${theme.fonts.mono} ${
+                        className={`px-2 py-0.5 rounded text-xs font-bold ${t.fonts.mono} ${
                           actionEconomy.simple > 0
                             ? "bg-blue-500/20 text-blue-500"
                             : "bg-muted text-muted-foreground"
@@ -706,7 +711,7 @@ export function ActionPanel({
                     <div className="flex items-center gap-1" title="Complex Actions">
                       <span className="text-xs text-muted-foreground">C</span>
                       <span
-                        className={`px-2 py-0.5 rounded text-xs font-bold ${theme.fonts.mono} ${
+                        className={`px-2 py-0.5 rounded text-xs font-bold ${t.fonts.mono} ${
                           actionEconomy.complex > 0
                             ? "bg-purple-500/20 text-purple-500"
                             : "bg-muted text-muted-foreground"
@@ -730,9 +735,7 @@ export function ActionPanel({
                   {/* Available Actions */}
                   {availableActions.length > 0 && (
                     <div className="space-y-2">
-                      <div
-                        className={`text-xs uppercase ${theme.fonts.mono} ${theme.colors.muted}`}
-                      >
+                      <div className={`text-xs uppercase ${t.fonts.mono} ${t.colors.muted}`}>
                         Available Actions
                       </div>
                       <div className="space-y-1">
@@ -762,7 +765,7 @@ export function ActionPanel({
                               isAvailable={canUse}
                               isInCombat={isInCombat}
                               isLoading={combatLoading}
-                              theme={theme}
+                              theme={t}
                             />
                           );
                         })}
@@ -774,7 +777,7 @@ export function ActionPanel({
                   {unavailableActions.length > 0 && (
                     <div className="space-y-2">
                       <div
-                        className={`text-xs uppercase ${theme.fonts.mono} ${theme.colors.muted} flex items-center gap-2`}
+                        className={`text-xs uppercase ${t.fonts.mono} ${t.colors.muted} flex items-center gap-2`}
                       >
                         <Lock className="w-3 h-3" />
                         Unavailable Actions
@@ -819,7 +822,7 @@ export function ActionPanel({
                                 {action.name}
                               </span>
                               <span
-                                className={`text-[10px] ${theme.fonts.mono} px-1.5 py-0.5 rounded bg-background/50 text-muted-foreground`}
+                                className={`text-[10px] ${t.fonts.mono} px-1.5 py-0.5 rounded bg-background/50 text-muted-foreground`}
                               >
                                 {typeLabels[actionType]}
                               </span>
@@ -828,7 +831,7 @@ export function ActionPanel({
                           );
                         })}
                       </div>
-                      <div className={`text-[10px] ${theme.colors.muted} italic`}>
+                      <div className={`text-[10px] ${t.colors.muted} italic`}>
                         Hover over an action to see requirements
                       </div>
                     </div>
@@ -839,9 +842,7 @@ export function ActionPanel({
                     <>
                       {/* Attack Actions */}
                       <div className="space-y-2">
-                        <div
-                          className={`text-xs uppercase ${theme.fonts.mono} ${theme.colors.muted}`}
-                        >
+                        <div className={`text-xs uppercase ${t.fonts.mono} ${t.colors.muted}`}>
                           Attack Actions
                         </div>
                         <div className="space-y-1">
@@ -857,7 +858,7 @@ export function ActionPanel({
                             isAvailable={canUseAction("complex")}
                             isInCombat={isInCombat}
                             isLoading={combatLoading}
-                            theme={theme}
+                            theme={t}
                           />
                           <CombatActionButton
                             label="Ranged Attack"
@@ -871,16 +872,14 @@ export function ActionPanel({
                             isAvailable={canUseAction("simple")}
                             isInCombat={isInCombat}
                             isLoading={combatLoading}
-                            theme={theme}
+                            theme={t}
                           />
                         </div>
                       </div>
 
                       {/* Defense Actions */}
                       <div className="space-y-2">
-                        <div
-                          className={`text-xs uppercase ${theme.fonts.mono} ${theme.colors.muted}`}
-                        >
+                        <div className={`text-xs uppercase ${t.fonts.mono} ${t.colors.muted}`}>
                           Defense Actions
                         </div>
                         <div className="space-y-1">
@@ -896,7 +895,7 @@ export function ActionPanel({
                             isAvailable={canUseAction("interrupt")}
                             isInCombat={isInCombat}
                             isLoading={combatLoading}
-                            theme={theme}
+                            theme={t}
                           />
                           <CombatActionButton
                             label="Block"
@@ -910,16 +909,14 @@ export function ActionPanel({
                             isAvailable={canUseAction("interrupt")}
                             isInCombat={isInCombat}
                             isLoading={combatLoading}
-                            theme={theme}
+                            theme={t}
                           />
                         </div>
                       </div>
 
                       {/* Resistance */}
                       <div className="space-y-2">
-                        <div
-                          className={`text-xs uppercase ${theme.fonts.mono} ${theme.colors.muted}`}
-                        >
+                        <div className={`text-xs uppercase ${t.fonts.mono} ${t.colors.muted}`}>
                           Resistance
                         </div>
                         <div className="space-y-1">
@@ -935,7 +932,7 @@ export function ActionPanel({
                             isAvailable={true}
                             isInCombat={isInCombat}
                             isLoading={combatLoading}
-                            theme={theme}
+                            theme={t}
                           />
                         </div>
                       </div>
@@ -954,7 +951,7 @@ export function ActionPanel({
                     >
                       <ArrowLeft className="w-4 h-4" />
                     </Button>
-                    <span className={`text-sm font-medium ${theme.colors.heading}`}>
+                    <span className={`text-sm font-medium ${t.colors.heading}`}>
                       Select Target for {selectedAction.name}
                     </span>
                   </div>
@@ -962,7 +959,7 @@ export function ActionPanel({
                   {/* Target Selector */}
                   <TargetSelector
                     characterId={character.id}
-                    theme={theme}
+                    theme={t}
                     onTargetSelect={handleTargetSelect}
                     variant="inline"
                     selectedTargetId={selectedTargetId}
@@ -974,8 +971,8 @@ export function ActionPanel({
                     className={`
                       w-full flex items-center justify-center gap-2
                       px-3 py-2 rounded text-sm
-                      ${theme.components.card.wrapper} ${theme.components.card.border}
-                      ${theme.colors.muted} hover:text-foreground
+                      ${t.components.card.wrapper} ${t.components.card.border}
+                      ${t.colors.muted} hover:text-foreground
                       transition-colors
                     `}
                   >
@@ -1003,24 +1000,24 @@ export function ActionPanel({
                     >
                       <ArrowLeft className="w-4 h-4" />
                     </Button>
-                    <span className={`text-sm font-medium ${theme.colors.heading}`}>
+                    <span className={`text-sm font-medium ${t.colors.heading}`}>
                       Confirm Action
                     </span>
                   </div>
 
                   {/* Action Summary */}
                   <div
-                    className={`p-3 rounded ${theme.components.card.wrapper} ${theme.components.card.border}`}
+                    className={`p-3 rounded ${t.components.card.wrapper} ${t.components.card.border}`}
                   >
                     <div className="flex items-center gap-3 mb-3">
                       <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center">
                         {getActionIcon(selectedAction)}
                       </div>
                       <div>
-                        <div className={`font-medium ${theme.colors.heading}`}>
+                        <div className={`font-medium ${t.colors.heading}`}>
                           {selectedAction.name}
                         </div>
-                        <div className={`text-xs ${theme.colors.muted}`}>
+                        <div className={`text-xs ${t.colors.muted}`}>
                           {selectedAction.description}
                         </div>
                       </div>
@@ -1036,8 +1033,8 @@ export function ActionPanel({
 
                     {/* Dice Pool Preview */}
                     <div className="flex items-center justify-between p-2 rounded bg-muted/30">
-                      <span className={`text-sm ${theme.colors.muted}`}>Dice Pool:</span>
-                      <span className={`font-bold ${theme.fonts.mono} ${theme.colors.accent}`}>
+                      <span className={`text-sm ${t.colors.muted}`}>Dice Pool:</span>
+                      <span className={`font-bold ${t.fonts.mono} ${t.colors.accent}`}>
                         {calculateActionPool(selectedAction)}d6
                       </span>
                     </div>
@@ -1120,12 +1117,12 @@ export function ActionPanel({
             <div
               className={`
               flex items-center gap-2 p-2 rounded text-xs border
-              ${theme.components.badge.negative}
+              ${t.components.badge.negative}
             `}
             >
               <span>Wound Modifier:</span>
-              <span className={`${theme.fonts.mono} font-bold`}>{woundModifier}</span>
-              <span className={theme.colors.muted}>(applied to all tests)</span>
+              <span className={`${t.fonts.mono} font-bold`}>{woundModifier}</span>
+              <span className={t.colors.muted}>(applied to all tests)</span>
             </div>
           )}
         </div>

--- a/app/characters/[id]/components/QuickCombatControls.tsx
+++ b/app/characters/[id]/components/QuickCombatControls.tsx
@@ -29,7 +29,7 @@ import {
 } from "lucide-react";
 import { useCombatSession } from "@/lib/combat";
 import type { Character } from "@/lib/types";
-import type { Theme } from "@/lib/themes";
+import { THEMES, DEFAULT_THEME, type Theme } from "@/lib/themes";
 
 interface QuickCombatControlsProps {
   /** Character data */
@@ -37,7 +37,7 @@ interface QuickCombatControlsProps {
   /** Edition code */
   editionCode: string;
   /** Current theme */
-  theme: Theme;
+  theme?: Theme;
   /** Callback when combat state changes */
   onCombatStateChange?: (isInCombat: boolean) => void;
 }
@@ -83,9 +83,10 @@ function rollInitiative(character: Character): {
 export function QuickCombatControls({
   character,
   editionCode,
-  theme,
+  theme: themeProp,
   onCombatStateChange,
 }: QuickCombatControlsProps) {
+  const theme = themeProp || THEMES[DEFAULT_THEME];
   // Combat session context
   const {
     session,

--- a/app/characters/[id]/components/QuickNPCPanel.tsx
+++ b/app/characters/[id]/components/QuickNPCPanel.tsx
@@ -26,7 +26,7 @@ import {
 } from "lucide-react";
 import { useCombatSession } from "@/lib/combat";
 import type { CombatParticipant } from "@/lib/types";
-import type { Theme } from "@/lib/themes";
+import { THEMES, DEFAULT_THEME, type Theme } from "@/lib/themes";
 
 /**
  * Quick NPC template for fast opponent creation
@@ -142,14 +142,20 @@ interface QuickNPCPanelProps {
   /** Current session ID */
   sessionId?: string;
   /** Current theme */
-  theme: Theme;
+  theme?: Theme;
   /** Callback when NPC is added */
   onNPCAdded?: (participant: CombatParticipant) => void;
   /** Callback when NPC is removed */
   onNPCRemoved?: (participantId: string) => void;
 }
 
-export function QuickNPCPanel({ sessionId, theme, onNPCAdded, onNPCRemoved }: QuickNPCPanelProps) {
+export function QuickNPCPanel({
+  sessionId,
+  theme: themeProp,
+  onNPCAdded,
+  onNPCRemoved,
+}: QuickNPCPanelProps) {
+  const theme = themeProp || THEMES[DEFAULT_THEME];
   const { session, isInCombat } = useCombatSession();
   const [isExpanded, setIsExpanded] = useState(true);
   const [isLoading, setIsLoading] = useState(false);

--- a/app/characters/[id]/components/TargetSelector.tsx
+++ b/app/characters/[id]/components/TargetSelector.tsx
@@ -15,13 +15,13 @@ import { Button, Dialog, DialogTrigger, Modal, ModalOverlay, Heading } from "rea
 import { Target, X, Shield, Heart, AlertTriangle, User, Bot, Skull } from "lucide-react";
 import { useCombatSession } from "@/lib/combat";
 import type { CombatParticipant } from "@/lib/types";
-import type { Theme } from "@/lib/themes";
+import { THEMES, DEFAULT_THEME, type Theme } from "@/lib/themes";
 
 interface TargetSelectorProps {
   /** Character ID (to exclude self from targets) */
   characterId: string;
   /** Current theme */
-  theme: Theme;
+  theme?: Theme;
   /** Callback when target is selected */
   onTargetSelect: (targetId: string, targetName: string) => void;
   /** Optional filter for valid target types */
@@ -74,10 +74,11 @@ interface TargetCardProps {
   participant: CombatParticipant;
   isSelected: boolean;
   onSelect: () => void;
-  theme: Theme;
+  theme?: Theme;
 }
 
-function TargetCard({ participant, isSelected, onSelect, theme }: TargetCardProps) {
+function TargetCard({ participant, isSelected, onSelect, theme: themeProp }: TargetCardProps) {
+  const theme = themeProp || THEMES[DEFAULT_THEME];
   const isDefeated = participant.status === "out";
 
   return (
@@ -153,12 +154,13 @@ function TargetCard({ participant, isSelected, onSelect, theme }: TargetCardProp
 
 export function TargetSelector({
   characterId,
-  theme,
+  theme: themeProp,
   onTargetSelect,
   validTargetTypes,
   variant = "modal",
   selectedTargetId,
 }: TargetSelectorProps) {
+  const theme = themeProp || THEMES[DEFAULT_THEME];
   const { session, participant } = useCombatSession();
   const [isOpen, setIsOpen] = useState(false);
 

--- a/components/character/sheet/CombatDisplay.tsx
+++ b/components/character/sheet/CombatDisplay.tsx
@@ -4,13 +4,13 @@ import { DisplayCard } from "./DisplayCard";
 import { Swords } from "lucide-react";
 import { CombatQuickReference } from "@/app/characters/[id]/components/CombatQuickReference";
 import type { Character } from "@/lib/types";
-import type { Theme } from "@/lib/themes";
+import { THEMES, DEFAULT_THEME, type Theme } from "@/lib/themes";
 
 interface CombatDisplayProps {
   character: Character;
   woundModifier: number;
   physicalLimit: number;
-  theme: Theme;
+  theme?: Theme;
   onPoolSelect: (pool: number, context: string) => void;
 }
 
@@ -21,13 +21,14 @@ export function CombatDisplay({
   theme,
   onPoolSelect,
 }: CombatDisplayProps) {
+  const t = theme || THEMES[DEFAULT_THEME];
   return (
     <DisplayCard title="Combat" icon={<Swords className="h-4 w-4 text-zinc-400" />}>
       <CombatQuickReference
         character={character}
         woundModifier={woundModifier}
         physicalLimit={physicalLimit}
-        theme={theme}
+        theme={t}
         onPoolSelect={onPoolSelect}
       />
     </DisplayCard>

--- a/components/character/sheet/ConditionDisplay.tsx
+++ b/components/character/sheet/ConditionDisplay.tsx
@@ -4,14 +4,14 @@ import { DisplayCard } from "./DisplayCard";
 import { Heart } from "lucide-react";
 import { InteractiveConditionMonitor } from "@/app/characters/[id]/components/InteractiveConditionMonitor";
 import type { Character } from "@/lib/types";
-import type { Theme } from "@/lib/themes";
+import { THEMES, DEFAULT_THEME, type Theme } from "@/lib/themes";
 
 interface ConditionDisplayProps {
   character: Character;
   woundModifier: number;
   physicalMonitorMax: number;
   stunMonitorMax: number;
-  theme: Theme;
+  theme?: Theme;
   readonly: boolean;
   onDamageApplied: (type: "physical" | "stun" | "overflow", newValue: number) => void;
 }
@@ -25,6 +25,7 @@ export function ConditionDisplay({
   readonly,
   onDamageApplied,
 }: ConditionDisplayProps) {
+  const t = theme || THEMES[DEFAULT_THEME];
   return (
     <DisplayCard title="Condition" icon={<Heart className="h-4 w-4 text-zinc-400" />}>
       <div className="space-y-6">
@@ -40,7 +41,7 @@ export function ConditionDisplay({
             type="physical"
             current={character.condition?.physicalDamage ?? 0}
             max={physicalMonitorMax}
-            theme={theme}
+            theme={t}
             readonly={readonly}
             onDamageApplied={(newValue) => onDamageApplied("physical", newValue)}
           />
@@ -49,7 +50,7 @@ export function ConditionDisplay({
             type="stun"
             current={character.condition?.stunDamage ?? 0}
             max={stunMonitorMax}
-            theme={theme}
+            theme={t}
             readonly={readonly}
             onDamageApplied={(newValue) => onDamageApplied("stun", newValue)}
           />
@@ -59,7 +60,7 @@ export function ConditionDisplay({
           type="overflow"
           current={character.condition?.overflowDamage ?? 0}
           max={character.attributes?.body || 3}
-          theme={theme}
+          theme={t}
           readonly={readonly}
           onDamageApplied={(newValue) => onDamageApplied("overflow", newValue)}
         />


### PR DESCRIPTION
## Summary
- Removed `ThemeSelector` component, theme state (`currentThemeId`, `theme`), and `handleThemeChange` from `page.tsx` (~60 lines deleted)
- Replaced dynamic `theme.colors.*` styling in the dice roller modal and page wrapper with hardcoded Tailwind classes (`bg-background`, `border-border`, `bg-card/80`, `text-foreground`, `text-emerald-400`)
- Made `theme` prop optional in 6 child components (`ConditionDisplay`, `CombatDisplay`, `ActionPanel`, `QuickCombatControls`, `QuickNPCPanel`, `TargetSelector`) with `THEMES[DEFAULT_THEME]` fallbacks, so they continue to work unchanged
- Removed `theme={theme}` prop passing from all 8 child component call sites in page.tsx

## Test plan
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm lint` — 0 errors (365 pre-existing warnings)
- [x] `grep theme page.tsx` — zero hits
- [x] `grep ThemeSelector` — zero hits
- [ ] Manual: open character sheet, verify all sections render with default styling
- [ ] Manual: verify dice roller modal opens/closes correctly
- [ ] Manual: verify condition monitors, combat display, action panel all functional

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)