### PR TITLE
refactor(sheet): Redesign AugmentationsDisplay with sunken containers and value pills

### DIFF
--- a/components/character/sheet/AugmentationsDisplay.tsx
+++ b/components/character/sheet/AugmentationsDisplay.tsx
@@ -2,70 +2,97 @@
 
 import type { Character, CyberwareItem, BiowareItem } from "@/lib/types";
 import { DisplayCard } from "./DisplayCard";
-import { Cpu } from "lucide-react";
+import { Cpu, Dna } from "lucide-react";
 
-interface AugmentationsDisplayProps {
-  character: Character;
-}
+// ---------------------------------------------------------------------------
+// Section & variant configuration
+// ---------------------------------------------------------------------------
 
-function AugmentationCard({ item }: { item: CyberwareItem | BiowareItem }) {
-  const isCyber = "grade" in item && (item as CyberwareItem).grade !== undefined;
-  const grade = isCyber ? (item as CyberwareItem).grade : (item as BiowareItem).grade;
+const AUGMENTATION_SECTIONS = [
+  { key: "cyber" as const, label: "Cyberware", icon: Cpu, iconColor: "text-cyan-400" },
+  { key: "bio" as const, label: "Bioware", icon: Dna, iconColor: "text-emerald-400" },
+];
+
+const VARIANT_COLORS = {
+  cyber: {
+    pill: "bg-cyan-50 border-cyan-200 text-cyan-700 dark:bg-cyan-400/12 dark:border-cyan-400/20 dark:text-cyan-300",
+  },
+  bio: {
+    pill: "border border-emerald-500/20 bg-emerald-500/12 text-emerald-600 dark:text-emerald-300",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// AugmentationRow
+// ---------------------------------------------------------------------------
+
+function AugmentationRow({
+  item,
+  variant,
+}: {
+  item: CyberwareItem | BiowareItem;
+  variant: "cyber" | "bio";
+}) {
+  const colors = VARIANT_COLORS[variant];
 
   return (
     <div
-      className={`p-3 rounded transition-all group border bg-zinc-50 dark:bg-zinc-800/30 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 ${
-        isCyber ? "border-cyan-500/30" : "border-emerald-500/30"
-      }`}
+      data-testid="augmentation-row"
+      className="rounded px-1 py-[7px] transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
     >
-      <div className="flex items-start justify-between">
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <span
-              className={`text-sm font-bold text-zinc-900 dark:text-zinc-100 transition-colors ${
-                isCyber ? "group-hover:text-cyan-500" : "group-hover:text-emerald-500"
-              }`}
-            >
-              {item.name}
-            </span>
-            <span
-              className={`text-[9px] font-mono uppercase tracking-tighter px-1.5 py-0.5 border rounded ${
-                isCyber
-                  ? "border-cyan-500/30 text-cyan-500 bg-cyan-500/5"
-                  : "border-emerald-500/30 text-emerald-500 bg-emerald-500/5"
-              }`}
-            >
-              {grade}
-            </span>
-          </div>
-          <div className="flex flex-wrap gap-x-3 gap-y-1 text-[10px] font-mono uppercase text-zinc-500 dark:text-zinc-400 opacity-70">
-            <span>{item.category}</span>
-            {item.rating && <span>Rating: {item.rating}</span>}
-          </div>
-          {item.attributeBonuses && Object.keys(item.attributeBonuses).length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-1">
-              {Object.entries(item.attributeBonuses).map(([attr, bonus]) => (
-                <span
-                  key={attr}
-                  className="px-1.5 py-0.5 text-[10px] font-mono bg-zinc-100 dark:bg-zinc-800 text-emerald-400 rounded"
-                >
-                  {attr.toUpperCase()} +{bonus}
-                </span>
-              ))}
-            </div>
-          )}
+      {/* Line 1: Name + grade pill ... essence pill */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+            {item.name}
+          </span>
+          <span
+            data-testid="grade-pill"
+            className={`rounded border px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase ${colors.pill}`}
+          >
+            {item.grade}
+          </span>
         </div>
-        <div className="text-right shrink-0">
-          <div className="text-[10px] text-zinc-500 dark:text-zinc-400 uppercase font-mono leading-none mb-1">
-            Essence
-          </div>
-          <div className="text-sm font-mono text-zinc-700 dark:text-zinc-300 font-bold leading-none">
-            {(item.essenceCost ?? 0).toFixed(2)}
-          </div>
-        </div>
+        <span
+          data-testid="essence-pill"
+          className={`flex h-7 w-12 items-center justify-center rounded-md border font-mono text-sm font-bold ${colors.pill}`}
+        >
+          {(item.essenceCost ?? 0).toFixed(2)}
+        </span>
       </div>
+
+      {/* Line 2: Category + optional rating */}
+      <div className="ml-0.5 mt-0.5 text-xs capitalize text-zinc-500 dark:text-zinc-400">
+        {item.category.replace(/-/g, " ")}
+        {item.rating != null && (
+          <span className="text-zinc-400 dark:text-zinc-500"> &bull; Rating {item.rating}</span>
+        )}
+      </div>
+
+      {/* Line 3: Attribute bonuses (conditional) */}
+      {item.attributeBonuses && Object.keys(item.attributeBonuses).length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {Object.entries(item.attributeBonuses).map(([attr, bonus]) => (
+            <span
+              key={attr}
+              data-testid="bonus-pill"
+              className="inline-flex rounded-full bg-emerald-100 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+            >
+              {attr.toUpperCase()} +{bonus}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// AugmentationsDisplay
+// ---------------------------------------------------------------------------
+
+interface AugmentationsDisplayProps {
+  character: Character;
 }
 
 export function AugmentationsDisplay({ character }: AugmentationsDisplayProps) {
@@ -74,29 +101,34 @@ export function AugmentationsDisplay({ character }: AugmentationsDisplayProps) {
 
   if (!hasCyber && !hasBio) return null;
 
+  const items: Record<"cyber" | "bio", (CyberwareItem | BiowareItem)[]> = {
+    cyber: hasCyber
+      ? [...character.cyberware!].sort((a, b) => (b.essenceCost ?? 0) - (a.essenceCost ?? 0))
+      : [],
+    bio: hasBio
+      ? [...character.bioware!].sort((a, b) => (b.essenceCost ?? 0) - (a.essenceCost ?? 0))
+      : [],
+  };
+
   return (
     <DisplayCard title="Augmentations" icon={<Cpu className="h-4 w-4 text-zinc-400" />}>
-      <div className="space-y-4">
-        {hasCyber && (
-          <div>
-            <span className="text-xs font-mono text-cyan-500 uppercase mb-2 block">Cyberware</span>
-            <div className="space-y-3">
-              {character.cyberware!.map((item, idx) => (
-                <AugmentationCard key={`cyber-${idx}`} item={item} />
-              ))}
+      <div className="space-y-3">
+        {AUGMENTATION_SECTIONS.map(({ key, label, icon: Icon, iconColor }) => {
+          if (items[key].length === 0) return null;
+          return (
+            <div key={key}>
+              <div className="mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                <Icon className={`h-3 w-3 ${iconColor}`} />
+                {label}
+              </div>
+              <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1 dark:border-zinc-800 dark:bg-zinc-950">
+                {items[key].map((item, idx) => (
+                  <AugmentationRow key={`${key}-${idx}`} item={item} variant={key} />
+                ))}
+              </div>
             </div>
-          </div>
-        )}
-        {hasBio && (
-          <div>
-            <span className="text-xs font-mono text-emerald-500 uppercase mb-2 block">Bioware</span>
-            <div className="space-y-3">
-              {character.bioware!.map((item, idx) => (
-                <AugmentationCard key={`bio-${idx}`} item={item} />
-              ))}
-            </div>
-          </div>
-        )}
+          );
+        })}
       </div>
     </DisplayCard>
   );

--- a/components/character/sheet/__tests__/test-helpers.tsx
+++ b/components/character/sheet/__tests__/test-helpers.tsx
@@ -130,6 +130,7 @@ export const LUCIDE_MOCK = {
   Fingerprint: createIconMock("Fingerprint"),
   Zap: createIconMock("Zap"),
   Car: createIconMock("Car"),
+  Dna: createIconMock("Dna"),
   Home: createIconMock("Home"),
   Star: createIconMock("Star"),
   CirclePlus: createIconMock("CirclePlus"),


### PR DESCRIPTION
## Summary
- Redesign AugmentationsDisplay to match the grouped-sections + sunken-container + value-pills aesthetic established by AttributesDisplay, SkillsDisplay, AdeptPowersDisplay, and KnowledgeLanguagesDisplay
- Replace individually bordered cards with two labeled sunken sections (Cyberware with cyan Cpu icon, Bioware with emerald Dna icon) containing compact rows with grade pills, essence cost pills, and emerald bonus pills
- Eliminate fragile `isCyber` duck typing by passing explicit `variant` prop; sort augmentations by essence cost descending

## Test plan
- [x] All 14 AugmentationsDisplay tests pass (including 2 new: sort order, emerald styling)
- [x] All 201 sheet display tests pass (no regressions from test-helpers change)
- [x] TypeScript type-check passes
- [ ] Visual check on character sheet in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)