### PR TITLE
refactor(sheet): Redesign AttributesDisplay with grouped sections

### DIFF
--- a/components/character/sheet/AttributesDisplay.tsx
+++ b/components/character/sheet/AttributesDisplay.tsx
@@ -1,138 +1,263 @@
 "use client";
 
 import type { Character } from "@/lib/types";
-import { useMetatypes } from "@/lib/rules";
 import { DisplayCard } from "./DisplayCard";
-import { ATTRIBUTE_DISPLAY, getAttributeBonus } from "./constants";
-import { BarChart3 } from "lucide-react";
+import { getAttributeBonus } from "./constants";
+import { BarChart3, Star, Sparkles, Cpu, CirclePlus, ArrowUp } from "lucide-react";
+import { Tooltip } from "@/components/ui";
+import { Button as AriaButton } from "react-aria-components";
 
 interface AttributesDisplayProps {
   character: Character;
   onSelect?: (attrId: string, value: number) => void;
 }
 
-const ATTRIBUTES = [
+const PHYSICAL_ATTRIBUTES = [
   { id: "body", label: "Body" },
   { id: "agility", label: "Agility" },
   { id: "reaction", label: "Reaction" },
   { id: "strength", label: "Strength" },
+];
+
+const MENTAL_ATTRIBUTES = [
   { id: "willpower", label: "Willpower" },
   { id: "logic", label: "Logic" },
   { id: "intuition", label: "Intuition" },
   { id: "charisma", label: "Charisma" },
 ];
 
-export function AttributesDisplay({ character, onSelect }: AttributesDisplayProps) {
-  const metatypes = useMetatypes();
-  const metatypeData = metatypes.find(
-    (m) => m.name.toLowerCase() === character.metatype.toLowerCase()
+/**
+ * Special attribute display config.
+ * Dark-mode colors match the approved HTML mock exactly; light-mode
+ * uses the closest readable equivalent on a white/zinc-50 background.
+ */
+const SPECIAL_ATTR_CONFIG: Record<
+  string,
+  {
+    icon: React.ComponentType<{ className?: string }>;
+    iconColor: string;
+    nameColor: string;
+    pillClasses: string;
+  }
+> = {
+  // Edge — amber  (mock: icon #f59e0b, name #fbbf24, pill bg amber/15)
+  edge: {
+    icon: Star,
+    iconColor: "text-amber-500",
+    nameColor: "text-amber-600 dark:text-amber-400",
+    pillClasses:
+      "bg-amber-50 border-amber-200 text-amber-700 dark:bg-amber-500/15 dark:border-amber-500/20 dark:text-amber-400",
+  },
+  // Essence — cyan  (mock: icon #22d3ee, name #67e8f9, pill bg cyan/12)
+  essence: {
+    icon: CirclePlus,
+    iconColor: "text-cyan-500 dark:text-cyan-400",
+    nameColor: "text-cyan-600 dark:text-cyan-300",
+    pillClasses:
+      "bg-cyan-50 border-cyan-200 text-cyan-700 dark:bg-cyan-400/12 dark:border-cyan-400/20 dark:text-cyan-300",
+  },
+  // Magic — purple  (mock: icon #a855f7, name #c084fc, pill bg purple/15)
+  magic: {
+    icon: Sparkles,
+    iconColor: "text-purple-500",
+    nameColor: "text-purple-600 dark:text-purple-400",
+    pillClasses:
+      "bg-purple-50 border-purple-200 text-purple-700 dark:bg-purple-500/15 dark:border-purple-500/20 dark:text-purple-400",
+  },
+  // Resonance — sky  (mock: icon #38bdf8, name #7dd3fc, pill bg sky/12)
+  resonance: {
+    icon: Cpu,
+    iconColor: "text-sky-500 dark:text-sky-400",
+    nameColor: "text-sky-600 dark:text-sky-300",
+    pillClasses:
+      "bg-sky-50 border-sky-200 text-sky-700 dark:bg-sky-400/12 dark:border-sky-400/20 dark:text-sky-300",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function AugTooltipContent({ bonuses }: { bonuses: Array<{ source: string; value: number }> }) {
+  const total = bonuses.reduce((sum, b) => sum + b.value, 0);
+  return (
+    <div className="space-y-1">
+      {bonuses.map((b, i) => (
+        <div key={i} className="flex items-center justify-between gap-4">
+          <span className="text-zinc-400">{b.source}</span>
+          <span className="font-mono font-semibold text-emerald-400">+{b.value}</span>
+        </div>
+      ))}
+      {bonuses.length > 1 && (
+        <>
+          <div className="border-t border-zinc-600" />
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-200">
+              Total Aug
+            </span>
+            <span className="font-mono font-bold text-emerald-300">+{total}</span>
+          </div>
+        </>
+      )}
+    </div>
   );
+}
+
+function CoreAttributeRow({
+  label,
+  base,
+  augTotal,
+  bonuses,
+  onClick,
+}: {
+  label: string;
+  base: number;
+  augTotal: number;
+  bonuses: Array<{ source: string; value: number }>;
+  onClick?: () => void;
+}) {
+  const effective = base + augTotal;
+  const isAugmented = augTotal > 0;
+
+  return (
+    <div
+      onClick={onClick}
+      className="group flex cursor-pointer items-center justify-between rounded px-1 py-[7px] transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+    >
+      <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">{label}</span>
+      <div className="flex items-center gap-2">
+        {isAugmented && (
+          <span onClick={(e) => e.stopPropagation()}>
+            <Tooltip
+              content={<AugTooltipContent bonuses={bonuses} />}
+              delay={200}
+              showArrow={false}
+            >
+              <AriaButton
+                aria-label={`${label} augmentation details`}
+                className="inline-flex items-center gap-0.5 rounded bg-emerald-500/15 px-1.5 py-0.5 font-mono text-[11px] font-semibold text-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              >
+                +{augTotal}
+                <ArrowUp className="h-2.5 w-2.5" />
+              </AriaButton>
+            </Tooltip>
+          </span>
+        )}
+        <div
+          className={`flex h-7 w-8 items-center justify-center rounded-md font-mono text-sm font-bold ${
+            isAugmented
+              ? "border border-emerald-500/20 bg-emerald-500/12 text-emerald-300"
+              : "bg-zinc-200 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+          }`}
+        >
+          {effective}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SpecialAttributeRow({
+  attrKey,
+  value,
+  onClick,
+}: {
+  attrKey: string;
+  value: number;
+  onClick?: () => void;
+}) {
+  const config = SPECIAL_ATTR_CONFIG[attrKey];
+  if (!config) return null;
+
+  const Icon = config.icon;
+  const label = attrKey.charAt(0).toUpperCase() + attrKey.slice(1);
+  const isEssence = attrKey === "essence";
+  const displayValue = isEssence ? value.toFixed(2) : String(value);
+
+  return (
+    <div
+      onClick={isEssence ? undefined : onClick}
+      className={`group flex items-center justify-between rounded px-1 py-[7px] transition-colors [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50 ${
+        isEssence ? "" : "cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-700/30"
+      }`}
+    >
+      <div className="flex items-center gap-1.5">
+        <Icon className={`h-3.5 w-3.5 shrink-0 ${config.iconColor}`} />
+        <span className={`text-[13px] font-medium ${config.nameColor}`}>{label}</span>
+      </div>
+      <div
+        className={`flex h-7 items-center justify-center rounded-md border font-mono text-sm font-bold ${config.pillClasses} ${
+          isEssence ? "w-12" : "w-8"
+        }`}
+      >
+        {displayValue}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function AttributesDisplay({ character, onSelect }: AttributesDisplayProps) {
+  function renderCoreSection(title: string, attrs: Array<{ id: string; label: string }>) {
+    return (
+      <>
+        <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+          {title}
+        </div>
+        <div className="mb-3 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1 dark:border-zinc-800 dark:bg-zinc-950">
+          {attrs.map(({ id, label }) => {
+            const base = character.attributes[id] || 0;
+            const bonuses = getAttributeBonus(character, id);
+            const augTotal = bonuses.reduce((sum, b) => sum + b.value, 0);
+
+            return (
+              <CoreAttributeRow
+                key={id}
+                label={label}
+                base={base}
+                augTotal={augTotal}
+                bonuses={bonuses}
+                onClick={() => onSelect?.(id, base + augTotal)}
+              />
+            );
+          })}
+        </div>
+      </>
+    );
+  }
 
   return (
     <DisplayCard title="Attributes" icon={<BarChart3 className="h-4 w-4 text-zinc-400" />}>
-      <div className="w-full overflow-x-auto">
-        <table className="w-full text-left border-collapse font-mono text-xs">
-          <thead>
-            <tr className="border-b border-zinc-200 dark:border-zinc-700/50">
-              <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase">
-                Attribute
-              </th>
-              <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-center">
-                Base
-              </th>
-              <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-center">
-                Aug
-              </th>
-              <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-center">
-                Min/Max
-              </th>
-              <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase">
-                Notes
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {ATTRIBUTES.map(({ id, label }) => {
-              const base = character.attributes[id] || 0;
-              const bonuses = getAttributeBonus(character, id);
-              const augTotal = bonuses.reduce((sum, b) => sum + b.value, 0);
-              const display = ATTRIBUTE_DISPLAY[id];
+      {renderCoreSection("Physical", PHYSICAL_ATTRIBUTES)}
+      {renderCoreSection("Mental", MENTAL_ATTRIBUTES)}
 
-              const limit = metatypeData?.attributes[id];
-              const minMaxStr =
-                limit && "min" in limit && "max" in limit ? `(${limit.min}/${limit.max})` : "(1/6)";
-
-              return (
-                <tr
-                  key={id}
-                  onClick={() => onSelect?.(id, base + augTotal)}
-                  className="group border-b border-zinc-100 dark:border-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/30 cursor-pointer transition-colors"
-                >
-                  <td className="py-2 px-1">
-                    <span
-                      className={`font-bold ${display?.color || "text-zinc-900 dark:text-zinc-100"}`}
-                    >
-                      {label}
-                    </span>
-                  </td>
-                  <td className="py-2 px-1 text-center font-bold text-zinc-900 dark:text-zinc-100">
-                    [{base}]
-                  </td>
-                  <td className="py-2 px-1 text-center font-bold text-emerald-500">
-                    {augTotal > 0 ? `[+${augTotal}]` : "[  ]"}
-                  </td>
-                  <td className="py-2 px-1 text-center text-zinc-500 dark:text-zinc-400">
-                    {minMaxStr}
-                  </td>
-                  <td
-                    className="py-2 px-1 text-[10px] text-zinc-500 dark:text-zinc-400 italic truncate max-w-[120px]"
-                    title={bonuses.map((b) => `${b.source} (+${b.value})`).join(", ")}
-                  >
-                    {bonuses.length > 0 ? bonuses.map((b) => b.source).join(", ") : ""}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-
-        <div className="mt-4 pt-4 border-t border-zinc-200 dark:border-zinc-700/50 grid grid-cols-1 sm:grid-cols-2 gap-4 font-mono text-xs">
-          <div className="flex items-center justify-between">
-            <span className="text-zinc-500 dark:text-zinc-400 uppercase">Edge</span>
-            <div className="flex items-center gap-2">
-              <span className="font-bold text-zinc-900 dark:text-zinc-100">
-                [{character.specialAttributes.edge}]
-              </span>
-              <span className="text-zinc-500 dark:text-zinc-400">/</span>
-              <span className="font-bold text-zinc-900 dark:text-zinc-100">
-                [{character.specialAttributes.edge}]
-              </span>
-            </div>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-zinc-500 dark:text-zinc-400 uppercase">Essence</span>
-            <span className="font-bold text-blue-400">
-              [{character.specialAttributes.essence.toFixed(2)}]
-            </span>
-          </div>
-          {(character.specialAttributes.magic !== undefined ||
-            character.specialAttributes.resonance !== undefined) && (
-            <div className="flex items-center justify-between">
-              <span className="text-zinc-500 dark:text-zinc-400 uppercase">
-                {character.specialAttributes.magic !== undefined ? "Magic" : "Resonance"}
-              </span>
-              <span
-                className={`font-bold ${
-                  character.specialAttributes.magic !== undefined
-                    ? "text-violet-400"
-                    : "text-cyan-400"
-                }`}
-              >
-                [{character.specialAttributes.magic ?? character.specialAttributes.resonance}]
-              </span>
-            </div>
-          )}
-        </div>
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+        Special
+      </div>
+      <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1 dark:border-zinc-800 dark:bg-zinc-950">
+        <SpecialAttributeRow
+          attrKey="edge"
+          value={character.specialAttributes.edge}
+          onClick={() => onSelect?.("edge", character.specialAttributes.edge)}
+        />
+        <SpecialAttributeRow attrKey="essence" value={character.specialAttributes.essence} />
+        {character.specialAttributes.magic !== undefined && (
+          <SpecialAttributeRow
+            attrKey="magic"
+            value={character.specialAttributes.magic}
+            onClick={() => onSelect?.("magic", character.specialAttributes.magic!)}
+          />
+        )}
+        {character.specialAttributes.resonance !== undefined && (
+          <SpecialAttributeRow
+            attrKey="resonance"
+            value={character.specialAttributes.resonance}
+            onClick={() => onSelect?.("resonance", character.specialAttributes.resonance!)}
+          />
+        )}
       </div>
     </DisplayCard>
   );

--- a/components/character/sheet/__tests__/AttributesDisplay.test.tsx
+++ b/components/character/sheet/__tests__/AttributesDisplay.test.tsx
@@ -1,14 +1,14 @@
 /**
  * AttributesDisplay Component Tests
  *
- * Tests the character attributes table. Mocks useMetatypes hook.
- * Shows 8 core attributes, augmented values, Edge/Essence/Magic row,
- * and onSelect callback.
+ * Tests the character attributes display with Physical/Mental/Special
+ * grouped sections, augmentation pills with tooltips, and special
+ * attribute icons.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { createSheetCharacter, MOCK_METATYPE_HUMAN } from "./test-helpers";
+import { createSheetCharacter, MOCK_CYBERWARE, MOCK_BIOWARE } from "./test-helpers";
 
 vi.mock("../DisplayCard", () => ({
   DisplayCard: ({ title, children }: { title: string; children: React.ReactNode }) => (
@@ -20,46 +20,26 @@ vi.mock("../DisplayCard", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
-  Activity: (props: Record<string, unknown>) => <span data-testid="icon-Activity" {...props} />,
-  Shield: (props: Record<string, unknown>) => <span data-testid="icon-Shield" {...props} />,
-  Heart: (props: Record<string, unknown>) => <span data-testid="icon-Heart" {...props} />,
-  Brain: (props: Record<string, unknown>) => <span data-testid="icon-Brain" {...props} />,
-  Footprints: (props: Record<string, unknown>) => <span data-testid="icon-Footprints" {...props} />,
-  ShieldCheck: (props: Record<string, unknown>) => (
-    <span data-testid="icon-ShieldCheck" {...props} />
-  ),
   BarChart3: (props: Record<string, unknown>) => <span data-testid="icon-BarChart3" {...props} />,
-  Crosshair: (props: Record<string, unknown>) => <span data-testid="icon-Crosshair" {...props} />,
-  Swords: (props: Record<string, unknown>) => <span data-testid="icon-Swords" {...props} />,
-  Package: (props: Record<string, unknown>) => <span data-testid="icon-Package" {...props} />,
-  Pill: (props: Record<string, unknown>) => <span data-testid="icon-Pill" {...props} />,
+  Star: (props: Record<string, unknown>) => <span data-testid="icon-Star" {...props} />,
   Sparkles: (props: Record<string, unknown>) => <span data-testid="icon-Sparkles" {...props} />,
-  Braces: (props: Record<string, unknown>) => <span data-testid="icon-Braces" {...props} />,
   Cpu: (props: Record<string, unknown>) => <span data-testid="icon-Cpu" {...props} />,
-  BookOpen: (props: Record<string, unknown>) => <span data-testid="icon-BookOpen" {...props} />,
-  Users: (props: Record<string, unknown>) => <span data-testid="icon-Users" {...props} />,
-  Fingerprint: (props: Record<string, unknown>) => (
-    <span data-testid="icon-Fingerprint" {...props} />
+  CirclePlus: (props: Record<string, unknown>) => <span data-testid="icon-CirclePlus" {...props} />,
+  ArrowUp: (props: Record<string, unknown>) => <span data-testid="icon-ArrowUp" {...props} />,
+}));
+
+vi.mock("@/components/ui", () => ({
+  Tooltip: ({ children, content }: { children: React.ReactNode; content: React.ReactNode }) => (
+    <div>
+      {children}
+      <div data-testid="tooltip-content">{content}</div>
+    </div>
   ),
-  Zap: (props: Record<string, unknown>) => <span data-testid="icon-Zap" {...props} />,
-  Car: (props: Record<string, unknown>) => <span data-testid="icon-Car" {...props} />,
-  Home: (props: Record<string, unknown>) => <span data-testid="icon-Home" {...props} />,
 }));
 
-vi.mock("@/lib/rules", () => ({
-  useMetatypes: vi.fn(),
-}));
-
-import { useMetatypes } from "@/lib/rules";
 import { AttributesDisplay } from "../AttributesDisplay";
 
 describe("AttributesDisplay", () => {
-  beforeEach(() => {
-    vi.mocked(useMetatypes).mockReturnValue([MOCK_METATYPE_HUMAN] as ReturnType<
-      typeof useMetatypes
-    >);
-  });
-
   it("renders all 8 core attributes", () => {
     const character = createSheetCharacter();
     render(<AttributesDisplay character={character} />);
@@ -74,7 +54,16 @@ describe("AttributesDisplay", () => {
     expect(screen.getByText("Charisma")).toBeInTheDocument();
   });
 
-  it("renders base attribute values in brackets", () => {
+  it("renders Physical, Mental, Special section headers", () => {
+    const character = createSheetCharacter();
+    render(<AttributesDisplay character={character} />);
+
+    expect(screen.getByText("Physical")).toBeInTheDocument();
+    expect(screen.getByText("Mental")).toBeInTheDocument();
+    expect(screen.getByText("Special")).toBeInTheDocument();
+  });
+
+  it("renders augmentation pill when bonus > 0", () => {
     const character = createSheetCharacter({
       attributes: {
         body: 5,
@@ -86,16 +75,27 @@ describe("AttributesDisplay", () => {
         intuition: 4,
         charisma: 2,
       },
+      cyberware: [MOCK_CYBERWARE],
     });
     render(<AttributesDisplay character={character} />);
-    // Body=5 and Reaction=5 both render [5], so check for multiple
-    const fives = screen.getAllByText("[5]");
-    expect(fives.length).toBeGreaterThanOrEqual(1);
-    // Agility=6 renders [6]
-    expect(screen.getByText("[6]")).toBeInTheDocument();
+    // Wired Reflexes gives +1 reaction — aug pill and tooltip both show "+1"
+    const plusOnes = screen.getAllByText("+1");
+    expect(plusOnes.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders augmented column with green text for augmented values", () => {
+  it("does not render augmentation pill when no bonuses", () => {
+    const character = createSheetCharacter({
+      cyberware: [],
+      bioware: [],
+    });
+    render(<AttributesDisplay character={character} />);
+    // No ArrowUp icons should be present (aug pills contain ArrowUp)
+    expect(screen.queryByTestId("icon-ArrowUp")).not.toBeInTheDocument();
+  });
+
+  it("renders multi-source augmentation tooltip with total", () => {
+    // MOCK_CYBERWARE gives reaction: +1, MOCK_BIOWARE gives agility: +2
+    // We need two sources on the SAME attribute to test the total row
     const character = createSheetCharacter({
       attributes: {
         body: 5,
@@ -109,43 +109,35 @@ describe("AttributesDisplay", () => {
       },
       cyberware: [
         {
-          catalogId: "wired-reflexes",
-          name: "Wired Reflexes",
-          category: "bodyware",
-          grade: "standard",
-          baseEssenceCost: 2,
-          essenceCost: 2,
-          cost: 39000,
-          availability: 8,
-          attributeBonuses: { reaction: 1 },
+          ...MOCK_CYBERWARE,
+          attributeBonuses: { agility: 1 },
         },
       ],
+      bioware: [MOCK_BIOWARE],
     });
     render(<AttributesDisplay character={character} />);
-    // The augmented value should show [+1]
-    expect(screen.getByText("[+1]")).toBeInTheDocument();
-  });
 
-  it("renders min/max from metatype data", () => {
-    const character = createSheetCharacter({ metatype: "Human" });
-    render(<AttributesDisplay character={character} />);
-    // Human attributes have (1/6) range
-    const ranges = screen.getAllByText("(1/6)");
-    expect(ranges.length).toBe(8); // All 8 core attributes
+    // Tooltip should show both source names
+    expect(screen.getByText("Wired Reflexes")).toBeInTheDocument();
+    expect(screen.getByText("Muscle Toner")).toBeInTheDocument();
+    // Total row should show "Total Aug"
+    expect(screen.getByText("Total Aug")).toBeInTheDocument();
   });
 
   it("renders Edge in the special attributes section", () => {
     const character = createSheetCharacter({ specialAttributes: { edge: 3, essence: 6 } });
     render(<AttributesDisplay character={character} />);
     expect(screen.getByText("Edge")).toBeInTheDocument();
-    expect(screen.getAllByText("[3]").length).toBeGreaterThanOrEqual(1);
+    // Edge value "3" appears alongside other attribute values - verify it exists
+    const threes = screen.getAllByText("3");
+    expect(threes.length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders Essence with 2 decimal places", () => {
     const character = createSheetCharacter({ specialAttributes: { edge: 3, essence: 4.2 } });
     render(<AttributesDisplay character={character} />);
     expect(screen.getByText("Essence")).toBeInTheDocument();
-    expect(screen.getByText("[4.20]")).toBeInTheDocument();
+    expect(screen.getByText("4.20")).toBeInTheDocument();
   });
 
   it("renders Magic attribute when present", () => {
@@ -154,7 +146,7 @@ describe("AttributesDisplay", () => {
     });
     render(<AttributesDisplay character={character} />);
     expect(screen.getByText("Magic")).toBeInTheDocument();
-    expect(screen.getByText("[7]")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
   });
 
   it("renders Resonance attribute when present", () => {
@@ -163,6 +155,25 @@ describe("AttributesDisplay", () => {
     });
     render(<AttributesDisplay character={character} />);
     expect(screen.getByText("Resonance")).toBeInTheDocument();
+  });
+
+  it("does not render Magic or Resonance when neither defined", () => {
+    const character = createSheetCharacter({
+      specialAttributes: { edge: 3, essence: 6 },
+    });
+    render(<AttributesDisplay character={character} />);
+    expect(screen.queryByText("Magic")).not.toBeInTheDocument();
+    expect(screen.queryByText("Resonance")).not.toBeInTheDocument();
+  });
+
+  it("renders special attribute icons", () => {
+    const character = createSheetCharacter({
+      specialAttributes: { edge: 3, essence: 6, magic: 5 },
+    });
+    render(<AttributesDisplay character={character} />);
+    expect(screen.getByTestId("icon-Star")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-CirclePlus")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-Sparkles")).toBeInTheDocument();
   });
 
   it("calls onSelect with attribute id and total value when clicked", () => {
@@ -181,7 +192,6 @@ describe("AttributesDisplay", () => {
     });
     render(<AttributesDisplay character={character} onSelect={onSelect} />);
 
-    // Click on Body row
     fireEvent.click(screen.getByText("Body"));
     expect(onSelect).toHaveBeenCalledWith("body", 5);
   });
@@ -199,34 +209,12 @@ describe("AttributesDisplay", () => {
         intuition: 4,
         charisma: 2,
       },
-      cyberware: [
-        {
-          catalogId: "wired-reflexes",
-          name: "Wired Reflexes",
-          category: "bodyware",
-          grade: "standard",
-          baseEssenceCost: 2,
-          essenceCost: 2,
-          cost: 39000,
-          availability: 8,
-          attributeBonuses: { reaction: 1 },
-        },
-      ],
+      cyberware: [MOCK_CYBERWARE],
     });
     render(<AttributesDisplay character={character} onSelect={onSelect} />);
 
     // Click on Reaction row - should be base 5 + aug 1 = 6
     fireEvent.click(screen.getByText("Reaction"));
     expect(onSelect).toHaveBeenCalledWith("reaction", 6);
-  });
-
-  it("renders table column headers", () => {
-    const character = createSheetCharacter();
-    render(<AttributesDisplay character={character} />);
-    expect(screen.getByText("Attribute")).toBeInTheDocument();
-    expect(screen.getByText("Base")).toBeInTheDocument();
-    expect(screen.getByText("Aug")).toBeInTheDocument();
-    expect(screen.getByText("Min/Max")).toBeInTheDocument();
-    expect(screen.getByText("Notes")).toBeInTheDocument();
   });
 });

--- a/components/character/sheet/__tests__/test-helpers.tsx
+++ b/components/character/sheet/__tests__/test-helpers.tsx
@@ -81,6 +81,19 @@ export function setupReactAriaMock() {
         {children}
       </a>
     ),
+    Button: ({
+      children,
+      className,
+      ...props
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      [key: string]: unknown;
+    }) => (
+      <button className={className} {...props}>
+        {children}
+      </button>
+    ),
   }));
 }
 
@@ -118,6 +131,9 @@ export const LUCIDE_MOCK = {
   Zap: createIconMock("Zap"),
   Car: createIconMock("Car"),
   Home: createIconMock("Home"),
+  Star: createIconMock("Star"),
+  CirclePlus: createIconMock("CirclePlus"),
+  ArrowUp: createIconMock("ArrowUp"),
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace flat 5-column table layout with Physical/Mental/Special grouped sections using flex rows
- Add emerald augmentation pills with multi-source tooltips (AriaButton trigger for proper focus/hover)
- Add semantic icons and per-attribute colors for special attributes (Edge/Essence/Magic/Resonance)
- Implement proper light/dark mode support matching the approved HTML mock
- Rewrite tests (13 tests) and fix shared `react-aria-components` mock in test-helpers to include `Button`

## Test plan
- [x] `pnpm type-check` passes
- [x] `npx vitest run "sheet/__tests__/AttributesDisplay"` — 13 tests pass
- [x] `npx vitest run "sheet/__tests__/"` — all 18 test files (193 tests) pass
- [x] `pnpm lint` — 0 errors
- [ ] Manual: verify Physical/Mental/Special sections render correctly in both themes
- [ ] Manual: verify augmented attributes show emerald pill + tooltip with source breakdown
- [ ] Manual: verify clicking aug pill does NOT trigger dice roller
- [ ] Manual: verify Edge/Magic/Resonance show correct icons and colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)