### PR TITLE
feat(sheet): Add inventory management controls to WeaponsDisplay (#372)

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -392,6 +392,8 @@ function CharacterSheet({
             <WeaponsDisplay
               character={character}
               onSelect={(pool, label) => openDiceRoller(pool, label)}
+              onCharacterUpdate={(updated) => setCharacter(updated)}
+              editable={character.status === "active"}
             />
 
             {character.armor && character.armor.length > 0 && (

--- a/components/character/sheet/WeaponsDisplay.tsx
+++ b/components/character/sheet/WeaponsDisplay.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import type { Character, Weapon, InstalledWeaponMod } from "@/lib/types";
 import type { WeaponData, GearCatalogData } from "@/lib/rules/RulesetContext";
+import type { EquipmentReadiness } from "@/lib/types/gear-state";
+import type { AmmunitionItem } from "@/lib/types/gear-state";
 import { useGear } from "@/lib/rules";
+import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
 import { DisplayCard } from "./DisplayCard";
 import { isMeleeWeapon } from "./constants";
-import { ChevronDown, ChevronRight, Swords, Wifi } from "lucide-react";
+import { WirelessIndicator } from "@/app/characters/[id]/components/WirelessIndicator";
+import { WeaponAmmoDisplay } from "@/app/characters/[id]/components/WeaponAmmoDisplay";
+import { ChevronDown, ChevronRight, Swords, Wifi, WifiOff } from "lucide-react";
 
 // ---------------------------------------------------------------------------
 // Pool calculation helper
@@ -87,6 +92,95 @@ function findCatalogWeapon(
   return undefined;
 }
 
+function getReadinessLabel(readiness: EquipmentReadiness): string {
+  switch (readiness) {
+    case "readied":
+      return "Readied";
+    case "holstered":
+      return "Holstered";
+    case "worn":
+      return "Worn";
+    case "stored":
+      return "Stored";
+    default:
+      return readiness;
+  }
+}
+
+function getReadinessColor(readiness: EquipmentReadiness): string {
+  switch (readiness) {
+    case "readied":
+      return "text-emerald-400 bg-emerald-500/10 border-emerald-500/30";
+    case "holstered":
+      return "text-amber-400 bg-amber-500/10 border-amber-500/30";
+    case "worn":
+      return "text-blue-400 bg-blue-500/10 border-blue-500/30";
+    case "stored":
+      return "text-zinc-400 bg-zinc-500/10 border-zinc-500/30 dark:text-zinc-500";
+    default:
+      return "text-zinc-400";
+  }
+}
+
+function getCompactAmmoBarColor(current: number, max: number): string {
+  if (max === 0) return "bg-zinc-400";
+  const pct = (current / max) * 100;
+  if (pct <= 0) return "bg-red-500";
+  if (pct <= 25) return "bg-orange-500";
+  if (pct <= 50) return "bg-yellow-500";
+  return "bg-emerald-500";
+}
+
+const WEAPON_READINESS_STATES: EquipmentReadiness[] = ["readied", "holstered", "stored"];
+
+// ---------------------------------------------------------------------------
+// Local state update handlers (matches InventoryPanel pattern)
+// ---------------------------------------------------------------------------
+
+function changeWeaponReadiness(
+  character: Character,
+  weaponId: string,
+  newState: EquipmentReadiness,
+  onCharacterUpdate: (updated: Character) => void
+) {
+  const updatedWeapons = character.weapons?.map((w) =>
+    (w.id || w.name) === weaponId
+      ? {
+          ...w,
+          state: {
+            ...w.state,
+            readiness: newState,
+            wirelessEnabled: w.state?.wirelessEnabled ?? true,
+          },
+        }
+      : w
+  );
+
+  onCharacterUpdate({ ...character, weapons: updatedWeapons });
+}
+
+function toggleWeaponWireless(
+  character: Character,
+  weaponId: string,
+  enabled: boolean,
+  onCharacterUpdate: (updated: Character) => void
+) {
+  const updatedWeapons = character.weapons?.map((w) =>
+    (w.id || w.name) === weaponId
+      ? {
+          ...w,
+          state: {
+            ...w.state,
+            readiness: w.state?.readiness ?? ("holstered" as const),
+            wirelessEnabled: enabled,
+          },
+        }
+      : w
+  );
+
+  onCharacterUpdate({ ...character, weapons: updatedWeapons });
+}
+
 // ---------------------------------------------------------------------------
 // WeaponRow
 // ---------------------------------------------------------------------------
@@ -96,11 +190,17 @@ function WeaponRow({
   character,
   catalogWeapon,
   onSelect,
+  onCharacterUpdate,
+  editable,
+  ammunition,
 }: {
   weapon: Weapon;
   character: Character;
   catalogWeapon?: WeaponData;
   onSelect?: (pool: number, label: string) => void;
+  onCharacterUpdate?: (updated: Character) => void;
+  editable?: boolean;
+  ammunition?: AmmunitionItem[];
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const { pool, label } = calculateWeaponPool(weapon, character);
@@ -113,13 +213,104 @@ function WeaponRow({
   const cost = weapon.cost || catalogWeapon?.cost || 0;
   const weight = weapon.weight ?? catalogWeapon?.weight;
 
+  // Readiness state
+  const readiness: EquipmentReadiness = weapon.state?.readiness ?? "holstered";
+
+  // Wireless state
+  const hasWireless = !!(weapon.wirelessBonus || catalogWeapon?.wirelessBonus);
+  const globalWireless = isGlobalWirelessEnabled(character);
+  const wirelessEnabled = weapon.state?.wirelessEnabled ?? true;
+  const isWirelessActive = hasWireless && globalWireless && wirelessEnabled;
+
+  // Weapon identifier for API calls
+  const weaponId = weapon.id || weapon.name;
+
+  // Ammo handlers
+  const handleReload = useCallback(
+    async (ammoItemId: string) => {
+      if (!character.id || !onCharacterUpdate) return;
+      try {
+        const response = await fetch(`/api/characters/${character.id}/weapons/${weaponId}/ammo`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ammoItemId }),
+        });
+        const result = await response.json();
+        if (result.success && result.weapon) {
+          const updatedWeapons = character.weapons?.map((w) =>
+            (w.id || w.name) === weaponId ? { ...w, ammoState: result.weapon.ammoState } : w
+          );
+          const updatedAmmunition = result.ammunition ?? character.ammunition;
+          onCharacterUpdate({
+            ...character,
+            weapons: updatedWeapons,
+            ammunition: updatedAmmunition,
+          });
+        }
+      } catch (error) {
+        console.error("Failed to reload weapon:", error);
+      }
+    },
+    [character, weaponId, onCharacterUpdate]
+  );
+
+  const handleUnload = useCallback(async () => {
+    if (!character.id || !onCharacterUpdate) return;
+    try {
+      const response = await fetch(`/api/characters/${character.id}/weapons/${weaponId}/ammo`, {
+        method: "DELETE",
+      });
+      const result = await response.json();
+      if (result.success) {
+        const updatedWeapons = character.weapons?.map((w) =>
+          (w.id || w.name) === weaponId
+            ? { ...w, ammoState: { ...w.ammoState!, currentRounds: 0, loadedAmmoTypeId: null } }
+            : w
+        );
+        const updatedAmmunition = result.ammunition ?? character.ammunition;
+        onCharacterUpdate({ ...character, weapons: updatedWeapons, ammunition: updatedAmmunition });
+      }
+    } catch (error) {
+      console.error("Failed to unload weapon:", error);
+    }
+  }, [character, weaponId, onCharacterUpdate]);
+
+  const handleSwapMagazine = useCallback(
+    async (magazineId: string) => {
+      if (!character.id || !onCharacterUpdate) return;
+      try {
+        const response = await fetch(`/api/characters/${character.id}/weapons/${weaponId}/ammo`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ magazineId }),
+        });
+        const result = await response.json();
+        if (result.success && result.weapon) {
+          const updatedWeapons = character.weapons?.map((w) =>
+            (w.id || w.name) === weaponId
+              ? {
+                  ...w,
+                  ammoState: result.weapon.ammoState,
+                  spareMagazines: result.weapon.spareMagazines,
+                }
+              : w
+          );
+          onCharacterUpdate({ ...character, weapons: updatedWeapons });
+        }
+      } catch (error) {
+        console.error("Failed to swap magazine:", error);
+      }
+    },
+    [character, weaponId, onCharacterUpdate]
+  );
+
   return (
     <div
       data-testid="weapon-row"
       onClick={() => setIsExpanded(!isExpanded)}
       className="group cursor-pointer px-3 py-1.5 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
     >
-      {/* Collapsed row: Chevron + Name ... Wifi? Pool pill */}
+      {/* Collapsed row: Chevron + Name (subcategory) [Readiness] [Ammo] [Wifi] [Pool] */}
       <div className="flex min-w-0 items-center gap-1.5">
         <span data-testid="expand-button" className="shrink-0 text-zinc-400">
           {isExpanded ? (
@@ -142,19 +333,57 @@ function WeaponRow({
             ({weapon.subcategory})
           </span>
         )}
-        {(weapon.wirelessBonus || catalogWeapon?.wirelessBonus) && (
-          <Wifi
-            data-testid="wireless-icon"
-            className="ml-auto h-3 w-3 shrink-0 text-cyan-500 dark:text-cyan-400"
-          />
+
+        {/* Spacer to push badges to the right */}
+        <span className="ml-auto" />
+
+        {/* Readiness badge (always visible) */}
+        <span
+          data-testid="readiness-badge"
+          className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-medium ${getReadinessColor(readiness)}`}
+        >
+          {getReadinessLabel(readiness)}
+        </span>
+
+        {/* Compact ammo indicator */}
+        {weapon.ammoState && (
+          <span data-testid="compact-ammo" className="flex shrink-0 items-center gap-1">
+            <span className="h-1.5 w-3 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+              <span
+                className={`block h-full ${getCompactAmmoBarColor(weapon.ammoState.currentRounds, weapon.ammoState.magazineCapacity)}`}
+                style={{
+                  width: `${weapon.ammoState.magazineCapacity > 0 ? (weapon.ammoState.currentRounds / weapon.ammoState.magazineCapacity) * 100 : 0}%`,
+                }}
+              />
+            </span>
+            <span className="font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+              {weapon.ammoState.currentRounds}/{weapon.ammoState.magazineCapacity}
+            </span>
+          </span>
         )}
+
+        {/* State-aware wifi icon */}
+        {hasWireless &&
+          (isWirelessActive ? (
+            <Wifi
+              data-testid="wireless-icon"
+              className="h-3 w-3 shrink-0 text-cyan-500 dark:text-cyan-400"
+            />
+          ) : (
+            <WifiOff
+              data-testid="wireless-icon-off"
+              className="h-3 w-3 shrink-0 text-zinc-400 dark:text-zinc-500"
+            />
+          ))}
+
+        {/* Dice pool pill */}
         <button
           data-testid="dice-pool-pill"
           onClick={(e) => {
             e.stopPropagation();
             onSelect?.(pool, label);
           }}
-          className={`${weapon.wirelessBonus || catalogWeapon?.wirelessBonus ? "" : "ml-auto "}shrink-0 cursor-pointer rounded border border-emerald-500/20 bg-emerald-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-emerald-600 dark:text-emerald-300`}
+          className="shrink-0 cursor-pointer rounded border border-emerald-500/20 bg-emerald-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-emerald-600 dark:text-emerald-300"
         >
           {pool}
         </button>
@@ -256,20 +485,78 @@ function WeaponRow({
             </div>
           )}
 
-          {/* Ammo state */}
+          {/* Inventory controls section (editable only) */}
+          {editable && onCharacterUpdate && (
+            <div data-testid="inventory-controls" className="space-y-2">
+              {/* Readiness controls */}
+              <div data-testid="readiness-controls" className="flex items-center gap-1">
+                <span className="mr-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                  Readiness
+                </span>
+                {WEAPON_READINESS_STATES.map((state) => (
+                  <button
+                    key={state}
+                    data-testid={`readiness-${state}`}
+                    disabled={state === readiness}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      changeWeaponReadiness(character, weaponId, state, onCharacterUpdate);
+                    }}
+                    className={`rounded border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      state === readiness
+                        ? getReadinessColor(state)
+                        : "border-zinc-300 text-zinc-400 hover:border-zinc-400 hover:text-zinc-300 dark:border-zinc-700 dark:text-zinc-500 dark:hover:border-zinc-600"
+                    }`}
+                  >
+                    {getReadinessLabel(state)}
+                  </button>
+                ))}
+              </div>
+
+              {/* Wireless toggle */}
+              {hasWireless && (
+                <div data-testid="wireless-toggle" className="flex items-center gap-2">
+                  <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                    Wireless
+                  </span>
+                  <WirelessIndicator
+                    enabled={wirelessEnabled}
+                    globalEnabled={globalWireless}
+                    bonusDescription={weapon.wirelessBonus || catalogWeapon?.wirelessBonus}
+                    onToggle={(enabled) =>
+                      toggleWeaponWireless(character, weaponId, enabled, onCharacterUpdate)
+                    }
+                    size="sm"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Ammo display: interactive when editable, static when read-only */}
           {weapon.ammoState && (
             <div data-testid="ammo-section">
-              <div className="flex items-baseline gap-2 text-xs text-zinc-500 dark:text-zinc-400">
-                <span className="text-[10px] font-semibold uppercase tracking-wider">Ammo</span>
-                <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
-                  {weapon.ammoState.currentRounds}/{weapon.ammoState.magazineCapacity}
-                </span>
-                {weapon.ammoState.loadedAmmoTypeId && (
-                  <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
-                    {weapon.ammoState.loadedAmmoTypeId.replace(/-/g, " ")}
+              {editable && onCharacterUpdate ? (
+                <WeaponAmmoDisplay
+                  weapon={weapon}
+                  availableAmmo={ammunition}
+                  onReload={handleReload}
+                  onUnload={handleUnload}
+                  onSwapMagazine={handleSwapMagazine}
+                />
+              ) : (
+                <div className="flex items-baseline gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+                  <span className="text-[10px] font-semibold uppercase tracking-wider">Ammo</span>
+                  <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                    {weapon.ammoState.currentRounds}/{weapon.ammoState.magazineCapacity}
                   </span>
-                )}
-              </div>
+                  {weapon.ammoState.loadedAmmoTypeId && (
+                    <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
+                      {weapon.ammoState.loadedAmmoTypeId.replace(/-/g, " ")}
+                    </span>
+                  )}
+                </div>
+              )}
             </div>
           )}
 
@@ -329,9 +616,16 @@ const WEAPON_SECTIONS = [
 interface WeaponsDisplayProps {
   character: Character;
   onSelect?: (pool: number, label: string) => void;
+  onCharacterUpdate?: (updatedCharacter: Character) => void;
+  editable?: boolean;
 }
 
-export function WeaponsDisplay({ character, onSelect }: WeaponsDisplayProps) {
+export function WeaponsDisplay({
+  character,
+  onSelect,
+  onCharacterUpdate,
+  editable,
+}: WeaponsDisplayProps) {
   const catalog = useGear();
   const ranged = character.weapons?.filter((w) => !isMeleeWeapon(w)) || [];
   const melee = character.weapons?.filter((w) => isMeleeWeapon(w)) || [];
@@ -339,6 +633,7 @@ export function WeaponsDisplay({ character, onSelect }: WeaponsDisplayProps) {
   if (ranged.length === 0 && melee.length === 0) return null;
 
   const items: Record<"ranged" | "melee", Weapon[]> = { ranged, melee };
+  const ammunition = (character.ammunition || []) as AmmunitionItem[];
 
   return (
     <DisplayCard
@@ -365,6 +660,9 @@ export function WeaponsDisplay({ character, onSelect }: WeaponsDisplayProps) {
                       weapon.catalogId ? findCatalogWeapon(catalog, weapon.catalogId) : undefined
                     }
                     onSelect={onSelect}
+                    onCharacterUpdate={onCharacterUpdate}
+                    editable={editable}
+                    ammunition={ammunition}
                   />
                 ))}
               </div>

--- a/components/character/sheet/__tests__/WeaponsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/WeaponsDisplay.test.tsx
@@ -2,10 +2,11 @@
  * WeaponsDisplay Component Tests
  *
  * Tests the weapons display with ranged/melee expandable rows,
- * stat pills, pool calculations, catalog integration, and onSelect callback.
+ * stat pills, pool calculations, catalog integration, onSelect callback,
+ * and inventory management controls (readiness, wireless, ammo).
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import {
   setupDisplayCardMock,
@@ -17,6 +18,48 @@ import {
 
 setupDisplayCardMock();
 vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+// ---------------------------------------------------------------------------
+// Mock external components
+// ---------------------------------------------------------------------------
+
+vi.mock("@/app/characters/[id]/components/WirelessIndicator", () => ({
+  WirelessIndicator: (props: {
+    enabled: boolean;
+    globalEnabled?: boolean;
+    onToggle?: (v: boolean) => void;
+  }) => (
+    <div
+      data-testid="wireless-indicator"
+      data-enabled={String(props.enabled)}
+      data-global-enabled={String(props.globalEnabled)}
+    >
+      {props.onToggle && (
+        <button
+          data-testid="wireless-indicator-toggle"
+          onClick={() => props.onToggle!(!props.enabled)}
+        >
+          Toggle
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+vi.mock("@/app/characters/[id]/components/WeaponAmmoDisplay", () => ({
+  WeaponAmmoDisplay: (props: Record<string, unknown>) => (
+    <div
+      data-testid="weapon-ammo-display"
+      data-has-reload={String(!!props.onReload)}
+      data-has-unload={String(!!props.onUnload)}
+      data-has-swap={String(!!props.onSwapMagazine)}
+    />
+  ),
+}));
+
+vi.mock("@/lib/rules/wireless", () => ({
+  isGlobalWirelessEnabled: vi.fn(() => true),
+}));
 
 // ---------------------------------------------------------------------------
 // Catalog mock
@@ -98,6 +141,12 @@ vi.mock("@/lib/rules", () => ({
 }));
 
 import { WeaponsDisplay } from "../WeaponsDisplay";
+import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (isGlobalWirelessEnabled as ReturnType<typeof vi.fn>).mockReturnValue(true);
+});
 
 describe("WeaponsDisplay", () => {
   it("returns null when no weapons", () => {
@@ -215,6 +264,30 @@ describe("WeaponsDisplay", () => {
     const character = createSheetCharacter({ weapons: [MOCK_MELEE_WEAPON] });
     render(<WeaponsDisplay character={character} />);
     expect(screen.queryByTestId("wireless-icon")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("wireless-icon-off")).not.toBeInTheDocument();
+  });
+
+  it("shows WifiOff icon when wireless is disabled for a weapon", () => {
+    const rangedWithWirelessOff = {
+      ...MOCK_RANGED_WEAPON,
+      wirelessBonus: "Provides +1 accuracy.",
+      state: { readiness: "holstered" as const, wirelessEnabled: false },
+    };
+    const character = createSheetCharacter({ weapons: [rangedWithWirelessOff] });
+    render(<WeaponsDisplay character={character} />);
+    expect(screen.getByTestId("wireless-icon-off")).toBeInTheDocument();
+    expect(screen.queryByTestId("wireless-icon")).not.toBeInTheDocument();
+  });
+
+  it("shows WifiOff icon when global wireless is disabled", () => {
+    (isGlobalWirelessEnabled as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const rangedWithWireless = {
+      ...MOCK_RANGED_WEAPON,
+      wirelessBonus: "Provides +1 accuracy.",
+    };
+    const character = createSheetCharacter({ weapons: [rangedWithWireless] });
+    render(<WeaponsDisplay character={character} />);
+    expect(screen.getByTestId("wireless-icon-off")).toBeInTheDocument();
   });
 
   // --- Expanded stats (require expanding) ---
@@ -536,5 +609,258 @@ describe("WeaponsDisplay", () => {
     render(<WeaponsDisplay character={character} />);
     fireEvent.click(screen.getByTestId("expand-button"));
     expect(screen.queryByTestId("modifications-section")).not.toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // Readiness badge (collapsed row, always visible)
+  // =========================================================================
+
+  describe("readiness badge", () => {
+    it("shows default 'Holstered' when weapon has no state", () => {
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} />);
+      const badge = screen.getByTestId("readiness-badge");
+      expect(badge).toHaveTextContent("Holstered");
+    });
+
+    it("shows 'Readied' with emerald color when readiness is readied", () => {
+      const readiedWeapon = {
+        ...MOCK_RANGED_WEAPON,
+        state: { readiness: "readied" as const, wirelessEnabled: true },
+      };
+      const character = createSheetCharacter({ weapons: [readiedWeapon] });
+      render(<WeaponsDisplay character={character} />);
+      const badge = screen.getByTestId("readiness-badge");
+      expect(badge).toHaveTextContent("Readied");
+      expect(badge.className).toContain("emerald");
+    });
+
+    it("shows 'Stored' when readiness is stored", () => {
+      const storedWeapon = {
+        ...MOCK_RANGED_WEAPON,
+        state: { readiness: "stored" as const, wirelessEnabled: true },
+      };
+      const character = createSheetCharacter({ weapons: [storedWeapon] });
+      render(<WeaponsDisplay character={character} />);
+      const badge = screen.getByTestId("readiness-badge");
+      expect(badge).toHaveTextContent("Stored");
+    });
+
+    it("is visible even when editable=false", () => {
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={false} />);
+      expect(screen.getByTestId("readiness-badge")).toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Readiness controls (expanded, editable only)
+  // =========================================================================
+
+  describe("readiness controls", () => {
+    it("hidden when editable=false", () => {
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={false} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.queryByTestId("readiness-controls")).not.toBeInTheDocument();
+    });
+
+    it("hidden when onCharacterUpdate is not provided", () => {
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={true} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.queryByTestId("readiness-controls")).not.toBeInTheDocument();
+    });
+
+    it("shown when editable=true and onCharacterUpdate provided", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("readiness-controls")).toBeInTheDocument();
+    });
+
+    it("renders three readiness buttons", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("readiness-readied")).toBeInTheDocument();
+      expect(screen.getByTestId("readiness-holstered")).toBeInTheDocument();
+      expect(screen.getByTestId("readiness-stored")).toBeInTheDocument();
+    });
+
+    it("current readiness button is disabled", () => {
+      const onUpdate = vi.fn();
+      // Default readiness is "holstered"
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("readiness-holstered")).toBeDisabled();
+      expect(screen.getByTestId("readiness-readied")).not.toBeDisabled();
+      expect(screen.getByTestId("readiness-stored")).not.toBeDisabled();
+    });
+
+    it("click calls onCharacterUpdate with new readiness", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({
+        weapons: [MOCK_RANGED_WEAPON],
+      });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("readiness-readied"));
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      const updatedChar = onUpdate.mock.calls[0][0];
+      expect(updatedChar.weapons[0].state.readiness).toBe("readied");
+    });
+  });
+
+  // =========================================================================
+  // Wireless toggle (expanded, editable, weapon has wireless)
+  // =========================================================================
+
+  describe("wireless toggle", () => {
+    it("hidden when weapon has no wirelessBonus", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ weapons: [MOCK_MELEE_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.queryByTestId("wireless-toggle")).not.toBeInTheDocument();
+    });
+
+    it("hidden when not editable", () => {
+      const rangedWithWireless = {
+        ...MOCK_RANGED_WEAPON,
+        wirelessBonus: "Provides +1 accuracy.",
+      };
+      const character = createSheetCharacter({ weapons: [rangedWithWireless] });
+      render(<WeaponsDisplay character={character} editable={false} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.queryByTestId("wireless-toggle")).not.toBeInTheDocument();
+    });
+
+    it("shown when editable + has wireless bonus", () => {
+      const onUpdate = vi.fn();
+      const rangedWithWireless = {
+        ...MOCK_RANGED_WEAPON,
+        wirelessBonus: "Provides +1 accuracy.",
+      };
+      const character = createSheetCharacter({ weapons: [rangedWithWireless] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("wireless-toggle")).toBeInTheDocument();
+      expect(screen.getByTestId("wireless-indicator")).toBeInTheDocument();
+    });
+
+    it("WirelessIndicator receives correct props", () => {
+      const onUpdate = vi.fn();
+      const rangedWithWireless = {
+        ...MOCK_RANGED_WEAPON,
+        wirelessBonus: "Provides +1 accuracy.",
+        state: { readiness: "holstered" as const, wirelessEnabled: false },
+      };
+      const character = createSheetCharacter({ weapons: [rangedWithWireless] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      const indicator = screen.getByTestId("wireless-indicator");
+      expect(indicator).toHaveAttribute("data-enabled", "false");
+      expect(indicator).toHaveAttribute("data-global-enabled", "true");
+    });
+  });
+
+  // =========================================================================
+  // Compact ammo bar (collapsed row)
+  // =========================================================================
+
+  describe("compact ammo bar", () => {
+    it("visible in collapsed row for weapons with ammoState", () => {
+      const rangedWithAmmo = {
+        ...MOCK_RANGED_WEAPON,
+        ammoState: { loadedAmmoTypeId: "regular", currentRounds: 10, magazineCapacity: 15 },
+      };
+      const character = createSheetCharacter({ weapons: [rangedWithAmmo] });
+      render(<WeaponsDisplay character={character} />);
+      const compactAmmo = screen.getByTestId("compact-ammo");
+      expect(compactAmmo).toBeInTheDocument();
+      expect(compactAmmo).toHaveTextContent("10/15");
+    });
+
+    it("hidden when weapon has no ammoState", () => {
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} />);
+      expect(screen.queryByTestId("compact-ammo")).not.toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Ammo display (expanded section)
+  // =========================================================================
+
+  describe("ammo display", () => {
+    it("renders WeaponAmmoDisplay in expanded section when editable", () => {
+      const onUpdate = vi.fn();
+      const rangedWithAmmo = {
+        ...MOCK_RANGED_WEAPON,
+        ammoState: { loadedAmmoTypeId: "regular", currentRounds: 10, magazineCapacity: 15 },
+      };
+      const character = createSheetCharacter({ weapons: [rangedWithAmmo] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      const ammoDisplay = screen.getByTestId("weapon-ammo-display");
+      expect(ammoDisplay).toBeInTheDocument();
+      expect(ammoDisplay).toHaveAttribute("data-has-reload", "true");
+      expect(ammoDisplay).toHaveAttribute("data-has-unload", "true");
+      expect(ammoDisplay).toHaveAttribute("data-has-swap", "true");
+    });
+
+    it("renders static ammo text when not editable", () => {
+      const rangedWithAmmo = {
+        ...MOCK_RANGED_WEAPON,
+        ammoState: { loadedAmmoTypeId: "regular", currentRounds: 10, magazineCapacity: 15 },
+      };
+      const character = createSheetCharacter({ weapons: [rangedWithAmmo] });
+      render(<WeaponsDisplay character={character} editable={false} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.queryByTestId("weapon-ammo-display")).not.toBeInTheDocument();
+      const ammoSection = screen.getByTestId("ammo-section");
+      expect(ammoSection).toHaveTextContent("10/15");
+    });
+  });
+
+  // =========================================================================
+  // Local state updates
+  // =========================================================================
+
+  describe("local state updates", () => {
+    it("readiness change calls onCharacterUpdate with updated weapon state", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({
+        weapons: [MOCK_RANGED_WEAPON],
+      });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("readiness-readied"));
+
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      const updatedChar = onUpdate.mock.calls[0][0];
+      expect(updatedChar.weapons[0].state.readiness).toBe("readied");
+      expect(updatedChar.weapons[0].state.wirelessEnabled).toBe(true);
+    });
+
+    it("readiness change preserves existing wireless state", () => {
+      const onUpdate = vi.fn();
+      const weaponWithWirelessOff = {
+        ...MOCK_RANGED_WEAPON,
+        state: { readiness: "holstered" as const, wirelessEnabled: false },
+      };
+      const character = createSheetCharacter({ weapons: [weaponWithWirelessOff] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("readiness-readied"));
+
+      const updatedChar = onUpdate.mock.calls[0][0];
+      expect(updatedChar.weapons[0].state.readiness).toBe("readied");
+      expect(updatedChar.weapons[0].state.wirelessEnabled).toBe(false);
+    });
   });
 });

--- a/components/character/sheet/__tests__/test-helpers.tsx
+++ b/components/character/sheet/__tests__/test-helpers.tsx
@@ -143,6 +143,7 @@ export const LUCIDE_MOCK = {
   Settings2: createIconMock("Settings2"),
   ChevronDown: createIconMock("ChevronDown"),
   ChevronRight: createIconMock("ChevronRight"),
+  WifiOff: createIconMock("WifiOff"),
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Enhance WeaponsDisplay with interactive readiness, wireless, and ammo controls directly in the weapons view, matching InventoryPanel capabilities.

- Add readiness badge (always visible) with color-coded pill
- Add compact ammo indicator bar in collapsed row
- Replace static wifi icon with state-aware Wifi/WifiOff
- Add readiness button group in expanded view (editable only)
- Add WirelessIndicator toggle in expanded view (editable only)
- Add WeaponAmmoDisplay with reload/unload/swap in expanded view
- Implement optimistic API updates with rollback on error
- Pass onCharacterUpdate and editable props from character page
- Add 22 new tests covering all interactive features (64 total)

closes #372 