### PR TITLE
feat(sheet): Add Matrix Marks management UI (#414)

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -37,6 +37,7 @@ import {
   KnowledgeLanguagesDisplay,
   MatrixActionsDisplay,
   MatrixDevicesDisplay,
+  MatrixMarksDisplay,
   MatrixSummaryDisplay,
   ProgramManagerDisplay,
   QualitiesDisplay,
@@ -427,6 +428,7 @@ function CharacterSheet({
                   onSelect={(pool, label) => openDiceRoller(pool, label)}
                   editable={character.status === "active"}
                 />
+                <MatrixMarksDisplay character={character} />
               </>
             )}
 

--- a/components/character/sheet/MatrixActionsDisplay.tsx
+++ b/components/character/sheet/MatrixActionsDisplay.tsx
@@ -6,6 +6,7 @@ import type { ActionDefinition } from "@/lib/types/action-definitions";
 import { DisplayCard } from "./DisplayCard";
 import { Zap, ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
 import { useMatrixActions } from "@/lib/rules/RulesetContext";
+import { useMatrixMarks } from "@/lib/matrix";
 
 interface MatrixActionsDisplayProps {
   character: Character;
@@ -78,10 +79,12 @@ function ActionRow({
   action,
   character,
   onSelect,
+  hasMarksOnAnyTarget,
 }: {
   action: ActionDefinition;
   character: Character;
   onSelect?: (pool: number, label: string) => void;
+  hasMarksOnAnyTarget: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const illegal = isActionIllegal(action);
@@ -116,7 +119,18 @@ function ActionRow({
 
         {/* Marks required */}
         {marks > 0 && (
-          <span className="rounded border border-amber-300/40 bg-amber-50 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-amber-700 dark:border-amber-500/20 dark:bg-amber-500/10 dark:text-amber-400">
+          <span
+            className={`rounded border px-1.5 py-0.5 font-mono text-[10px] font-semibold ${
+              hasMarksOnAnyTarget
+                ? "border-amber-300/40 bg-amber-50 text-amber-700 dark:border-amber-500/20 dark:bg-amber-500/10 dark:text-amber-400"
+                : "border-red-300/40 bg-red-50 text-red-600 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-400"
+            }`}
+            title={
+              hasMarksOnAnyTarget
+                ? `Requires ${marks} mark(s)`
+                : `No marks held — requires ${marks}`
+            }
+          >
             {marks}M
           </span>
         )}
@@ -161,6 +175,14 @@ function ActionRow({
             <span className="capitalize">{action.type}</span> Action
           </div>
 
+          {/* Mark warning */}
+          {marks > 0 && !hasMarksOnAnyTarget && (
+            <div className="flex items-center gap-1 text-xs text-red-500 dark:text-red-400">
+              <AlertTriangle className="h-3 w-3" />
+              <span>Requires {marks} mark(s) on target before use</span>
+            </div>
+          )}
+
           {/* OS risk indicator */}
           {illegal && (
             <div className="flex items-center gap-1 text-xs text-red-500 dark:text-red-400">
@@ -183,6 +205,7 @@ function ActionRow({
 
 export function MatrixActionsDisplay({ character, onSelect }: MatrixActionsDisplayProps) {
   const matrixActions = useMatrixActions();
+  const { marksHeld } = useMatrixMarks();
 
   // Group actions by subcategory first, then by domain category
   const categorizedActions = useMemo(() => {
@@ -234,6 +257,7 @@ export function MatrixActionsDisplay({ character, onSelect }: MatrixActionsDispl
                   action={action}
                   character={character}
                   onSelect={onSelect}
+                  hasMarksOnAnyTarget={marksHeld.length > 0}
                 />
               ))}
             </div>

--- a/components/character/sheet/MatrixDevicesDisplay.tsx
+++ b/components/character/sheet/MatrixDevicesDisplay.tsx
@@ -182,10 +182,9 @@ export function MatrixDevicesDisplay({
                 {isActive && (
                   <Star className="h-3.5 w-3.5 shrink-0 fill-amber-400 text-amber-400" />
                 )}
-                <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+                <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
                   {deck.customName ?? deck.name}
                 </span>
-                <span className="ml-auto" />
                 <span
                   className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${DEVICE_TYPE_BADGE.cyberdeck.style}`}
                 >
@@ -256,10 +255,9 @@ export function MatrixDevicesDisplay({
                 {isActive && (
                   <Star className="h-3.5 w-3.5 shrink-0 fill-amber-400 text-amber-400" />
                 )}
-                <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+                <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
                   {fullComm.customName ?? comm.name}
                 </span>
-                <span className="ml-auto" />
                 <span
                   className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${DEVICE_TYPE_BADGE.commlink.style}`}
                 >

--- a/components/character/sheet/MatrixMarksDisplay.tsx
+++ b/components/character/sheet/MatrixMarksDisplay.tsx
@@ -1,0 +1,535 @@
+"use client";
+
+import { useState } from "react";
+import type { Character } from "@/lib/types";
+import type { MarkTargetType, MatrixMark } from "@/lib/types/matrix";
+import { useMatrixMarks, useMatrixSession } from "@/lib/matrix";
+import { getAuthorizationLevel } from "@/lib/rules/matrix/mark-tracker";
+import { Crosshair, ChevronDown, ChevronRight, Plus, Minus, Trash2 } from "lucide-react";
+import { DisplayCard } from "./DisplayCard";
+
+interface MatrixMarksDisplayProps {
+  character: Character;
+}
+
+const AUTH_LEVEL_COLORS: Record<string, string> = {
+  Outsider: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400",
+  User: "bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-400",
+  Security: "bg-orange-50 text-orange-700 dark:bg-orange-500/10 dark:text-orange-400",
+  Admin: "bg-red-50 text-red-700 dark:bg-red-500/10 dark:text-red-400",
+};
+
+const TARGET_TYPE_COLORS: Record<MarkTargetType, { label: string; style: string }> = {
+  device: {
+    label: "Device",
+    style: "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400",
+  },
+  persona: {
+    label: "Persona",
+    style: "bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-400",
+  },
+  file: {
+    label: "File",
+    style: "bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-400",
+  },
+  host: {
+    label: "Host",
+    style: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400",
+  },
+  ic: {
+    label: "IC",
+    style: "bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-400",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// MarkRow — expandable row for a mark held on a target
+// ---------------------------------------------------------------------------
+
+function MarkRow({
+  mark,
+  onAddOne,
+  onRemoveOne,
+  onRemoveAll,
+}: {
+  mark: MatrixMark;
+  onAddOne: () => void;
+  onRemoveOne: () => void;
+  onRemoveAll: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const authLevel = getAuthorizationLevel(mark.markCount);
+  const typeInfo = TARGET_TYPE_COLORS[mark.targetType];
+  const authStyle = AUTH_LEVEL_COLORS[authLevel] ?? AUTH_LEVEL_COLORS.Outsider;
+
+  return (
+    <div className="[&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50">
+      <div
+        className="flex items-center gap-2 px-3 py-1.5 cursor-pointer transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3 shrink-0 text-zinc-400" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0 text-zinc-400" />
+        )}
+
+        <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+          {mark.targetName}
+        </span>
+
+        {/* Target type badge */}
+        <span
+          className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${typeInfo.style}`}
+        >
+          {typeInfo.label}
+        </span>
+
+        {/* Auth level badge */}
+        <span
+          className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${authStyle}`}
+        >
+          {authLevel}
+        </span>
+
+        <div className="flex-1" />
+
+        {/* Mark count stepper */}
+        <div className="flex shrink-0 items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
+          <button
+            onClick={onRemoveOne}
+            className="rounded p-0.5 text-zinc-500 transition-colors hover:bg-zinc-300/50 dark:text-zinc-400 dark:hover:bg-zinc-600/50"
+            title="Remove 1 mark"
+          >
+            <Minus className="h-3 w-3" />
+          </button>
+          <span className="min-w-[28px] rounded bg-zinc-200 px-1.5 py-0.5 text-center font-mono text-[10px] font-semibold text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300">
+            {mark.markCount}/3
+          </span>
+          <button
+            onClick={onAddOne}
+            disabled={mark.markCount >= 3}
+            className="rounded p-0.5 text-zinc-500 transition-colors hover:bg-zinc-300/50 disabled:opacity-30 disabled:hover:bg-transparent dark:text-zinc-400 dark:hover:bg-zinc-600/50"
+            title="Add 1 mark"
+          >
+            <Plus className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="ml-5 space-y-1.5 border-l-2 border-zinc-200 px-3 pb-2 dark:border-zinc-700">
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            <span className="font-semibold">Placed:</span>{" "}
+            {new Date(mark.placedAt).toLocaleString()}
+          </p>
+
+          {mark.expiresAt && (
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              <span className="font-semibold">Expires:</span>{" "}
+              {new Date(mark.expiresAt).toLocaleString()}
+            </p>
+          )}
+
+          {mark.markCount > 1 && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemoveAll();
+              }}
+              className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-red-500 transition-colors hover:bg-red-500/10"
+            >
+              <Trash2 className="h-3 w-3" />
+              Remove All
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ReceivedMarkRow — non-expandable row for marks received on self
+// ---------------------------------------------------------------------------
+
+function ReceivedMarkRow({
+  mark,
+  onAddOne,
+  onRemoveAll,
+}: {
+  mark: MatrixMark;
+  onAddOne: () => void;
+  onRemoveAll: () => void;
+}) {
+  const authLevel = getAuthorizationLevel(mark.markCount);
+  const typeInfo = TARGET_TYPE_COLORS[mark.targetType];
+  const authStyle = AUTH_LEVEL_COLORS[authLevel] ?? AUTH_LEVEL_COLORS.Outsider;
+
+  return (
+    <div className="[&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50">
+      <div className="flex items-center gap-2 px-3 py-1.5">
+        <span className="text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
+          {mark.targetName}
+        </span>
+
+        {/* Source type badge */}
+        <span
+          className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${typeInfo.style}`}
+        >
+          {typeInfo.label}
+        </span>
+
+        {/* Auth level badge */}
+        <span
+          className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${authStyle}`}
+        >
+          {authLevel}
+        </span>
+
+        <div className="flex-1" />
+
+        {/* Mark count stepper */}
+        <div className="flex shrink-0 items-center gap-0.5">
+          <button
+            onClick={onRemoveAll}
+            className="rounded p-0.5 text-zinc-500 transition-colors hover:bg-zinc-300/50 dark:text-zinc-400 dark:hover:bg-zinc-600/50"
+            title="Remove received marks"
+          >
+            <Minus className="h-3 w-3" />
+          </button>
+          <span className="min-w-[28px] rounded bg-zinc-200 px-1.5 py-0.5 text-center font-mono text-[10px] font-semibold text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300">
+            {mark.markCount}/3
+          </span>
+          <button
+            onClick={onAddOne}
+            disabled={mark.markCount >= 3}
+            className="rounded p-0.5 text-zinc-500 transition-colors hover:bg-zinc-300/50 disabled:opacity-30 disabled:hover:bg-transparent dark:text-zinc-400 dark:hover:bg-zinc-600/50"
+            title="Add 1 received mark"
+          >
+            <Plus className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PlaceMarkForm — inline form to place marks on a target
+// ---------------------------------------------------------------------------
+
+function PlaceMarkForm({
+  onSubmit,
+  onCancel,
+}: {
+  onSubmit: (
+    targetId: string,
+    targetType: MarkTargetType,
+    targetName: string,
+    count: number
+  ) => void;
+  onCancel: () => void;
+}) {
+  const [targetName, setTargetName] = useState("");
+  const [targetType, setTargetType] = useState<MarkTargetType>("device");
+  const [markCount, setMarkCount] = useState(1);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = targetName.trim();
+    if (!trimmed) return;
+    const targetId = trimmed.toLowerCase().replace(/\s+/g, "-");
+    onSubmit(targetId, targetType, trimmed, markCount);
+    setTargetName("");
+    setTargetType("device");
+    setMarkCount(1);
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      <input
+        type="text"
+        placeholder="Target name"
+        value={targetName}
+        onChange={(e) => setTargetName(e.target.value)}
+        className="w-full rounded border border-zinc-300 bg-white px-2 py-1 text-xs text-zinc-800 placeholder:text-zinc-400 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:placeholder:text-zinc-500"
+        autoFocus
+      />
+      <div className="flex items-center gap-2">
+        <select
+          value={targetType}
+          onChange={(e) => setTargetType(e.target.value as MarkTargetType)}
+          className="min-w-0 flex-1 rounded border border-zinc-300 bg-white px-2 py-1 text-xs text-zinc-800 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200"
+        >
+          <option value="device">Device</option>
+          <option value="persona">Persona</option>
+          <option value="file">File</option>
+          <option value="host">Host</option>
+          <option value="ic">IC</option>
+        </select>
+        <input
+          type="number"
+          min={1}
+          max={3}
+          value={markCount}
+          onChange={(e) => setMarkCount(Math.min(3, Math.max(1, Number(e.target.value))))}
+          className="w-12 shrink-0 rounded border border-zinc-300 bg-white px-2 py-1 text-xs text-zinc-800 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200"
+          title="Mark count"
+        />
+        <button
+          type="button"
+          onClick={onCancel}
+          className="shrink-0 rounded px-2 py-1 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-200 dark:hover:bg-zinc-800"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={!targetName.trim()}
+          className="shrink-0 rounded bg-emerald-600 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+        >
+          Place Mark
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ReceiveMarkForm — inline form to record marks placed on self
+// ---------------------------------------------------------------------------
+
+function ReceiveMarkForm({
+  onSubmit,
+  onCancel,
+}: {
+  onSubmit: (mark: MatrixMark) => void;
+  onCancel: () => void;
+}) {
+  const [sourceName, setSourceName] = useState("");
+  const [sourceType, setSourceType] = useState<MarkTargetType>("persona");
+  const [markCount, setMarkCount] = useState(1);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = sourceName.trim();
+    if (!trimmed) return;
+    const mark: MatrixMark = {
+      id: `mark-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      targetId: trimmed.toLowerCase().replace(/\s+/g, "-"),
+      targetType: sourceType,
+      targetName: trimmed,
+      markCount,
+      placedAt: new Date().toISOString(),
+    };
+    onSubmit(mark);
+    setSourceName("");
+    setSourceType("persona");
+    setMarkCount(1);
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-2 rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-950"
+    >
+      <input
+        type="text"
+        placeholder="Source name"
+        value={sourceName}
+        onChange={(e) => setSourceName(e.target.value)}
+        className="w-full rounded border border-zinc-300 bg-white px-2 py-1 text-xs text-zinc-800 placeholder:text-zinc-400 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:placeholder:text-zinc-500"
+        autoFocus
+      />
+      <div className="flex items-center gap-2">
+        <select
+          value={sourceType}
+          onChange={(e) => setSourceType(e.target.value as MarkTargetType)}
+          className="min-w-0 flex-1 rounded border border-zinc-300 bg-white px-2 py-1 text-xs text-zinc-800 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200"
+        >
+          <option value="device">Device</option>
+          <option value="persona">Persona</option>
+          <option value="file">File</option>
+          <option value="host">Host</option>
+          <option value="ic">IC</option>
+        </select>
+        <input
+          type="number"
+          min={1}
+          max={3}
+          value={markCount}
+          onChange={(e) => setMarkCount(Math.min(3, Math.max(1, Number(e.target.value))))}
+          className="w-12 shrink-0 rounded border border-zinc-300 bg-white px-2 py-1 text-xs text-zinc-800 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200"
+          title="Mark count"
+        />
+        <button
+          type="button"
+          onClick={onCancel}
+          className="shrink-0 rounded px-2 py-1 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-200 dark:hover:bg-zinc-800"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={!sourceName.trim()}
+          className="shrink-0 rounded bg-emerald-600 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+        >
+          Add Received
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MatrixMarksDisplay — main component
+// ---------------------------------------------------------------------------
+
+export function MatrixMarksDisplay({}: MatrixMarksDisplayProps) {
+  const { marksHeld, marksReceived } = useMatrixMarks();
+  const {
+    placeMark,
+    removeMark,
+    clearAllMarks,
+    receiveMarkOnSelf,
+    removeReceivedMark,
+    hasMatrixHardware,
+  } = useMatrixSession();
+
+  const [showPlaceForm, setShowPlaceForm] = useState(false);
+  const [showReceiveForm, setShowReceiveForm] = useState(false);
+
+  if (!hasMatrixHardware) return null;
+
+  const hasAnyMarks = marksHeld.length > 0 || marksReceived.length > 0;
+
+  return (
+    <DisplayCard
+      id="sheet-matrix-marks"
+      title="Matrix Marks"
+      icon={<Crosshair className="h-4 w-4 text-emerald-400" />}
+      collapsible
+      defaultCollapsed
+      headerAction={
+        hasAnyMarks ? (
+          <button
+            onClick={clearAllMarks}
+            className="rounded px-2 py-0.5 text-[10px] font-medium text-red-500 transition-colors hover:bg-red-500/10"
+          >
+            Clear All
+          </button>
+        ) : undefined
+      }
+    >
+      <div className="space-y-3">
+        {/* Marks Held section */}
+        <div>
+          <div className="mb-1 flex items-center gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Marks Held
+            </span>
+            {marksHeld.length > 0 && (
+              <span className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300">
+                {marksHeld.length}
+              </span>
+            )}
+          </div>
+
+          {marksHeld.length > 0 ? (
+            <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+              {marksHeld.map((mark) => (
+                <MarkRow
+                  key={mark.targetId}
+                  mark={mark}
+                  onAddOne={() => placeMark(mark.targetId, mark.targetType, mark.targetName, 1)}
+                  onRemoveOne={() => removeMark(mark.targetId, 1)}
+                  onRemoveAll={() => removeMark(mark.targetId)}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs italic text-zinc-400 dark:text-zinc-500">No marks placed</p>
+          )}
+
+          {showPlaceForm ? (
+            <div className="mt-2">
+              <PlaceMarkForm
+                onSubmit={(targetId, targetType, targetName, count) => {
+                  placeMark(targetId, targetType, targetName, count);
+                  setShowPlaceForm(false);
+                }}
+                onCancel={() => setShowPlaceForm(false)}
+              />
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowPlaceForm(true)}
+              className="mt-2 flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-emerald-600 transition-colors hover:bg-emerald-500/10 dark:text-emerald-400"
+            >
+              <Plus className="h-3 w-3" />
+              Place Mark
+            </button>
+          )}
+        </div>
+
+        {/* Marks On You section */}
+        <div>
+          <div className="mb-1 flex items-center gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Marks On You
+            </span>
+            {marksReceived.length > 0 && (
+              <span className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-700 dark:bg-zinc-700 dark:text-zinc-300">
+                {marksReceived.length}
+              </span>
+            )}
+          </div>
+
+          {marksReceived.length > 0 ? (
+            <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
+              {marksReceived.map((mark) => (
+                <ReceivedMarkRow
+                  key={mark.id}
+                  mark={mark}
+                  onAddOne={() =>
+                    receiveMarkOnSelf({
+                      ...mark,
+                      markCount: 1,
+                    })
+                  }
+                  onRemoveAll={() => removeReceivedMark(mark.targetId)}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs italic text-zinc-400 dark:text-zinc-500">No marks received</p>
+          )}
+
+          {showReceiveForm ? (
+            <div className="mt-2">
+              <ReceiveMarkForm
+                onSubmit={(mark) => {
+                  receiveMarkOnSelf(mark);
+                  setShowReceiveForm(false);
+                }}
+                onCancel={() => setShowReceiveForm(false)}
+              />
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowReceiveForm(true)}
+              className="mt-2 flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-emerald-600 transition-colors hover:bg-emerald-500/10 dark:text-emerald-400"
+            >
+              <Plus className="h-3 w-3" />
+              Add Received
+            </button>
+          )}
+        </div>
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/__tests__/MatrixActionsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/MatrixActionsDisplay.test.tsx
@@ -93,10 +93,16 @@ vi.mock("@/lib/rules/RulesetContext", () => ({
   useMatrixActions: vi.fn(),
 }));
 
+vi.mock("@/lib/matrix", () => ({
+  useMatrixMarks: vi.fn(),
+}));
+
 import { MatrixActionsDisplay } from "../MatrixActionsDisplay";
 import { useMatrixActions } from "@/lib/rules/RulesetContext";
+import { useMatrixMarks } from "@/lib/matrix";
 
 const mockUseMatrixActions = vi.mocked(useMatrixActions);
+const mockUseMatrixMarks = vi.mocked(useMatrixMarks);
 
 const deckerCharacter = createDeckerCharacter();
 
@@ -104,6 +110,12 @@ describe("MatrixActionsDisplay", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseMatrixActions.mockReturnValue(MOCK_MATRIX_ACTIONS);
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [],
+      marksReceived: [],
+      getMarksOnTarget: () => 0,
+      hasRequiredMarks: () => false,
+    });
   });
 
   it("groups actions by category with section headers", () => {
@@ -168,5 +180,40 @@ describe("MatrixActionsDisplay", () => {
     render(<MatrixActionsDisplay character={deckerCharacter} />);
     fireEvent.click(screen.getByText("Hack on the Fly"));
     expect(screen.getByText("SR5 Core p.240")).toBeInTheDocument();
+  });
+
+  it("mark badge is red when no marks held", () => {
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    // Edit File requires 1 mark — badge should have red styling
+    const badge = screen.getByText("1M");
+    expect(badge.className).toContain("text-red-600");
+  });
+
+  it("mark badge is amber when marks exist", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [
+        {
+          id: "m1",
+          targetId: "target-1",
+          targetType: "host",
+          targetName: "Test Host",
+          markCount: 1,
+          placedAt: "2025-01-01T00:00:00.000Z",
+        },
+      ],
+      marksReceived: [],
+      getMarksOnTarget: () => 1,
+      hasRequiredMarks: () => true,
+    });
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    const badge = screen.getByText("1M");
+    expect(badge.className).toContain("text-amber-700");
+  });
+
+  it("shows mark warning text in expanded row when no marks", () => {
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    // Expand Edit File which requires 1 mark
+    fireEvent.click(screen.getByText("Edit File"));
+    expect(screen.getByText("Requires 1 mark(s) on target before use")).toBeInTheDocument();
   });
 });

--- a/components/character/sheet/__tests__/MatrixMarksDisplay.test.tsx
+++ b/components/character/sheet/__tests__/MatrixMarksDisplay.test.tsx
@@ -1,0 +1,280 @@
+/**
+ * MatrixMarksDisplay Component Tests
+ *
+ * Tests the mark management card showing marks held on targets,
+ * marks received on self, and forms to place/receive marks.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { setupDisplayCardMock, LUCIDE_MOCK, createDeckerCharacter } from "./test-helpers";
+import type { MarkTargetType, MatrixMark } from "@/lib/types/matrix";
+
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+vi.mock("@/lib/matrix", () => ({
+  useMatrixMarks: vi.fn(),
+  useMatrixSession: vi.fn(),
+}));
+
+vi.mock("@/lib/rules/matrix/mark-tracker", () => ({
+  getAuthorizationLevel: vi.fn(),
+}));
+
+import { MatrixMarksDisplay } from "../MatrixMarksDisplay";
+import { useMatrixMarks, useMatrixSession } from "@/lib/matrix";
+import { getAuthorizationLevel } from "@/lib/rules/matrix/mark-tracker";
+
+const mockUseMatrixMarks = vi.mocked(useMatrixMarks);
+const mockUseMatrixSession = vi.mocked(useMatrixSession);
+const mockGetAuthorizationLevel = vi.mocked(getAuthorizationLevel);
+
+const deckerCharacter = createDeckerCharacter();
+
+function createMockMark(overrides: Partial<MatrixMark> = {}): MatrixMark {
+  return {
+    id: "mark-1",
+    targetId: "corp-server",
+    targetType: "host" as MarkTargetType,
+    targetName: "Corp Server",
+    markCount: 1,
+    placedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const mockPlaceMark = vi.fn(() => ({
+  success: true,
+  mark: null,
+  errors: [],
+  newMarkCount: 1,
+}));
+const mockRemoveMark = vi.fn(() => ({
+  success: true,
+  marksRemoved: 1,
+  remainingMarks: 0,
+}));
+const mockClearAllMarks = vi.fn();
+const mockReceiveMarkOnSelf = vi.fn();
+const mockRemoveReceivedMark = vi.fn();
+
+describe("MatrixMarksDisplay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [],
+      marksReceived: [],
+      getMarksOnTarget: () => 0,
+      hasRequiredMarks: () => false,
+    });
+    mockUseMatrixSession.mockReturnValue({
+      placeMark: mockPlaceMark,
+      removeMark: mockRemoveMark,
+      clearAllMarks: mockClearAllMarks,
+      receiveMarkOnSelf: mockReceiveMarkOnSelf,
+      removeReceivedMark: mockRemoveReceivedMark,
+      hasMatrixHardware: true,
+    } as unknown as ReturnType<typeof useMatrixSession>);
+    mockGetAuthorizationLevel.mockImplementation(
+      (n: number) => ["Outsider", "User", "Security", "Admin"][n] ?? "Outsider"
+    );
+  });
+
+  it("renders Matrix Marks card", () => {
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    expect(screen.getByText("Matrix Marks")).toBeInTheDocument();
+  });
+
+  it("returns null when no matrix hardware", () => {
+    mockUseMatrixSession.mockReturnValue({
+      placeMark: mockPlaceMark,
+      removeMark: mockRemoveMark,
+      clearAllMarks: mockClearAllMarks,
+      receiveMarkOnSelf: mockReceiveMarkOnSelf,
+      removeReceivedMark: mockRemoveReceivedMark,
+      hasMatrixHardware: false,
+    } as unknown as ReturnType<typeof useMatrixSession>);
+    const { container } = render(<MatrixMarksDisplay character={deckerCharacter} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows empty state when no marks held", () => {
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    expect(screen.getByText("No marks placed")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no marks received", () => {
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    expect(screen.getByText("No marks received")).toBeInTheDocument();
+  });
+
+  it("shows marks held with target name and auth level", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [createMockMark()],
+      marksReceived: [],
+      getMarksOnTarget: () => 1,
+      hasRequiredMarks: () => true,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    expect(screen.getByText("Corp Server")).toBeInTheDocument();
+    expect(screen.getByText("User")).toBeInTheDocument();
+  });
+
+  it("shows mark count pill (N/3)", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [createMockMark({ markCount: 2 })],
+      marksReceived: [],
+      getMarksOnTarget: () => 2,
+      hasRequiredMarks: () => true,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    expect(screen.getByText("2/3")).toBeInTheDocument();
+  });
+
+  it("shows target type badge", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [createMockMark({ targetType: "host" })],
+      marksReceived: [],
+      getMarksOnTarget: () => 1,
+      hasRequiredMarks: () => true,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    expect(screen.getByText("Host")).toBeInTheDocument();
+  });
+
+  it("stepper minus button calls removeMark", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [createMockMark({ markCount: 2 })],
+      marksReceived: [],
+      getMarksOnTarget: () => 2,
+      hasRequiredMarks: () => true,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    fireEvent.click(screen.getByTitle("Remove 1 mark"));
+    expect(mockRemoveMark).toHaveBeenCalledWith("corp-server", 1);
+  });
+
+  it("stepper plus button calls placeMark to increment", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [createMockMark({ markCount: 1 })],
+      marksReceived: [],
+      getMarksOnTarget: () => 1,
+      hasRequiredMarks: () => true,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    fireEvent.click(screen.getByTitle("Add 1 mark"));
+    expect(mockPlaceMark).toHaveBeenCalledWith("corp-server", "host", "Corp Server", 1);
+  });
+
+  it("stepper plus button is disabled at 3 marks", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [createMockMark({ markCount: 3 })],
+      marksReceived: [],
+      getMarksOnTarget: () => 3,
+      hasRequiredMarks: () => true,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    expect(screen.getByTitle("Add 1 mark")).toBeDisabled();
+  });
+
+  it("expand mark row shows Remove All when count > 1", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [createMockMark({ markCount: 2 })],
+      marksReceived: [],
+      getMarksOnTarget: () => 2,
+      hasRequiredMarks: () => true,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    fireEvent.click(screen.getByText("Corp Server"));
+    expect(screen.getByText("Remove All")).toBeInTheDocument();
+  });
+
+  it("shows marks received with source info", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [],
+      marksReceived: [
+        createMockMark({
+          id: "recv-1",
+          targetId: "enemy-decker",
+          targetType: "persona",
+          targetName: "Enemy Decker",
+          markCount: 1,
+        }),
+      ],
+      getMarksOnTarget: () => 0,
+      hasRequiredMarks: () => false,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    expect(screen.getByText("Enemy Decker")).toBeInTheDocument();
+    expect(screen.getByText("Persona")).toBeInTheDocument();
+  });
+
+  it("received mark stepper plus calls receiveMarkOnSelf", () => {
+    const receivedMark = createMockMark({
+      id: "recv-1",
+      targetId: "enemy-decker",
+      targetType: "persona",
+      targetName: "Enemy Decker",
+      markCount: 1,
+    });
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [],
+      marksReceived: [receivedMark],
+      getMarksOnTarget: () => 0,
+      hasRequiredMarks: () => false,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    fireEvent.click(screen.getByTitle("Add 1 received mark"));
+    expect(mockReceiveMarkOnSelf).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: "enemy-decker", markCount: 1 })
+    );
+  });
+
+  it("received mark stepper minus calls removeReceivedMark", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [],
+      marksReceived: [
+        createMockMark({
+          id: "recv-1",
+          targetId: "enemy-decker",
+          targetType: "persona",
+          targetName: "Enemy Decker",
+          markCount: 1,
+        }),
+      ],
+      getMarksOnTarget: () => 0,
+      hasRequiredMarks: () => false,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    fireEvent.click(screen.getByTitle("Remove received marks"));
+    expect(mockRemoveReceivedMark).toHaveBeenCalledWith("enemy-decker");
+  });
+
+  it("Place Mark form appears on button click", () => {
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    fireEvent.click(screen.getByText("Place Mark"));
+    expect(screen.getByPlaceholderText("Target name")).toBeInTheDocument();
+  });
+
+  it("Place Mark form calls placeMark on submit", () => {
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    fireEvent.click(screen.getByText("Place Mark"));
+    const input = screen.getByPlaceholderText("Target name");
+    fireEvent.change(input, { target: { value: "Corp Server" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(mockPlaceMark).toHaveBeenCalledWith("corp-server", "device", "Corp Server", 1);
+  });
+
+  it("Clear All button calls clearAllMarks", () => {
+    mockUseMatrixMarks.mockReturnValue({
+      marksHeld: [createMockMark()],
+      marksReceived: [],
+      getMarksOnTarget: () => 1,
+      hasRequiredMarks: () => true,
+    });
+    render(<MatrixMarksDisplay character={deckerCharacter} />);
+    fireEvent.click(screen.getByText("Clear All"));
+    expect(mockClearAllMarks).toHaveBeenCalled();
+  });
+});

--- a/components/character/sheet/__tests__/test-helpers.tsx
+++ b/components/character/sheet/__tests__/test-helpers.tsx
@@ -151,6 +151,10 @@ export const LUCIDE_MOCK = {
   Monitor: createIconMock("Monitor"),
   ArrowUpDown: createIconMock("ArrowUpDown"),
   Smartphone: createIconMock("Smartphone"),
+  Minus: createIconMock("Minus"),
+  Plus: createIconMock("Plus"),
+  Trash2: createIconMock("Trash2"),
+  X: createIconMock("X"),
   // Rigging icons
   Gamepad2: createIconMock("Gamepad2"),
   Radio: createIconMock("Radio"),

--- a/components/character/sheet/index.ts
+++ b/components/character/sheet/index.ts
@@ -25,6 +25,7 @@ export { VehiclesDisplay } from "./VehiclesDisplay";
 export { CyberdeckConfigDisplay } from "./CyberdeckConfigDisplay";
 export { MatrixActionsDisplay } from "./MatrixActionsDisplay";
 export { MatrixDevicesDisplay } from "./MatrixDevicesDisplay";
+export { MatrixMarksDisplay } from "./MatrixMarksDisplay";
 export { MatrixSummaryDisplay } from "./MatrixSummaryDisplay";
 export { ProgramManagerDisplay } from "./ProgramManagerDisplay";
 export { WeaponsDisplay } from "./WeaponsDisplay";

--- a/lib/matrix/MatrixSessionContext.tsx
+++ b/lib/matrix/MatrixSessionContext.tsx
@@ -56,6 +56,7 @@ import {
   removeMarks as removeMarksFromState,
   clearAllMarks as clearAllMarksFromState,
   receiveMarkOnSelf as receiveMarkOnSelfState,
+  removeReceivedMarks as removeReceivedMarksFromState,
   getMarksOnTarget as getMarksOnTargetFromState,
   hasRequiredMarks as hasRequiredMarksFromState,
 } from "@/lib/rules/matrix/mark-tracker";
@@ -112,6 +113,8 @@ export interface MatrixSessionActions {
   clearAllMarks: () => void;
   /** Record a mark placed on this persona */
   receiveMarkOnSelf: (mark: MatrixMark) => void;
+  /** Remove all marks from a specific source on this persona */
+  removeReceivedMark: (markerId: string) => void;
   /** Apply matrix damage to condition monitor */
   applyMatrixDamage: (amount: number) => void;
   /** Heal matrix damage */
@@ -480,6 +483,13 @@ export function MatrixSessionProvider({ character, children }: MatrixSessionProv
     [matrixState]
   );
 
+  const removeReceivedMarkAction = useCallback((markerId: string) => {
+    setMatrixState((prev) => {
+      if (!prev) return prev;
+      return removeReceivedMarksFromState(prev, markerId);
+    });
+  }, []);
+
   const applyMatrixDamage = useCallback((amount: number) => {
     setMatrixState((prev) => {
       if (!prev) return prev;
@@ -578,6 +588,7 @@ export function MatrixSessionProvider({ character, children }: MatrixSessionProv
       removeMark: removeMarkAction,
       clearAllMarks: clearAllMarksAction,
       receiveMarkOnSelf: receiveMarkOnSelfAction,
+      removeReceivedMark: removeReceivedMarkAction,
       applyMatrixDamage,
       healMatrixDamage,
       triggerConvergence: triggerConvergenceAction,
@@ -605,6 +616,7 @@ export function MatrixSessionProvider({ character, children }: MatrixSessionProv
       removeMarkAction,
       clearAllMarksAction,
       receiveMarkOnSelfAction,
+      removeReceivedMarkAction,
       applyMatrixDamage,
       healMatrixDamage,
       triggerConvergenceAction,
@@ -654,6 +666,7 @@ export function useMatrixSession(): MatrixSessionContextValue {
       removeMark: () => ({ success: false, marksRemoved: 0, remainingMarks: 0 }),
       clearAllMarks: () => {},
       receiveMarkOnSelf: () => {},
+      removeReceivedMark: () => {},
       applyMatrixDamage: () => {},
       healMatrixDamage: () => {},
       triggerConvergence: () => null,


### PR DESCRIPTION
## Summary
- Add **MatrixMarksDisplay** card for tracking marks held on targets and marks received on self
- Inline **+/- stepper controls** on each mark row for quick increment/decrement without re-entering target names
- **PlaceMarkForm** and **ReceiveMarkForm** for adding new mark entries (stacked layout to avoid overflow on narrow screens)
- "Clear All" header action for bulk mark removal
- Enhance **MatrixActionsDisplay** mark badges with sufficiency coloring: red when no marks held, amber when marks exist, plus warning text in expanded rows
- Wire up `removeReceivedMark` action in **MatrixSessionContext** (connecting existing `removeReceivedMarks` engine function)
- Fix text overflow in **MatrixDevicesDisplay** name rows by replacing empty `ml-auto` spacer with `flex-1 min-w-0` on the name span

## Test plan
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 341 files, 7631 tests passing, 0 failures
- [x] `pnpm lint` — clean
- [ ] Manual: Load decker character, verify Matrix Marks card appears in Matrix Operations section
- [ ] Manual: Place a mark via the form, verify it appears with correct auth level badge
- [ ] Manual: Use +/- stepper to increment/decrement marks without opening forms
- [ ] Manual: Verify "1M" badge on MatrixActionsDisplay is red when no marks held, amber when marks exist
- [ ] Manual: Commlink-only character — no Matrix Marks card (no matrix hardware)
- [ ] Manual: Verify device names truncate properly in MatrixDevicesDisplay on narrow widths

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)