### PR TITLE
feat(sheet): Add readiness and wireless controls to ArmorDisplay

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -396,9 +396,11 @@ function CharacterSheet({
               editable={character.status === "active"}
             />
 
-            {character.armor && character.armor.length > 0 && (
-              <ArmorDisplay armor={character.armor} />
-            )}
+            <ArmorDisplay
+              character={character}
+              onCharacterUpdate={(updated) => setCharacter(updated)}
+              editable={character.status === "active"}
+            />
 
             <AugmentationsDisplay
               character={character}

--- a/components/character/sheet/ArmorDisplay.tsx
+++ b/components/character/sheet/ArmorDisplay.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import type { ArmorItem } from "@/lib/types";
+import type { Character, ArmorItem } from "@/lib/types";
+import type { ArmorData, GearCatalogData } from "@/lib/rules/RulesetContext";
+import type { EquipmentReadiness } from "@/lib/types/gear-state";
+import { useGear } from "@/lib/rules";
+import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
 import { DisplayCard } from "./DisplayCard";
-import { ChevronDown, ChevronRight, Shield } from "lucide-react";
+import { WirelessIndicator } from "@/app/characters/[id]/components/WirelessIndicator";
+import { ChevronDown, ChevronRight, Shield, Wifi, WifiOff } from "lucide-react";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -19,6 +24,88 @@ function formatLegality(legality: string): string {
   return "";
 }
 
+function getReadinessLabel(readiness: EquipmentReadiness): string {
+  switch (readiness) {
+    case "worn":
+      return "Worn";
+    case "stored":
+      return "Stored";
+    default:
+      return readiness;
+  }
+}
+
+function getReadinessColor(readiness: EquipmentReadiness): string {
+  switch (readiness) {
+    case "worn":
+      return "text-blue-400 bg-blue-500/10 border-blue-500/30";
+    case "stored":
+      return "text-zinc-400 bg-zinc-500/10 border-zinc-500/30 dark:text-zinc-500";
+    default:
+      return "text-zinc-400";
+  }
+}
+
+/** Search the armor catalog array by id. */
+function findCatalogArmor(
+  catalog: GearCatalogData | null,
+  catalogId: string
+): ArmorData | undefined {
+  if (!catalog?.armor) return undefined;
+  return catalog.armor.find((item) => item.id === catalogId);
+}
+
+const ARMOR_READINESS_STATES: EquipmentReadiness[] = ["worn", "stored"];
+
+// ---------------------------------------------------------------------------
+// Local state update handlers
+// ---------------------------------------------------------------------------
+
+function changeArmorReadiness(
+  character: Character,
+  armorIndex: number,
+  newState: EquipmentReadiness,
+  onCharacterUpdate: (updated: Character) => void
+) {
+  const updatedArmor = character.armor?.map((a, idx) =>
+    idx === armorIndex
+      ? {
+          ...a,
+          equipped: newState === "worn",
+          state: {
+            ...a.state,
+            readiness: newState,
+            wirelessEnabled: a.state?.wirelessEnabled ?? true,
+          },
+        }
+      : a
+  );
+
+  onCharacterUpdate({ ...character, armor: updatedArmor });
+}
+
+function toggleArmorWireless(
+  character: Character,
+  armorIndex: number,
+  enabled: boolean,
+  onCharacterUpdate: (updated: Character) => void
+) {
+  const updatedArmor = character.armor?.map((a, idx) =>
+    idx === armorIndex
+      ? {
+          ...a,
+          state: {
+            ...a.state,
+            readiness: a.state?.readiness ?? ("worn" as const),
+            wirelessEnabled: enabled,
+          },
+        }
+      : a
+  );
+
+  onCharacterUpdate({ ...character, armor: updatedArmor });
+}
+
 // ---------------------------------------------------------------------------
 // Section config
 // ---------------------------------------------------------------------------
@@ -32,16 +119,42 @@ const ARMOR_SECTIONS = [
 // ArmorRow
 // ---------------------------------------------------------------------------
 
-function ArmorRow({ item }: { item: ArmorItem }) {
-  const [isExpanded, setIsExpanded] = useState(false);
+function ArmorRow({
+  item,
+  itemIndex,
+  character,
+  catalogArmor,
+  onCharacterUpdate,
+  editable,
+  isExpanded,
+  onToggleExpand,
+}: {
+  item: ArmorItem;
+  itemIndex: number;
+  character: Character;
+  catalogArmor?: ArmorData;
+  onCharacterUpdate?: (updated: Character) => void;
+  editable?: boolean;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+}) {
+  // Readiness state
+  const readiness: EquipmentReadiness =
+    item.state?.readiness ?? (item.equipped ? "worn" : "stored");
+
+  // Wireless state
+  const hasWireless = !!(item.wirelessBonus || catalogArmor?.wirelessBonus);
+  const globalWireless = isGlobalWirelessEnabled(character);
+  const wirelessEnabled = item.state?.wirelessEnabled ?? true;
+  const isWirelessActive = hasWireless && globalWireless && wirelessEnabled;
 
   return (
     <div
       data-testid="armor-row"
       className="cursor-pointer px-3 py-1.5 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
-      onClick={() => setIsExpanded(!isExpanded)}
+      onClick={onToggleExpand}
     >
-      {/* Collapsed row: Chevron + Name + Accessory badge + Rating pill */}
+      {/* Collapsed row: Chevron + Name + Accessory badge + [Readiness] [Wifi] Rating pill */}
       <div className="flex min-w-0 items-center gap-1.5">
         <span data-testid="expand-button" className="shrink-0 text-zinc-400">
           {isExpanded ? (
@@ -61,9 +174,35 @@ function ArmorRow({ item }: { item: ArmorItem }) {
             ({item.subcategory.charAt(0).toUpperCase() + item.subcategory.slice(1)})
           </span>
         )}
+
+        {/* Spacer to push badges to the right */}
+        <span className="ml-auto" />
+
+        {/* Readiness badge (always visible) */}
+        <span
+          data-testid="readiness-badge"
+          className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-medium ${getReadinessColor(readiness)}`}
+        >
+          {getReadinessLabel(readiness)}
+        </span>
+
+        {/* State-aware wifi icon */}
+        {hasWireless &&
+          (isWirelessActive ? (
+            <Wifi
+              data-testid="wireless-icon"
+              className="h-3 w-3 shrink-0 text-cyan-500 dark:text-cyan-400"
+            />
+          ) : (
+            <WifiOff
+              data-testid="wireless-icon-off"
+              className="h-3 w-3 shrink-0 text-zinc-400 dark:text-zinc-500"
+            />
+          ))}
+
         <span
           data-testid="rating-pill"
-          className="ml-auto shrink-0 rounded border border-sky-500/20 bg-sky-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-sky-600 dark:text-sky-300"
+          className="shrink-0 rounded border border-sky-500/20 bg-sky-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-sky-600 dark:text-sky-300"
         >
           {item.armorRating}
         </span>
@@ -110,6 +249,54 @@ function ArmorRow({ item }: { item: ArmorItem }) {
             </div>
           )}
 
+          {/* Inventory controls section (editable only) */}
+          {editable && onCharacterUpdate && (
+            <div data-testid="inventory-controls" className="space-y-2">
+              {/* Readiness controls */}
+              <div data-testid="readiness-controls" className="flex items-center gap-1">
+                <span className="mr-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                  Readiness
+                </span>
+                {ARMOR_READINESS_STATES.map((state) => (
+                  <button
+                    key={state}
+                    data-testid={`readiness-${state}`}
+                    disabled={state === readiness}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      changeArmorReadiness(character, itemIndex, state, onCharacterUpdate);
+                    }}
+                    className={`rounded border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      state === readiness
+                        ? getReadinessColor(state)
+                        : "border-zinc-300 text-zinc-400 hover:border-zinc-400 hover:text-zinc-300 dark:border-zinc-700 dark:text-zinc-500 dark:hover:border-zinc-600"
+                    }`}
+                  >
+                    {getReadinessLabel(state)}
+                  </button>
+                ))}
+              </div>
+
+              {/* Wireless toggle */}
+              {hasWireless && (
+                <div data-testid="wireless-toggle" className="flex items-center gap-2">
+                  <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                    Wireless
+                  </span>
+                  <WirelessIndicator
+                    enabled={wirelessEnabled}
+                    globalEnabled={globalWireless}
+                    bonusDescription={item.wirelessBonus || catalogArmor?.wirelessBonus}
+                    onToggle={(enabled) =>
+                      toggleArmorWireless(character, itemIndex, enabled, onCharacterUpdate)
+                    }
+                    size="sm"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
           {/* Modifications */}
           {item.modifications && item.modifications.length > 0 && (
             <div data-testid="modifications-section">
@@ -145,16 +332,30 @@ function ArmorRow({ item }: { item: ArmorItem }) {
 // ---------------------------------------------------------------------------
 
 interface ArmorDisplayProps {
-  armor: ArmorItem[];
+  character: Character;
+  onCharacterUpdate?: (updatedCharacter: Character) => void;
+  editable?: boolean;
 }
 
-export function ArmorDisplay({ armor }: ArmorDisplayProps) {
+export function ArmorDisplay({ character, onCharacterUpdate, editable }: ArmorDisplayProps) {
+  const catalog = useGear();
+  const [expandedIndices, setExpandedIndices] = useState<Set<number>>(new Set());
+  const armor = character.armor || [];
+
   if (armor.length === 0) return null;
 
-  const grouped: Record<"worn" | "stored", ArmorItem[]> = {
-    worn: armor.filter(isWorn),
-    stored: armor.filter((a) => !isWorn(a)),
+  const grouped: Record<"worn" | "stored", { item: ArmorItem; index: number }[]> = {
+    worn: [],
+    stored: [],
   };
+
+  armor.forEach((item, index) => {
+    if (isWorn(item)) {
+      grouped.worn.push({ item, index });
+    } else {
+      grouped.stored.push({ item, index });
+    }
+  });
 
   return (
     <DisplayCard
@@ -172,8 +373,27 @@ export function ArmorDisplay({ armor }: ArmorDisplayProps) {
                 {label}
               </div>
               <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
-                {grouped[key].map((item, idx) => (
-                  <ArmorRow key={`${item.name}-${idx}`} item={item} />
+                {grouped[key].map(({ item, index }) => (
+                  <ArmorRow
+                    key={`${item.name}-${index}`}
+                    item={item}
+                    itemIndex={index}
+                    character={character}
+                    catalogArmor={
+                      item.catalogId ? findCatalogArmor(catalog, item.catalogId) : undefined
+                    }
+                    onCharacterUpdate={onCharacterUpdate}
+                    editable={editable}
+                    isExpanded={expandedIndices.has(index)}
+                    onToggleExpand={() => {
+                      setExpandedIndices((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(index)) next.delete(index);
+                        else next.add(index);
+                        return next;
+                      });
+                    }}
+                  />
                 ))}
               </div>
             </div>

--- a/components/character/sheet/__tests__/ArmorDisplay.test.tsx
+++ b/components/character/sheet/__tests__/ArmorDisplay.test.tsx
@@ -3,11 +3,11 @@
  *
  * Tests the armor display with expandable rows grouped into Worn/Stored sections.
  * Validates section grouping, collapsed/expanded states, stats, capacity bar,
- * modifications, and accessory badge rendering.
+ * modifications, readiness controls, wireless toggle, and accessory badge rendering.
  */
 
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   setupDisplayCardMock,
@@ -16,86 +16,244 @@ import {
   MOCK_ARMOR_STORED,
   MOCK_ARMOR_WITH_MODS,
   MOCK_ARMOR_ACCESSORY,
+  MOCK_ARMOR_WITH_WIRELESS,
+  createSheetCharacter,
 } from "./test-helpers";
 
 setupDisplayCardMock();
 vi.mock("lucide-react", () => LUCIDE_MOCK);
 
+// ---------------------------------------------------------------------------
+// Mock external components
+// ---------------------------------------------------------------------------
+
+vi.mock("@/app/characters/[id]/components/WirelessIndicator", () => ({
+  WirelessIndicator: (props: {
+    enabled: boolean;
+    globalEnabled?: boolean;
+    onToggle?: (v: boolean) => void;
+  }) => (
+    <div
+      data-testid="wireless-indicator"
+      data-enabled={String(props.enabled)}
+      data-global-enabled={String(props.globalEnabled)}
+    >
+      {props.onToggle && (
+        <button
+          data-testid="wireless-indicator-toggle"
+          onClick={() => props.onToggle!(!props.enabled)}
+        >
+          toggle
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/rules/wireless", () => ({
+  isGlobalWirelessEnabled: vi.fn(() => true),
+}));
+
+// ---------------------------------------------------------------------------
+// Catalog mock
+// ---------------------------------------------------------------------------
+
+const MOCK_GEAR_CATALOG = {
+  categories: [],
+  weapons: {
+    melee: [],
+    pistols: [],
+    smgs: [],
+    rifles: [],
+    shotguns: [],
+    sniperRifles: [],
+    throwingWeapons: [],
+    grenades: [],
+  },
+  armor: [
+    {
+      id: "berwick-suit",
+      name: "Berwick Suit",
+      category: "armor",
+      subcategory: "armor-clothing",
+      armorRating: 8,
+      cost: 2600,
+      availability: 8,
+      wirelessBonus: "+1 to Social limit while wireless is active.",
+    },
+  ],
+  commlinks: [],
+  cyberdecks: [],
+  electronics: [],
+  tools: [],
+  survival: [],
+  medical: [],
+  security: [],
+  miscellaneous: [],
+  ammunition: [],
+  rfidTags: [],
+  industrialChemicals: [],
+};
+
+vi.mock("@/lib/rules", () => ({
+  useGear: () => MOCK_GEAR_CATALOG,
+}));
+
 import { ArmorDisplay } from "../ArmorDisplay";
+import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (isGlobalWirelessEnabled as ReturnType<typeof vi.fn>).mockReturnValue(true);
+});
 
 describe("ArmorDisplay", () => {
   // --- Empty state ---
 
   it("returns null when armor array is empty", () => {
-    const { container } = render(<ArmorDisplay armor={[]} />);
+    const character = createSheetCharacter({ armor: [] });
+    const { container } = render(<ArmorDisplay character={character} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when armor is undefined", () => {
+    const character = createSheetCharacter({ armor: undefined });
+    const { container } = render(<ArmorDisplay character={character} />);
     expect(container.innerHTML).toBe("");
   });
 
   // --- Section grouping ---
 
   it("renders Worn section for worn armor", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
-    expect(screen.getByText("Worn")).toBeInTheDocument();
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
+    // "Worn" appears as section header and readiness badge
+    expect(screen.getAllByText("Worn").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders Stored section for stored armor", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_STORED]} />);
-    expect(screen.getByText("Stored")).toBeInTheDocument();
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_STORED] });
+    render(<ArmorDisplay character={character} />);
+    // "Stored" appears as section header and readiness badge
+    expect(screen.getAllByText("Stored").length).toBeGreaterThanOrEqual(1);
   });
 
   it("hides Stored section when all armor is worn", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
+    // "Stored" should not appear anywhere (no section header, no badge)
     expect(screen.queryByText("Stored")).not.toBeInTheDocument();
   });
 
   it("hides Worn section when all armor is stored", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_STORED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_STORED] });
+    render(<ArmorDisplay character={character} />);
+    // "Worn" should not appear anywhere (no section header, no badge)
     expect(screen.queryByText("Worn")).not.toBeInTheDocument();
   });
 
   it("renders both sections when armor includes worn and stored", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED, MOCK_ARMOR_STORED]} />);
-    expect(screen.getByText("Worn")).toBeInTheDocument();
-    expect(screen.getByText("Stored")).toBeInTheDocument();
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED, MOCK_ARMOR_STORED] });
+    render(<ArmorDisplay character={character} />);
+    // Each appears as section header + readiness badge
+    expect(screen.getAllByText("Worn").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Stored").length).toBeGreaterThanOrEqual(2);
   });
 
   it("falls back to equipped field when state is absent", () => {
     const legacyEquipped = { ...MOCK_ARMOR_EQUIPPED, state: undefined, equipped: true };
     const legacyStored = { ...MOCK_ARMOR_STORED, state: undefined, equipped: false };
-    render(<ArmorDisplay armor={[legacyEquipped, legacyStored]} />);
-    expect(screen.getByText("Worn")).toBeInTheDocument();
-    expect(screen.getByText("Stored")).toBeInTheDocument();
+    const character = createSheetCharacter({ armor: [legacyEquipped, legacyStored] });
+    render(<ArmorDisplay character={character} />);
+    expect(screen.getAllByText("Worn").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Stored").length).toBeGreaterThanOrEqual(2);
   });
 
   // --- Collapsed row ---
 
   it("renders armor name in collapsed row", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
     expect(screen.getByText("Armor Jacket")).toBeInTheDocument();
   });
 
   it("renders armor rating in sky-colored pill", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
     const pill = screen.getByTestId("rating-pill");
     expect(pill).toHaveTextContent("12");
     expect(pill.className).toContain("sky");
   });
 
   it("renders subcategory label when subcategory is present", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_ACCESSORY]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_ACCESSORY] });
+    render(<ArmorDisplay character={character} />);
     expect(screen.getByTestId("subcategory-label")).toBeInTheDocument();
   });
 
   it("does not show expanded content by default", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
     expect(screen.queryByTestId("expanded-content")).not.toBeInTheDocument();
+  });
+
+  // --- Readiness badge (collapsed row) ---
+
+  it("shows Worn readiness badge for worn armor", () => {
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
+    const badge = screen.getByTestId("readiness-badge");
+    expect(badge).toHaveTextContent("Worn");
+    expect(badge.className).toContain("blue");
+  });
+
+  it("shows Stored readiness badge for stored armor", () => {
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_STORED] });
+    render(<ArmorDisplay character={character} />);
+    const badge = screen.getByTestId("readiness-badge");
+    expect(badge).toHaveTextContent("Stored");
+    expect(badge.className).toContain("zinc");
+  });
+
+  // --- Wireless icon (collapsed row) ---
+
+  it("shows Wifi icon when armor has wireless and is active", () => {
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_WIRELESS] });
+    render(<ArmorDisplay character={character} />);
+    expect(screen.getByTestId("wireless-icon")).toBeInTheDocument();
+  });
+
+  it("shows WifiOff icon when armor wireless is disabled", () => {
+    const armorWirelessOff = {
+      ...MOCK_ARMOR_WITH_WIRELESS,
+      state: { readiness: "worn" as const, wirelessEnabled: false },
+    };
+    const character = createSheetCharacter({ armor: [armorWirelessOff] });
+    render(<ArmorDisplay character={character} />);
+    expect(screen.getByTestId("wireless-icon-off")).toBeInTheDocument();
+    expect(screen.queryByTestId("wireless-icon")).not.toBeInTheDocument();
+  });
+
+  it("shows WifiOff icon when global wireless is disabled", () => {
+    (isGlobalWirelessEnabled as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_WIRELESS] });
+    render(<ArmorDisplay character={character} />);
+    expect(screen.getByTestId("wireless-icon-off")).toBeInTheDocument();
+  });
+
+  it("does not show wireless icons for armor without wirelessBonus", () => {
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
+    expect(screen.queryByTestId("wireless-icon")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("wireless-icon-off")).not.toBeInTheDocument();
   });
 
   // --- Expand/collapse ---
 
   it("expands row on chevron click", async () => {
     const user = userEvent.setup();
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getByTestId("expand-button"));
     expect(screen.getByTestId("expanded-content")).toBeInTheDocument();
@@ -103,7 +261,8 @@ describe("ArmorDisplay", () => {
 
   it("collapses row on second chevron click", async () => {
     const user = userEvent.setup();
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getByTestId("expand-button"));
     expect(screen.getByTestId("expanded-content")).toBeInTheDocument();
@@ -116,7 +275,8 @@ describe("ArmorDisplay", () => {
 
   it("renders availability with legality suffix when expanded", async () => {
     const user = userEvent.setup();
-    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_MODS] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getAllByTestId("expand-button")[0]);
 
@@ -126,7 +286,8 @@ describe("ArmorDisplay", () => {
 
   it("renders weight when present and expanded", async () => {
     const user = userEvent.setup();
-    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_MODS] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getAllByTestId("expand-button")[0]);
 
@@ -136,7 +297,8 @@ describe("ArmorDisplay", () => {
 
   it("does not render availability when absent", async () => {
     const user = userEvent.setup();
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getByTestId("expand-button"));
     expect(screen.queryByTestId("stat-availability")).not.toBeInTheDocument();
@@ -146,7 +308,8 @@ describe("ArmorDisplay", () => {
 
   it("renders capacity as used/total text for non-custom armor", async () => {
     const user = userEvent.setup();
-    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_MODS] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getAllByTestId("expand-button")[0]);
     const section = screen.getByTestId("capacity-section");
@@ -156,7 +319,8 @@ describe("ArmorDisplay", () => {
   it("hides capacity section for custom items", async () => {
     const user = userEvent.setup();
     const customArmor = { ...MOCK_ARMOR_EQUIPPED, isCustom: true };
-    render(<ArmorDisplay armor={[customArmor]} />);
+    const character = createSheetCharacter({ armor: [customArmor] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getByTestId("expand-button"));
     expect(screen.queryByTestId("capacity-section")).not.toBeInTheDocument();
@@ -166,7 +330,8 @@ describe("ArmorDisplay", () => {
 
   it("renders modifications section when mods exist", async () => {
     const user = userEvent.setup();
-    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_MODS] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getAllByTestId("expand-button")[0]);
     expect(screen.getByTestId("modifications-section")).toBeInTheDocument();
@@ -175,7 +340,8 @@ describe("ArmorDisplay", () => {
 
   it("renders mod names and ratings", async () => {
     const user = userEvent.setup();
-    render(<ArmorDisplay armor={[MOCK_ARMOR_WITH_MODS]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_MODS] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getAllByTestId("expand-button")[0]);
 
@@ -190,7 +356,8 @@ describe("ArmorDisplay", () => {
 
   it("does not render modifications section when no mods", async () => {
     const user = userEvent.setup();
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+    render(<ArmorDisplay character={character} />);
 
     await user.click(screen.getByTestId("expand-button"));
     expect(screen.queryByTestId("modifications-section")).not.toBeInTheDocument();
@@ -199,8 +366,159 @@ describe("ArmorDisplay", () => {
   // --- Multiple items ---
 
   it("renders multiple armor items", () => {
-    render(<ArmorDisplay armor={[MOCK_ARMOR_EQUIPPED, MOCK_ARMOR_STORED]} />);
+    const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED, MOCK_ARMOR_STORED] });
+    render(<ArmorDisplay character={character} />);
     expect(screen.getByText("Armor Jacket")).toBeInTheDocument();
     expect(screen.getByText("Lined Coat")).toBeInTheDocument();
+  });
+
+  // --- Readiness controls (expanded, editable) ---
+
+  describe("readiness controls", () => {
+    it("hidden when editable=false", () => {
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} editable={false} onCharacterUpdate={vi.fn()} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.queryByTestId("inventory-controls")).not.toBeInTheDocument();
+    });
+
+    it("hidden when no onCharacterUpdate", () => {
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} editable={true} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.queryByTestId("inventory-controls")).not.toBeInTheDocument();
+    });
+
+    it("shows Worn/Stored buttons when editable", () => {
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={vi.fn()} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("readiness-controls")).toBeInTheDocument();
+      expect(screen.getByTestId("readiness-worn")).toBeInTheDocument();
+      expect(screen.getByTestId("readiness-stored")).toBeInTheDocument();
+    });
+
+    it("disables current readiness state button", () => {
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={vi.fn()} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("readiness-worn")).toBeDisabled();
+      expect(screen.getByTestId("readiness-stored")).not.toBeDisabled();
+    });
+
+    it("calls onCharacterUpdate when toggling readiness to stored", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("readiness-stored"));
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      const updated = onUpdate.mock.calls[0][0];
+      expect(updated.armor[0].state.readiness).toBe("stored");
+      expect(updated.armor[0].equipped).toBe(false);
+    });
+
+    it("calls onCharacterUpdate when toggling readiness to worn", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_STORED] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("readiness-worn"));
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      const updated = onUpdate.mock.calls[0][0];
+      expect(updated.armor[0].state.readiness).toBe("worn");
+      expect(updated.armor[0].equipped).toBe(true);
+    });
+
+    it("preserves wireless state during readiness change", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_WIRELESS] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("readiness-stored"));
+      const updated = onUpdate.mock.calls[0][0];
+      expect(updated.armor[0].state.wirelessEnabled).toBe(true);
+    });
+
+    it("keeps row expanded after readiness change re-render", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      const { rerender } = render(
+        <ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />
+      );
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("expanded-content")).toBeInTheDocument();
+
+      // Simulate parent re-rendering with updated character (worn -> stored)
+      fireEvent.click(screen.getByTestId("readiness-stored"));
+      const updated = onUpdate.mock.calls[0][0];
+      rerender(<ArmorDisplay character={updated} editable={true} onCharacterUpdate={onUpdate} />);
+
+      // Row should still be expanded after moving from Worn to Stored section
+      expect(screen.getByTestId("expanded-content")).toBeInTheDocument();
+    });
+  });
+
+  // --- Wireless toggle (expanded, editable) ---
+
+  describe("wireless toggle", () => {
+    it("hidden when armor has no wirelessBonus", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.queryByTestId("wireless-toggle")).not.toBeInTheDocument();
+    });
+
+    it("hidden when not editable", () => {
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_WIRELESS] });
+      render(<ArmorDisplay character={character} editable={false} onCharacterUpdate={vi.fn()} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.queryByTestId("wireless-toggle")).not.toBeInTheDocument();
+    });
+
+    it("shows WirelessIndicator when armor has wirelessBonus and editable", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_WIRELESS] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("wireless-toggle")).toBeInTheDocument();
+      expect(screen.getByTestId("wireless-indicator")).toBeInTheDocument();
+    });
+
+    it("WirelessIndicator receives correct props", () => {
+      const onUpdate = vi.fn();
+      const armorOff = {
+        ...MOCK_ARMOR_WITH_WIRELESS,
+        state: { readiness: "worn" as const, wirelessEnabled: false },
+      };
+      const character = createSheetCharacter({ armor: [armorOff] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      const indicator = screen.getByTestId("wireless-indicator");
+      expect(indicator).toHaveAttribute("data-enabled", "false");
+      expect(indicator).toHaveAttribute("data-global-enabled", "true");
+    });
+
+    it("calls onCharacterUpdate when wireless is toggled", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_WIRELESS] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("wireless-indicator-toggle"));
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+      const updated = onUpdate.mock.calls[0][0];
+      expect(updated.armor[0].state.wirelessEnabled).toBe(false);
+    });
+
+    it("passes globalEnabled from character wireless state", () => {
+      (isGlobalWirelessEnabled as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_WITH_WIRELESS] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      const indicator = screen.getByTestId("wireless-indicator");
+      expect(indicator).toHaveAttribute("data-global-enabled", "false");
+    });
   });
 });

--- a/components/character/sheet/__tests__/test-helpers.tsx
+++ b/components/character/sheet/__tests__/test-helpers.tsx
@@ -291,6 +291,20 @@ export const MOCK_ARMOR_ACCESSORY = {
   state: { readiness: "worn" as const, wirelessEnabled: false },
 };
 
+export const MOCK_ARMOR_WITH_WIRELESS = {
+  name: "Berwick Suit",
+  category: "armor",
+  subcategory: "armor-clothing",
+  armorRating: 8,
+  equipped: true,
+  cost: 2600,
+  quantity: 1,
+  readiness: "ready" as const,
+  state: { readiness: "worn" as const, wirelessEnabled: true },
+  wirelessBonus: "+1 to Social limit while wireless is active.",
+  catalogId: "berwick-suit",
+};
+
 // ---------------------------------------------------------------------------
 // Mock augmentation data
 // ---------------------------------------------------------------------------

--- a/lib/rules/RulesetContext.tsx
+++ b/lib/rules/RulesetContext.tsx
@@ -283,6 +283,8 @@ export interface ArmorData extends GearItemData {
   capacity?: number;
   /** Weight in kilograms */
   weight?: number;
+  /** Wireless bonus description (human-readable) */
+  wirelessBonus?: string;
 }
 
 export interface CommlinkData extends GearItemData {

--- a/lib/types/character.ts
+++ b/lib/types/character.ts
@@ -932,6 +932,9 @@ export interface ArmorItem extends GearItem {
    */
   state?: GearState;
 
+  /** Wireless bonus description (human-readable) */
+  wirelessBonus?: string;
+
   /**
    * @deprecated Use state.readiness === 'worn' instead
    * Kept for backward compatibility during migration


### PR DESCRIPTION
## Summary
- Add interactive readiness toggle (Worn/Stored) and conditional wireless toggle to ArmorDisplay, matching WeaponsDisplay and AugmentationsDisplay patterns
- Add `wirelessBonus` field to `ArmorItem` and `ArmorData` types to support future armor wireless data
- Lift expanded row state to parent component so rows stay open when items move between Worn/Stored sections on readiness change

Closes #374

## Changes
| File | Change |
|------|--------|
| `lib/types/character.ts` | Add `wirelessBonus?: string` to `ArmorItem` |
| `lib/rules/RulesetContext.tsx` | Add `wirelessBonus?: string` to `ArmorData` |
| `components/character/sheet/ArmorDisplay.tsx` | Rewrite with `character`/`onCharacterUpdate`/`editable` props, readiness badges, wireless icons, inventory controls |
| `app/characters/[id]/page.tsx` | Pass new props to ArmorDisplay |
| `components/character/sheet/__tests__/test-helpers.tsx` | Add `MOCK_ARMOR_WITH_WIRELESS` fixture |
| `components/character/sheet/__tests__/ArmorDisplay.test.tsx` | Rewrite 26 existing + add 17 new tests (43 total) |

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test "sheet/__tests__/ArmorDisplay"` — 43/43 pass
- [x] `pnpm test` — full suite 7404/7404 pass
- [x] `pnpm lint` — 0 errors
- [x] Pre-commit hooks pass (lint-staged, type-check, test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)