### PR TITLE
refactor(sheet): Redesign KnowledgeLanguagesDisplay with sunken containers and value pills

### DIFF
--- a/components/character/sheet/KnowledgeLanguagesDisplay.tsx
+++ b/components/character/sheet/KnowledgeLanguagesDisplay.tsx
@@ -1,17 +1,102 @@
 "use client";
 
-import type { Character } from "@/lib/types";
+import type { Character, KnowledgeSkill, LanguageSkill } from "@/lib/types";
 import { DisplayCard } from "./DisplayCard";
 import { BookOpen } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface KnowledgeLanguagesDisplayProps {
   character: Character;
   onSelect?: (pool: number, label: string) => void;
 }
 
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function KnowledgeSkillRow({ skill, onClick }: { skill: KnowledgeSkill; onClick?: () => void }) {
+  return (
+    <div
+      onClick={onClick}
+      className="group cursor-pointer rounded px-1 py-[7px] transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+    >
+      {/* Line 1: Name + Rating pill */}
+      <div className="flex items-center justify-between">
+        <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+          {skill.name}
+        </span>
+        <div
+          data-testid="rating-pill"
+          className="flex h-7 w-8 items-center justify-center rounded-md font-mono text-sm font-bold bg-zinc-200 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+        >
+          {skill.rating}
+        </div>
+      </div>
+
+      {/* Line 2: Category subtitle */}
+      <div className="ml-1 mt-0.5 text-xs capitalize text-zinc-500 dark:text-zinc-400">
+        {skill.category}
+      </div>
+
+      {/* Line 3: Specialization (conditional) */}
+      {skill.specialization && (
+        <div className="ml-1 mt-1 flex flex-wrap gap-1">
+          <span
+            data-testid="specialization-pill"
+            className="inline-flex items-center rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+          >
+            {skill.specialization}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LanguageRow({ language, onClick }: { language: LanguageSkill; onClick?: () => void }) {
+  return (
+    <div
+      onClick={language.isNative ? undefined : onClick}
+      className={`group rounded px-1 py-[7px] transition-colors [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50 ${
+        language.isNative ? "" : "cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-700/30"
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+          {language.name}
+        </span>
+        {language.isNative ? (
+          <div
+            data-testid="native-pill"
+            className="flex h-7 w-8 items-center justify-center rounded-md font-mono text-sm font-bold border border-emerald-500/20 bg-emerald-500/12 text-emerald-600 dark:text-emerald-300"
+          >
+            N
+          </div>
+        ) : (
+          <div
+            data-testid="rating-pill"
+            className="flex h-7 w-8 items-center justify-center rounded-md font-mono text-sm font-bold bg-zinc-200 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+          >
+            {language.rating}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
 export function KnowledgeLanguagesDisplay({ character, onSelect }: KnowledgeLanguagesDisplayProps) {
   const knowledgeSkills = character.knowledgeSkills || [];
   const languages = character.languages || [];
+
+  const sortedKnowledge = [...knowledgeSkills].sort((a, b) => b.rating - a.rating);
 
   return (
     <DisplayCard
@@ -21,64 +106,36 @@ export function KnowledgeLanguagesDisplay({ character, onSelect }: KnowledgeLang
       {knowledgeSkills.length === 0 && languages.length === 0 ? (
         <p className="text-sm text-zinc-500 italic px-1">No knowledge skills or languages</p>
       ) : (
-        <div className="space-y-6">
-          {knowledgeSkills.length > 0 && (
-            <div className="w-full overflow-x-auto">
-              <table className="w-full text-left border-collapse font-mono text-xs">
-                <thead>
-                  <tr className="border-b border-zinc-200 dark:border-zinc-700/50">
-                    <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px]">
-                      Knowledge Skill
-                    </th>
-                    <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-center">
-                      Type
-                    </th>
-                    <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-right">
-                      Rating
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {knowledgeSkills.map((skill, index) => (
-                    <tr
-                      key={index}
-                      onClick={() => onSelect?.(skill.rating, skill.name)}
-                      className="border-b border-zinc-100 dark:border-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors cursor-pointer group"
-                    >
-                      <td className="py-2 px-1 text-zinc-700 dark:text-zinc-300 group-hover:text-zinc-900 dark:group-hover:text-zinc-100">
-                        {skill.name}
-                      </td>
-                      <td className="py-2 px-1 text-center text-zinc-500 dark:text-zinc-400 capitalize text-[10px]">
-                        {skill.category}
-                      </td>
-                      <td className="py-2 px-1 text-right font-bold tabular-nums text-zinc-900 dark:text-zinc-100">
-                        [{skill.rating}]
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+        <div className="space-y-3">
+          {sortedKnowledge.length > 0 && (
+            <div>
+              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                Knowledge
+              </div>
+              <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1 dark:border-zinc-800 dark:bg-zinc-950">
+                {sortedKnowledge.map((skill, index) => (
+                  <KnowledgeSkillRow
+                    key={index}
+                    skill={skill}
+                    onClick={() => onSelect?.(skill.rating, skill.name)}
+                  />
+                ))}
+              </div>
             </div>
           )}
 
           {languages.length > 0 && (
-            <div className="pt-2 border-t border-zinc-200 dark:border-zinc-700/50">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-[10px] font-bold text-zinc-500 dark:text-zinc-400 uppercase font-mono">
-                  Languages:
-                </span>
+            <div>
+              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                Languages
+              </div>
+              <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1 dark:border-zinc-800 dark:bg-zinc-950">
                 {languages.map((lang, index) => (
-                  <span
+                  <LanguageRow
                     key={index}
-                    onClick={() => !lang.isNative && onSelect?.(lang.rating, lang.name)}
-                    className={`px-2 py-1 text-[11px] rounded border transition-colors ${
-                      lang.isNative
-                        ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30 font-medium"
-                        : "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 border-zinc-200 dark:border-zinc-700 hover:bg-zinc-200 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100 cursor-pointer"
-                    }`}
-                  >
-                    {lang.name} {lang.isNative ? "(N)" : `(${lang.rating})`}
-                  </span>
+                    language={lang}
+                    onClick={() => onSelect?.(lang.rating, lang.name)}
+                  />
                 ))}
               </div>
             </div>

--- a/components/character/sheet/__tests__/KnowledgeLanguagesDisplay.test.tsx
+++ b/components/character/sheet/__tests__/KnowledgeLanguagesDisplay.test.tsx
@@ -2,49 +2,16 @@
  * KnowledgeLanguagesDisplay Component Tests
  *
  * Tests the knowledge skills and languages display.
- * Shows empty state, knowledge skills table with category/rating,
- * native language badges, and onSelect callback.
+ * Uses grouped sunken sections with value pills, category subtitles,
+ * specialization amber pills, and native emerald pills.
  */
 
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { createSheetCharacter } from "./test-helpers";
+import { createSheetCharacter, setupDisplayCardMock, LUCIDE_MOCK } from "./test-helpers";
 
-vi.mock("../DisplayCard", () => ({
-  DisplayCard: ({ title, children }: { title: string; children: React.ReactNode }) => (
-    <div data-testid="display-card">
-      <h2>{title}</h2>
-      {children}
-    </div>
-  ),
-}));
-
-vi.mock("lucide-react", () => ({
-  Activity: (props: Record<string, unknown>) => <span data-testid="icon-Activity" {...props} />,
-  Shield: (props: Record<string, unknown>) => <span data-testid="icon-Shield" {...props} />,
-  Heart: (props: Record<string, unknown>) => <span data-testid="icon-Heart" {...props} />,
-  Brain: (props: Record<string, unknown>) => <span data-testid="icon-Brain" {...props} />,
-  Footprints: (props: Record<string, unknown>) => <span data-testid="icon-Footprints" {...props} />,
-  ShieldCheck: (props: Record<string, unknown>) => (
-    <span data-testid="icon-ShieldCheck" {...props} />
-  ),
-  BarChart3: (props: Record<string, unknown>) => <span data-testid="icon-BarChart3" {...props} />,
-  Crosshair: (props: Record<string, unknown>) => <span data-testid="icon-Crosshair" {...props} />,
-  Swords: (props: Record<string, unknown>) => <span data-testid="icon-Swords" {...props} />,
-  Package: (props: Record<string, unknown>) => <span data-testid="icon-Package" {...props} />,
-  Pill: (props: Record<string, unknown>) => <span data-testid="icon-Pill" {...props} />,
-  Sparkles: (props: Record<string, unknown>) => <span data-testid="icon-Sparkles" {...props} />,
-  Braces: (props: Record<string, unknown>) => <span data-testid="icon-Braces" {...props} />,
-  Cpu: (props: Record<string, unknown>) => <span data-testid="icon-Cpu" {...props} />,
-  BookOpen: (props: Record<string, unknown>) => <span data-testid="icon-BookOpen" {...props} />,
-  Users: (props: Record<string, unknown>) => <span data-testid="icon-Users" {...props} />,
-  Fingerprint: (props: Record<string, unknown>) => (
-    <span data-testid="icon-Fingerprint" {...props} />
-  ),
-  Zap: (props: Record<string, unknown>) => <span data-testid="icon-Zap" {...props} />,
-  Car: (props: Record<string, unknown>) => <span data-testid="icon-Car" {...props} />,
-  Home: (props: Record<string, unknown>) => <span data-testid="icon-Home" {...props} />,
-}));
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
 
 import { KnowledgeLanguagesDisplay } from "../KnowledgeLanguagesDisplay";
 
@@ -71,37 +38,35 @@ describe("KnowledgeLanguagesDisplay", () => {
     expect(screen.getByText("professional")).toBeInTheDocument();
   });
 
-  it("renders knowledge skill rating in brackets", () => {
+  it("renders knowledge skill rating as value pill", () => {
     const character = createSheetCharacter({
       knowledgeSkills: [{ name: "Security Design", category: "professional", rating: 4 }],
     });
     render(<KnowledgeLanguagesDisplay character={character} />);
-    expect(screen.getByText("[4]")).toBeInTheDocument();
+    const pill = screen.getAllByTestId("rating-pill")[0];
+    expect(pill).toHaveTextContent("4");
+    expect(screen.queryByText("[4]")).not.toBeInTheDocument();
   });
 
-  it("renders native language with (N) marker", () => {
+  it("renders native language name with emerald N pill", () => {
     const character = createSheetCharacter({
       languages: [{ name: "English", rating: 0, isNative: true }],
     });
     render(<KnowledgeLanguagesDisplay character={character} />);
-    expect(screen.getByText("English (N)")).toBeInTheDocument();
+    expect(screen.getByText("English")).toBeInTheDocument();
+    const nativePill = screen.getByTestId("native-pill");
+    expect(nativePill).toHaveTextContent("N");
+    expect(nativePill.className).toContain("emerald");
   });
 
-  it("renders non-native language with rating", () => {
+  it("renders non-native language name with rating pill", () => {
     const character = createSheetCharacter({
       languages: [{ name: "Japanese", rating: 3, isNative: false }],
     });
     render(<KnowledgeLanguagesDisplay character={character} />);
-    expect(screen.getByText("Japanese (3)")).toBeInTheDocument();
-  });
-
-  it("renders native language with green styling", () => {
-    const character = createSheetCharacter({
-      languages: [{ name: "English", rating: 0, isNative: true }],
-    });
-    render(<KnowledgeLanguagesDisplay character={character} />);
-    const badge = screen.getByText("English (N)");
-    expect(badge.className).toContain("emerald");
+    expect(screen.getByText("Japanese")).toBeInTheDocument();
+    const pill = screen.getByTestId("rating-pill");
+    expect(pill).toHaveTextContent("3");
   });
 
   it("calls onSelect for knowledge skill clicks", () => {
@@ -122,7 +87,7 @@ describe("KnowledgeLanguagesDisplay", () => {
     });
     render(<KnowledgeLanguagesDisplay character={character} onSelect={onSelect} />);
 
-    fireEvent.click(screen.getByText("Japanese (3)"));
+    fireEvent.click(screen.getByText("Japanese"));
     expect(onSelect).toHaveBeenCalledWith(3, "Japanese");
   });
 
@@ -133,25 +98,67 @@ describe("KnowledgeLanguagesDisplay", () => {
     });
     render(<KnowledgeLanguagesDisplay character={character} onSelect={onSelect} />);
 
-    fireEvent.click(screen.getByText("English (N)"));
+    fireEvent.click(screen.getByText("English"));
     expect(onSelect).not.toHaveBeenCalled();
   });
 
-  it("renders table headers for knowledge skills", () => {
+  it("renders Knowledge and Languages section headers", () => {
+    const character = createSheetCharacter({
+      knowledgeSkills: [{ name: "Security Design", category: "professional", rating: 4 }],
+      languages: [{ name: "English", rating: 0, isNative: true }],
+    });
+    render(<KnowledgeLanguagesDisplay character={character} />);
+    expect(screen.getByText("Knowledge")).toBeInTheDocument();
+    expect(screen.getByText("Languages")).toBeInTheDocument();
+  });
+
+  it("hides Knowledge section when no knowledge skills", () => {
+    const character = createSheetCharacter({
+      knowledgeSkills: [],
+      languages: [{ name: "English", rating: 0, isNative: true }],
+    });
+    render(<KnowledgeLanguagesDisplay character={character} />);
+    expect(screen.queryByText("Knowledge")).not.toBeInTheDocument();
+    expect(screen.getByText("Languages")).toBeInTheDocument();
+  });
+
+  it("sorts knowledge skills by rating descending", () => {
+    const character = createSheetCharacter({
+      knowledgeSkills: [
+        { name: "History", category: "academic", rating: 2 },
+        { name: "Security Design", category: "professional", rating: 5 },
+        { name: "Street Rumors", category: "street", rating: 3 },
+      ],
+    });
+    render(<KnowledgeLanguagesDisplay character={character} />);
+    const pills = screen.getAllByTestId("rating-pill");
+    expect(pills[0]).toHaveTextContent("5");
+    expect(pills[1]).toHaveTextContent("3");
+    expect(pills[2]).toHaveTextContent("2");
+  });
+
+  it("renders specialization as amber pill when present", () => {
+    const character = createSheetCharacter({
+      knowledgeSkills: [
+        {
+          name: "Security Design",
+          category: "professional",
+          rating: 4,
+          specialization: "Maglocks",
+        },
+      ],
+    });
+    render(<KnowledgeLanguagesDisplay character={character} />);
+    const specPill = screen.getByTestId("specialization-pill");
+    expect(specPill).toHaveTextContent("Maglocks");
+    expect(specPill.className).toContain("amber");
+  });
+
+  it("does not render specialization when absent", () => {
     const character = createSheetCharacter({
       knowledgeSkills: [{ name: "Security Design", category: "professional", rating: 4 }],
     });
     render(<KnowledgeLanguagesDisplay character={character} />);
-    expect(screen.getByText("Knowledge Skill")).toBeInTheDocument();
-    expect(screen.getByText("Type")).toBeInTheDocument();
-    expect(screen.getByText("Rating")).toBeInTheDocument();
-  });
-
-  it("renders Languages label", () => {
-    const character = createSheetCharacter({
-      languages: [{ name: "English", rating: 0, isNative: true }],
-    });
-    render(<KnowledgeLanguagesDisplay character={character} />);
-    expect(screen.getByText("Languages:")).toBeInTheDocument();
+    expect(screen.queryByTestId("specialization-pill")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Replace table layout and flex-wrap chips with grouped "Knowledge" and "Languages" sunken sections using value pills, matching the aesthetic established by AttributesDisplay, SkillsDisplay, and AdeptPowersDisplay
- Sort knowledge skills by rating descending; show category as capitalized subtitle per row
- Surface `specialization` field as amber pill (previously ignored); native languages get emerald "N" pill
- Switch tests to shared `setupDisplayCardMock()` and `LUCIDE_MOCK`; add tests for sorting, specialization, and section visibility

## Test plan

- [x] `npx vitest run "sheet/__tests__/KnowledgeLanguagesDisplay"` — 14/14 passing
- [x] `pnpm type-check` — clean
- [ ] Visual check on character sheet in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)