### PR TITLE
feat(sheet): Add Rigging/Drone System UI components (#89)

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -46,8 +46,14 @@ import {
   WirelessDisplay,
   ArmorDisplay,
   AugmentationsDisplay,
+  RiggingSummaryDisplay,
+  DroneNetworkDisplay,
+  JumpInControlDisplay,
+  VehicleActionsDisplay,
+  AutosoftManagerDisplay,
 } from "@/components/character/sheet";
 import { hasMatrixAccess } from "@/lib/rules/matrix/cyberdeck-validator";
+import { hasRiggingAccess } from "@/components/character/sheet/rigging-helpers";
 
 // =============================================================================
 // MAIN CHARACTER SHEET PAGE
@@ -415,6 +421,37 @@ function CharacterSheet({
                 <MatrixActionsDisplay
                   character={character}
                   onSelect={(pool, label) => openDiceRoller(pool, label)}
+                  editable={character.status === "active"}
+                />
+              </>
+            )}
+
+            {/* Rigging Operations */}
+            {hasRiggingAccess(character) && (
+              <>
+                <RiggingSummaryDisplay
+                  character={character}
+                  onCharacterUpdate={(updated) => setCharacter(updated)}
+                  editable={character.status === "active"}
+                />
+                <DroneNetworkDisplay
+                  character={character}
+                  onCharacterUpdate={(updated) => setCharacter(updated)}
+                  editable={character.status === "active"}
+                />
+                <JumpInControlDisplay
+                  character={character}
+                  onCharacterUpdate={(updated) => setCharacter(updated)}
+                  editable={character.status === "active"}
+                />
+                <VehicleActionsDisplay
+                  character={character}
+                  onSelect={(pool, label) => openDiceRoller(pool, label)}
+                  editable={character.status === "active"}
+                />
+                <AutosoftManagerDisplay
+                  character={character}
+                  onCharacterUpdate={(updated) => setCharacter(updated)}
                   editable={character.status === "active"}
                 />
               </>

--- a/components/character/sheet/AutosoftManagerDisplay.tsx
+++ b/components/character/sheet/AutosoftManagerDisplay.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { Character, CharacterAutosoft } from "@/lib/types";
+import { DisplayCard } from "./DisplayCard";
+import { Cpu, ChevronDown, ChevronRight } from "lucide-react";
+import { getOwnedAutosofts, getOwnedDrones, getActiveRCC } from "@/lib/rules/rigging";
+import { AUTOSOFT_CATEGORY_BADGE } from "./rigging-helpers";
+
+// ---------------------------------------------------------------------------
+// AutosoftRow
+// ---------------------------------------------------------------------------
+
+interface AutosoftRowProps {
+  autosoft: CharacterAutosoft;
+}
+
+function AutosoftRow({ autosoft }: AutosoftRowProps) {
+  const catBadge = AUTOSOFT_CATEGORY_BADGE[autosoft.category] ?? AUTOSOFT_CATEGORY_BADGE.stealth;
+
+  return (
+    <div
+      data-testid="autosoft-row"
+      className="flex items-center gap-2 px-3 py-1.5 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+    >
+      <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+        {autosoft.name}
+      </span>
+      <span
+        data-testid="category-badge"
+        className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-semibold ${catBadge.style}`}
+      >
+        {catBadge.label}
+      </span>
+      <span
+        data-testid="rating-pill"
+        className="shrink-0 rounded border border-indigo-500/20 bg-indigo-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-indigo-600 dark:text-indigo-300"
+      >
+        R{autosoft.rating}
+      </span>
+      {autosoft.target && (
+        <span className="text-[10px] text-zinc-500 dark:text-zinc-400">({autosoft.target})</span>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AutosoftManagerDisplay
+// ---------------------------------------------------------------------------
+
+interface AutosoftManagerDisplayProps {
+  character: Character;
+  onCharacterUpdate?: (updated: Character) => void;
+  editable?: boolean;
+}
+
+export function AutosoftManagerDisplay({ character }: AutosoftManagerDisplayProps) {
+  const [showAvailable, setShowAvailable] = useState(false);
+  const autosofts = useMemo(() => getOwnedAutosofts(character), [character]);
+  const drones = useMemo(() => getOwnedDrones(character), [character]);
+  const rcc = useMemo(() => getActiveRCC(character), [character]);
+
+  const runningAutosofts = rcc?.runningAutosofts ?? [];
+
+  // Drones with installed autosofts
+  const dronesWithAutosofts = useMemo(
+    () => drones.filter((d) => d.installedAutosofts && d.installedAutosofts.length > 0),
+    [drones]
+  );
+
+  const hasContent =
+    autosofts.length > 0 || runningAutosofts.length > 0 || dronesWithAutosofts.length > 0;
+
+  if (!hasContent) return null;
+
+  return (
+    <DisplayCard
+      id="sheet-autosofts"
+      title="Autosofts"
+      icon={<Cpu className="h-4 w-4 text-zinc-400" />}
+      collapsible
+      defaultCollapsed
+    >
+      <div className="space-y-3">
+        {/* RCC Running Autosofts */}
+        {runningAutosofts.length > 0 && (
+          <div data-testid="rcc-running-section">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Running on RCC ({runningAutosofts.length})
+            </div>
+            <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+              {runningAutosofts.map((soft, idx) => (
+                <div
+                  key={`${soft}-${idx}`}
+                  data-testid="rcc-autosoft-row"
+                  className="flex items-center gap-2 px-3 py-1.5 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+                >
+                  <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+                    {soft}
+                  </span>
+                  <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-400">
+                    Shared
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Per-Drone Installed Autosofts */}
+        {dronesWithAutosofts.map((drone, droneIdx) => (
+          <div key={`drone-${drone.name}-${droneIdx}`} data-testid="drone-autosofts-section">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              {drone.customName ?? drone.name}
+            </div>
+            <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+              {drone.installedAutosofts!.map((soft, idx) => (
+                <div
+                  key={`${soft}-${idx}`}
+                  data-testid="drone-autosoft-row"
+                  className="flex items-center gap-2 px-3 py-1.5 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+                >
+                  <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+                    {soft}
+                  </span>
+                  <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                    Installed
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {/* Available (Owned) Autosofts */}
+        {autosofts.length > 0 && (
+          <div data-testid="available-section">
+            <button
+              data-testid="available-toggle"
+              onClick={() => setShowAvailable(!showAvailable)}
+              className="mb-1 flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+            >
+              {showAvailable ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+              Owned ({autosofts.length})
+            </button>
+            {showAvailable && (
+              <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+                {autosofts.map((soft, idx) => (
+                  <AutosoftRow key={`${soft.catalogId}-${idx}`} autosoft={soft} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/DroneNetworkDisplay.tsx
+++ b/components/character/sheet/DroneNetworkDisplay.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { Character, CharacterDrone, CharacterRCC } from "@/lib/types";
+import { DisplayCard } from "./DisplayCard";
+import { Radio, ChevronDown, ChevronRight } from "lucide-react";
+import { getOwnedDrones, getActiveRCC, calculateMaxSlavedDrones } from "@/lib/rules/rigging";
+import { AUTOSOFT_CATEGORY_BADGE } from "./rigging-helpers";
+
+// ---------------------------------------------------------------------------
+// DroneRow
+// ---------------------------------------------------------------------------
+
+interface DroneRowProps {
+  drone: CharacterDrone;
+  index: number;
+}
+
+function DroneRow({ drone }: DroneRowProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const displayName = drone.customName ?? drone.name;
+  const sizeLabel = drone.size.charAt(0).toUpperCase() + drone.size.slice(1);
+
+  return (
+    <div
+      data-testid="drone-row"
+      onClick={() => setIsExpanded(!isExpanded)}
+      className="cursor-pointer px-3 py-1.5 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+    >
+      {/* Collapsed row */}
+      <div className="flex min-w-0 items-center gap-1.5">
+        <span data-testid="expand-button" className="shrink-0 text-zinc-400">
+          {isExpanded ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+        </span>
+        <span
+          title={displayName}
+          className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200"
+        >
+          {displayName}
+        </span>
+        <span
+          data-testid="size-badge"
+          className="shrink-0 rounded border border-zinc-400/20 bg-zinc-400/10 px-1 text-[9px] font-bold uppercase text-zinc-500 dark:text-zinc-400"
+        >
+          {sizeLabel}
+        </span>
+        <span className="ml-auto" />
+        <span
+          data-testid="pilot-badge"
+          className="shrink-0 rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+        >
+          Pilot {drone.pilot}
+        </span>
+      </div>
+
+      {/* Expanded section */}
+      {isExpanded && (
+        <div
+          data-testid="expanded-content"
+          onClick={(e) => e.stopPropagation()}
+          className="ml-5 mt-2 space-y-2 border-l-2 border-zinc-200 pl-3 dark:border-zinc-700"
+        >
+          {/* Stats row */}
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500 dark:text-zinc-400">
+            <span data-testid="stat-body">
+              Body{" "}
+              <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                {drone.body}
+              </span>
+            </span>
+            <span data-testid="stat-armor">
+              Armor{" "}
+              <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                {drone.armor}
+              </span>
+            </span>
+            <span data-testid="stat-handling">
+              Handling{" "}
+              <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                {drone.handling}
+              </span>
+            </span>
+            <span data-testid="stat-speed">
+              Speed{" "}
+              <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                {drone.speed}
+              </span>
+            </span>
+            <span data-testid="stat-sensor">
+              Sensor{" "}
+              <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                {drone.sensor}
+              </span>
+            </span>
+          </div>
+
+          {/* Condition Monitor */}
+          <div className="flex items-center gap-x-4 text-xs text-zinc-500 dark:text-zinc-400">
+            <span data-testid="stat-condition">
+              Condition Monitor{" "}
+              <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+                {Math.ceil(drone.body / 2) + 8}
+              </span>
+            </span>
+          </div>
+
+          {/* Installed Autosofts */}
+          {drone.installedAutosofts && drone.installedAutosofts.length > 0 && (
+            <div data-testid="installed-autosofts">
+              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+                Installed Autosofts
+              </div>
+              <div className="space-y-0.5">
+                {drone.installedAutosofts.map((soft, idx) => (
+                  <div
+                    key={`${soft}-${idx}`}
+                    data-testid="autosoft-row"
+                    className="text-xs font-medium text-zinc-700 dark:text-zinc-300"
+                  >
+                    {soft}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Notes */}
+          {drone.notes && (
+            <div data-testid="notes" className="text-xs italic text-zinc-500 dark:text-zinc-400">
+              {drone.notes}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DroneNetworkDisplay
+// ---------------------------------------------------------------------------
+
+interface DroneNetworkDisplayProps {
+  character: Character;
+  onCharacterUpdate?: (updated: Character) => void;
+  editable?: boolean;
+}
+
+export function DroneNetworkDisplay({ character }: DroneNetworkDisplayProps) {
+  const drones = useMemo(() => getOwnedDrones(character), [character]);
+  const rcc = useMemo(() => getActiveRCC(character), [character]);
+
+  const maxSlaved = useMemo(() => (rcc ? calculateMaxSlavedDrones(rcc.dataProcessing) : 0), [rcc]);
+
+  if (drones.length === 0 && !rcc) return null;
+
+  const runningAutosofts = rcc?.runningAutosofts ?? [];
+
+  return (
+    <DisplayCard
+      id="sheet-drone-network"
+      title="Drone Network"
+      icon={<Radio className="h-4 w-4 text-zinc-400" />}
+      collapsible
+    >
+      <div className="space-y-3">
+        {/* Network Header */}
+        {rcc && (
+          <div data-testid="network-header" className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+                {rcc.customName ?? rcc.name}
+              </span>
+              <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-400">
+                RCC
+              </span>
+            </div>
+            <span
+              data-testid="capacity-badge"
+              className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+            >
+              0 / {maxSlaved} Slaved
+            </span>
+          </div>
+        )}
+
+        {/* Drone List */}
+        {drones.length > 0 && (
+          <div>
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Drones ({drones.length})
+            </div>
+            <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+              {drones.map((drone, idx) => (
+                <DroneRow key={`${drone.name}-${idx}`} drone={drone} index={idx} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Shared Autosofts from RCC */}
+        {runningAutosofts.length > 0 && (
+          <div data-testid="shared-autosofts">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Shared Autosofts (RCC)
+            </div>
+            <div className="space-y-1">
+              {runningAutosofts.map((soft, idx) => (
+                <div
+                  key={`${soft}-${idx}`}
+                  data-testid="shared-autosoft-row"
+                  className="flex items-center gap-2 text-xs font-medium text-zinc-700 dark:text-zinc-300"
+                >
+                  <span>{soft}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/JumpInControlDisplay.tsx
+++ b/components/character/sheet/JumpInControlDisplay.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useMemo } from "react";
+import type { Character } from "@/lib/types";
+import { DisplayCard } from "./DisplayCard";
+import { PlugZap, AlertTriangle } from "lucide-react";
+import {
+  hasVehicleControlRig,
+  getVehicleControlRig,
+  calculateJumpedInInitiative,
+  getHotSimRiskDescription,
+  getColdSimBenefitsDescription,
+  getOwnedDrones,
+} from "@/lib/rules/rigging";
+import { VR_MODE_BADGE } from "./rigging-helpers";
+
+interface JumpInControlDisplayProps {
+  character: Character;
+  onCharacterUpdate?: (updated: Character) => void;
+  editable?: boolean;
+}
+
+export function JumpInControlDisplay({ character }: JumpInControlDisplayProps) {
+  const hasVCR = useMemo(() => hasVehicleControlRig(character), [character]);
+  const vcr = useMemo(() => getVehicleControlRig(character), [character]);
+  const drones = useMemo(() => getOwnedDrones(character), [character]);
+
+  const coldSimInit = useMemo(() => {
+    if (!vcr) return null;
+    const reaction = character.attributes?.reaction ?? 1;
+    const intuition = character.attributes?.intuition ?? 1;
+    return calculateJumpedInInitiative(reaction, intuition, vcr.rating, "cold-sim");
+  }, [vcr, character.attributes?.reaction, character.attributes?.intuition]);
+
+  const hotSimInit = useMemo(() => {
+    if (!vcr) return null;
+    const reaction = character.attributes?.reaction ?? 1;
+    const intuition = character.attributes?.intuition ?? 1;
+    return calculateJumpedInInitiative(reaction, intuition, vcr.rating, "hot-sim");
+  }, [vcr, character.attributes?.reaction, character.attributes?.intuition]);
+
+  const hotSimRisk = useMemo(() => getHotSimRiskDescription(), []);
+  const coldSimBenefits = useMemo(() => getColdSimBenefitsDescription(), []);
+
+  if (!hasVCR || !vcr) return null;
+
+  const vehicles = character.vehicles ?? [];
+  const jumpTargets = [
+    ...vehicles.map((v) => ({
+      id: v.catalogId ?? v.name,
+      name: v.name,
+      type: "Vehicle" as const,
+      pilot: v.pilot,
+    })),
+    ...drones.map((d) => ({
+      id: d.catalogId ?? d.name,
+      name: d.customName ?? d.name,
+      type: "Drone" as const,
+      pilot: d.pilot,
+    })),
+  ];
+
+  return (
+    <DisplayCard
+      id="sheet-jump-in"
+      title="Jump-In Control"
+      icon={<PlugZap className="h-4 w-4 text-emerald-400" />}
+      collapsible
+    >
+      <div className="space-y-3">
+        {/* VCR Info */}
+        <div data-testid="vcr-info">
+          <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+            Vehicle Control Rig
+          </div>
+          <div className="flex items-center gap-2">
+            <span
+              data-testid="vcr-rating"
+              className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
+            >
+              Rating {vcr.rating}
+            </span>
+            {vcr.grade && vcr.grade !== "standard" && (
+              <span className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                {vcr.grade}
+              </span>
+            )}
+            <span className="ml-auto" />
+            <span
+              data-testid="control-bonus"
+              className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+            >
+              +{vcr.controlBonus} to vehicle tests
+            </span>
+          </div>
+        </div>
+
+        {/* Jumpable Targets */}
+        {jumpTargets.length > 0 && (
+          <div data-testid="jump-targets">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Available Targets ({jumpTargets.length})
+            </div>
+            <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+              {jumpTargets.map((target, idx) => (
+                <div
+                  key={`${target.id}-${idx}`}
+                  data-testid="jump-target-row"
+                  className="flex items-center gap-1.5 px-3 py-1.5 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+                >
+                  <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+                    {target.name}
+                  </span>
+                  <span
+                    className={`shrink-0 rounded border border-zinc-400/20 bg-zinc-400/10 px-1 text-[9px] font-bold uppercase text-zinc-500 dark:text-zinc-400`}
+                  >
+                    {target.type}
+                  </span>
+                  <span className="ml-auto" />
+                  <span className="shrink-0 rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50">
+                    Pilot {target.pilot}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* VR Mode Preview */}
+        <div data-testid="vr-modes">
+          <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+            VR Mode
+          </div>
+          <div className="space-y-2">
+            {/* Cold-Sim */}
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-2.5 dark:border-zinc-800 dark:bg-zinc-950">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${VR_MODE_BADGE["cold-sim"].style}`}
+                >
+                  {VR_MODE_BADGE["cold-sim"].label}
+                </span>
+                {coldSimInit && (
+                  <span className="ml-auto font-mono text-[11px] text-zinc-500 dark:text-zinc-400">
+                    Init {coldSimInit.initiative}+{coldSimInit.initiativeDice}D6
+                  </span>
+                )}
+              </div>
+              <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400">{coldSimBenefits}</p>
+            </div>
+
+            {/* Hot-Sim */}
+            <div className="rounded-lg border border-red-200 bg-red-50/50 p-2.5 dark:border-red-900/40 dark:bg-red-950/30">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${VR_MODE_BADGE["hot-sim"].style}`}
+                >
+                  {VR_MODE_BADGE["hot-sim"].label}
+                </span>
+                {hotSimInit && (
+                  <span className="ml-auto font-mono text-[11px] text-zinc-500 dark:text-zinc-400">
+                    Init {hotSimInit.initiative}+{hotSimInit.initiativeDice}D6
+                  </span>
+                )}
+              </div>
+              <div className="mt-1 flex items-start gap-1">
+                <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-red-500" />
+                <p
+                  data-testid="hotsim-warning"
+                  className="text-[11px] text-red-600 dark:text-red-400"
+                >
+                  {hotSimRisk}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/RiggingSummaryDisplay.tsx
+++ b/components/character/sheet/RiggingSummaryDisplay.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useMemo } from "react";
+import type { Character } from "@/lib/types";
+import { DisplayCard } from "./DisplayCard";
+import { Gamepad2 } from "lucide-react";
+import {
+  hasVehicleControlRig,
+  getVehicleControlRig,
+  hasRCC,
+  getActiveRCC,
+  calculateMaxSlavedDrones,
+  calculateNoiseReduction,
+  getOwnedDrones,
+  getOwnedAutosofts,
+} from "@/lib/rules/rigging";
+import { hasRiggingAccess } from "./rigging-helpers";
+
+interface RiggingSummaryDisplayProps {
+  character: Character;
+  onCharacterUpdate?: (updated: Character) => void;
+  editable?: boolean;
+}
+
+export function RiggingSummaryDisplay({ character }: RiggingSummaryDisplayProps) {
+  const hasAccess = useMemo(() => hasRiggingAccess(character), [character]);
+  const vcr = useMemo(() => getVehicleControlRig(character), [character]);
+  const hasVCR = useMemo(() => hasVehicleControlRig(character), [character]);
+  const rcc = useMemo(() => getActiveRCC(character), [character]);
+  const hasRCCDevice = useMemo(() => hasRCC(character), [character]);
+  const drones = useMemo(() => getOwnedDrones(character), [character]);
+  const autosofts = useMemo(() => getOwnedAutosofts(character), [character]);
+
+  const maxSlaved = useMemo(() => (rcc ? calculateMaxSlavedDrones(rcc.dataProcessing) : 0), [rcc]);
+  const noiseReduction = useMemo(
+    () => (rcc ? calculateNoiseReduction(rcc.deviceRating) : 0),
+    [rcc]
+  );
+
+  if (!hasAccess) return null;
+
+  const vehicleCount = character.vehicles?.length ?? 0;
+  const droneCount = drones.length;
+  const autosoftCount = autosofts.length;
+
+  return (
+    <DisplayCard
+      id="sheet-rigging-summary"
+      title="Rigging"
+      icon={<Gamepad2 className="h-4 w-4 text-emerald-400" />}
+      collapsible
+    >
+      <div className="space-y-3">
+        {/* VCR Info */}
+        {hasVCR && vcr && (
+          <div data-testid="vcr-section">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Vehicle Control Rig
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+                Control Rig
+              </span>
+              <span
+                data-testid="vcr-rating"
+                className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
+              >
+                R{vcr.rating}
+              </span>
+              <span className="ml-auto" />
+              <span
+                data-testid="vcr-control-bonus"
+                className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+              >
+                +{vcr.controlBonus} Control
+              </span>
+              <span
+                data-testid="vcr-init-dice"
+                className="rounded bg-blue-100 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+              >
+                +{vcr.initiativeDiceBonus}D6 Init
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Active RCC */}
+        {hasRCCDevice && rcc && (
+          <div data-testid="rcc-section">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Rigger Command Console
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+                  {rcc.customName ?? rcc.name}
+                </span>
+                <span className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50">
+                  DR {rcc.deviceRating}
+                </span>
+              </div>
+            </div>
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-zinc-500 dark:text-zinc-400">
+              <span data-testid="rcc-dp" className="font-mono">
+                DP{" "}
+                <span className="font-semibold text-zinc-700 dark:text-zinc-300">
+                  {rcc.dataProcessing}
+                </span>
+              </span>
+              <span>·</span>
+              <span data-testid="rcc-fw" className="font-mono">
+                FW{" "}
+                <span className="font-semibold text-zinc-700 dark:text-zinc-300">
+                  {rcc.firewall}
+                </span>
+              </span>
+              <span>·</span>
+              <span data-testid="rcc-noise-reduction" className="font-mono">
+                NR{" "}
+                <span className="font-semibold text-zinc-700 dark:text-zinc-300">
+                  {noiseReduction}
+                </span>
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Network Capacity */}
+        {hasRCCDevice && rcc && (
+          <div data-testid="network-capacity" className="flex items-center justify-between">
+            <span className="text-xs text-zinc-500 dark:text-zinc-400">Drone Slots</span>
+            <span className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50">
+              0 / {maxSlaved}
+            </span>
+          </div>
+        )}
+
+        {/* Equipment Counts */}
+        <div
+          data-testid="equipment-counts"
+          className="flex flex-wrap gap-x-2 text-[11px] text-zinc-500 dark:text-zinc-400"
+        >
+          {vehicleCount > 0 && (
+            <span>
+              {vehicleCount} Vehicle{vehicleCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {vehicleCount > 0 && droneCount > 0 && <span>·</span>}
+          {droneCount > 0 && (
+            <span>
+              {droneCount} Drone{droneCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {(vehicleCount > 0 || droneCount > 0) && autosoftCount > 0 && <span>·</span>}
+          {autosoftCount > 0 && (
+            <span>
+              {autosoftCount} Autosoft{autosoftCount !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/VehicleActionsDisplay.tsx
+++ b/components/character/sheet/VehicleActionsDisplay.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState } from "react";
+import type { Character } from "@/lib/types";
+import type { VehicleActionType } from "@/lib/types/rigging";
+import { DisplayCard } from "./DisplayCard";
+import { Zap, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  requiresJumpedIn,
+  canPerformRemotely,
+  getActionTypeDescription,
+  getTestTypeForAction,
+  getSkillForAction,
+} from "@/lib/rules/rigging";
+
+// ---------------------------------------------------------------------------
+// Action definitions grouped by category
+// ---------------------------------------------------------------------------
+
+interface ActionDef {
+  type: VehicleActionType;
+  category: string;
+}
+
+const ACTION_CATEGORIES: { key: string; label: string; actions: VehicleActionType[] }[] = [
+  {
+    key: "movement",
+    label: "Movement",
+    actions: ["accelerate", "decelerate", "turn"],
+  },
+  {
+    key: "pursuit",
+    label: "Pursuit",
+    actions: ["catch_up", "cut_off", "evasive_driving"],
+  },
+  {
+    key: "combat",
+    label: "Combat",
+    actions: ["ram", "fire_weapon", "sensor_targeting", "stunt"],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// ActionRow
+// ---------------------------------------------------------------------------
+
+interface ActionRowProps {
+  actionType: VehicleActionType;
+  character: Character;
+  onSelect?: (pool: number, label: string) => void;
+}
+
+function ActionRow({ actionType, character, onSelect }: ActionRowProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const name = getActionTypeDescription(actionType);
+  const needsJumpedIn = requiresJumpedIn(actionType);
+  const canRemote = canPerformRemotely(actionType);
+  const testType = getTestTypeForAction(actionType);
+  const skill = getSkillForAction(actionType);
+
+  // Estimate a dice pool from character skills (simplified, no rigging state)
+  const skillRating =
+    skill === "gunnery"
+      ? (character.skills?.gunnery ?? 0)
+      : skill === "perception"
+        ? (character.skills?.perception ?? 0)
+        : (character.skills?.["pilot-ground-craft"] ?? character.skills?.["pilot-aircraft"] ?? 0);
+
+  const attrValue =
+    skill === "gunnery"
+      ? (character.attributes?.agility ?? 0)
+      : skill === "perception"
+        ? (character.attributes?.intuition ?? 0)
+        : (character.attributes?.reaction ?? 0);
+
+  const estimatedPool = skillRating + attrValue;
+
+  return (
+    <div
+      data-testid="action-row"
+      onClick={() => setIsExpanded(!isExpanded)}
+      className="cursor-pointer px-3 py-1.5 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50"
+    >
+      {/* Collapsed row */}
+      <div className="flex min-w-0 items-center gap-1.5">
+        <span data-testid="expand-button" className="shrink-0 text-zinc-400">
+          {isExpanded ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+        </span>
+        <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+          {name}
+        </span>
+
+        {/* Requirement badge */}
+        {needsJumpedIn && (
+          <span
+            data-testid="jumped-in-badge"
+            className="shrink-0 rounded border border-amber-400/30 bg-amber-400/10 px-1 text-[9px] font-bold uppercase text-amber-600 dark:text-amber-400"
+          >
+            Jumped-In
+          </span>
+        )}
+        {!needsJumpedIn && canRemote && (
+          <span
+            data-testid="remote-badge"
+            className="shrink-0 rounded border border-blue-400/30 bg-blue-400/10 px-1 text-[9px] font-bold uppercase text-blue-600 dark:text-blue-400"
+          >
+            Remote
+          </span>
+        )}
+
+        <span className="ml-auto" />
+
+        {/* Dice pool pill */}
+        {estimatedPool > 0 && (
+          <button
+            data-testid="pool-pill"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelect?.(estimatedPool, name);
+            }}
+            className="shrink-0 rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 hover:bg-emerald-100 hover:text-emerald-700 dark:bg-zinc-800 dark:text-zinc-50 dark:hover:bg-emerald-900/30 dark:hover:text-emerald-400"
+          >
+            {estimatedPool}d6
+          </button>
+        )}
+      </div>
+
+      {/* Expanded content */}
+      {isExpanded && (
+        <div
+          data-testid="expanded-content"
+          onClick={(e) => e.stopPropagation()}
+          className="ml-5 mt-2 space-y-1.5 border-l-2 border-zinc-200 pl-3 dark:border-zinc-700"
+        >
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] text-zinc-500 dark:text-zinc-400">
+            <span>
+              Test:{" "}
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                {testType.charAt(0).toUpperCase() + testType.slice(1).replace(/_/g, " ")}
+              </span>
+            </span>
+            <span>
+              Skill:{" "}
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                {skill.charAt(0).toUpperCase() + skill.slice(1)}
+              </span>
+            </span>
+          </div>
+          {estimatedPool > 0 && (
+            <div className="text-[11px] text-zinc-500 dark:text-zinc-400">
+              Pool:{" "}
+              <span className="font-mono font-medium text-zinc-700 dark:text-zinc-300">
+                {attrValue} (attr) + {skillRating} (skill) = {estimatedPool}
+              </span>
+            </div>
+          )}
+          {needsJumpedIn && (
+            <div className="text-[11px] text-amber-600 dark:text-amber-400">
+              Requires jumped-in control via VCR
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// VehicleActionsDisplay
+// ---------------------------------------------------------------------------
+
+interface VehicleActionsDisplayProps {
+  character: Character;
+  onSelect?: (pool: number, label: string) => void;
+  editable?: boolean;
+}
+
+export function VehicleActionsDisplay({ character, onSelect }: VehicleActionsDisplayProps) {
+  const hasVehicles = (character.vehicles?.length ?? 0) > 0;
+  const hasDrones = (character.drones?.length ?? 0) > 0;
+
+  if (!hasVehicles && !hasDrones) return null;
+
+  return (
+    <DisplayCard
+      id="sheet-vehicle-actions"
+      title="Vehicle Actions"
+      icon={<Zap className="h-4 w-4 text-zinc-400" />}
+      collapsible
+      defaultCollapsed
+    >
+      <div className="space-y-3">
+        {ACTION_CATEGORIES.map(({ key, label, actions }) => (
+          <div key={key}>
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              {label}
+            </div>
+            <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+              {actions.map((actionType) => (
+                <ActionRow
+                  key={actionType}
+                  actionType={actionType}
+                  character={character}
+                  onSelect={onSelect}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/__tests__/AutosoftManagerDisplay.test.tsx
+++ b/components/character/sheet/__tests__/AutosoftManagerDisplay.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  setupDisplayCardMock,
+  LUCIDE_MOCK,
+  createRiggerCharacter,
+  createSheetCharacter,
+  MOCK_DRONE_WITH_AUTOSOFTS,
+  MOCK_RCC_WITH_OPTIONS,
+  MOCK_AUTOSOFT_PERCEPTION,
+  MOCK_AUTOSOFT_COMBAT,
+  MOCK_AUTOSOFT_MOVEMENT,
+} from "./test-helpers";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+const mockGetOwnedAutosofts = vi.fn();
+const mockGetOwnedDrones = vi.fn();
+const mockGetActiveRCC = vi.fn();
+
+vi.mock("@/lib/rules/rigging", () => ({
+  getOwnedAutosofts: (...args: unknown[]) => mockGetOwnedAutosofts(...args),
+  getOwnedDrones: (...args: unknown[]) => mockGetOwnedDrones(...args),
+  getActiveRCC: (...args: unknown[]) => mockGetActiveRCC(...args),
+}));
+
+import { AutosoftManagerDisplay } from "../AutosoftManagerDisplay";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AutosoftManagerDisplay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOwnedAutosofts.mockReturnValue([]);
+    mockGetOwnedDrones.mockReturnValue([]);
+    mockGetActiveRCC.mockReturnValue(null);
+  });
+
+  it("returns null when no autosofts, no running autosofts, no drone autosofts", () => {
+    const character = createSheetCharacter();
+    const { container } = render(<AutosoftManagerDisplay character={character} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders RCC running autosofts section", () => {
+    mockGetActiveRCC.mockReturnValue(MOCK_RCC_WITH_OPTIONS);
+
+    const character = createRiggerCharacter();
+    render(<AutosoftManagerDisplay character={character} />);
+
+    expect(screen.getByTestId("rcc-running-section")).toBeInTheDocument();
+    expect(screen.getByText("Electronic Warfare")).toBeInTheDocument();
+    expect(screen.getByText("Stealth")).toBeInTheDocument();
+  });
+
+  it("renders per-drone installed autosofts section", () => {
+    mockGetOwnedDrones.mockReturnValue([MOCK_DRONE_WITH_AUTOSOFTS]);
+
+    const character = createRiggerCharacter();
+    render(<AutosoftManagerDisplay character={character} />);
+
+    expect(screen.getByTestId("drone-autosofts-section")).toBeInTheDocument();
+    expect(screen.getByText("Rex")).toBeInTheDocument(); // customName of MOCK_DRONE_WITH_AUTOSOFTS
+    expect(screen.getByText("Clearsight")).toBeInTheDocument();
+    expect(screen.getByText("Targeting (Automatics)")).toBeInTheDocument();
+  });
+
+  it("shows available autosofts section with toggle", () => {
+    mockGetOwnedAutosofts.mockReturnValue([
+      MOCK_AUTOSOFT_PERCEPTION,
+      MOCK_AUTOSOFT_COMBAT,
+      MOCK_AUTOSOFT_MOVEMENT,
+    ]);
+
+    const character = createRiggerCharacter();
+    render(<AutosoftManagerDisplay character={character} />);
+
+    // Available section exists but collapsed by default
+    expect(screen.getByTestId("available-section")).toBeInTheDocument();
+    expect(screen.getByTestId("available-toggle")).toHaveTextContent("Owned (3)");
+
+    // No autosoft rows visible initially (collapsed)
+    expect(screen.queryAllByTestId("autosoft-row")).toHaveLength(0);
+
+    // Click to expand
+    fireEvent.click(screen.getByTestId("available-toggle"));
+
+    // Now autosoft rows are visible
+    const rows = screen.getAllByTestId("autosoft-row");
+    expect(rows).toHaveLength(3);
+  });
+
+  it("displays category badges with correct labels", () => {
+    mockGetOwnedAutosofts.mockReturnValue([
+      MOCK_AUTOSOFT_PERCEPTION,
+      MOCK_AUTOSOFT_COMBAT,
+      MOCK_AUTOSOFT_MOVEMENT,
+    ]);
+
+    const character = createRiggerCharacter();
+    render(<AutosoftManagerDisplay character={character} />);
+
+    // Expand to see badges
+    fireEvent.click(screen.getByTestId("available-toggle"));
+
+    const badges = screen.getAllByTestId("category-badge");
+    const badgeTexts = badges.map((b) => b.textContent);
+    expect(badgeTexts).toContain("Perception");
+    expect(badgeTexts).toContain("Combat");
+    expect(badgeTexts).toContain("Movement");
+  });
+
+  it("displays rating pills", () => {
+    mockGetOwnedAutosofts.mockReturnValue([MOCK_AUTOSOFT_PERCEPTION]);
+
+    const character = createRiggerCharacter();
+    render(<AutosoftManagerDisplay character={character} />);
+
+    // Expand available section
+    fireEvent.click(screen.getByTestId("available-toggle"));
+
+    const ratingPills = screen.getAllByTestId("rating-pill");
+    expect(ratingPills[0]).toHaveTextContent("R3");
+  });
+
+  it("shows target text for targeted autosofts", () => {
+    mockGetOwnedAutosofts.mockReturnValue([MOCK_AUTOSOFT_COMBAT]);
+
+    const character = createRiggerCharacter();
+    render(<AutosoftManagerDisplay character={character} />);
+
+    fireEvent.click(screen.getByTestId("available-toggle"));
+
+    expect(screen.getByText("(automatics)")).toBeInTheDocument();
+  });
+});

--- a/components/character/sheet/__tests__/DroneNetworkDisplay.test.tsx
+++ b/components/character/sheet/__tests__/DroneNetworkDisplay.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  setupDisplayCardMock,
+  LUCIDE_MOCK,
+  createRiggerCharacter,
+  createSheetCharacter,
+  MOCK_DRONE,
+  MOCK_DRONE_WITH_AUTOSOFTS,
+  MOCK_RCC,
+  MOCK_RCC_WITH_OPTIONS,
+} from "./test-helpers";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+const mockGetOwnedDrones = vi.fn();
+const mockGetActiveRCC = vi.fn();
+const mockCalculateMaxSlavedDrones = vi.fn();
+
+vi.mock("@/lib/rules/rigging", () => ({
+  getOwnedDrones: (...args: unknown[]) => mockGetOwnedDrones(...args),
+  getActiveRCC: (...args: unknown[]) => mockGetActiveRCC(...args),
+  calculateMaxSlavedDrones: (...args: unknown[]) => mockCalculateMaxSlavedDrones(...args),
+}));
+
+import { DroneNetworkDisplay } from "../DroneNetworkDisplay";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DroneNetworkDisplay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOwnedDrones.mockReturnValue([]);
+    mockGetActiveRCC.mockReturnValue(null);
+    mockCalculateMaxSlavedDrones.mockReturnValue(0);
+  });
+
+  it("returns null when no drones and no RCC", () => {
+    const character = createSheetCharacter();
+    const { container } = render(<DroneNetworkDisplay character={character} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders drone rows with name, size badge, and pilot rating", () => {
+    mockGetOwnedDrones.mockReturnValue([MOCK_DRONE, MOCK_DRONE_WITH_AUTOSOFTS]);
+    mockGetActiveRCC.mockReturnValue(null);
+
+    const character = createRiggerCharacter();
+    render(<DroneNetworkDisplay character={character} />);
+
+    const rows = screen.getAllByTestId("drone-row");
+    expect(rows).toHaveLength(2);
+
+    expect(screen.getByText("MCT Fly-Spy")).toBeInTheDocument();
+    expect(screen.getByText("Rex")).toBeInTheDocument(); // customName
+  });
+
+  it("shows expanded content with stats on click", () => {
+    mockGetOwnedDrones.mockReturnValue([MOCK_DRONE]);
+    mockGetActiveRCC.mockReturnValue(null);
+
+    const character = createRiggerCharacter();
+    render(<DroneNetworkDisplay character={character} />);
+
+    // Initially no expanded content
+    expect(screen.queryByTestId("expanded-content")).not.toBeInTheDocument();
+
+    // Click to expand
+    fireEvent.click(screen.getByTestId("drone-row"));
+    expect(screen.getByTestId("expanded-content")).toBeInTheDocument();
+    expect(screen.getByTestId("stat-body")).toHaveTextContent("Body");
+    expect(screen.getByTestId("stat-armor")).toHaveTextContent("Armor");
+  });
+
+  it("shows installed autosofts in expanded drone section", () => {
+    mockGetOwnedDrones.mockReturnValue([MOCK_DRONE_WITH_AUTOSOFTS]);
+    mockGetActiveRCC.mockReturnValue(null);
+
+    const character = createRiggerCharacter();
+    render(<DroneNetworkDisplay character={character} />);
+
+    // Expand the drone row
+    fireEvent.click(screen.getByTestId("drone-row"));
+
+    expect(screen.getByTestId("installed-autosofts")).toBeInTheDocument();
+    const rows = screen.getAllByTestId("autosoft-row");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("Clearsight")).toBeInTheDocument();
+    expect(screen.getByText("Targeting (Automatics)")).toBeInTheDocument();
+  });
+
+  it("renders network header with RCC and capacity", () => {
+    mockGetOwnedDrones.mockReturnValue([MOCK_DRONE]);
+    mockGetActiveRCC.mockReturnValue(MOCK_RCC);
+    mockCalculateMaxSlavedDrones.mockReturnValue(12);
+
+    const character = createRiggerCharacter();
+    render(<DroneNetworkDisplay character={character} />);
+
+    expect(screen.getByTestId("network-header")).toBeInTheDocument();
+    expect(screen.getByText("RCC-Standard")).toBeInTheDocument();
+    expect(screen.getByTestId("capacity-badge")).toHaveTextContent("0 / 12 Slaved");
+  });
+
+  it("renders shared autosofts section when RCC has running autosofts", () => {
+    mockGetOwnedDrones.mockReturnValue([]);
+    mockGetActiveRCC.mockReturnValue(MOCK_RCC_WITH_OPTIONS);
+    mockCalculateMaxSlavedDrones.mockReturnValue(18);
+
+    const character = createRiggerCharacter();
+    render(<DroneNetworkDisplay character={character} />);
+
+    expect(screen.getByTestId("shared-autosofts")).toBeInTheDocument();
+    expect(screen.getByText("Electronic Warfare")).toBeInTheDocument();
+    expect(screen.getByText("Stealth")).toBeInTheDocument();
+  });
+});

--- a/components/character/sheet/__tests__/JumpInControlDisplay.test.tsx
+++ b/components/character/sheet/__tests__/JumpInControlDisplay.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  setupDisplayCardMock,
+  LUCIDE_MOCK,
+  createRiggerCharacter,
+  createSheetCharacter,
+  MOCK_DRONE,
+  MOCK_VEHICLE,
+} from "./test-helpers";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+const mockHasVehicleControlRig = vi.fn();
+const mockGetVehicleControlRig = vi.fn();
+const mockCalculateJumpedInInitiative = vi.fn();
+const mockGetHotSimRiskDescription = vi.fn();
+const mockGetColdSimBenefitsDescription = vi.fn();
+const mockGetOwnedDrones = vi.fn();
+
+vi.mock("@/lib/rules/rigging", () => ({
+  hasVehicleControlRig: (...args: unknown[]) => mockHasVehicleControlRig(...args),
+  getVehicleControlRig: (...args: unknown[]) => mockGetVehicleControlRig(...args),
+  calculateJumpedInInitiative: (...args: unknown[]) => mockCalculateJumpedInInitiative(...args),
+  getHotSimRiskDescription: () => mockGetHotSimRiskDescription(),
+  getColdSimBenefitsDescription: () => mockGetColdSimBenefitsDescription(),
+  getOwnedDrones: (...args: unknown[]) => mockGetOwnedDrones(...args),
+}));
+
+import { JumpInControlDisplay } from "../JumpInControlDisplay";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("JumpInControlDisplay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOwnedDrones.mockReturnValue([]);
+    mockGetHotSimRiskDescription.mockReturnValue(
+      "Hot-sim provides additional initiative dice but biofeedback causes physical damage."
+    );
+    mockGetColdSimBenefitsDescription.mockReturnValue(
+      "Cold-sim provides safer operation with biofeedback causing only stun damage."
+    );
+    mockCalculateJumpedInInitiative.mockReturnValue({
+      initiative: 12,
+      initiativeDice: 3,
+      breakdown: { base: 10, reactionBonus: 5, intuitionBonus: 5, vcrBonus: 2, vrModeBonus: 1 },
+    });
+  });
+
+  it("returns null when character has no VCR", () => {
+    mockHasVehicleControlRig.mockReturnValue(false);
+    mockGetVehicleControlRig.mockReturnValue(null);
+
+    const character = createSheetCharacter();
+    const { container } = render(<JumpInControlDisplay character={character} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders VCR info with rating and control bonus", () => {
+    mockHasVehicleControlRig.mockReturnValue(true);
+    mockGetVehicleControlRig.mockReturnValue({
+      rating: 2,
+      controlBonus: 2,
+      initiativeDiceBonus: 2,
+      essenceCost: 1.0,
+    });
+
+    const character = createRiggerCharacter();
+    render(<JumpInControlDisplay character={character} />);
+
+    expect(screen.getByTestId("vcr-info")).toBeInTheDocument();
+    expect(screen.getByTestId("vcr-rating")).toHaveTextContent("Rating 2");
+    expect(screen.getByTestId("control-bonus")).toHaveTextContent("+2 to vehicle tests");
+  });
+
+  it("lists jumpable targets with type badges", () => {
+    mockHasVehicleControlRig.mockReturnValue(true);
+    mockGetVehicleControlRig.mockReturnValue({
+      rating: 2,
+      controlBonus: 2,
+      initiativeDiceBonus: 2,
+      essenceCost: 1.0,
+    });
+    mockGetOwnedDrones.mockReturnValue([MOCK_DRONE]);
+
+    const character = createRiggerCharacter({ vehicles: [MOCK_VEHICLE] });
+    render(<JumpInControlDisplay character={character} />);
+
+    expect(screen.getByTestId("jump-targets")).toBeInTheDocument();
+    const rows = screen.getAllByTestId("jump-target-row");
+    expect(rows).toHaveLength(2); // 1 vehicle + 1 drone
+
+    expect(screen.getByText("Dodge Scoot")).toBeInTheDocument();
+    expect(screen.getByText("MCT Fly-Spy")).toBeInTheDocument();
+    expect(screen.getByText("Vehicle")).toBeInTheDocument();
+    expect(screen.getByText("Drone")).toBeInTheDocument();
+  });
+
+  it("displays VR mode badges with descriptions", () => {
+    mockHasVehicleControlRig.mockReturnValue(true);
+    mockGetVehicleControlRig.mockReturnValue({
+      rating: 2,
+      controlBonus: 2,
+      initiativeDiceBonus: 2,
+      essenceCost: 1.0,
+    });
+
+    const character = createRiggerCharacter();
+    render(<JumpInControlDisplay character={character} />);
+
+    expect(screen.getByTestId("vr-modes")).toBeInTheDocument();
+    expect(screen.getByText("Cold-Sim")).toBeInTheDocument();
+    expect(screen.getByText("Hot-Sim")).toBeInTheDocument();
+  });
+
+  it("shows hot-sim warning text", () => {
+    mockHasVehicleControlRig.mockReturnValue(true);
+    mockGetVehicleControlRig.mockReturnValue({
+      rating: 2,
+      controlBonus: 2,
+      initiativeDiceBonus: 2,
+      essenceCost: 1.0,
+    });
+
+    const character = createRiggerCharacter();
+    render(<JumpInControlDisplay character={character} />);
+
+    expect(screen.getByTestId("hotsim-warning")).toHaveTextContent(
+      "biofeedback causes physical damage"
+    );
+  });
+
+  it("displays initiative preview for VR modes", () => {
+    mockHasVehicleControlRig.mockReturnValue(true);
+    mockGetVehicleControlRig.mockReturnValue({
+      rating: 2,
+      controlBonus: 2,
+      initiativeDiceBonus: 2,
+      essenceCost: 1.0,
+    });
+    mockCalculateJumpedInInitiative.mockReturnValue({
+      initiative: 12,
+      initiativeDice: 3,
+      breakdown: { base: 10, reactionBonus: 5, intuitionBonus: 5, vcrBonus: 2, vrModeBonus: 1 },
+    });
+
+    const character = createRiggerCharacter();
+    render(<JumpInControlDisplay character={character} />);
+
+    // Initiative values should be displayed
+    expect(screen.getAllByText(/Init 12\+3D6/)).toHaveLength(2); // cold-sim and hot-sim
+  });
+});

--- a/components/character/sheet/__tests__/RiggingSummaryDisplay.test.tsx
+++ b/components/character/sheet/__tests__/RiggingSummaryDisplay.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  setupDisplayCardMock,
+  LUCIDE_MOCK,
+  createRiggerCharacter,
+  createSheetCharacter,
+  MOCK_RCC,
+  MOCK_DRONE,
+  MOCK_VEHICLE,
+} from "./test-helpers";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+// Mock rigging functions
+const mockHasVehicleControlRig = vi.fn();
+const mockGetVehicleControlRig = vi.fn();
+const mockHasRCC = vi.fn();
+const mockGetActiveRCC = vi.fn();
+const mockCalculateMaxSlavedDrones = vi.fn();
+const mockCalculateNoiseReduction = vi.fn();
+const mockGetOwnedDrones = vi.fn();
+const mockGetOwnedAutosofts = vi.fn();
+const mockCanPerformRiggingActions = vi.fn();
+
+vi.mock("@/lib/rules/rigging", () => ({
+  hasVehicleControlRig: (...args: unknown[]) => mockHasVehicleControlRig(...args),
+  getVehicleControlRig: (...args: unknown[]) => mockGetVehicleControlRig(...args),
+  hasRCC: (...args: unknown[]) => mockHasRCC(...args),
+  getActiveRCC: (...args: unknown[]) => mockGetActiveRCC(...args),
+  calculateMaxSlavedDrones: (...args: unknown[]) => mockCalculateMaxSlavedDrones(...args),
+  calculateNoiseReduction: (...args: unknown[]) => mockCalculateNoiseReduction(...args),
+  getOwnedDrones: (...args: unknown[]) => mockGetOwnedDrones(...args),
+  getOwnedAutosofts: (...args: unknown[]) => mockGetOwnedAutosofts(...args),
+  canPerformRiggingActions: (...args: unknown[]) => mockCanPerformRiggingActions(...args),
+}));
+
+import { RiggingSummaryDisplay } from "../RiggingSummaryDisplay";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RiggingSummaryDisplay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOwnedDrones.mockReturnValue([]);
+    mockGetOwnedAutosofts.mockReturnValue([]);
+  });
+
+  it("returns null when character has no rigging gear", () => {
+    mockCanPerformRiggingActions.mockReturnValue(false);
+    mockHasVehicleControlRig.mockReturnValue(false);
+    mockGetVehicleControlRig.mockReturnValue(null);
+    mockHasRCC.mockReturnValue(false);
+    mockGetActiveRCC.mockReturnValue(null);
+
+    const character = createSheetCharacter();
+    const { container } = render(<RiggingSummaryDisplay character={character} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders VCR section with rating, control bonus, and initiative dice", () => {
+    mockCanPerformRiggingActions.mockReturnValue(true);
+    mockHasVehicleControlRig.mockReturnValue(true);
+    mockGetVehicleControlRig.mockReturnValue({
+      rating: 2,
+      controlBonus: 2,
+      initiativeDiceBonus: 2,
+      essenceCost: 1.0,
+    });
+    mockHasRCC.mockReturnValue(false);
+    mockGetActiveRCC.mockReturnValue(null);
+
+    const character = createRiggerCharacter();
+    render(<RiggingSummaryDisplay character={character} />);
+
+    expect(screen.getByTestId("vcr-section")).toBeInTheDocument();
+    expect(screen.getByTestId("vcr-rating")).toHaveTextContent("R2");
+    expect(screen.getByTestId("vcr-control-bonus")).toHaveTextContent("+2 Control");
+    expect(screen.getByTestId("vcr-init-dice")).toHaveTextContent("+2D6 Init");
+  });
+
+  it("renders RCC section with DR, DP, FW, and noise reduction", () => {
+    mockCanPerformRiggingActions.mockReturnValue(true);
+    mockHasVehicleControlRig.mockReturnValue(false);
+    mockGetVehicleControlRig.mockReturnValue(null);
+    mockHasRCC.mockReturnValue(true);
+    mockGetActiveRCC.mockReturnValue(MOCK_RCC);
+    mockCalculateMaxSlavedDrones.mockReturnValue(12);
+    mockCalculateNoiseReduction.mockReturnValue(5);
+
+    const character = createRiggerCharacter();
+    render(<RiggingSummaryDisplay character={character} />);
+
+    expect(screen.getByTestId("rcc-section")).toBeInTheDocument();
+    expect(screen.getByText("RCC-Standard")).toBeInTheDocument();
+    expect(screen.getByText("DR 5")).toBeInTheDocument();
+    expect(screen.getByTestId("rcc-dp")).toBeInTheDocument();
+    expect(screen.getByTestId("rcc-fw")).toBeInTheDocument();
+    expect(screen.getByTestId("rcc-noise-reduction")).toBeInTheDocument();
+  });
+
+  it("displays network capacity when RCC is present", () => {
+    mockCanPerformRiggingActions.mockReturnValue(true);
+    mockHasVehicleControlRig.mockReturnValue(false);
+    mockGetVehicleControlRig.mockReturnValue(null);
+    mockHasRCC.mockReturnValue(true);
+    mockGetActiveRCC.mockReturnValue(MOCK_RCC);
+    mockCalculateMaxSlavedDrones.mockReturnValue(12);
+    mockCalculateNoiseReduction.mockReturnValue(5);
+
+    const character = createRiggerCharacter();
+    render(<RiggingSummaryDisplay character={character} />);
+
+    expect(screen.getByTestId("network-capacity")).toBeInTheDocument();
+    expect(screen.getByText("0 / 12")).toBeInTheDocument();
+  });
+
+  it("displays equipment counts", () => {
+    mockCanPerformRiggingActions.mockReturnValue(true);
+    mockHasVehicleControlRig.mockReturnValue(false);
+    mockGetVehicleControlRig.mockReturnValue(null);
+    mockHasRCC.mockReturnValue(false);
+    mockGetActiveRCC.mockReturnValue(null);
+    mockGetOwnedDrones.mockReturnValue([MOCK_DRONE]);
+    mockGetOwnedAutosofts.mockReturnValue([{ name: "Clearsight", rating: 3 }]);
+
+    const character = createRiggerCharacter({ vehicles: [MOCK_VEHICLE] });
+    render(<RiggingSummaryDisplay character={character} />);
+
+    const counts = screen.getByTestId("equipment-counts");
+    expect(counts).toHaveTextContent("1 Vehicle");
+    expect(counts).toHaveTextContent("1 Drone");
+    expect(counts).toHaveTextContent("1 Autosoft");
+  });
+});

--- a/components/character/sheet/__tests__/VehicleActionsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/VehicleActionsDisplay.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  setupDisplayCardMock,
+  LUCIDE_MOCK,
+  createRiggerCharacter,
+  createSheetCharacter,
+  MOCK_VEHICLE,
+  MOCK_DRONE,
+} from "./test-helpers";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+vi.mock("@/lib/rules/rigging", () => ({
+  requiresJumpedIn: (actionType: string) =>
+    ["stunt", "ram", "evasive_driving"].includes(actionType),
+  canPerformRemotely: (actionType: string) =>
+    [
+      "accelerate",
+      "decelerate",
+      "turn",
+      "catch_up",
+      "cut_off",
+      "fire_weapon",
+      "sensor_targeting",
+    ].includes(actionType),
+  getActionTypeDescription: (actionType: string) => {
+    const map: Record<string, string> = {
+      accelerate: "Accelerate",
+      decelerate: "Decelerate",
+      turn: "Turn",
+      catch_up: "Catch Up / Overtake",
+      cut_off: "Cut Off",
+      evasive_driving: "Evasive Driving",
+      ram: "Ram",
+      fire_weapon: "Fire Vehicle Weapon",
+      sensor_targeting: "Sensor Targeting",
+      stunt: "Stunt",
+    };
+    return map[actionType] || actionType;
+  },
+  getTestTypeForAction: (actionType: string) => {
+    const map: Record<string, string> = {
+      accelerate: "control",
+      decelerate: "control",
+      turn: "control",
+      catch_up: "chase",
+      cut_off: "chase",
+      ram: "ramming",
+      stunt: "stunt",
+      fire_weapon: "gunnery",
+      sensor_targeting: "sensor",
+      evasive_driving: "control",
+    };
+    return map[actionType] || "control";
+  },
+  getSkillForAction: (actionType: string) => {
+    if (actionType === "fire_weapon") return "gunnery";
+    if (actionType === "sensor_targeting") return "perception";
+    return "pilot";
+  },
+}));
+
+import { VehicleActionsDisplay } from "../VehicleActionsDisplay";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("VehicleActionsDisplay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when no vehicles and no drones", () => {
+    const character = createSheetCharacter({ vehicles: undefined, drones: undefined });
+    const { container } = render(<VehicleActionsDisplay character={character} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders action categories in order", () => {
+    const character = createRiggerCharacter({ vehicles: [MOCK_VEHICLE] });
+    render(<VehicleActionsDisplay character={character} />);
+
+    expect(screen.getByText("Movement")).toBeInTheDocument();
+    expect(screen.getByText("Pursuit")).toBeInTheDocument();
+    expect(screen.getByText("Combat")).toBeInTheDocument();
+  });
+
+  it("renders action rows with names", () => {
+    const character = createRiggerCharacter({ vehicles: [MOCK_VEHICLE] });
+    render(<VehicleActionsDisplay character={character} />);
+
+    expect(screen.getByText("Accelerate")).toBeInTheDocument();
+    expect(screen.getByText("Turn")).toBeInTheDocument();
+    expect(screen.getByText("Fire Vehicle Weapon")).toBeInTheDocument();
+  });
+
+  it("shows Jumped-In badge for actions requiring it", () => {
+    const character = createRiggerCharacter({ vehicles: [MOCK_VEHICLE] });
+    render(<VehicleActionsDisplay character={character} />);
+
+    const jumpedInBadges = screen.getAllByTestId("jumped-in-badge");
+    expect(jumpedInBadges.length).toBeGreaterThan(0);
+  });
+
+  it("shows Remote badge for remote-capable actions", () => {
+    const character = createRiggerCharacter({ vehicles: [MOCK_VEHICLE] });
+    render(<VehicleActionsDisplay character={character} />);
+
+    const remoteBadges = screen.getAllByTestId("remote-badge");
+    expect(remoteBadges.length).toBeGreaterThan(0);
+  });
+
+  it("shows dice pool pills for actions with calculated pools", () => {
+    const character = createRiggerCharacter({ vehicles: [MOCK_VEHICLE] });
+    render(<VehicleActionsDisplay character={character} />);
+
+    const poolPills = screen.getAllByTestId("pool-pill");
+    expect(poolPills.length).toBeGreaterThan(0);
+  });
+
+  it("expands action row to show details on click", () => {
+    const character = createRiggerCharacter({ vehicles: [MOCK_VEHICLE] });
+    render(<VehicleActionsDisplay character={character} />);
+
+    // Click the first action row
+    const actionRows = screen.getAllByTestId("action-row");
+    fireEvent.click(actionRows[0]);
+
+    expect(screen.getByTestId("expanded-content")).toBeInTheDocument();
+  });
+
+  it("calls onSelect when pool pill is clicked", () => {
+    const onSelect = vi.fn();
+    const character = createRiggerCharacter({ vehicles: [MOCK_VEHICLE] });
+    render(<VehicleActionsDisplay character={character} onSelect={onSelect} />);
+
+    const poolPills = screen.getAllByTestId("pool-pill");
+    fireEvent.click(poolPills[0]);
+
+    expect(onSelect).toHaveBeenCalledWith(expect.any(Number), expect.any(String));
+  });
+
+  it("renders with drones only (no vehicles)", () => {
+    const character = createRiggerCharacter({ vehicles: undefined, drones: [MOCK_DRONE] });
+    render(<VehicleActionsDisplay character={character} />);
+
+    expect(screen.getByText("Movement")).toBeInTheDocument();
+  });
+});

--- a/components/character/sheet/__tests__/test-helpers.tsx
+++ b/components/character/sheet/__tests__/test-helpers.tsx
@@ -151,6 +151,12 @@ export const LUCIDE_MOCK = {
   Monitor: createIconMock("Monitor"),
   ArrowUpDown: createIconMock("ArrowUpDown"),
   Smartphone: createIconMock("Smartphone"),
+  // Rigging icons
+  Gamepad2: createIconMock("Gamepad2"),
+  Radio: createIconMock("Radio"),
+  PlugZap: createIconMock("PlugZap"),
+  Signal: createIconMock("Signal"),
+  Unplug: createIconMock("Unplug"),
 };
 
 // ---------------------------------------------------------------------------
@@ -894,6 +900,96 @@ export function createCommlinkCharacter(overrides?: Partial<Character>): Charact
     },
     commlinks: [MOCK_COMMLINK],
     activeMatrixDeviceId: "comm-1",
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mock autosoft data
+// ---------------------------------------------------------------------------
+export const MOCK_AUTOSOFT_PERCEPTION: import("@/lib/types").CharacterAutosoft = {
+  id: "soft-1",
+  catalogId: "clearsight",
+  name: "Clearsight",
+  category: "perception",
+  rating: 3,
+  cost: 2500,
+  availability: 4,
+};
+
+export const MOCK_AUTOSOFT_COMBAT: import("@/lib/types").CharacterAutosoft = {
+  id: "soft-2",
+  catalogId: "targeting-automatics",
+  name: "Targeting (Automatics)",
+  category: "combat",
+  rating: 3,
+  target: "automatics",
+  cost: 2500,
+  availability: 4,
+};
+
+export const MOCK_AUTOSOFT_MOVEMENT: import("@/lib/types").CharacterAutosoft = {
+  id: "soft-3",
+  catalogId: "maneuvering-ground",
+  name: "Maneuvering (Ground Craft)",
+  category: "movement",
+  rating: 3,
+  target: "ground",
+  cost: 2500,
+  availability: 4,
+};
+
+// ---------------------------------------------------------------------------
+// Rigger character factory
+// ---------------------------------------------------------------------------
+
+/** Character with VCR, RCC, drones, and autosofts — a full rigger */
+export function createRiggerCharacter(overrides?: Partial<Character>): Character {
+  return createMockCharacter({
+    name: "Chrome Wheelman",
+    metatype: "Human",
+    status: "active",
+    magicalPath: "mundane",
+    editionCode: "sr5",
+    attributes: {
+      body: 4,
+      agility: 4,
+      reaction: 5,
+      strength: 3,
+      willpower: 4,
+      logic: 5,
+      intuition: 5,
+      charisma: 2,
+    },
+    specialAttributes: {
+      edge: 3,
+      essence: 3.8,
+    },
+    skills: {
+      "pilot-ground-craft": 6,
+      "pilot-aircraft": 4,
+      gunnery: 5,
+      perception: 4,
+      "electronic-warfare": 3,
+      computer: 3,
+    },
+    cyberware: [
+      {
+        catalogId: "control-rig",
+        name: "Control Rig",
+        category: "headware" as const,
+        grade: "standard" as const,
+        baseEssenceCost: 1.0,
+        essenceCost: 1.0,
+        rating: 2,
+        cost: 97000,
+        availability: 12,
+      },
+    ],
+    rccs: [MOCK_RCC],
+    drones: [MOCK_DRONE, MOCK_DRONE_WITH_AUTOSOFTS],
+    vehicles: [MOCK_VEHICLE],
+    autosofts: [MOCK_AUTOSOFT_PERCEPTION, MOCK_AUTOSOFT_COMBAT, MOCK_AUTOSOFT_MOVEMENT],
     ...overrides,
   });
 }

--- a/components/character/sheet/index.ts
+++ b/components/character/sheet/index.ts
@@ -29,3 +29,10 @@ export { MatrixSummaryDisplay } from "./MatrixSummaryDisplay";
 export { ProgramManagerDisplay } from "./ProgramManagerDisplay";
 export { WeaponsDisplay } from "./WeaponsDisplay";
 export { WirelessDisplay } from "./WirelessDisplay";
+
+// Rigging components
+export { RiggingSummaryDisplay } from "./RiggingSummaryDisplay";
+export { DroneNetworkDisplay } from "./DroneNetworkDisplay";
+export { JumpInControlDisplay } from "./JumpInControlDisplay";
+export { VehicleActionsDisplay } from "./VehicleActionsDisplay";
+export { AutosoftManagerDisplay } from "./AutosoftManagerDisplay";

--- a/components/character/sheet/rigging-helpers.ts
+++ b/components/character/sheet/rigging-helpers.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared utilities for rigging display components.
+ *
+ * Provides guard function, common props interface, and badge style constants
+ * used across all rigging display components.
+ */
+
+import type { Character } from "@/lib/types";
+import { canPerformRiggingActions } from "@/lib/rules/rigging";
+
+/**
+ * Check if a character has rigging-related capabilities.
+ * Mirrors `hasMatrixAccess` pattern for conditional rendering.
+ */
+export const hasRiggingAccess = (character: Character): boolean =>
+  canPerformRiggingActions(character);
+
+/** Standard props interface for rigging display components */
+export interface RiggingDisplayProps {
+  character: Character;
+  onCharacterUpdate?: (updated: Character) => void;
+  editable?: boolean;
+  onSelect?: (pool: number, label: string) => void;
+}
+
+/** Control mode badge styles */
+export const CONTROL_MODE_BADGE: Record<string, { label: string; style: string }> = {
+  manual: {
+    label: "Manual",
+    style: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400",
+  },
+  remote: {
+    label: "Remote",
+    style: "bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-400",
+  },
+  "jumped-in": {
+    label: "Jumped-In",
+    style: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400",
+  },
+};
+
+/** VR mode badge styles */
+export const VR_MODE_BADGE: Record<string, { label: string; style: string }> = {
+  "cold-sim": {
+    label: "Cold-Sim",
+    style: "bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-400",
+  },
+  "hot-sim": {
+    label: "Hot-Sim",
+    style: "bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-400",
+  },
+};
+
+/** Drone command type badge styles */
+export const COMMAND_TYPE_BADGE: Record<string, { label: string; style: string }> = {
+  watch: {
+    label: "Watch",
+    style: "bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-400",
+  },
+  defend: {
+    label: "Defend",
+    style: "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-400",
+  },
+  attack: {
+    label: "Attack",
+    style: "bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-400",
+  },
+  pursue: {
+    label: "Pursue",
+    style: "bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-400",
+  },
+  return: {
+    label: "Return",
+    style: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400",
+  },
+  hold: {
+    label: "Hold",
+    style: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400",
+  },
+  custom: {
+    label: "Custom",
+    style: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400",
+  },
+};
+
+/** Autosoft category badge styles */
+export const AUTOSOFT_CATEGORY_BADGE: Record<string, { label: string; style: string }> = {
+  perception: {
+    label: "Perception",
+    style:
+      "bg-blue-100 text-blue-700 border-blue-300/40 dark:bg-blue-500/15 dark:text-blue-400 dark:border-blue-500/20",
+  },
+  defense: {
+    label: "Defense",
+    style:
+      "bg-amber-100 text-amber-700 border-amber-300/40 dark:bg-amber-500/15 dark:text-amber-400 dark:border-amber-500/20",
+  },
+  movement: {
+    label: "Movement",
+    style:
+      "bg-emerald-100 text-emerald-700 border-emerald-300/40 dark:bg-emerald-500/15 dark:text-emerald-400 dark:border-emerald-500/20",
+  },
+  combat: {
+    label: "Combat",
+    style:
+      "bg-red-100 text-red-700 border-red-300/40 dark:bg-red-500/15 dark:text-red-400 dark:border-red-500/20",
+  },
+  "electronic-warfare": {
+    label: "EW",
+    style:
+      "bg-violet-100 text-violet-700 border-violet-300/40 dark:bg-violet-500/15 dark:text-violet-400 dark:border-violet-500/20",
+  },
+  stealth: {
+    label: "Stealth",
+    style:
+      "bg-zinc-100 text-zinc-600 border-zinc-300/40 dark:bg-zinc-800 dark:text-zinc-400 dark:border-zinc-700",
+  },
+};


### PR DESCRIPTION
## Summary

- Add 5 new display-mode rigging UI components that expose the rigging rule engine through the character sheet
- **RiggingSummaryDisplay**: VCR rating/bonuses, RCC stats (DR/DP/FW/NR), network capacity, equipment counts
- **DroneNetworkDisplay**: Expandable drone list with stats, installed autosofts, RCC shared autosofts, capacity badge
- **JumpInControlDisplay**: VCR info, jumpable targets (vehicles + drones), VR mode preview (cold/hot-sim), initiative calculation, hot-sim warning
- **VehicleActionsDisplay**: Categorized vehicle/drone actions (Movement/Pursuit/Combat) with dice pool pills, requirement badges, expandable details
- **AutosoftManagerDisplay**: RCC running autosofts, per-drone installed autosofts, collapsible owned inventory with category badges and rating pills
- Add shared `rigging-helpers.ts` with `hasRiggingAccess` guard and badge constants
- Integrate all 5 components into character sheet page gated by `hasRiggingAccess(character)`
- Add rigger test factories and mock data to shared test helpers
- 33 new tests across 5 test files

## Test plan

- [x] `pnpm type-check` passes (0 errors)
- [x] `pnpm test` passes (339 files, 7572 tests)
- [x] `pnpm lint` passes
- [x] Pre-commit hooks pass (lint-staged, type-check, test coverage)
- [ ] Manual: Load demo-rigger character — all 5 rigging sections render
- [ ] Manual: Load non-rigger character — no rigging sections appear
- [ ] Manual: Verify expandable drone rows and action rows work

🤖 Generated with [Claude Code](https://claude.com/claude-code)