### PR TITLE
feat(sheet): Add EncumbranceDisplay component (#376)

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
   ContactsDisplay,
   DerivedStatsDisplay,
   DrugsDisplay,
+  EncumbranceDisplay,
   FociDisplay,
   GearDisplay,
   IdentitiesDisplay,
@@ -312,6 +313,8 @@ function CharacterSheet({
             />
 
             <DerivedStatsDisplay character={character} />
+
+            <EncumbranceDisplay character={character} />
 
             <ConditionDisplay
               character={character}

--- a/components/character/sheet/EncumbranceDisplay.tsx
+++ b/components/character/sheet/EncumbranceDisplay.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useMemo } from "react";
+import type { Character } from "@/lib/types";
+import { DisplayCard } from "./DisplayCard";
+import { Weight, AlertTriangle } from "lucide-react";
+import {
+  calculateEncumbrance,
+  getEncumbranceStatus,
+  calculateWeaponWeight,
+  calculateArmorWeight,
+  calculateGearWeight,
+  calculateAmmunitionWeight,
+} from "@/lib/rules/encumbrance/calculator";
+
+interface EncumbranceDisplayProps {
+  character: Character;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatWeight(kg: number): string {
+  if (kg < 1 && kg > 0) {
+    return `${Math.round(kg * 1000)}g`;
+  }
+  return `${kg.toFixed(1)}kg`;
+}
+
+const BAR_COLORS: Record<string, { fill: string; badge: string; text: string }> = {
+  green: {
+    fill: "bg-emerald-500",
+    badge: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400",
+    text: "text-emerald-600 dark:text-emerald-400",
+  },
+  blue: {
+    fill: "bg-blue-500",
+    badge: "bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-400",
+    text: "text-blue-600 dark:text-blue-400",
+  },
+  yellow: {
+    fill: "bg-amber-500",
+    badge: "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-400",
+    text: "text-amber-600 dark:text-amber-400",
+  },
+  red: {
+    fill: "bg-red-500",
+    badge: "bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-400",
+    text: "text-red-600 dark:text-red-400",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function WeightRow({ label, weight }: { label: string; weight: number }) {
+  if (weight === 0) return null;
+  return (
+    <div className="flex items-center justify-between px-3 py-1.5 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50">
+      <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">{label}</span>
+      <span className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50">
+        {formatWeight(weight)}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function EncumbranceDisplay({ character }: EncumbranceDisplayProps) {
+  const encumbrance = useMemo(() => calculateEncumbrance(character), [character]);
+  const status = useMemo(() => getEncumbranceStatus(encumbrance), [encumbrance]);
+
+  const categoryWeights = useMemo(
+    () => ({
+      weapons: calculateWeaponWeight(character.weapons || []),
+      armor: calculateArmorWeight(character.armor || []),
+      gear: calculateGearWeight(character.gear || []),
+      ammo: calculateAmmunitionWeight(character.ammunition || []),
+    }),
+    [character]
+  );
+
+  const colors = BAR_COLORS[status.color] || BAR_COLORS.green;
+  const fillPercent = Math.min((encumbrance.currentWeight / encumbrance.maxCapacity) * 100, 100);
+  const isOverflow = encumbrance.currentWeight > encumbrance.maxCapacity;
+  const hasBreakdown =
+    categoryWeights.weapons > 0 ||
+    categoryWeights.armor > 0 ||
+    categoryWeights.gear > 0 ||
+    categoryWeights.ammo > 0;
+
+  return (
+    <DisplayCard
+      id="sheet-encumbrance"
+      title="Encumbrance"
+      icon={<Weight className="h-4 w-4 text-zinc-400" />}
+      collapsible
+    >
+      <div className="space-y-3">
+        {/* Header: status badge + weight */}
+        <div className="flex items-center justify-between">
+          <span
+            className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${colors.badge}`}
+          >
+            {status.description}
+          </span>
+          <span className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50">
+            {formatWeight(encumbrance.currentWeight)} / {formatWeight(encumbrance.maxCapacity)}
+          </span>
+        </div>
+
+        {/* Progress bar */}
+        <div className="relative h-2 rounded-full bg-zinc-200 dark:bg-zinc-800 overflow-hidden">
+          <div
+            className={`absolute left-0 top-0 h-full ${colors.fill} transition-all duration-300 rounded-full`}
+            style={{ width: `${fillPercent}%` }}
+          />
+          {isOverflow && (
+            <div className="absolute inset-0 h-full bg-red-500 animate-pulse rounded-full" />
+          )}
+        </div>
+
+        {/* Penalty warning */}
+        {encumbrance.isEncumbered && (
+          <div className="flex items-start gap-2 rounded-lg bg-red-100 px-3 py-2 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-600 dark:text-red-400" />
+            <p className="text-xs text-red-600 dark:text-red-400">
+              Carrying {formatWeight(encumbrance.currentWeight - encumbrance.maxCapacity)} over
+              capacity. Physical pools suffer {encumbrance.overweightPenalty} penalty.
+            </p>
+          </div>
+        )}
+
+        {/* Weight breakdown */}
+        {hasBreakdown && (
+          <div>
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Weight Breakdown
+            </div>
+            <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+              <WeightRow label="Weapons" weight={categoryWeights.weapons} />
+              <WeightRow label="Armor" weight={categoryWeights.armor} />
+              <WeightRow label="Gear" weight={categoryWeights.gear} />
+              <WeightRow label="Ammo" weight={categoryWeights.ammo} />
+            </div>
+          </div>
+        )}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/__tests__/EncumbranceDisplay.test.tsx
+++ b/components/character/sheet/__tests__/EncumbranceDisplay.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * EncumbranceDisplay Component Tests
+ *
+ * Tests the encumbrance card showing weight, capacity, status,
+ * progress bar, penalty warnings, and category breakdown.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { setupDisplayCardMock, LUCIDE_MOCK, createSheetCharacter } from "./test-helpers";
+
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+import { EncumbranceDisplay } from "../EncumbranceDisplay";
+
+// Default character: STR=4 → capacity = 40kg
+const baseCharacter = createSheetCharacter();
+
+describe("EncumbranceDisplay", () => {
+  it("renders card with Encumbrance title", () => {
+    render(<EncumbranceDisplay character={baseCharacter} />);
+    expect(screen.getByText("Encumbrance")).toBeInTheDocument();
+  });
+
+  it("shows weight and capacity text", () => {
+    // STR=4 → 40.0kg capacity; no gear → 0.0kg
+    render(<EncumbranceDisplay character={baseCharacter} />);
+    expect(screen.getByText("0.0kg / 40.0kg")).toBeInTheDocument();
+  });
+
+  it('shows "Light load" when under 50% capacity', () => {
+    // 10kg weapons on a 40kg capacity → 25% → light
+    const char = createSheetCharacter({
+      weapons: [
+        {
+          name: "Heavy Pistol",
+          category: "Pistols",
+          subcategory: "Heavy Pistols",
+          damage: "8P",
+          ap: -1,
+          mode: ["SA"],
+          accuracy: 5,
+          cost: 700,
+          quantity: 1,
+          weight: 10,
+          state: { readiness: "holstered" as const, wirelessEnabled: false },
+        },
+      ],
+    });
+    render(<EncumbranceDisplay character={char} />);
+    expect(screen.getByText("Light load")).toBeInTheDocument();
+  });
+
+  it('shows "Normal load" when 50-75% capacity', () => {
+    // 25kg on 40kg capacity → 62.5% → normal
+    const char = createSheetCharacter({
+      gear: [
+        {
+          name: "Heavy Kit",
+          category: "survival-gear",
+          subcategory: "kits",
+          cost: 500,
+          quantity: 1,
+          weight: 25,
+          state: { readiness: "worn" as const, wirelessEnabled: false },
+        },
+      ],
+    });
+    render(<EncumbranceDisplay character={char} />);
+    expect(screen.getByText("Normal load")).toBeInTheDocument();
+  });
+
+  it('shows "Heavy load" when 75-100% capacity', () => {
+    // 35kg on 40kg capacity → 87.5% → heavy
+    const char = createSheetCharacter({
+      gear: [
+        {
+          name: "Very Heavy Kit",
+          category: "survival-gear",
+          subcategory: "kits",
+          cost: 500,
+          quantity: 1,
+          weight: 35,
+          state: { readiness: "worn" as const, wirelessEnabled: false },
+        },
+      ],
+    });
+    render(<EncumbranceDisplay character={char} />);
+    expect(screen.getByText("Heavy load")).toBeInTheDocument();
+  });
+
+  it("shows overloaded status and penalty when over capacity", () => {
+    // 50kg on 40kg capacity → 125% → overloaded
+    const char = createSheetCharacter({
+      gear: [
+        {
+          name: "Massive Kit",
+          category: "survival-gear",
+          subcategory: "kits",
+          cost: 500,
+          quantity: 1,
+          weight: 50,
+          state: { readiness: "worn" as const, wirelessEnabled: false },
+        },
+      ],
+    });
+    render(<EncumbranceDisplay character={char} />);
+    // getEncumbranceStatus returns description like "Overloaded (-10 penalty)"
+    expect(screen.getByText(/Overloaded/)).toBeInTheDocument();
+    // Penalty warning should appear
+    expect(screen.getByText(/over capacity/)).toBeInTheDocument();
+  });
+
+  it("shows weight breakdown rows for categories with weight > 0", () => {
+    const char = createSheetCharacter({
+      weapons: [
+        {
+          name: "Pistol",
+          category: "Pistols",
+          subcategory: "Heavy Pistols",
+          damage: "8P",
+          ap: -1,
+          mode: ["SA"],
+          accuracy: 5,
+          cost: 700,
+          quantity: 1,
+          weight: 2,
+          state: { readiness: "holstered" as const, wirelessEnabled: false },
+        },
+      ],
+      armor: [
+        {
+          name: "Jacket",
+          category: "armor",
+          subcategory: "armor",
+          armorRating: 12,
+          equipped: true,
+          cost: 1000,
+          quantity: 1,
+          weight: 5,
+          state: { readiness: "worn" as const, wirelessEnabled: false },
+        },
+      ],
+    });
+    render(<EncumbranceDisplay character={char} />);
+    expect(screen.getByText("Weight Breakdown")).toBeInTheDocument();
+    expect(screen.getByText("Weapons")).toBeInTheDocument();
+    expect(screen.getByText("Armor")).toBeInTheDocument();
+    // Gear and Ammo should NOT appear (weight=0)
+    expect(screen.queryByText("Gear")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ammo")).not.toBeInTheDocument();
+  });
+
+  it("handles character with no gear", () => {
+    const char = createSheetCharacter({
+      weapons: [],
+      armor: [],
+      gear: [],
+      ammunition: [],
+    });
+    render(<EncumbranceDisplay character={char} />);
+    expect(screen.getByText("Light load")).toBeInTheDocument();
+    expect(screen.getByText("0.0kg / 40.0kg")).toBeInTheDocument();
+    // No breakdown when everything is 0
+    expect(screen.queryByText("Weight Breakdown")).not.toBeInTheDocument();
+  });
+});

--- a/components/character/sheet/__tests__/test-helpers.tsx
+++ b/components/character/sheet/__tests__/test-helpers.tsx
@@ -144,6 +144,8 @@ export const LUCIDE_MOCK = {
   ChevronDown: createIconMock("ChevronDown"),
   ChevronRight: createIconMock("ChevronRight"),
   WifiOff: createIconMock("WifiOff"),
+  Weight: createIconMock("Weight"),
+  AlertTriangle: createIconMock("AlertTriangle"),
 };
 
 // ---------------------------------------------------------------------------

--- a/components/character/sheet/index.ts
+++ b/components/character/sheet/index.ts
@@ -13,6 +13,7 @@ export { ConditionDisplay } from "./ConditionDisplay";
 export { ContactsDisplay } from "./ContactsDisplay";
 export { DerivedStatsDisplay } from "./DerivedStatsDisplay";
 export { DrugsDisplay } from "./DrugsDisplay";
+export { EncumbranceDisplay } from "./EncumbranceDisplay";
 export { FociDisplay } from "./FociDisplay";
 export { GearDisplay } from "./GearDisplay";
 export { IdentitiesDisplay } from "./IdentitiesDisplay";


### PR DESCRIPTION
## Summary
- Add new `EncumbranceDisplay` character sheet card showing weight/capacity with 4-level color-coded status (light/normal/heavy/overloaded)
- Includes progress bar, penalty warning banner when overloaded, and per-category weight breakdown (weapons, armor, gear, ammo)
- Placed between Derived Stats and Condition Monitor in the left column of the character sheet

Closes #376

## Test plan
- [x] 8 new unit tests covering all load statuses, weight display, breakdown rows, penalty warnings, and empty gear
- [x] TypeScript type-check passes
- [x] All 7457 existing tests pass (no regressions)
- [ ] Manual: `pnpm dev` → navigate to character sheet → verify encumbrance card appears between Derived Stats and Condition Monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)