### PR TITLE
refactor(sheet): Redesign ArmorDisplay with expandable rows

### DIFF
--- a/components/character/sheet/ArmorDisplay.tsx
+++ b/components/character/sheet/ArmorDisplay.tsx
@@ -1,8 +1,184 @@
 "use client";
 
+import { useState } from "react";
 import type { ArmorItem } from "@/lib/types";
 import { DisplayCard } from "./DisplayCard";
-import { Shield } from "lucide-react";
+import { ChevronDown, ChevronRight, Shield } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isWorn(a: ArmorItem): boolean {
+  return a.state?.readiness === "worn" || (!a.state && a.equipped);
+}
+
+function getCapacityPercentage(armor: ArmorItem): number {
+  const total = armor.capacity ?? armor.armorRating;
+  const used = armor.capacityUsed ?? 0;
+  if (total === 0) return 0;
+  return Math.min(100, (used / total) * 100);
+}
+
+function getCapacityColor(percentage: number): string {
+  if (percentage >= 90) return "bg-red-500";
+  if (percentage >= 70) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
+function formatLegality(legality: string): string {
+  if (legality === "restricted") return "R";
+  if (legality === "forbidden") return "F";
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Section config
+// ---------------------------------------------------------------------------
+
+const ARMOR_SECTIONS = [
+  { key: "worn" as const, label: "Worn" },
+  { key: "stored" as const, label: "Stored" },
+];
+
+// ---------------------------------------------------------------------------
+// ArmorRow
+// ---------------------------------------------------------------------------
+
+function ArmorRow({ item }: { item: ArmorItem }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const totalCapacity = item.capacity ?? item.armorRating;
+  const usedCapacity = item.capacityUsed ?? 0;
+  const remaining = totalCapacity - usedCapacity;
+  const pct = getCapacityPercentage(item);
+
+  return (
+    <div
+      data-testid="armor-row"
+      className="px-3 py-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+    >
+      {/* Collapsed row: Chevron + Name + Accessory badge + Rating pill */}
+      <div className="flex min-w-0 items-center gap-1.5">
+        <button
+          data-testid="expand-button"
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+        >
+          {isExpanded ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+        </button>
+        <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+          {item.name}
+        </span>
+        {item.armorModifier && (
+          <span
+            data-testid="accessory-badge"
+            className="rounded border border-amber-500/20 bg-amber-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase text-amber-600 dark:text-amber-300"
+          >
+            Accessory
+          </span>
+        )}
+        <span
+          data-testid="rating-pill"
+          className="ml-auto shrink-0 rounded border border-sky-500/20 bg-sky-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-sky-600 dark:text-sky-300"
+        >
+          {item.armorRating}
+        </span>
+      </div>
+
+      {/* Expanded section */}
+      {isExpanded && (
+        <div
+          data-testid="expanded-content"
+          className="ml-5 mt-2 space-y-2 border-l-2 border-zinc-200 pl-3 dark:border-zinc-700"
+        >
+          {/* Stats row */}
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500 dark:text-zinc-400">
+            {item.availability != null && (
+              <span data-testid="stat-availability">
+                Avail{" "}
+                <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                  {item.availability}
+                  {item.legality ? formatLegality(item.legality) : ""}
+                </span>
+              </span>
+            )}
+            {item.cost != null && (
+              <span data-testid="stat-cost">
+                Cost{" "}
+                <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                  {item.cost.toLocaleString()}&yen;
+                </span>
+              </span>
+            )}
+            {item.weight != null && (
+              <span data-testid="stat-weight">
+                Weight{" "}
+                <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                  {item.weight}kg
+                </span>
+              </span>
+            )}
+          </div>
+
+          {/* Capacity bar (non-custom items only) */}
+          {!item.isCustom && (
+            <div data-testid="capacity-section">
+              <div className="mb-1 flex items-baseline justify-between text-[10px]">
+                <span className="font-semibold uppercase tracking-wider text-zinc-500">
+                  Capacity
+                </span>
+                <span className="font-mono text-zinc-500 dark:text-zinc-400">
+                  {remaining}/{totalCapacity}
+                </span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+                <div
+                  data-testid="capacity-bar"
+                  className={`h-full rounded-full transition-all ${getCapacityColor(pct)}`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Modifications */}
+          {item.modifications && item.modifications.length > 0 && (
+            <div data-testid="modifications-section">
+              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                Modifications
+              </div>
+              <div className="space-y-0.5">
+                {item.modifications.map((mod, idx) => (
+                  <div
+                    key={`${mod.catalogId}-${idx}`}
+                    data-testid="mod-row"
+                    className="flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-400"
+                  >
+                    <span className="font-medium text-zinc-700 dark:text-zinc-300">{mod.name}</span>
+                    {mod.rating != null && (
+                      <span className="font-mono text-zinc-500">R{mod.rating}</span>
+                    )}
+                    <span className="font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+                      [{mod.capacityUsed}]
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ArmorDisplay
+// ---------------------------------------------------------------------------
 
 interface ArmorDisplayProps {
   armor: ArmorItem[];
@@ -11,50 +187,29 @@ interface ArmorDisplayProps {
 export function ArmorDisplay({ armor }: ArmorDisplayProps) {
   if (armor.length === 0) return null;
 
+  const grouped: Record<"worn" | "stored", ArmorItem[]> = {
+    worn: armor.filter(isWorn),
+    stored: armor.filter((a) => !isWorn(a)),
+  };
+
   return (
     <DisplayCard title="Armor" icon={<Shield className="h-4 w-4 text-zinc-400" />}>
-      <div className="w-full overflow-x-auto">
-        <table className="w-full text-left border-collapse font-mono text-xs">
-          <thead>
-            <tr className="border-b border-zinc-200 dark:border-zinc-700/50">
-              <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px]">
-                Name
-              </th>
-              <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-center">
-                Rating
-              </th>
-              <th className="py-2 px-1 font-bold text-zinc-500 dark:text-zinc-400 uppercase text-[10px] text-right">
-                Status
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {armor.map((a, idx) => (
-              <tr
-                key={`${a.name}-${idx}`}
-                className="border-b border-zinc-100 dark:border-zinc-800/50 hover:bg-zinc-50 dark:hover:bg-zinc-800/10 transition-colors"
-              >
-                <td className="py-2 px-1">
-                  <span className="font-bold text-zinc-900 dark:text-zinc-100">{a.name}</span>
-                </td>
-                <td className="py-2 px-1 text-center">
-                  <span className="text-blue-400 font-bold">{a.armorRating}</span>
-                </td>
-                <td className="py-2 px-1 text-right">
-                  {a.equipped ? (
-                    <span className="text-[9px] bg-blue-500/20 text-blue-400 border border-blue-500/30 px-1 py-0.5 rounded uppercase font-bold">
-                      Equipped
-                    </span>
-                  ) : (
-                    <span className="text-[9px] text-zinc-400 dark:text-zinc-500 uppercase">
-                      Stored
-                    </span>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <div className="space-y-3">
+        {ARMOR_SECTIONS.map(({ key, label }) => {
+          if (grouped[key].length === 0) return null;
+          return (
+            <div key={key}>
+              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                {label}
+              </div>
+              <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+                {grouped[key].map((item, idx) => (
+                  <ArmorRow key={`${item.name}-${idx}`} item={item} />
+                ))}
+              </div>
+            </div>
+          );
+        })}
       </div>
     </DisplayCard>
   );

--- a/components/character/sheet/__tests__/ArmorDisplay.test.tsx
+++ b/components/character/sheet/__tests__/ArmorDisplay.test.tsx
@@ -1,84 +1,253 @@
 /**
  * ArmorDisplay Component Tests
  *
- * Tests the armor table display. Returns null when armor array is empty.
- * Shows name, rating, and equipped/stored status badges.
+ * Tests the armor display with expandable rows grouped into Worn/Stored sections.
+ * Validates section grouping, collapsed/expanded states, stats, capacity bar,
+ * modifications, and accessory badge rendering.
  */
 
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MOCK_ARMOR_EQUIPPED, MOCK_ARMOR_STORED } from "./test-helpers";
+import userEvent from "@testing-library/user-event";
+import {
+  setupDisplayCardMock,
+  LUCIDE_MOCK,
+  MOCK_ARMOR_EQUIPPED,
+  MOCK_ARMOR_STORED,
+  MOCK_ARMOR_WITH_MODS,
+  MOCK_ARMOR_ACCESSORY,
+} from "./test-helpers";
 
-vi.mock("../DisplayCard", () => ({
-  DisplayCard: ({ title, children }: { title: string; children: React.ReactNode }) => (
-    <div data-testid="display-card">
-      <h2>{title}</h2>
-      {children}
-    </div>
-  ),
-}));
-
-vi.mock("lucide-react", () => ({
-  Activity: (props: Record<string, unknown>) => <span data-testid="icon-Activity" {...props} />,
-  Shield: (props: Record<string, unknown>) => <span data-testid="icon-Shield" {...props} />,
-  Heart: (props: Record<string, unknown>) => <span data-testid="icon-Heart" {...props} />,
-  Brain: (props: Record<string, unknown>) => <span data-testid="icon-Brain" {...props} />,
-  Footprints: (props: Record<string, unknown>) => <span data-testid="icon-Footprints" {...props} />,
-  ShieldCheck: (props: Record<string, unknown>) => (
-    <span data-testid="icon-ShieldCheck" {...props} />
-  ),
-  BarChart3: (props: Record<string, unknown>) => <span data-testid="icon-BarChart3" {...props} />,
-  Crosshair: (props: Record<string, unknown>) => <span data-testid="icon-Crosshair" {...props} />,
-  Swords: (props: Record<string, unknown>) => <span data-testid="icon-Swords" {...props} />,
-  Package: (props: Record<string, unknown>) => <span data-testid="icon-Package" {...props} />,
-  Pill: (props: Record<string, unknown>) => <span data-testid="icon-Pill" {...props} />,
-  Sparkles: (props: Record<string, unknown>) => <span data-testid="icon-Sparkles" {...props} />,
-  Braces: (props: Record<string, unknown>) => <span data-testid="icon-Braces" {...props} />,
-  Cpu: (props: Record<string, unknown>) => <span data-testid="icon-Cpu" {...props} />,
-  BookOpen: (props: Record<string, unknown>) => <span data-testid="icon-BookOpen" {...props} />,
-  Users: (props: Record<string, unknown>) => <span data-testid="icon-Users" {...props} />,
-  Fingerprint: (props: Record<string, unknown>) => (
-    <span data-testid="icon-Fingerprint" {...props} />
-  ),
-  Zap: (props: Record<string, unknown>) => <span data-testid="icon-Zap" {...props} />,
-  Car: (props: Record<string, unknown>) => <span data-testid="icon-Car" {...props} />,
-  Home: (props: Record<string, unknown>) => <span data-testid="icon-Home" {...props} />,
-}));
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
 
 import { ArmorDisplay } from "../ArmorDisplay";
 
 describe("ArmorDisplay", () => {
+  // --- Empty state ---
+
   it("returns null when armor array is empty", () => {
     const { container } = render(<ArmorDisplay armor={[]} />);
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders armor table with name and rating", () => {
+  // --- Section grouping ---
+
+  it("renders Worn section for worn armor", () => {
     render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
-    expect(screen.getByText("Armor Jacket")).toBeInTheDocument();
-    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("Worn")).toBeInTheDocument();
   });
 
-  it("shows Equipped badge for equipped armor", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
-    expect(screen.getByText("Equipped")).toBeInTheDocument();
-  });
-
-  it("shows Stored badge for unequipped armor", () => {
+  it("renders Stored section for stored armor", () => {
     render(<ArmorDisplay armor={[MOCK_ARMOR_STORED]} />);
     expect(screen.getByText("Stored")).toBeInTheDocument();
   });
+
+  it("hides Stored section when all armor is worn", () => {
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    expect(screen.queryByText("Stored")).not.toBeInTheDocument();
+  });
+
+  it("hides Worn section when all armor is stored", () => {
+    render(<ArmorDisplay armor={[MOCK_ARMOR_STORED]} />);
+    expect(screen.queryByText("Worn")).not.toBeInTheDocument();
+  });
+
+  it("renders both sections when armor includes worn and stored", () => {
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED, MOCK_ARMOR_STORED]} />);
+    expect(screen.getByText("Worn")).toBeInTheDocument();
+    expect(screen.getByText("Stored")).toBeInTheDocument();
+  });
+
+  it("falls back to equipped field when state is absent", () => {
+    const legacyEquipped = { ...MOCK_ARMOR_EQUIPPED, state: undefined, equipped: true };
+    const legacyStored = { ...MOCK_ARMOR_STORED, state: undefined, equipped: false };
+    render(<ArmorDisplay armor={[legacyEquipped, legacyStored]} />);
+    expect(screen.getByText("Worn")).toBeInTheDocument();
+    expect(screen.getByText("Stored")).toBeInTheDocument();
+  });
+
+  // --- Collapsed row ---
+
+  it("renders armor name in collapsed row", () => {
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    expect(screen.getByText("Armor Jacket")).toBeInTheDocument();
+  });
+
+  it("renders armor rating in sky-colored pill", () => {
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    const pill = screen.getByTestId("rating-pill");
+    expect(pill).toHaveTextContent("12");
+    expect(pill.className).toContain("sky");
+  });
+
+  it("renders accessory badge for armor modifiers", () => {
+    render(<ArmorDisplay armor={[MOCK_ARMOR_ACCESSORY]} />);
+    expect(screen.getByTestId("accessory-badge")).toHaveTextContent("Accessory");
+  });
+
+  it("does not render accessory badge for regular armor", () => {
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    expect(screen.queryByTestId("accessory-badge")).not.toBeInTheDocument();
+  });
+
+  it("does not show expanded content by default", () => {
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    expect(screen.queryByTestId("expanded-content")).not.toBeInTheDocument();
+  });
+
+  // --- Expand/collapse ---
+
+  it("expands row on chevron click", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+
+    await user.click(screen.getByTestId("expand-button"));
+    expect(screen.getByTestId("expanded-content")).toBeInTheDocument();
+  });
+
+  it("collapses row on second chevron click", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+
+    await user.click(screen.getByTestId("expand-button"));
+    expect(screen.getByTestId("expanded-content")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("expand-button"));
+    expect(screen.queryByTestId("expanded-content")).not.toBeInTheDocument();
+  });
+
+  // --- Expanded stats ---
+
+  it("renders availability with legality suffix when expanded", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+
+    await user.click(screen.getAllByTestId("expand-button")[0]);
+
+    const avail = screen.getByTestId("stat-availability");
+    expect(avail).toHaveTextContent("14R");
+  });
+
+  it("renders cost formatted with yen when expanded", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+
+    await user.click(screen.getAllByTestId("expand-button")[0]);
+
+    const cost = screen.getByTestId("stat-cost");
+    expect(cost).toHaveTextContent("8,000¥");
+  });
+
+  it("renders weight when present and expanded", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+
+    await user.click(screen.getAllByTestId("expand-button")[0]);
+
+    const weight = screen.getByTestId("stat-weight");
+    expect(weight).toHaveTextContent("8kg");
+  });
+
+  it("does not render availability when absent", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+
+    await user.click(screen.getByTestId("expand-button"));
+    expect(screen.queryByTestId("stat-availability")).not.toBeInTheDocument();
+  });
+
+  // --- Capacity bar ---
+
+  it("renders capacity section for non-custom armor", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+
+    await user.click(screen.getAllByTestId("expand-button")[0]);
+    expect(screen.getByTestId("capacity-section")).toBeInTheDocument();
+    expect(screen.getByText("8/15")).toBeInTheDocument();
+  });
+
+  it("hides capacity section for custom items", async () => {
+    const user = userEvent.setup();
+    const customArmor = { ...MOCK_ARMOR_EQUIPPED, isCustom: true };
+    render(<ArmorDisplay armor={[customArmor]} />);
+
+    await user.click(screen.getByTestId("expand-button"));
+    expect(screen.queryByTestId("capacity-section")).not.toBeInTheDocument();
+  });
+
+  it("renders capacity bar with emerald color at low usage", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+
+    await user.click(screen.getAllByTestId("expand-button")[0]);
+    const bar = screen.getByTestId("capacity-bar");
+    expect(bar.className).toContain("bg-emerald-500");
+  });
+
+  it("renders capacity bar with amber color at high usage", async () => {
+    const user = userEvent.setup();
+    const highUsage = { ...MOCK_ARMOR_WITH_MODS, capacity: 10, capacityUsed: 8 };
+    render(<ArmorDisplay armor={[highUsage]} />);
+
+    await user.click(screen.getAllByTestId("expand-button")[0]);
+    const bar = screen.getByTestId("capacity-bar");
+    expect(bar.className).toContain("bg-amber-500");
+  });
+
+  it("renders capacity bar with red color at critical usage", async () => {
+    const user = userEvent.setup();
+    const criticalUsage = { ...MOCK_ARMOR_WITH_MODS, capacity: 10, capacityUsed: 10 };
+    render(<ArmorDisplay armor={[criticalUsage]} />);
+
+    await user.click(screen.getAllByTestId("expand-button")[0]);
+    const bar = screen.getByTestId("capacity-bar");
+    expect(bar.className).toContain("bg-red-500");
+  });
+
+  // --- Modifications ---
+
+  it("renders modifications section when mods exist", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+
+    await user.click(screen.getAllByTestId("expand-button")[0]);
+    expect(screen.getByTestId("modifications-section")).toBeInTheDocument();
+    expect(screen.getByText("Modifications")).toBeInTheDocument();
+  });
+
+  it("renders mod names, ratings, and capacity used", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+
+    await user.click(screen.getAllByTestId("expand-button")[0]);
+
+    const modRows = screen.getAllByTestId("mod-row");
+    expect(modRows).toHaveLength(2);
+
+    expect(screen.getByText("Fire Resistance")).toBeInTheDocument();
+    expect(screen.getByText("R3")).toBeInTheDocument();
+    expect(screen.getByText("[3]")).toBeInTheDocument();
+
+    expect(screen.getByText("Chemical Protection")).toBeInTheDocument();
+    expect(screen.getByText("R4")).toBeInTheDocument();
+    expect(screen.getByText("[4]")).toBeInTheDocument();
+  });
+
+  it("does not render modifications section when no mods", async () => {
+    const user = userEvent.setup();
+    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+
+    await user.click(screen.getByTestId("expand-button"));
+    expect(screen.queryByTestId("modifications-section")).not.toBeInTheDocument();
+  });
+
+  // --- Multiple items ---
 
   it("renders multiple armor items", () => {
     render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED, MOCK_ARMOR_STORED]} />);
     expect(screen.getByText("Armor Jacket")).toBeInTheDocument();
     expect(screen.getByText("Lined Coat")).toBeInTheDocument();
-  });
-
-  it("renders table headers", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
-    expect(screen.getByText("Name")).toBeInTheDocument();
-    expect(screen.getByText("Rating")).toBeInTheDocument();
-    expect(screen.getByText("Status")).toBeInTheDocument();
   });
 });

--- a/components/character/sheet/__tests__/test-helpers.tsx
+++ b/components/character/sheet/__tests__/test-helpers.tsx
@@ -226,6 +226,7 @@ export const MOCK_ARMOR_EQUIPPED = {
   cost: 1000,
   quantity: 1,
   readiness: "ready" as const,
+  state: { readiness: "worn" as const, wirelessEnabled: true },
 };
 
 export const MOCK_ARMOR_STORED = {
@@ -237,6 +238,55 @@ export const MOCK_ARMOR_STORED = {
   cost: 900,
   quantity: 1,
   readiness: "stored" as const,
+  state: { readiness: "stored" as const, wirelessEnabled: false },
+};
+
+export const MOCK_ARMOR_WITH_MODS = {
+  name: "Full Body Armor",
+  category: "armor",
+  subcategory: "full-body-armor",
+  armorRating: 15,
+  equipped: true,
+  cost: 8000,
+  quantity: 1,
+  readiness: "ready" as const,
+  state: { readiness: "worn" as const, wirelessEnabled: true },
+  availability: 14,
+  legality: "restricted" as const,
+  capacity: 15,
+  capacityUsed: 7,
+  weight: 8,
+  modifications: [
+    {
+      catalogId: "fire-resistance",
+      name: "Fire Resistance",
+      rating: 3,
+      capacityUsed: 3,
+      cost: 750,
+      availability: 6,
+    },
+    {
+      catalogId: "chemical-protection",
+      name: "Chemical Protection",
+      rating: 4,
+      capacityUsed: 4,
+      cost: 1000,
+      availability: 6,
+    },
+  ],
+};
+
+export const MOCK_ARMOR_ACCESSORY = {
+  name: "Ballistic Shield",
+  category: "armor",
+  subcategory: "shields",
+  armorRating: 6,
+  armorModifier: true,
+  equipped: true,
+  cost: 1200,
+  quantity: 1,
+  readiness: "ready" as const,
+  state: { readiness: "worn" as const, wirelessEnabled: false },
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace flat HTML table with grouped **Worn/Stored** sections using sunken containers and expandable `ArmorRow` sub-component
- Collapsed rows show name, optional accessory badge, and sky-colored armor rating pill
- Expanded rows reveal availability (with R/F legality suffix), cost (¥ formatted), weight, color-coded capacity bar (emerald/amber/red), and installed modifications list
- Add `MOCK_ARMOR_WITH_MODS` and `MOCK_ARMOR_ACCESSORY` test fixtures; add `state` fields to existing armor mocks

## Test plan

- [x] `pnpm type-check` passes
- [x] 27 ArmorDisplay tests pass (empty state, section grouping, legacy fallback, collapsed row, expand/collapse, stats, capacity bar colors, modifications)
- [x] Full `sheet/__tests__/` suite passes with no regressions
- [x] `pnpm lint` passes (0 errors)
- [ ] Visual review of Worn/Stored sections on character sheet
- [ ] Verify expand/collapse interaction in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)