### PR TITLE
feat(sheet): Add WirelessDisplay component with global toggle and bonus summary (#377)

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -39,6 +39,7 @@ import {
   SpellsDisplay,
   VehiclesDisplay,
   WeaponsDisplay,
+  WirelessDisplay,
   ArmorDisplay,
   AugmentationsDisplay,
 } from "@/components/character/sheet";
@@ -315,6 +316,12 @@ function CharacterSheet({
             <DerivedStatsDisplay character={character} />
 
             <EncumbranceDisplay character={character} />
+
+            <WirelessDisplay
+              character={character}
+              onCharacterUpdate={(updated) => setCharacter(updated)}
+              editable={character.status === "active"}
+            />
 
             <ConditionDisplay
               character={character}

--- a/components/character/sheet/WirelessDisplay.tsx
+++ b/components/character/sheet/WirelessDisplay.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useMemo } from "react";
+import type { Character } from "@/lib/types";
+import { DisplayCard } from "./DisplayCard";
+import { Wifi, WifiOff } from "lucide-react";
+import { isGlobalWirelessEnabled, getWirelessBonusSummary } from "@/lib/rules/wireless";
+import { getEquipmentStateSummary } from "@/lib/rules/inventory";
+
+interface WirelessDisplayProps {
+  character: Character;
+  onCharacterUpdate?: (character: Character) => void;
+  editable?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function WirelessDisplay({ character, onCharacterUpdate, editable }: WirelessDisplayProps) {
+  const globalWireless = useMemo(() => isGlobalWirelessEnabled(character), [character]);
+
+  const equipmentSummary = useMemo(() => getEquipmentStateSummary(character), [character]);
+
+  const bonusSummary = useMemo(
+    () => (globalWireless ? getWirelessBonusSummary(character) : []),
+    [character, globalWireless]
+  );
+
+  const handleToggle = () => {
+    if (!onCharacterUpdate) return;
+    onCharacterUpdate({ ...character, wirelessBonusesEnabled: !globalWireless });
+  };
+
+  return (
+    <DisplayCard
+      id="sheet-wireless"
+      title="Wireless"
+      icon={
+        globalWireless ? (
+          <Wifi className="h-4 w-4 text-cyan-400" />
+        ) : (
+          <WifiOff className="h-4 w-4 text-zinc-400" />
+        )
+      }
+      collapsible
+    >
+      <div className="space-y-3">
+        {/* Status row */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {globalWireless ? (
+              <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-cyan-100 text-cyan-700 dark:bg-cyan-500/15 dark:text-cyan-400">
+                Wireless Active
+              </span>
+            ) : (
+              <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500">
+                Wireless Silent
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-mono text-zinc-500">
+              {equipmentSummary.wirelessEnabled} on / {equipmentSummary.wirelessDisabled} off
+            </span>
+            {editable && (
+              <button
+                onClick={handleToggle}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors ${
+                  globalWireless ? "bg-cyan-500" : "bg-zinc-300 dark:bg-zinc-700"
+                }`}
+                role="switch"
+                aria-checked={globalWireless}
+                aria-label="Toggle global wireless"
+              >
+                <span
+                  className={`pointer-events-none inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform ${
+                    globalWireless ? "translate-x-4" : "translate-x-0.5"
+                  }`}
+                />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Bonus breakdown (only when wireless ON) */}
+        {globalWireless && (
+          <div>
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Active Bonuses
+            </div>
+            {bonusSummary.length > 0 ? (
+              <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+                {bonusSummary.map((bonus, i) => (
+                  <div
+                    key={`${bonus.category}-${i}`}
+                    className="flex items-center justify-between px-3 py-1.5 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-400">
+                        {bonus.category}
+                      </span>
+                      <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+                        {bonus.description}
+                      </span>
+                    </div>
+                    <span className="rounded bg-cyan-100 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400">
+                      {bonus.modifier}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-zinc-400 italic">No active wireless bonuses</p>
+            )}
+          </div>
+        )}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/__tests__/WirelessDisplay.test.tsx
+++ b/components/character/sheet/__tests__/WirelessDisplay.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * WirelessDisplay Component Tests
+ *
+ * Tests the wireless status card showing global toggle state,
+ * equipment counts, active bonus summary, and toggle interaction.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { setupDisplayCardMock, LUCIDE_MOCK, createSheetCharacter } from "./test-helpers";
+
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+vi.mock("@/lib/rules/wireless", () => ({
+  isGlobalWirelessEnabled: vi.fn(),
+  getWirelessBonusSummary: vi.fn(),
+}));
+
+vi.mock("@/lib/rules/inventory", () => ({
+  getEquipmentStateSummary: vi.fn(),
+}));
+
+import { WirelessDisplay } from "../WirelessDisplay";
+import { isGlobalWirelessEnabled, getWirelessBonusSummary } from "@/lib/rules/wireless";
+import { getEquipmentStateSummary } from "@/lib/rules/inventory";
+
+const mockIsGlobalWirelessEnabled = vi.mocked(isGlobalWirelessEnabled);
+const mockGetWirelessBonusSummary = vi.mocked(getWirelessBonusSummary);
+const mockGetEquipmentStateSummary = vi.mocked(getEquipmentStateSummary);
+
+// Default mocks
+function setupMocks({
+  enabled = true,
+  bonuses = [] as { category: string; description: string; modifier: string }[],
+  wirelessEnabled = 3,
+  wirelessDisabled = 1,
+}: {
+  enabled?: boolean;
+  bonuses?: { category: string; description: string; modifier: string }[];
+  wirelessEnabled?: number;
+  wirelessDisabled?: number;
+} = {}) {
+  mockIsGlobalWirelessEnabled.mockReturnValue(enabled);
+  mockGetWirelessBonusSummary.mockReturnValue(bonuses);
+  mockGetEquipmentStateSummary.mockReturnValue({
+    readiedWeapons: 1,
+    holsteredWeapons: 0,
+    storedWeapons: 0,
+    stashedWeapons: 0,
+    wornArmor: 1,
+    storedArmor: 0,
+    stashedArmor: 0,
+    wirelessEnabled,
+    wirelessDisabled,
+    brickedDevices: 0,
+  });
+}
+
+const baseCharacter = createSheetCharacter();
+
+describe("WirelessDisplay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders card with Wireless title", () => {
+    setupMocks();
+    render(<WirelessDisplay character={baseCharacter} />);
+    expect(screen.getByText("Wireless")).toBeInTheDocument();
+  });
+
+  it('shows "Wireless Active" when enabled', () => {
+    setupMocks({ enabled: true });
+    render(<WirelessDisplay character={baseCharacter} />);
+    expect(screen.getByText("Wireless Active")).toBeInTheDocument();
+  });
+
+  it('shows "Wireless Silent" when disabled', () => {
+    setupMocks({ enabled: false });
+    render(<WirelessDisplay character={baseCharacter} />);
+    expect(screen.getByText("Wireless Silent")).toBeInTheDocument();
+  });
+
+  it("shows equipment counts", () => {
+    setupMocks({ wirelessEnabled: 5, wirelessDisabled: 2 });
+    render(<WirelessDisplay character={baseCharacter} />);
+    expect(screen.getByText("5 on / 2 off")).toBeInTheDocument();
+  });
+
+  it("shows toggle switch only when editable", () => {
+    setupMocks();
+    const { rerender } = render(<WirelessDisplay character={baseCharacter} editable={false} />);
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+
+    rerender(<WirelessDisplay character={baseCharacter} editable={true} />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+  });
+
+  it("calls onCharacterUpdate with toggled wirelessBonusesEnabled on click", () => {
+    setupMocks({ enabled: true });
+    const onUpdate = vi.fn();
+    render(
+      <WirelessDisplay character={baseCharacter} onCharacterUpdate={onUpdate} editable={true} />
+    );
+
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const updated = onUpdate.mock.calls[0][0];
+    expect(updated.wirelessBonusesEnabled).toBe(false);
+  });
+
+  it("toggles from disabled to enabled", () => {
+    setupMocks({ enabled: false });
+    const onUpdate = vi.fn();
+    render(
+      <WirelessDisplay character={baseCharacter} onCharacterUpdate={onUpdate} editable={true} />
+    );
+
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const updated = onUpdate.mock.calls[0][0];
+    expect(updated.wirelessBonusesEnabled).toBe(true);
+  });
+
+  it("renders bonus summary rows when bonuses exist and wireless ON", () => {
+    setupMocks({
+      enabled: true,
+      bonuses: [
+        { category: "Attack", description: "Wireless bonus to attack pools", modifier: "+2" },
+        { category: "Initiative", description: "Wireless bonus to Initiative", modifier: "+1" },
+      ],
+    });
+    render(<WirelessDisplay character={baseCharacter} />);
+    expect(screen.getByText("Active Bonuses")).toBeInTheDocument();
+    expect(screen.getByText("Attack")).toBeInTheDocument();
+    expect(screen.getByText("Wireless bonus to attack pools")).toBeInTheDocument();
+    expect(screen.getByText("+2")).toBeInTheDocument();
+    expect(screen.getByText("Initiative")).toBeInTheDocument();
+    expect(screen.getByText("+1")).toBeInTheDocument();
+  });
+
+  it('shows "No active wireless bonuses" when empty array and wireless ON', () => {
+    setupMocks({ enabled: true, bonuses: [] });
+    render(<WirelessDisplay character={baseCharacter} />);
+    expect(screen.getByText("Active Bonuses")).toBeInTheDocument();
+    expect(screen.getByText("No active wireless bonuses")).toBeInTheDocument();
+  });
+
+  it("hides bonus section when wireless OFF", () => {
+    setupMocks({ enabled: false });
+    render(<WirelessDisplay character={baseCharacter} />);
+    expect(screen.queryByText("Active Bonuses")).not.toBeInTheDocument();
+  });
+
+  it("handles wirelessBonusesEnabled: undefined (defaults to true)", () => {
+    const char = createSheetCharacter({ wirelessBonusesEnabled: undefined });
+    setupMocks({ enabled: true });
+    render(<WirelessDisplay character={char} />);
+    expect(screen.getByText("Wireless Active")).toBeInTheDocument();
+    expect(mockIsGlobalWirelessEnabled).toHaveBeenCalledWith(char);
+  });
+
+  it("does not call onCharacterUpdate when toggle clicked without handler", () => {
+    setupMocks({ enabled: true });
+    render(<WirelessDisplay character={baseCharacter} editable={true} />);
+    // Should not throw
+    fireEvent.click(screen.getByRole("switch"));
+  });
+});

--- a/components/character/sheet/index.ts
+++ b/components/character/sheet/index.ts
@@ -23,3 +23,4 @@ export { SkillsDisplay } from "./SkillsDisplay";
 export { SpellsDisplay } from "./SpellsDisplay";
 export { VehiclesDisplay } from "./VehiclesDisplay";
 export { WeaponsDisplay } from "./WeaponsDisplay";
+export { WirelessDisplay } from "./WirelessDisplay";


### PR DESCRIPTION
## Summary

- Adds a new `WirelessDisplay` component to the character sheet left column (between Encumbrance and Condition)
- Shows global wireless state as "Wireless Active" (cyan) or "Wireless Silent" (gray) with equipment counts
- Includes toggle switch for active characters and active bonus breakdown with cyan modifier pills
- Reuses existing `isGlobalWirelessEnabled`, `getWirelessBonusSummary`, and `getEquipmentStateSummary` — no new business logic

Closes #377

## Test plan

- [x] 12 new unit tests covering all states (active/silent, editable/readonly, bonuses/empty, toggle interaction)
- [x] All 501 sheet tests pass (no regressions)
- [x] All 7469 unit tests pass
- [x] TypeScript type-check passes
- [x] ESLint clean (0 errors)
- [ ] Manual: Load character sheet, verify wireless card between Encumbrance and Condition
- [ ] Manual: Toggle wireless on/off, verify cyan/gray state change + bonus summary appears/disappears
- [ ] Manual: Verify InventoryPanel toggle stays in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)