### PR TITLE
feat(wireless): Add wirelessEffects to 16 remaining CRB items

### DIFF
--- a/data/editions/sr5/core-rulebook.json
+++ b/data/editions/sr5/core-rulebook.json
@@ -7289,6 +7289,13 @@
               "accuracy": 0,
               "legality": "restricted",
               "wirelessBonus": "Recharges by induction, regaining one charge per full hour of wireless-enabled time.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "Recharges by induction, regaining one charge per full hour of wireless-enabled time."
+                }
+              ],
               "weight": 0.3
             },
             {
@@ -7576,6 +7583,13 @@
               "availability": 0,
               "cost": 250,
               "wirelessBonus": "A successful hit informs you of the target's basic health and Condition Monitors.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "A successful hit informs you of the target's basic health and Condition Monitors."
+                }
+              ],
               "weight": 0.5
             },
             {
@@ -7812,6 +7826,13 @@
               "availability": 0,
               "cost": 180,
               "wirelessBonus": "A successful hit informs you of the target's basic health and Condition Monitors.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "A successful hit informs you of the target's basic health and Condition Monitors."
+                }
+              ],
               "weight": 0.5
             }
           ],
@@ -8632,6 +8653,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "With smartlink, each knife/shuriken thrown at same target that Combat Turn gets +1 dice pool per knife thrown.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "With smartlink, each knife/shuriken thrown at same target that Combat Turn gets +1 dice pool per knife thrown."
+                }
+              ],
               "weight": 0.05
             },
             {
@@ -8648,6 +8676,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "With smartlink, each knife/shuriken thrown at same target that Combat Turn gets +1 dice pool per knife thrown.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "With smartlink, each knife/shuriken thrown at same target that Combat Turn gets +1 dice pool per knife thrown."
+                }
+              ],
               "weight": 0.15
             }
           ],
@@ -8794,6 +8829,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 5
             },
             {
@@ -8810,6 +8852,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 0.4
             },
             {
@@ -8824,6 +8873,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "Avoids directing strong flashes at subscribed characters (half glare penalties). Recharges by induction (1 charge/hour). Can also use wireless link trigger without DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "Avoids directing strong flashes at subscribed characters (half glare penalties). Recharges by induction (1 charge/hour). Can also use wireless link trigger without DNI."
+                }
+              ],
               "weight": 0.3
             },
             {
@@ -8840,6 +8896,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 0.4
             },
             {
@@ -8856,6 +8919,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 4.5
             },
             {
@@ -8870,6 +8940,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 0.4
             },
             {
@@ -8886,6 +8963,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 0.4
             },
             {
@@ -8902,6 +8986,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 0.4
             },
             {
@@ -8918,6 +9009,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 5
             },
             {
@@ -8934,6 +9032,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 0.4
             },
             {
@@ -8950,6 +9055,13 @@
               "stackable": true,
               "consumable": true,
               "wirelessBonus": "You can use the wireless link trigger, even if you don't have DNI.",
+              "wirelessEffects": [
+                {
+                  "type": "special",
+                  "modifier": 0,
+                  "description": "You can use the wireless link trigger, even if you don't have DNI."
+                }
+              ],
               "weight": 0.4
             }
           ]

--- a/docs/archive/SR5_CRB_Wireless_Audit.md
+++ b/docs/archive/SR5_CRB_Wireless_Audit.md
@@ -11,18 +11,19 @@ Gap analysis comparing the [SR5 Wireless Bonuses Catalog](SR5_Wireless_Bonuses_C
 | Metric                                        | Count |
 | --------------------------------------------- | ----- |
 | Items with `wirelessBonus` text               | 77    |
-| Items with `wirelessEffects` arrays           | 61    |
-| Items with text but **no** structured effects | 16    |
+| Items with `wirelessEffects` arrays           | 77    |
+| Items with text but **no** structured effects | 0     |
 
-The 16 remaining items without `wirelessEffects` are grenades/rockets (11) and weapons (5) that received `wirelessBonus` text in Phase 1 but whose effects (wireless trigger, cumulative smart-throwing bonuses) are deferred until the relevant subsystems exist.
+All 77 items with `wirelessBonus` text now have corresponding `wirelessEffects` arrays.
 
 ### Items With Structured `wirelessEffects`
 
-All 61 items have both `wirelessBonus` text and a `wirelessEffects` array:
+All 77 items have both `wirelessBonus` text and a `wirelessEffects` array:
 
 - **10 original items**: `smartgun-internal`, `smartgun-external`, `control-rig`, `reaction-enhancers`, `wired-reflexes`, `cyberlimb-gyromount`, `cyberlimb-holster`, `cyberlimb-hydraulic-jacks`, `cyberlimb-large-smuggling-compartment`, `muscle-toner`
 - **15 augmentation/gear items** (Phase 2 prep): `datajack`, `cybereyes`, `cyberears`, `audio-enhancement` (×2), `select-sound-filter`, `skilljack`, `skillwires`, `spatial-recognizer`, `thermal-damping`, `medkit`, `laser-sight`, `monofilament-whip`, `periscope`
 - **36 Tier 2–6 items** (Phase 4): See section 3 below
+- **16 deferred items** (Phase 5): See section 3 Tier 7 below
 
 ---
 
@@ -35,9 +36,9 @@ Phase 1 (commit `de07918`) added `wirelessBonus` text to all 16 items:
 
 ---
 
-## 3. Items Missing `wirelessEffects` Arrays — RESOLVED (Phases 2 + 4)
+## 3. Items Missing `wirelessEffects` Arrays — RESOLVED (Phases 2, 4, + 5)
 
-All 47 unique items that had `wirelessBonus` text without structured effects have been resolved.
+All 63 unique items that had `wirelessBonus` text without structured effects have been resolved.
 
 ### Tier 1: Structured Effects (Phase 2, commit `589f4d6`)
 
@@ -77,6 +78,16 @@ All 47 unique items that had `wirelessBonus` text without structured effects hav
 
 All Tier 2–6 items use `{ "type": "special", "modifier": 0, "description": "..." }` since their effects are action-economy, informational, or otherwise non-mechanical.
 
+### Tier 7: Deferred Items — Wireless Trigger, Cumulative, and Info-on-Hit (Phase 5)
+
+16 items that were deferred from earlier phases because their effects (wireless trigger, cumulative bonuses, info-on-hit) didn't map to existing structured effect types. All use `{ "type": "special", "modifier": 0, "description": "..." }`:
+
+- **10 grenades/rockets** (wireless trigger): `flash-bang-grenade`, `fragmentation-grenade`, `gas`, `gas-grenade-cs-tear`, `high-explosive-grenade`, `smoke-grenade`, `thermal-smoke-grenade`, `anti-vehicle-rocket`, `fragmentation-rocket`, `high-explosive-rocket`
+- **1 flash-pak** (compound bonus): `flash-pak`
+- **2 throwing weapons** (cumulative smart-throwing): `shuriken`, `throwing-knife`
+- **2 tasers** (target info on hit): `defiance-ex-shocker`, `yamaha-pulsar`
+- **1 melee** (induction recharging): `shock-gloves`
+
 ---
 
 ## 4. Items Entirely Missing from CRB JSON
@@ -105,6 +116,7 @@ These 3 items are not in `core-rulebook.json` and are excluded from this audit s
 | Phase 2 | Structured `wirelessEffects` Tier 1 (13) | Complete |
 | Phase 3 | Resolve missing CRB entries (jammers)    | Complete |
 | Phase 4 | Tier 2–6 `wirelessEffects` (36)          | Complete |
+| Phase 5 | Deferred items `wirelessEffects` (16)    | Complete |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #386

- Adds structured `wirelessEffects` arrays to the 16 remaining CRB items that had `wirelessBonus` text but no structured effects
- Achieves full parity: all 77 items with `wirelessBonus` now have `wirelessEffects`
- Updates the wireless audit doc with Phase 5 completion

### Items updated (all use `type: "special"`)

| Group | Count | Effect |
|-------|-------|--------|
| Grenades & rockets | 10 | Wireless link trigger without DNI |
| Flash-pak | 1 | Compound: half glare penalties, induction recharge, wireless trigger |
| Throwing weapons | 2 | Cumulative +1 dice pool per knife/shuriken with smartlink |
| Tasers | 2 | Target health/condition monitor info on hit |
| Shock gloves | 1 | Induction recharging (1 charge/hour) |

## Test plan

- [x] `pnpm verify-data` — valid JSON
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 7352 tests pass
- [x] grep confirms 77/77 wirelessBonus↔wirelessEffects parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)