### PR TITLE
refactor(sheet): Redesign WeaponsDisplay with expandable rows

### DIFF
--- a/components/character/sheet/WeaponsDisplay.tsx
+++ b/components/character/sheet/WeaponsDisplay.tsx
@@ -1,135 +1,194 @@
 "use client";
 
+import { useState } from "react";
 import type { Character, Weapon } from "@/lib/types";
 import { DisplayCard } from "./DisplayCard";
 import { isMeleeWeapon } from "./constants";
-import { Swords } from "lucide-react";
+import { ChevronDown, ChevronRight, Swords } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Pool calculation helper
+// ---------------------------------------------------------------------------
+
+function calculateWeaponPool(
+  weapon: Weapon,
+  character: Character
+): { pool: number; label: string } {
+  const skills = character.skills || {};
+  const isMelee = isMeleeWeapon(weapon);
+
+  let basePool = 0;
+  let poolLabel = weapon.name;
+
+  if (isMelee) {
+    basePool = character.attributes?.strength || 3;
+    poolLabel = `STR + ${weapon.name}`;
+  } else {
+    basePool = character.attributes?.agility || 3;
+    poolLabel = `AGI + ${weapon.name}`;
+  }
+
+  const commonCombatSkills = [
+    "pistols",
+    "automatics",
+    "longarms",
+    "unarmed-combat",
+    "blades",
+    "clubs",
+    "archery",
+    "throwing-weapons",
+  ];
+  const foundSkill = commonCombatSkills.find((s) =>
+    weapon.category.toLowerCase().includes(s.replace(/-/g, " "))
+  );
+
+  if (foundSkill && skills[foundSkill]) {
+    basePool += skills[foundSkill];
+    poolLabel = `${isMelee ? "STR" : "AGI"} + ${foundSkill.replace(/-/g, " ")}`;
+  }
+
+  return { pool: basePool, label: poolLabel };
+}
+
+// ---------------------------------------------------------------------------
+// Stat pill color configs
+// ---------------------------------------------------------------------------
+
+const STAT_COLORS = {
+  damage: "border-emerald-500/20 bg-emerald-500/12 text-emerald-600 dark:text-emerald-300",
+  ap: "border-amber-500/20 bg-amber-500/12 text-amber-600 dark:text-amber-300",
+  accuracy: "border-cyan-500/20 bg-cyan-500/12 text-cyan-600 dark:text-cyan-300",
+  reach: "border-purple-500/20 bg-purple-500/12 text-purple-600 dark:text-purple-300",
+  mode: "border-zinc-300/40 bg-zinc-100/60 text-zinc-600 dark:border-zinc-600/30 dark:bg-zinc-700/30 dark:text-zinc-300",
+};
+
+// ---------------------------------------------------------------------------
+// WeaponRow
+// ---------------------------------------------------------------------------
+
+function WeaponRow({
+  weapon,
+  character,
+  onSelect,
+}: {
+  weapon: Weapon;
+  character: Character;
+  onSelect?: (pool: number, label: string) => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { pool, label } = calculateWeaponPool(weapon, character);
+  const isMelee = isMeleeWeapon(weapon);
+  const modeStr = weapon.mode?.join("/") || "";
+
+  return (
+    <div
+      data-testid="weapon-row"
+      onClick={() => onSelect?.(pool, label)}
+      className={`px-3 py-1.5 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50 ${onSelect ? "cursor-pointer" : ""}`}
+    >
+      {/* Collapsed row: Chevron + Name ... Pool pill */}
+      <div className="flex min-w-0 items-center gap-1.5">
+        <button
+          data-testid="expand-button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsExpanded(!isExpanded);
+          }}
+          className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+        >
+          {isExpanded ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+        </button>
+        <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+          {weapon.name}
+        </span>
+        <span className="flex-1" />
+        <span
+          data-testid="pool-pill"
+          className="flex h-6 min-w-[1.5rem] items-center justify-center rounded-md border border-emerald-500/20 bg-emerald-500/12 px-1.5 font-mono text-xs font-bold text-emerald-600 dark:text-emerald-300"
+        >
+          {pool}
+        </span>
+      </div>
+
+      {/* Expanded section */}
+      {isExpanded && (
+        <div
+          data-testid="expanded-content"
+          onClick={(e) => e.stopPropagation()}
+          className="ml-5 mt-2 space-y-1.5 border-l-2 border-zinc-200 pl-3 dark:border-zinc-700"
+        >
+          {/* Stat pills */}
+          <div className="flex flex-wrap gap-1.5">
+            <span
+              data-testid="damage-pill"
+              className={`rounded border px-1.5 py-0.5 font-mono text-[10px] font-semibold ${STAT_COLORS.damage}`}
+            >
+              DMG {weapon.damage}
+            </span>
+            <span
+              data-testid="ap-pill"
+              className={`rounded border px-1.5 py-0.5 font-mono text-[10px] font-semibold ${STAT_COLORS.ap}`}
+            >
+              AP {weapon.ap}
+            </span>
+            {!isMelee && (
+              <span
+                data-testid="accuracy-pill"
+                className={`rounded border px-1.5 py-0.5 font-mono text-[10px] font-semibold ${STAT_COLORS.accuracy}`}
+              >
+                ACC {weapon.accuracy || "-"}
+              </span>
+            )}
+            {isMelee && weapon.reach != null && Number(weapon.reach) !== 0 && (
+              <span
+                data-testid="reach-pill"
+                className={`rounded border px-1.5 py-0.5 font-mono text-[10px] font-semibold ${STAT_COLORS.reach}`}
+              >
+                RCH {weapon.reach}
+              </span>
+            )}
+            {!isMelee && modeStr && (
+              <span
+                data-testid="mode-pill"
+                className={`rounded border px-1.5 py-0.5 font-mono text-[10px] font-semibold ${STAT_COLORS.mode}`}
+              >
+                MODE {modeStr}
+              </span>
+            )}
+          </div>
+
+          {/* Subcategory */}
+          {weapon.subcategory && (
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+              {weapon.subcategory}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section configuration
+// ---------------------------------------------------------------------------
+
+const WEAPON_SECTIONS = [
+  { key: "ranged" as const, label: "Ranged Weapons" },
+  { key: "melee" as const, label: "Melee Weapons" },
+];
+
+// ---------------------------------------------------------------------------
+// WeaponsDisplay
+// ---------------------------------------------------------------------------
 
 interface WeaponsDisplayProps {
   character: Character;
   onSelect?: (pool: number, label: string) => void;
-}
-
-function WeaponTable({
-  weapons,
-  character,
-  type,
-  onSelect,
-}: {
-  weapons: Weapon[];
-  character: Character;
-  type: "ranged" | "melee";
-  onSelect?: (pool: number, label: string) => void;
-}) {
-  const skills = character.skills || {};
-
-  return (
-    <div className="w-full overflow-x-auto">
-      <table className="w-full text-left border-collapse font-mono text-xs">
-        <thead>
-          <tr className="border-b border-zinc-200 dark:border-zinc-700/50">
-            <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px]">
-              Name
-            </th>
-            <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-center">
-              Dmg
-            </th>
-            <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-center">
-              AP
-            </th>
-            {type === "ranged" ? (
-              <>
-                <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-center">
-                  Acc
-                </th>
-                <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-center">
-                  Mode
-                </th>
-              </>
-            ) : (
-              <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-center">
-                Reach
-              </th>
-            )}
-            <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-right">
-              Pool
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {weapons.map((w, idx) => {
-            const isMelee = isMeleeWeapon(w);
-
-            let basePool = 0;
-            let poolLabel = w.name;
-
-            if (isMelee) {
-              basePool = character.attributes?.strength || 3;
-              poolLabel = `STR + ${w.name}`;
-            } else {
-              basePool = character.attributes?.agility || 3;
-              poolLabel = `AGI + ${w.name}`;
-            }
-
-            const commonCombatSkills = [
-              "pistols",
-              "automatics",
-              "longarms",
-              "unarmed-combat",
-              "blades",
-              "clubs",
-              "archery",
-              "throwing-weapons",
-            ];
-            const foundSkill = commonCombatSkills.find((s) =>
-              w.category.toLowerCase().includes(s.replace(/-/g, " "))
-            );
-
-            if (foundSkill && skills[foundSkill]) {
-              basePool += skills[foundSkill];
-              poolLabel = `${isMelee ? "STR" : "AGI"} + ${foundSkill.replace(/-/g, " ")}`;
-            }
-
-            return (
-              <tr
-                key={`${w.name}-${idx}`}
-                onClick={() => onSelect?.(basePool, poolLabel)}
-                className="group border-b border-zinc-100 dark:border-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/30 cursor-pointer transition-colors"
-              >
-                <td className="py-2 px-1">
-                  <div className="flex flex-col">
-                    <span className="font-bold text-zinc-900 dark:text-zinc-100">{w.name}</span>
-                    <span className="text-[9px] text-zinc-500 dark:text-zinc-400 uppercase opacity-70">
-                      {w.subcategory}
-                    </span>
-                  </div>
-                </td>
-                <td className="py-2 px-1 text-center">
-                  <span className="text-emerald-500">{w.damage}</span>
-                </td>
-                <td className="py-2 px-1 text-center text-amber-500">{w.ap}</td>
-                {type === "ranged" ? (
-                  <>
-                    <td className="py-2 px-1 text-center text-cyan-500">{w.accuracy || "-"}</td>
-                    <td className="py-2 px-1 text-center text-[9px] text-zinc-500 dark:text-zinc-400">
-                      {w.mode?.join("/") || "-"}
-                    </td>
-                  </>
-                ) : (
-                  <td className="py-2 px-1 text-center text-purple-500">
-                    {w.reach != null && Number(w.reach) !== 0 ? w.reach : "-"}
-                  </td>
-                )}
-                <td className="py-2 px-1 text-right font-bold tabular-nums">
-                  <span className="text-emerald-500">{basePool}</span>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
 }
 
 export function WeaponsDisplay({ character, onSelect }: WeaponsDisplayProps) {
@@ -138,25 +197,31 @@ export function WeaponsDisplay({ character, onSelect }: WeaponsDisplayProps) {
 
   if (ranged.length === 0 && melee.length === 0) return null;
 
+  const items: Record<"ranged" | "melee", Weapon[]> = { ranged, melee };
+
   return (
     <DisplayCard title="Weapons" icon={<Swords className="h-4 w-4 text-zinc-400" />}>
-      <div className="space-y-6">
-        {ranged.length > 0 && (
-          <div className="space-y-2">
-            <span className="text-[10px] font-mono text-zinc-500 dark:text-zinc-400 uppercase tracking-widest block ml-1">
-              Ranged Weapons
-            </span>
-            <WeaponTable type="ranged" character={character} weapons={ranged} onSelect={onSelect} />
-          </div>
-        )}
-        {melee.length > 0 && (
-          <div className="space-y-2">
-            <span className="text-[10px] font-mono text-zinc-500 dark:text-zinc-400 uppercase tracking-widest block ml-1">
-              Melee Weapons
-            </span>
-            <WeaponTable type="melee" character={character} weapons={melee} onSelect={onSelect} />
-          </div>
-        )}
+      <div className="space-y-3">
+        {WEAPON_SECTIONS.map(({ key, label }) => {
+          if (items[key].length === 0) return null;
+          return (
+            <div key={key}>
+              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                {label}
+              </div>
+              <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+                {items[key].map((weapon, idx) => (
+                  <WeaponRow
+                    key={`${key}-${idx}`}
+                    weapon={weapon}
+                    character={character}
+                    onSelect={onSelect}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
       </div>
     </DisplayCard>
   );


### PR DESCRIPTION
## Summary
- Replace flat HTML table layout with expandable row pattern matching other redesigned sheet components
- Add semantic stat pills (DMG/emerald, AP/amber, ACC/cyan, RCH/purple, MODE/zinc) with proper conditional rendering
- Extract `calculateWeaponPool()` helper, add section grouping with sunken containers
- Proper event isolation: expand button and expanded content don't trigger `onSelect`

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test -- "sheet/__tests__/WeaponsDisplay"` — 23 tests pass
- [x] `pnpm lint` — no new errors
- [ ] Visually verify on character sheet with weapons in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)