### PR TITLE
refactor(sheet): Redesign ContactsDisplay with sunken container and value pills

### DIFF
--- a/components/character/sheet/ContactsDisplay.tsx
+++ b/components/character/sheet/ContactsDisplay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Character } from "@/lib/types";
+import type { Character, Contact } from "@/lib/types";
 import { Link } from "react-aria-components";
 import { DisplayCard } from "./DisplayCard";
 import { Users } from "lucide-react";
@@ -9,7 +9,54 @@ interface ContactsDisplayProps {
   character: Character;
 }
 
+function ContactRow({ contact }: { contact: Contact }) {
+  return (
+    <div
+      data-testid="contact-row"
+      className="rounded px-1 py-[7px] transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+          {contact.name}
+        </span>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1">
+            <span className="text-[9px] font-semibold uppercase text-amber-500 dark:text-amber-400">
+              C
+            </span>
+            <span
+              data-testid="connection-pill"
+              className="flex h-6 w-6 items-center justify-center rounded-md font-mono text-xs font-bold bg-amber-50 border border-amber-200 text-amber-700 dark:bg-amber-400/12 dark:border-amber-400/20 dark:text-amber-300"
+            >
+              {contact.connection}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-[9px] font-semibold uppercase text-emerald-500 dark:text-emerald-400">
+              L
+            </span>
+            <span
+              data-testid="loyalty-pill"
+              className="flex h-6 w-6 items-center justify-center rounded-md font-mono text-xs font-bold bg-emerald-50 border border-emerald-200 text-emerald-700 dark:bg-emerald-400/12 dark:border-emerald-400/20 dark:text-emerald-300"
+            >
+              {contact.loyalty}
+            </span>
+          </div>
+        </div>
+      </div>
+      {contact.type && (
+        <div className="ml-0.5 mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">{contact.type}</div>
+      )}
+    </div>
+  );
+}
+
 export function ContactsDisplay({ character }: ContactsDisplayProps) {
+  const contacts = character.contacts ?? [];
+  const sorted = [...contacts].sort((a, b) => b.connection - a.connection);
+  const visible = sorted.slice(0, 5);
+  const remaining = contacts.length - 5;
+
   return (
     <DisplayCard
       title="Contacts"
@@ -24,51 +71,27 @@ export function ContactsDisplay({ character }: ContactsDisplayProps) {
       }
     >
       <div>
-        <span className="text-xs text-zinc-500 dark:text-zinc-400 block mb-3">
-          {character.contacts?.length || 0} contacts in network
-        </span>
-        {!character.contacts || character.contacts.length === 0 ? (
+        {contacts.length === 0 ? (
           <p className="text-sm text-zinc-500 italic">No contacts established</p>
         ) : (
-          <div className="space-y-2">
-            {character.contacts.slice(0, 5).map((contact, index) => (
-              <div
-                key={`contact-${index}`}
-                className="p-3 bg-zinc-50 dark:bg-zinc-800/30 rounded border-l-2 border-emerald-500/40 hover:bg-zinc-100 dark:hover:bg-zinc-800/50 transition-colors"
-              >
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    {contact.name}
-                  </span>
-                  {contact.type && (
-                    <span className="text-xs text-zinc-500 dark:text-zinc-400">{contact.type}</span>
-                  )}
-                </div>
-                <div className="flex gap-4 mt-2 text-xs">
-                  <span className="text-zinc-500 dark:text-zinc-400">
-                    Connection:{" "}
-                    <span className="text-amber-500 dark:text-amber-400 font-mono">
-                      {contact.connection}
-                    </span>
-                  </span>
-                  <span className="text-zinc-500 dark:text-zinc-400">
-                    Loyalty:{" "}
-                    <span className="text-emerald-600 dark:text-emerald-400 font-mono">
-                      {contact.loyalty}
-                    </span>
-                  </span>
-                </div>
-              </div>
-            ))}
-            {character.contacts.length > 5 && (
-              <Link
-                href={`/characters/${character.id}/contacts`}
-                className="block text-center text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 py-2"
-              >
-                +{character.contacts.length - 5} more contacts...
-              </Link>
-            )}
-          </div>
+          <>
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              {contacts.length} contacts in network
+            </div>
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1 dark:border-zinc-800 dark:bg-zinc-950">
+              {visible.map((contact, index) => (
+                <ContactRow key={`contact-${index}`} contact={contact} />
+              ))}
+              {remaining > 0 && (
+                <Link
+                  href={`/characters/${character.id}/contacts`}
+                  className="block text-center text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 py-2"
+                >
+                  +{remaining} more contacts...
+                </Link>
+              )}
+            </div>
+          </>
         )}
       </div>
     </DisplayCard>


### PR DESCRIPTION
## Summary
- Replace left-bordered contact cards with single sunken container, dual labeled value pills (amber Connection, emerald Loyalty), and type as muted subtitle
- Sort contacts by connection descending so most connected contacts appear first
- Switch tests to shared mocks from test-helpers, add sort order and pill styling assertions

## Test plan
- [x] All 15 ContactsDisplay tests pass (`npx vitest run "sheet/__tests__/ContactsDisplay"`)
- [x] TypeScript type-check passes
- [x] Pre-commit hooks pass (lint, type-check, test coverage)
- [ ] Visual check on character sheet page in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)