### PR TITLE
feat(wireless): Add armor wireless effects collection and derived armor total

### DIFF
--- a/components/character/sheet/ArmorDisplay.tsx
+++ b/components/character/sheet/ArmorDisplay.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import { Button as AriaButton } from "react-aria-components";
 import type { Character, ArmorItem } from "@/lib/types";
 import type { ArmorData, GearCatalogData } from "@/lib/rules/RulesetContext";
 import type { EquipmentReadiness } from "@/lib/types/gear-state";
 import { useGear } from "@/lib/rules";
+import { calculateArmorTotal } from "@/lib/rules/gameplay";
 import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
+import { Tooltip } from "@/components/ui";
 import { DisplayCard } from "./DisplayCard";
 import { WirelessIndicator } from "@/app/characters/[id]/components/WirelessIndicator";
 import { ChevronDown, ChevronRight, Shield, Wifi, WifiOff } from "lucide-react";
@@ -114,6 +117,60 @@ const ARMOR_SECTIONS = [
   { key: "worn" as const, label: "Worn" },
   { key: "stored" as const, label: "Stored" },
 ];
+
+// ---------------------------------------------------------------------------
+// ArmorTotalTooltipContent
+// ---------------------------------------------------------------------------
+
+function ArmorTotalTooltipContent({
+  breakdown,
+}: {
+  breakdown: {
+    baseArmorName?: string;
+    baseArmor: number;
+    accessories: Array<{ name: string; rating: number }>;
+    effectiveAccessoryBonus: number;
+    rawAccessoryBonus: number;
+    strength: number;
+    totalArmor: number;
+  };
+}) {
+  const isAccessoryCapped = breakdown.rawAccessoryBonus > breakdown.strength;
+
+  return (
+    <div className="space-y-1" data-testid="armor-total-tooltip">
+      {breakdown.baseArmorName && (
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-zinc-400">{breakdown.baseArmorName}</span>
+          <span className="font-mono font-semibold text-blue-400">{breakdown.baseArmor}</span>
+        </div>
+      )}
+      {breakdown.accessories.map((acc, i) => (
+        <div key={i} className="flex items-center justify-between gap-4">
+          <span className="text-zinc-400">{acc.name}</span>
+          <span className="font-mono font-semibold text-blue-400">+{acc.rating}</span>
+        </div>
+      ))}
+      {isAccessoryCapped && (
+        <div className="text-[10px] text-amber-400">
+          Accessory bonus capped at STR {breakdown.strength} (+{breakdown.effectiveAccessoryBonus}{" "}
+          of +{breakdown.rawAccessoryBonus})
+        </div>
+      )}
+      {(breakdown.baseArmorName || breakdown.accessories.length > 0) && (
+        <>
+          <div className="border-t border-zinc-600" />
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-200">
+              Total
+            </span>
+            <span className="font-mono font-bold text-blue-300">{breakdown.totalArmor}</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // ArmorRow
@@ -357,12 +414,49 @@ export function ArmorDisplay({ character, onCharacterUpdate, editable }: ArmorDi
     }
   });
 
+  // Compute armor total for worn armor
+  const strength = character.attributes?.strength || 0;
+  const armorCalc = calculateArmorTotal(armor, strength);
+
+  // Build accessory breakdown for tooltip
+  const wornAccessories = grouped.worn
+    .filter(({ item }) => item.armorModifier === true)
+    .map(({ item }) => ({ name: item.name, rating: item.armorRating }));
+
+  const armorBreakdown = {
+    baseArmorName: armorCalc.baseArmorName,
+    baseArmor: armorCalc.baseArmor,
+    accessories: wornAccessories,
+    effectiveAccessoryBonus: armorCalc.effectiveAccessoryBonus,
+    rawAccessoryBonus: armorCalc.rawAccessoryBonus,
+    strength,
+    totalArmor: armorCalc.totalArmor,
+  };
+
   return (
     <DisplayCard
       id="sheet-armor"
       title="Armor"
       icon={<Shield className="h-4 w-4 text-zinc-400" />}
       collapsible
+      headerAction={
+        grouped.worn.length > 0 ? (
+          <Tooltip
+            content={<ArmorTotalTooltipContent breakdown={armorBreakdown} />}
+            delay={200}
+            showArrow={false}
+          >
+            <AriaButton
+              aria-label="Armor total breakdown"
+              className="inline-flex items-center gap-0.5 rounded bg-blue-500/15 px-1.5 py-0.5 font-mono text-[11px] font-semibold text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              data-testid="armor-total-pill"
+            >
+              {armorCalc.totalArmor}
+              <Shield className="h-2.5 w-2.5" />
+            </AriaButton>
+          </Tooltip>
+        ) : undefined
+      }
     >
       <div className="space-y-3">
         {ARMOR_SECTIONS.map(({ key, label }) => {

--- a/components/character/sheet/__tests__/ArmorDisplay.test.tsx
+++ b/components/character/sheet/__tests__/ArmorDisplay.test.tsx
@@ -54,6 +54,46 @@ vi.mock("@/lib/rules/wireless", () => ({
   isGlobalWirelessEnabled: vi.fn(() => true),
 }));
 
+vi.mock("react-aria-components", () => ({
+  Button: ({
+    children,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    [key: string]: unknown;
+  }) => (
+    <button className={className} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui", () => ({
+  Tooltip: ({ content, children }: { content: React.ReactNode; children: React.ReactNode }) => (
+    <div data-testid="tooltip-wrapper">
+      {children}
+      <div data-testid="tooltip-content">{content}</div>
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/rules/gameplay", () => ({
+  calculateArmorTotal: vi.fn(() => ({
+    totalArmor: 12,
+    baseArmor: 12,
+    rawAccessoryBonus: 0,
+    effectiveAccessoryBonus: 0,
+    excessOverStrength: 0,
+    agilityPenalty: 0,
+    reactionPenalty: 0,
+    isEncumbered: false,
+    baseArmorName: "Armor Jacket",
+    accessoryNames: [],
+  })),
+}));
+
 // ---------------------------------------------------------------------------
 // Catalog mock
 // ---------------------------------------------------------------------------
@@ -101,6 +141,7 @@ vi.mock("@/lib/rules", () => ({
 
 import { ArmorDisplay } from "../ArmorDisplay";
 import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
+import { calculateArmorTotal } from "@/lib/rules/gameplay";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -174,7 +215,7 @@ describe("ArmorDisplay", () => {
   it("renders armor name in collapsed row", () => {
     const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
     render(<ArmorDisplay character={character} />);
-    expect(screen.getByText("Armor Jacket")).toBeInTheDocument();
+    expect(screen.getAllByText("Armor Jacket").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders armor rating in sky-colored pill", () => {
@@ -368,7 +409,7 @@ describe("ArmorDisplay", () => {
   it("renders multiple armor items", () => {
     const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED, MOCK_ARMOR_STORED] });
     render(<ArmorDisplay character={character} />);
-    expect(screen.getByText("Armor Jacket")).toBeInTheDocument();
+    expect(screen.getAllByText("Armor Jacket").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Lined Coat")).toBeInTheDocument();
   });
 
@@ -519,6 +560,89 @@ describe("ArmorDisplay", () => {
       fireEvent.click(screen.getByTestId("expand-button"));
       const indicator = screen.getByTestId("wireless-indicator");
       expect(indicator).toHaveAttribute("data-global-enabled", "false");
+    });
+  });
+
+  // --- Armor total pill ---
+
+  describe("armor total pill", () => {
+    it("displays armor total pill when worn armor exists", () => {
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} />);
+      const pill = screen.getByTestId("armor-total-pill");
+      expect(pill).toBeInTheDocument();
+      expect(pill).toHaveTextContent("12");
+    });
+
+    it("does not display armor total pill when no worn armor", () => {
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_STORED] });
+      render(<ArmorDisplay character={character} />);
+      expect(screen.queryByTestId("armor-total-pill")).not.toBeInTheDocument();
+    });
+
+    it("tooltip shows base armor name and rating", () => {
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} />);
+      const tooltip = screen.getByTestId("armor-total-tooltip");
+      expect(tooltip).toHaveTextContent("Armor Jacket");
+      expect(tooltip).toHaveTextContent("12");
+    });
+
+    it("tooltip shows accessories with individual ratings", () => {
+      (calculateArmorTotal as ReturnType<typeof vi.fn>).mockReturnValue({
+        totalArmor: 14,
+        baseArmor: 12,
+        rawAccessoryBonus: 6,
+        effectiveAccessoryBonus: 4,
+        excessOverStrength: 2,
+        agilityPenalty: -1,
+        reactionPenalty: -1,
+        isEncumbered: true,
+        baseArmorName: "Armor Jacket",
+        accessoryNames: ["Ballistic Shield"],
+      });
+      const character = createSheetCharacter({
+        armor: [MOCK_ARMOR_EQUIPPED, MOCK_ARMOR_ACCESSORY],
+        attributes: { ...createSheetCharacter().attributes, strength: 4 },
+      });
+      render(<ArmorDisplay character={character} />);
+      const tooltip = screen.getByTestId("armor-total-tooltip");
+      expect(tooltip).toHaveTextContent("Armor Jacket");
+      expect(tooltip).toHaveTextContent("Ballistic Shield");
+      expect(tooltip).toHaveTextContent("14");
+    });
+
+    it("shows accessory capping note when raw > strength", () => {
+      (calculateArmorTotal as ReturnType<typeof vi.fn>).mockReturnValue({
+        totalArmor: 16,
+        baseArmor: 12,
+        rawAccessoryBonus: 8,
+        effectiveAccessoryBonus: 4,
+        excessOverStrength: 4,
+        agilityPenalty: -2,
+        reactionPenalty: -2,
+        isEncumbered: true,
+        baseArmorName: "Armor Jacket",
+        accessoryNames: ["Helmet", "Ballistic Mask"],
+      });
+      const character = createSheetCharacter({
+        armor: [
+          MOCK_ARMOR_EQUIPPED,
+          { ...MOCK_ARMOR_ACCESSORY, name: "Helmet", armorRating: 4 },
+          { ...MOCK_ARMOR_ACCESSORY, name: "Ballistic Mask", armorRating: 4 },
+        ],
+        attributes: { ...createSheetCharacter().attributes, strength: 4 },
+      });
+      render(<ArmorDisplay character={character} />);
+      const tooltip = screen.getByTestId("armor-total-tooltip");
+      expect(tooltip).toHaveTextContent(/capped at STR 4/);
+    });
+
+    it("has correct aria-label for accessibility", () => {
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} />);
+      const pill = screen.getByTestId("armor-total-pill");
+      expect(pill).toHaveAttribute("aria-label", "Armor total breakdown");
     });
   });
 });

--- a/lib/rules/wireless/__tests__/bonus-calculator.test.ts
+++ b/lib/rules/wireless/__tests__/bonus-calculator.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { Character, CyberwareItem, Weapon, BiowareItem } from "@/lib/types";
+import type { Character, CyberwareItem, Weapon, BiowareItem, ArmorItem } from "@/lib/types";
 import type { WirelessEffect } from "@/lib/types/wireless-effects";
 import {
   isGlobalWirelessEnabled,
@@ -15,6 +15,7 @@ import {
   collectCyberwareEffects,
   collectBiowareEffects,
   collectWeaponModEffects,
+  collectArmorEffects,
   calculateWirelessBonuses,
   calculateContextualWirelessBonuses,
   getWirelessInitiativeBonus,
@@ -376,6 +377,124 @@ describe("Wireless Bonus Calculator", () => {
     });
   });
 
+  describe("collectArmorEffects", () => {
+    it("should return empty array when no armor", () => {
+      const character = createMinimalCharacter();
+      expect(collectArmorEffects(character)).toEqual([]);
+    });
+
+    it("should collect effects from worn armor with wirelessEffects", () => {
+      const effects: WirelessEffect[] = [{ type: "defense_pool", modifier: 1 }];
+      const armor: ArmorItem[] = [
+        {
+          name: "Armor Jacket",
+          category: "armor",
+          armorRating: 12,
+          equipped: true,
+          cost: 1000,
+          quantity: 1,
+          state: { readiness: "worn", wirelessEnabled: true },
+          wirelessEffects: effects,
+        } as ArmorItem,
+      ];
+      const character = createMinimalCharacter({ armor });
+
+      const result = collectArmorEffects(character);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ type: "defense_pool", modifier: 1 });
+    });
+
+    it("should skip stored armor with wirelessEffects", () => {
+      const armor: ArmorItem[] = [
+        {
+          name: "Armor Jacket",
+          category: "armor",
+          armorRating: 12,
+          equipped: false,
+          cost: 1000,
+          quantity: 1,
+          state: { readiness: "stored", wirelessEnabled: true },
+          wirelessEffects: [{ type: "defense_pool", modifier: 1 }],
+        } as ArmorItem,
+      ];
+      const character = createMinimalCharacter({ armor });
+
+      expect(collectArmorEffects(character)).toEqual([]);
+    });
+
+    it("should skip worn armor with wirelessEnabled false", () => {
+      const armor: ArmorItem[] = [
+        {
+          name: "Armor Jacket",
+          category: "armor",
+          armorRating: 12,
+          equipped: true,
+          cost: 1000,
+          quantity: 1,
+          state: { readiness: "worn", wirelessEnabled: false },
+          wirelessEffects: [{ type: "defense_pool", modifier: 1 }],
+        } as ArmorItem,
+      ];
+      const character = createMinimalCharacter({ armor });
+
+      expect(collectArmorEffects(character)).toEqual([]);
+    });
+
+    it("should collect effects from legacy equipped armor without state", () => {
+      const effects: WirelessEffect[] = [{ type: "armor", modifier: 2 }];
+      const armor: ArmorItem[] = [
+        {
+          name: "Armor Jacket",
+          category: "armor",
+          armorRating: 12,
+          equipped: true,
+          cost: 1000,
+          quantity: 1,
+          wirelessEffects: effects,
+        } as ArmorItem,
+      ];
+      const character = createMinimalCharacter({ armor });
+
+      const result = collectArmorEffects(character);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ type: "armor", modifier: 2 });
+    });
+
+    it("should skip legacy unequipped armor without state", () => {
+      const armor: ArmorItem[] = [
+        {
+          name: "Armor Jacket",
+          category: "armor",
+          armorRating: 12,
+          equipped: false,
+          cost: 1000,
+          quantity: 1,
+          wirelessEffects: [{ type: "defense_pool", modifier: 1 }],
+        } as ArmorItem,
+      ];
+      const character = createMinimalCharacter({ armor });
+
+      expect(collectArmorEffects(character)).toEqual([]);
+    });
+
+    it("should skip worn armor without wirelessEffects", () => {
+      const armor: ArmorItem[] = [
+        {
+          name: "Armor Jacket",
+          category: "armor",
+          armorRating: 12,
+          equipped: true,
+          cost: 1000,
+          quantity: 1,
+          state: { readiness: "worn", wirelessEnabled: true },
+        } as ArmorItem,
+      ];
+      const character = createMinimalCharacter({ armor });
+
+      expect(collectArmorEffects(character)).toEqual([]);
+    });
+  });
+
   // ===========================================================================
   // BONUS CALCULATION
   // ===========================================================================
@@ -457,6 +576,25 @@ describe("Wireless Bonus Calculator", () => {
       const result = calculateWirelessBonuses(character);
       expect(result.initiative).toBe(2);
       expect(result.attributes.reaction).toBe(1);
+      expect(result.defensePool).toBe(1);
+    });
+
+    it("should include armor wireless effects in aggregation", () => {
+      const armor: ArmorItem[] = [
+        {
+          name: "Smart Jacket",
+          category: "armor",
+          armorRating: 12,
+          equipped: true,
+          cost: 1000,
+          quantity: 1,
+          state: { readiness: "worn", wirelessEnabled: true },
+          wirelessEffects: [{ type: "defense_pool", modifier: 1 }],
+        } as ArmorItem,
+      ];
+      const character = createMinimalCharacter({ armor });
+
+      const result = calculateWirelessBonuses(character);
       expect(result.defensePool).toBe(1);
     });
   });

--- a/lib/rules/wireless/bonus-calculator.ts
+++ b/lib/rules/wireless/bonus-calculator.ts
@@ -162,6 +162,29 @@ export function collectWeaponModEffects(character: Character): WirelessEffect[] 
   return effects;
 }
 
+/**
+ * Collect wireless effects from worn armor items.
+ * Only armor with readiness "worn" contributes wireless bonuses.
+ */
+export function collectArmorEffects(character: Character): WirelessEffect[] {
+  const armorItems = character.armor || [];
+  const effects: WirelessEffect[] = [];
+
+  for (const armor of armorItems) {
+    // Only worn armor contributes wireless bonuses
+    if (armor.state?.readiness !== "worn" || armor.state?.wirelessEnabled === false) {
+      // Legacy fallback: no state but equipped === true
+      if (armor.state || !armor.equipped) continue;
+    }
+
+    if (armor.wirelessEffects) {
+      effects.push(...armor.wirelessEffects);
+    }
+  }
+
+  return effects;
+}
+
 // =============================================================================
 // BONUS CALCULATION
 // =============================================================================
@@ -187,8 +210,9 @@ export function calculateWirelessBonuses(character: Character): ActiveWirelessBo
   const cyberwareEffects = collectCyberwareEffects(character);
   const biowareEffects = collectBiowareEffects(character);
   const weaponEffects = collectWeaponModEffects(character);
+  const armorEffects = collectArmorEffects(character);
 
-  const allEffects = [...cyberwareEffects, ...biowareEffects, ...weaponEffects];
+  const allEffects = [...cyberwareEffects, ...biowareEffects, ...weaponEffects, ...armorEffects];
 
   // Apply each effect to bonuses
   for (const effect of allEffects) {
@@ -217,8 +241,9 @@ export function calculateContextualWirelessBonuses(
   const cyberwareEffects = collectCyberwareEffects(character);
   const biowareEffects = collectBiowareEffects(character);
   const weaponEffects = collectWeaponModEffects(character);
+  const armorEffects = collectArmorEffects(character);
 
-  const allEffects = [...cyberwareEffects, ...biowareEffects, ...weaponEffects];
+  const allEffects = [...cyberwareEffects, ...biowareEffects, ...weaponEffects, ...armorEffects];
 
   // Only apply effects that match the context
   for (const effect of allEffects) {

--- a/lib/rules/wireless/index.ts
+++ b/lib/rules/wireless/index.ts
@@ -13,6 +13,7 @@ export {
   collectCyberwareEffects,
   collectBiowareEffects,
   collectWeaponModEffects,
+  collectArmorEffects,
   // Main calculator
   calculateWirelessBonuses,
   calculateContextualWirelessBonuses,

--- a/lib/types/character.ts
+++ b/lib/types/character.ts
@@ -935,6 +935,9 @@ export interface ArmorItem extends GearItem {
   /** Wireless bonus description (human-readable) */
   wirelessBonus?: string;
 
+  /** Machine-readable wireless effects for calculation */
+  wirelessEffects?: WirelessEffect[];
+
   /**
    * @deprecated Use state.readiness === 'worn' instead
    * Kept for backward compatibility during migration


### PR DESCRIPTION
## Summary
- Add `collectArmorEffects()` to the wireless bonus calculator, gated on `readiness === "worn"`, with legacy `equipped` fallback and integration into both `calculateWirelessBonuses()` and `calculateContextualWirelessBonuses()`
- Add derived armor total pill (blue, monospace) in ArmorDisplay header with tooltip breakdown showing base armor, accessories, STR capping, and total — following the EssenceLossTooltipContent pattern
- Add `wirelessEffects?: WirelessEffect[]` to the `ArmorItem` type for future sourcebook items

## Test plan
- [x] 8 new unit tests for `collectArmorEffects()` (empty, worn, stored, wireless-off, legacy, no-effects, integration)
- [x] 5 new tests for armor total pill (display, hidden when no worn, tooltip content, accessory capping, accessibility)
- [x] All 327 test files / 7433 tests passing
- [x] Type-check clean

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)