### PR TITLE
feat(matrix): Add matrix action execution with session-aware dice pools (#416)

### DIFF
--- a/components/character/sheet/MatrixActionsDisplay.tsx
+++ b/components/character/sheet/MatrixActionsDisplay.tsx
@@ -3,10 +3,14 @@
 import { useState, useMemo } from "react";
 import type { Character } from "@/lib/types";
 import type { ActionDefinition } from "@/lib/types/action-definitions";
+import type { MatrixDicePoolResult } from "@/lib/rules/matrix/dice-pool-calculator";
 import { DisplayCard } from "./DisplayCard";
 import { Zap, ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
 import { useMatrixActions } from "@/lib/rules/RulesetContext";
-import { useMatrixMarks } from "@/lib/matrix";
+import { useMatrixMarks, useMatrixSession } from "@/lib/matrix";
+import { actionDefinitionToMatrixAction } from "@/lib/rules/matrix/action-mapper";
+import { calculateMatrixDicePool } from "@/lib/rules/matrix/dice-pool-calculator";
+import { isActionSupportedByDevice } from "@/lib/rules/matrix/action-validator";
 
 interface MatrixActionsDisplayProps {
   character: Character;
@@ -25,6 +29,12 @@ const CATEGORY_LABELS: Record<string, string> = {
   hacking: "Hacking",
   cybercombat: "Cybercombat",
   "electronic-warfare": "Electronic Warfare",
+};
+
+const CONNECTION_MODE_LABELS: Record<string, string> = {
+  ar: "AR",
+  "cold-sim-vr": "Cold-Sim VR",
+  "hot-sim-vr": "Hot-Sim VR",
 };
 
 /** Determine if an action is illegal based on its subcategory or tags */
@@ -80,19 +90,31 @@ function ActionRow({
   character,
   onSelect,
   hasMarksOnAnyTarget,
+  poolResult,
+  unsupported,
+  isHotSim,
 }: {
   action: ActionDefinition;
   character: Character;
   onSelect?: (pool: number, label: string) => void;
   hasMarksOnAnyTarget: boolean;
+  poolResult: MatrixDicePoolResult | null;
+  unsupported: boolean;
+  isHotSim: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const illegal = isActionIllegal(action);
   const marks = getMarksRequired(action);
-  const pool = estimateDicePool(action, character);
+
+  // Use full pool result if available, otherwise fall back to estimate
+  const pool = poolResult ? poolResult.pool.totalDice : estimateDicePool(action, character);
 
   return (
-    <div className="[&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50">
+    <div
+      className={`[&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50 ${
+        unsupported ? "opacity-40" : ""
+      }`}
+    >
       <div
         className="flex items-center gap-2 px-3 py-1.5 cursor-pointer transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-700/30"
         onClick={() => setExpanded(!expanded)}
@@ -135,10 +157,17 @@ function ActionRow({
           </span>
         )}
 
+        {/* Hot-sim indicator */}
+        {isHotSim && (
+          <span className="rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide bg-orange-100 text-orange-700 border border-orange-300/40 dark:bg-orange-500/15 dark:text-orange-400 dark:border-orange-500/20">
+            Hot-Sim
+          </span>
+        )}
+
         <div className="flex-1" />
 
         {/* Dice pool pill */}
-        {pool > 0 && (
+        {pool > 0 && !unsupported && (
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -158,14 +187,41 @@ function ActionRow({
             <p className="text-xs italic text-zinc-500 dark:text-zinc-400">{action.description}</p>
           )}
 
-          {/* Roll formula */}
+          {/* Roll formula — enhanced when session active */}
           {action.rollConfig && (
             <div className="text-xs text-zinc-500 dark:text-zinc-400">
               <span className="font-semibold">Pool:</span>{" "}
               {[action.rollConfig.skill, action.rollConfig.attribute].filter(Boolean).join(" + ")}
               {action.rollConfig.limitType && (
-                <span className="ml-2 text-zinc-400">[Limit: {action.rollConfig.limitType}]</span>
+                <span className="ml-2 text-zinc-400">
+                  [Limit: {action.rollConfig.limitType}
+                  {poolResult && <span className="font-mono"> ({poolResult.limit})</span>}]
+                </span>
               )}
+            </div>
+          )}
+
+          {/* Pool breakdown when session active */}
+          {poolResult && poolResult.breakdown.length > 0 && (
+            <div className="space-y-0.5">
+              {poolResult.breakdown.map((component, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-1 text-[11px] text-zinc-500 dark:text-zinc-400"
+                >
+                  <span className="w-12 text-right font-mono text-zinc-600 dark:text-zinc-300">
+                    {component.value > 0 ? "+" : ""}
+                    {component.value}
+                  </span>
+                  <span>
+                    {component.skill ??
+                      component.attribute ??
+                      component.program ??
+                      component.situation ??
+                      component.source}
+                  </span>
+                </div>
+              ))}
             </div>
           )}
 
@@ -174,6 +230,14 @@ function ActionRow({
             <span className="font-semibold">Type:</span>{" "}
             <span className="capitalize">{action.type}</span> Action
           </div>
+
+          {/* Unsupported device warning */}
+          {unsupported && (
+            <div className="flex items-center gap-1 text-xs text-amber-500 dark:text-amber-400">
+              <AlertTriangle className="h-3 w-3" />
+              <span>Not supported by current device</span>
+            </div>
+          )}
 
           {/* Mark warning */}
           {marks > 0 && !hasMarksOnAnyTarget && (
@@ -206,6 +270,38 @@ function ActionRow({
 export function MatrixActionsDisplay({ character, onSelect }: MatrixActionsDisplayProps) {
   const matrixActions = useMatrixActions();
   const { marksHeld } = useMatrixMarks();
+  const { matrixState, connectionMode, overwatchWarningLevel } = useMatrixSession();
+
+  const isHotSim = connectionMode === "hot-sim-vr";
+
+  // Pre-compute pool results for all actions when session is active
+  const poolResults = useMemo(() => {
+    if (!matrixState) return new Map<string, MatrixDicePoolResult>();
+
+    const results = new Map<string, MatrixDicePoolResult>();
+    for (const action of matrixActions) {
+      const mapped = actionDefinitionToMatrixAction(action);
+      if (mapped) {
+        const result = calculateMatrixDicePool(character, matrixState, mapped);
+        results.set(action.id, result);
+      }
+    }
+    return results;
+  }, [matrixActions, matrixState, character]);
+
+  // Pre-compute device support for all actions
+  const unsupportedActions = useMemo(() => {
+    if (!matrixState?.activeDeviceType) return new Set<string>();
+
+    const unsupported = new Set<string>();
+    for (const action of matrixActions) {
+      const mapped = actionDefinitionToMatrixAction(action);
+      if (mapped && !isActionSupportedByDevice(mapped, matrixState.activeDeviceType)) {
+        unsupported.add(action.id);
+      }
+    }
+    return unsupported;
+  }, [matrixActions, matrixState]);
 
   // Group actions by subcategory first, then by domain category
   const categorizedActions = useMemo(() => {
@@ -236,11 +332,46 @@ export function MatrixActionsDisplay({ character, onSelect }: MatrixActionsDispl
 
   if (matrixActions.length === 0) return null;
 
+  // Connection mode badge for header
+  const connectionBadge = matrixState ? (
+    <span
+      className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${
+        isHotSim
+          ? "bg-orange-100 text-orange-700 dark:bg-orange-500/15 dark:text-orange-400"
+          : "bg-zinc-200 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300"
+      }`}
+    >
+      {CONNECTION_MODE_LABELS[connectionMode] ?? connectionMode}
+    </span>
+  ) : null;
+
+  // OS warning in header
+  const osWarning =
+    overwatchWarningLevel !== "safe" && matrixState ? (
+      <span
+        className={`rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${
+          overwatchWarningLevel === "critical" || overwatchWarningLevel === "danger"
+            ? "bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-400"
+            : "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-400"
+        }`}
+      >
+        OS {overwatchWarningLevel}
+      </span>
+    ) : null;
+
+  const headerAction = (
+    <div className="flex items-center gap-1.5">
+      {osWarning}
+      {connectionBadge}
+    </div>
+  );
+
   return (
     <DisplayCard
       id="sheet-matrix-actions"
       title="Matrix Actions"
       icon={<Zap className="h-4 w-4 text-emerald-400" />}
+      headerAction={headerAction}
       collapsible
       defaultCollapsed
     >
@@ -258,6 +389,9 @@ export function MatrixActionsDisplay({ character, onSelect }: MatrixActionsDispl
                   character={character}
                   onSelect={onSelect}
                   hasMarksOnAnyTarget={marksHeld.length > 0}
+                  poolResult={poolResults.get(action.id) ?? null}
+                  unsupported={unsupportedActions.has(action.id)}
+                  isHotSim={isHotSim}
                 />
               ))}
             </div>

--- a/components/character/sheet/__tests__/MatrixActionsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/MatrixActionsDisplay.test.tsx
@@ -2,7 +2,8 @@
  * MatrixActionsDisplay Component Tests
  *
  * Tests the matrix actions card showing categorized actions
- * with legality badges, dice pools, and mark requirements.
+ * with legality badges, dice pools, mark requirements,
+ * session-aware pool calculations, and device compatibility.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -95,16 +96,91 @@ vi.mock("@/lib/rules/RulesetContext", () => ({
 
 vi.mock("@/lib/matrix", () => ({
   useMatrixMarks: vi.fn(),
+  useMatrixSession: vi.fn(),
+}));
+
+vi.mock("@/lib/rules/matrix/action-mapper", () => ({
+  actionDefinitionToMatrixAction: vi.fn(),
+}));
+
+vi.mock("@/lib/rules/matrix/dice-pool-calculator", () => ({
+  calculateMatrixDicePool: vi.fn(),
+}));
+
+vi.mock("@/lib/rules/matrix/action-validator", () => ({
+  isActionSupportedByDevice: vi.fn(),
 }));
 
 import { MatrixActionsDisplay } from "../MatrixActionsDisplay";
 import { useMatrixActions } from "@/lib/rules/RulesetContext";
-import { useMatrixMarks } from "@/lib/matrix";
+import { useMatrixMarks, useMatrixSession } from "@/lib/matrix";
+import { actionDefinitionToMatrixAction } from "@/lib/rules/matrix/action-mapper";
+import { calculateMatrixDicePool } from "@/lib/rules/matrix/dice-pool-calculator";
+import { isActionSupportedByDevice } from "@/lib/rules/matrix/action-validator";
 
 const mockUseMatrixActions = vi.mocked(useMatrixActions);
 const mockUseMatrixMarks = vi.mocked(useMatrixMarks);
+const mockUseMatrixSession = vi.mocked(useMatrixSession);
+const mockActionMapper = vi.mocked(actionDefinitionToMatrixAction);
+const mockCalculatePool = vi.mocked(calculateMatrixDicePool);
+const mockIsActionSupported = vi.mocked(isActionSupportedByDevice);
 
 const deckerCharacter = createDeckerCharacter();
+
+// Default no-session state (useMatrixSession returns this when no provider)
+const NO_SESSION = {
+  matrixState: null,
+  overwatchSession: null,
+  hasMatrixHardware: false,
+  isJackedIn: false,
+  connectionMode: "ar" as const,
+  overwatchScore: 0,
+  overwatchWarningLevel: "safe" as const,
+  isConverged: false,
+  isLoading: false,
+  error: null,
+  jackIn: vi.fn(),
+  jackOut: vi.fn(),
+  changeConnectionMode: vi.fn(),
+  addOverwatchScore: vi.fn(),
+  resetOverwatchScore: vi.fn(),
+  placeMark: vi.fn().mockReturnValue({ success: false, mark: null, errors: [], newMarkCount: 0 }),
+  removeMark: vi.fn().mockReturnValue({ success: false, marksRemoved: 0, remainingMarks: 0 }),
+  clearAllMarks: vi.fn(),
+  receiveMarkOnSelf: vi.fn(),
+  removeReceivedMark: vi.fn(),
+  applyMatrixDamage: vi.fn(),
+  healMatrixDamage: vi.fn(),
+  triggerConvergence: vi.fn().mockReturnValue(null),
+  enterHost: vi.fn(),
+  leaveHost: vi.fn(),
+  clearError: vi.fn(),
+};
+
+// Reusable mock MatrixState for cyberdeck sessions
+const MOCK_CYBERDECK_STATE = {
+  isConnected: true,
+  connectionMode: "cold-sim-vr" as const,
+  activeDeviceType: "cyberdeck" as const,
+  persona: {
+    personaId: "p1",
+    attack: 3,
+    sleaze: 6,
+    dataProcessing: 5,
+    firewall: 4,
+    deviceRating: 4,
+  },
+  marksHeld: [] as never[],
+  marksReceived: [] as never[],
+  loadedPrograms: [] as never[],
+  programSlotsUsed: 0,
+  programSlotsMax: 5,
+  matrixConditionMonitor: 12,
+  matrixDamageTaken: 0,
+  overwatchScore: 0,
+  overwatchThreshold: 40,
+  overwatchConverged: false,
+};
 
 describe("MatrixActionsDisplay", () => {
   beforeEach(() => {
@@ -116,6 +192,12 @@ describe("MatrixActionsDisplay", () => {
       getMarksOnTarget: () => 0,
       hasRequiredMarks: () => false,
     });
+    // Default: no active session
+    mockUseMatrixSession.mockReturnValue(NO_SESSION);
+    // Mapper returns null by default (no session calculation)
+    mockActionMapper.mockReturnValue(null);
+    // All actions supported by default
+    mockIsActionSupported.mockReturnValue(true);
   });
 
   it("groups actions by category with section headers", () => {
@@ -215,5 +297,158 @@ describe("MatrixActionsDisplay", () => {
     // Expand Edit File which requires 1 mark
     fireEvent.click(screen.getByText("Edit File"));
     expect(screen.getByText("Requires 1 mark(s) on target before use")).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // Session-aware pool calculation tests
+  // =========================================================================
+
+  it("shows limit value in expanded row when session active", () => {
+    mockUseMatrixSession.mockReturnValue({
+      ...NO_SESSION,
+      matrixState: MOCK_CYBERDECK_STATE,
+      isJackedIn: true,
+      connectionMode: "cold-sim-vr",
+    });
+
+    // Mapper returns a valid MatrixAction for hack-on-the-fly
+    mockActionMapper.mockImplementation((action) => {
+      if (action.id === "hack-on-the-fly") {
+        return {
+          id: "hack-on-the-fly",
+          name: "Hack on the Fly",
+          category: "sleaze",
+          legality: "illegal",
+          marksRequired: 0,
+          limitAttribute: "sleaze" as const,
+          skill: "hacking",
+          attribute: "logic",
+        };
+      }
+      return null;
+    });
+
+    mockCalculatePool.mockReturnValue({
+      pool: {
+        totalDice: 12,
+        basePool: 12,
+        attribute: "logic",
+        skill: "hacking",
+        modifiers: [],
+        limit: 6,
+        limitSource: "Sleaze",
+      },
+      formula: "logic (6) + hacking (6)",
+      breakdown: [
+        { source: "Attribute", attribute: "logic", value: 6 },
+        { source: "Skill", skill: "hacking", value: 6 },
+      ],
+      limit: 6,
+      limitType: "sleaze",
+      limitSource: "Sleaze",
+    });
+
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    fireEvent.click(screen.getByText("Hack on the Fly"));
+    // Limit should show numeric value
+    expect(screen.getByText(/\(6\)/)).toBeInTheDocument();
+  });
+
+  it("shows hot-sim badge when in hot-sim VR mode", () => {
+    mockUseMatrixSession.mockReturnValue({
+      ...NO_SESSION,
+      matrixState: { ...MOCK_CYBERDECK_STATE, connectionMode: "hot-sim-vr" as const },
+      isJackedIn: true,
+      connectionMode: "hot-sim-vr",
+    });
+
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    // Hot-Sim badges should appear on each action row
+    const hotSimBadges = screen.getAllByText("Hot-Sim");
+    expect(hotSimBadges.length).toBeGreaterThan(0);
+  });
+
+  it("shows connection mode badge in header", () => {
+    mockUseMatrixSession.mockReturnValue({
+      ...NO_SESSION,
+      matrixState: MOCK_CYBERDECK_STATE,
+      isJackedIn: true,
+      connectionMode: "cold-sim-vr",
+    });
+
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    expect(screen.getByText("Cold-Sim VR")).toBeInTheDocument();
+  });
+
+  it("dims unsupported actions on commlink", () => {
+    mockUseMatrixSession.mockReturnValue({
+      ...NO_SESSION,
+      matrixState: {
+        ...MOCK_CYBERDECK_STATE,
+        activeDeviceType: "commlink" as const,
+        connectionMode: "ar" as const,
+        persona: {
+          personaId: "p1",
+          attack: 0,
+          sleaze: 0,
+          dataProcessing: 4,
+          firewall: 4,
+          deviceRating: 4,
+        },
+      },
+      isJackedIn: true,
+      connectionMode: "ar",
+    });
+
+    // Illegal actions unsupported on commlink
+    mockIsActionSupported.mockImplementation((action) => {
+      return action.legality === "legal";
+    });
+    mockActionMapper.mockReturnValue({
+      id: "test",
+      name: "test",
+      category: "attack",
+      legality: "illegal",
+      marksRequired: 0,
+      limitAttribute: "attack",
+      skill: "cybercombat",
+      attribute: "logic",
+    });
+
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    // Expand an unsupported action
+    fireEvent.click(screen.getByText("Hack on the Fly"));
+    expect(screen.getByText("Not supported by current device")).toBeInTheDocument();
+  });
+
+  it("falls back to basic pool when no session", () => {
+    // Default NO_SESSION is already set in beforeEach
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    // Should still show basic pool (hacking 6 + logic 6 = 12)
+    expect(screen.getByText("12d6")).toBeInTheDocument();
+    // calculateMatrixDicePool should not have been called
+    expect(mockCalculatePool).not.toHaveBeenCalled();
+  });
+
+  it("shows OS warning in header when overwatch elevated", () => {
+    mockUseMatrixSession.mockReturnValue({
+      ...NO_SESSION,
+      matrixState: { ...MOCK_CYBERDECK_STATE, overwatchScore: 25 },
+      isJackedIn: true,
+      connectionMode: "cold-sim-vr",
+      overwatchScore: 25,
+      overwatchWarningLevel: "warning",
+    });
+
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    expect(screen.getByText("OS warning")).toBeInTheDocument();
+  });
+
+  it("no connection badge when not jacked in", () => {
+    // Default NO_SESSION (matrixState: null)
+    render(<MatrixActionsDisplay character={deckerCharacter} />);
+    expect(screen.queryByText("AR")).not.toBeInTheDocument();
+    expect(screen.queryByText("Cold-Sim VR")).not.toBeInTheDocument();
+    expect(screen.queryByText("Hot-Sim VR")).not.toBeInTheDocument();
   });
 });

--- a/data/editions/sr5/core-rulebook.json
+++ b/data/editions/sr5/core-rulebook.json
@@ -22886,7 +22886,608 @@
           }
         ],
         "magic": [],
-        "matrix": [],
+        "matrix": [
+          {
+            "id": "brute-force",
+            "name": "Brute Force",
+            "description": "Gain a mark on a target through sheer processing power. You may also cause Matrix damage. On a tie, no mark is placed but no alert is triggered.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "cybercombat",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "equipment",
+                "requirement": "cyberdeck",
+                "description": "Requires a cyberdeck"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "cybercombat",
+              "attribute": "logic",
+              "limitType": "Attack"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "willpower",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "mark",
+                "targetType": "target",
+                "calculation": { "baseValue": 1 },
+                "description": "Place 1 mark on target (2 marks with 4+ net hits)"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 238 }
+          },
+          {
+            "id": "hack-on-the-fly",
+            "name": "Hack on the Fly",
+            "description": "Gain a mark on a target without being noticed. Uses Sleaze to avoid detection. On a tie, no mark is placed but no alert is triggered.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "hacking",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "equipment",
+                "requirement": "cyberdeck",
+                "description": "Requires a cyberdeck"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "hacking",
+              "attribute": "logic",
+              "limitType": "Sleaze"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "intuition",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "mark",
+                "targetType": "target",
+                "calculation": { "baseValue": 1 },
+                "description": "Place 1 mark on target (2 marks with 4+ net hits)"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 240 }
+          },
+          {
+            "id": "data-spike",
+            "name": "Data Spike",
+            "description": "Attack a target persona or device with a concentrated burst of destructive Matrix energy, dealing Matrix damage.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "cybercombat",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "equipment",
+                "requirement": "cyberdeck",
+                "description": "Requires a cyberdeck"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "cybercombat",
+              "attribute": "logic",
+              "limitType": "Attack"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "intuition",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "damage",
+                "targetType": "target",
+                "damageType": "stun",
+                "calculation": {
+                  "formula": "attack_rating + net_hits",
+                  "addNetHits": true
+                },
+                "description": "Deal Matrix damage equal to Attack rating + net hits"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 238 }
+          },
+          {
+            "id": "crash-program",
+            "name": "Crash Program",
+            "description": "Crash a program running on a target device, forcing it to stop running.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "cybercombat",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "equipment",
+                "requirement": "cyberdeck",
+                "description": "Requires a cyberdeck"
+              },
+              {
+                "type": "resource",
+                "requirement": "marks",
+                "minimumValue": 1,
+                "description": "Requires 1 mark on target"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "cybercombat",
+              "attribute": "logic",
+              "limitType": "Attack"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "intuition",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "device_action",
+                "targetType": "device",
+                "calculation": { "baseValue": 1 },
+                "description": "Target program stops running"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 238 }
+          },
+          {
+            "id": "matrix-perception",
+            "name": "Matrix Perception",
+            "description": "Observe the Matrix around you, spotting icons, running silent devices, and other Matrix details. Each net hit reveals one piece of information.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "electronic-warfare",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "computer",
+              "attribute": "intuition",
+              "limitType": "Data Processing"
+            },
+            "opposedBy": {
+              "canBeOpposed": false
+            },
+            "effects": [
+              {
+                "type": "state_change",
+                "targetType": "self",
+                "calculation": { "addNetHits": true },
+                "description": "Each net hit reveals one piece of information about a Matrix object"
+              }
+            ],
+            "tags": [],
+            "source": { "book": "SR5 Core", "page": 241 }
+          },
+          {
+            "id": "matrix-search",
+            "name": "Matrix Search",
+            "description": "Search the Matrix for information. Time depends on the obscurity of the information sought.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "electronic-warfare",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "computer",
+              "attribute": "intuition",
+              "limitType": "Data Processing",
+              "extended": true
+            },
+            "opposedBy": {
+              "canBeOpposed": false
+            },
+            "effects": [
+              {
+                "type": "state_change",
+                "targetType": "self",
+                "calculation": { "addNetHits": true },
+                "description": "Find information. Threshold depends on obscurity."
+              }
+            ],
+            "tags": [],
+            "source": { "book": "SR5 Core", "page": 241 }
+          },
+          {
+            "id": "trace-icon",
+            "name": "Trace Icon",
+            "description": "Determine the physical location of an icon's device. Requires 2 marks on the target.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "electronic-warfare",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "resource",
+                "requirement": "marks",
+                "minimumValue": 2,
+                "description": "Requires 2 marks on target"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "computer",
+              "attribute": "intuition",
+              "limitType": "Data Processing"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "willpower",
+              "defaultDefenseSkill": "sleaze"
+            },
+            "effects": [
+              {
+                "type": "state_change",
+                "targetType": "self",
+                "calculation": { "addNetHits": true },
+                "description": "Determine physical location of icon's device"
+              }
+            ],
+            "tags": [],
+            "source": { "book": "SR5 Core", "page": 242 }
+          },
+          {
+            "id": "edit-file",
+            "name": "Edit File",
+            "description": "Create, change, copy, delete, or protect a file on a device or host. Requires 1 mark on the target.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "hacking",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "resource",
+                "requirement": "marks",
+                "minimumValue": 1,
+                "description": "Requires 1 mark on target"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "computer",
+              "attribute": "logic",
+              "limitType": "Data Processing"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "intuition",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "device_action",
+                "targetType": "device",
+                "calculation": { "baseValue": 1 },
+                "description": "File is created, changed, copied, deleted, or protected"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 239 }
+          },
+          {
+            "id": "erase-mark",
+            "name": "Erase Mark",
+            "description": "Remove a mark from your persona or a device you own. Multi-mark erases require multiple uses.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "hacking",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "computer",
+              "attribute": "logic",
+              "limitType": "Attack"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "intuition",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "state_change",
+                "targetType": "self",
+                "calculation": { "baseValue": 1 },
+                "description": "Remove one mark from your persona or device"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 240 }
+          },
+          {
+            "id": "snoop",
+            "name": "Snoop",
+            "description": "Intercept Matrix traffic to or from a target device. Requires 1 mark on the target.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "hacking",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "resource",
+                "requirement": "marks",
+                "minimumValue": 1,
+                "description": "Requires 1 mark on target"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "electronic-warfare",
+              "attribute": "intuition",
+              "limitType": "Sleaze"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "logic",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "state_change",
+                "targetType": "self",
+                "calculation": {},
+                "description": "Intercept all Matrix traffic to and from the target"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 241 }
+          },
+          {
+            "id": "spoof-command",
+            "name": "Spoof Command",
+            "description": "Send a command to a device, making it appear as though it came from an authorized user. Requires 1 mark on the icon you are impersonating.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "hacking",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "resource",
+                "requirement": "marks",
+                "minimumValue": 1,
+                "description": "Requires 1 mark on the icon you are impersonating"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "hacking",
+              "attribute": "intuition",
+              "limitType": "Sleaze"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "logic",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "device_action",
+                "targetType": "device",
+                "calculation": { "baseValue": 1 },
+                "description": "Target device accepts the spoofed command"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 241 }
+          },
+          {
+            "id": "control-device",
+            "name": "Control Device",
+            "description": "Operate a device as though you were its authorized user. Requires marks depending on the complexity of the action.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "electronic-warfare",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "resource",
+                "requirement": "marks",
+                "minimumValue": 1,
+                "description": "Requires 1+ marks (varies by action complexity)"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "electronic-warfare",
+              "attribute": "intuition",
+              "limitType": "Data Processing"
+            },
+            "opposedBy": {
+              "canBeOpposed": false
+            },
+            "effects": [
+              {
+                "type": "device_action",
+                "targetType": "device",
+                "calculation": {},
+                "description": "Remotely control the device for one action"
+              }
+            ],
+            "tags": [],
+            "source": { "book": "SR5 Core", "page": 238 }
+          },
+          {
+            "id": "format-device",
+            "name": "Format Device",
+            "description": "Wipe a device, erasing all data and programs. Requires 3 marks on the target.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "hacking",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "resource",
+                "requirement": "marks",
+                "minimumValue": 3,
+                "description": "Requires 3 marks on target"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "computer",
+              "attribute": "logic",
+              "limitType": "Sleaze"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "willpower",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "device_action",
+                "targetType": "device",
+                "calculation": {},
+                "description": "Target device is wiped clean of all data and programs"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 239 }
+          },
+          {
+            "id": "reboot-device",
+            "name": "Reboot Device",
+            "description": "Force a device to reboot, taking it offline temporarily. All marks on and from the device are erased. Requires 3 marks on the target.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "hacking",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [
+              {
+                "type": "resource",
+                "requirement": "marks",
+                "minimumValue": 3,
+                "description": "Requires 3 marks on target"
+              }
+            ],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "computer",
+              "attribute": "logic",
+              "limitType": "Data Processing"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "willpower",
+              "defaultDefenseSkill": "firewall"
+            },
+            "effects": [
+              {
+                "type": "device_action",
+                "targetType": "device",
+                "calculation": {},
+                "description": "Device reboots and all marks on/from it are erased"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 241 }
+          },
+          {
+            "id": "jam-signals",
+            "name": "Jam Signals",
+            "description": "Emit jamming signals that add noise to all Matrix connections in the area.",
+            "type": "complex",
+            "domain": "matrix",
+            "subcategory": "electronic-warfare",
+            "cost": { "actionType": "complex" },
+            "prerequisites": [],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "electronic-warfare",
+              "attribute": "logic",
+              "limitType": "Attack"
+            },
+            "opposedBy": {
+              "canBeOpposed": false
+            },
+            "effects": [
+              {
+                "type": "pool_modifier",
+                "targetType": "area",
+                "calculation": { "addNetHits": true },
+                "description": "Create noise equal to hits for all devices in area"
+              }
+            ],
+            "tags": ["illegal"],
+            "source": { "book": "SR5 Core", "page": 240 }
+          },
+          {
+            "id": "jack-out",
+            "name": "Jack Out",
+            "description": "Disconnect from the Matrix. If you have marks on you or are link-locked, this requires a test.",
+            "type": "simple",
+            "domain": "matrix",
+            "subcategory": "electronic-warfare",
+            "cost": { "actionType": "simple" },
+            "prerequisites": [],
+            "modifiers": [],
+            "rollConfig": {
+              "skill": "hardware",
+              "attribute": "willpower",
+              "limitType": "Firewall"
+            },
+            "opposedBy": {
+              "canBeOpposed": true,
+              "defaultDefenseAttribute": "logic",
+              "defaultDefenseSkill": "attack"
+            },
+            "effects": [
+              {
+                "type": "state_change",
+                "targetType": "self",
+                "calculation": {},
+                "description": "Disconnect from the Matrix. Dumpshock if in VR."
+              }
+            ],
+            "tags": [],
+            "source": { "book": "SR5 Core", "page": 240 }
+          },
+          {
+            "id": "send-message",
+            "name": "Send Message",
+            "description": "Send a text, audio, or video message to a user whose commcode you have.",
+            "type": "simple",
+            "domain": "matrix",
+            "subcategory": "electronic-warfare",
+            "cost": { "actionType": "simple" },
+            "prerequisites": [],
+            "modifiers": [],
+            "effects": [],
+            "tags": [],
+            "source": { "book": "SR5 Core", "page": 241 }
+          },
+          {
+            "id": "change-icon",
+            "name": "Change Icon",
+            "description": "Change the icon of your persona or a device you own to look like anything you want.",
+            "type": "simple",
+            "domain": "matrix",
+            "subcategory": "electronic-warfare",
+            "cost": { "actionType": "simple" },
+            "prerequisites": [],
+            "modifiers": [],
+            "effects": [],
+            "tags": [],
+            "source": { "book": "SR5 Core", "page": 237 }
+          }
+        ],
         "social": [],
         "vehicle": []
       }

--- a/lib/rules/matrix/__tests__/action-mapper.test.ts
+++ b/lib/rules/matrix/__tests__/action-mapper.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Action Mapper Tests
+ *
+ * Tests conversion from ActionDefinition (ruleset format)
+ * to MatrixAction (rule engine format).
+ */
+
+import { describe, it, expect } from "vitest";
+import type { ActionDefinition } from "@/lib/types/action-definitions";
+import {
+  actionDefinitionToMatrixAction,
+  subcategoryToMatrixCategory,
+  limitTypeToAttribute,
+} from "../action-mapper";
+
+// =============================================================================
+// subcategoryToMatrixCategory
+// =============================================================================
+
+describe("subcategoryToMatrixCategory", () => {
+  it("maps hacking to sleaze", () => {
+    expect(subcategoryToMatrixCategory("hacking")).toBe("sleaze");
+  });
+
+  it("maps cybercombat to attack", () => {
+    expect(subcategoryToMatrixCategory("cybercombat")).toBe("attack");
+  });
+
+  it("maps electronic-warfare to device", () => {
+    expect(subcategoryToMatrixCategory("electronic-warfare")).toBe("device");
+  });
+
+  it("maps technomancer to persona", () => {
+    expect(subcategoryToMatrixCategory("technomancer")).toBe("persona");
+  });
+
+  it("defaults to persona for unknown subcategory", () => {
+    expect(subcategoryToMatrixCategory(undefined)).toBe("persona");
+  });
+});
+
+// =============================================================================
+// limitTypeToAttribute
+// =============================================================================
+
+describe("limitTypeToAttribute", () => {
+  it("maps Attack to attack", () => {
+    expect(limitTypeToAttribute("Attack")).toBe("attack");
+  });
+
+  it("maps Sleaze to sleaze", () => {
+    expect(limitTypeToAttribute("Sleaze")).toBe("sleaze");
+  });
+
+  it("maps Data Processing to dataProcessing", () => {
+    expect(limitTypeToAttribute("Data Processing")).toBe("dataProcessing");
+  });
+
+  it("maps Firewall to firewall", () => {
+    expect(limitTypeToAttribute("Firewall")).toBe("firewall");
+  });
+
+  it("defaults to dataProcessing for unknown", () => {
+    expect(limitTypeToAttribute(undefined)).toBe("dataProcessing");
+    expect(limitTypeToAttribute("something-else")).toBe("dataProcessing");
+  });
+});
+
+// =============================================================================
+// actionDefinitionToMatrixAction
+// =============================================================================
+
+describe("actionDefinitionToMatrixAction", () => {
+  const hackOnTheFly: ActionDefinition = {
+    id: "hack-on-the-fly",
+    name: "Hack on the Fly",
+    description: "Gain a mark on a target without being noticed.",
+    type: "complex",
+    domain: "matrix",
+    subcategory: "hacking",
+    cost: { actionType: "complex" },
+    prerequisites: [],
+    modifiers: [],
+    effects: [],
+    tags: ["illegal"],
+    rollConfig: {
+      skill: "hacking",
+      attribute: "logic",
+      limitType: "Sleaze",
+    },
+  };
+
+  it("maps basic fields correctly", () => {
+    const result = actionDefinitionToMatrixAction(hackOnTheFly);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("hack-on-the-fly");
+    expect(result!.name).toBe("Hack on the Fly");
+    expect(result!.description).toBe("Gain a mark on a target without being noticed.");
+    expect(result!.skill).toBe("hacking");
+    expect(result!.attribute).toBe("logic");
+  });
+
+  it("maps illegal tag to legality", () => {
+    const result = actionDefinitionToMatrixAction(hackOnTheFly);
+    expect(result!.legality).toBe("illegal");
+  });
+
+  it("maps legal action correctly", () => {
+    const matrixPerception: ActionDefinition = {
+      ...hackOnTheFly,
+      id: "matrix-perception",
+      name: "Matrix Perception",
+      subcategory: "electronic-warfare",
+      tags: [],
+      rollConfig: { skill: "computer", attribute: "intuition", limitType: "Data Processing" },
+    };
+    const result = actionDefinitionToMatrixAction(matrixPerception);
+    expect(result!.legality).toBe("legal");
+  });
+
+  it("extracts mark requirement from prerequisites", () => {
+    const editFile: ActionDefinition = {
+      ...hackOnTheFly,
+      id: "edit-file",
+      prerequisites: [{ type: "resource", requirement: "marks", minimumValue: 1 }],
+    };
+    const result = actionDefinitionToMatrixAction(editFile);
+    expect(result!.marksRequired).toBe(1);
+  });
+
+  it("defaults to 0 marks when no mark prerequisite", () => {
+    const result = actionDefinitionToMatrixAction(hackOnTheFly);
+    expect(result!.marksRequired).toBe(0);
+  });
+
+  it("maps limitType to limitAttribute", () => {
+    const result = actionDefinitionToMatrixAction(hackOnTheFly);
+    expect(result!.limitAttribute).toBe("sleaze");
+  });
+
+  it("maps subcategory to category", () => {
+    const result = actionDefinitionToMatrixAction(hackOnTheFly);
+    expect(result!.category).toBe("sleaze"); // hacking → sleaze
+  });
+
+  it("returns null for actions without rollConfig", () => {
+    const sendMessage: ActionDefinition = {
+      ...hackOnTheFly,
+      id: "send-message",
+      rollConfig: undefined,
+    };
+    expect(actionDefinitionToMatrixAction(sendMessage)).toBeNull();
+  });
+
+  it("returns null for actions without skill in rollConfig", () => {
+    const noSkill: ActionDefinition = {
+      ...hackOnTheFly,
+      id: "no-skill",
+      rollConfig: { attribute: "logic" },
+    };
+    expect(actionDefinitionToMatrixAction(noSkill)).toBeNull();
+  });
+
+  it("returns null for actions without attribute in rollConfig", () => {
+    const noAttr: ActionDefinition = {
+      ...hackOnTheFly,
+      id: "no-attr",
+      rollConfig: { skill: "hacking" },
+    };
+    expect(actionDefinitionToMatrixAction(noAttr)).toBeNull();
+  });
+
+  it("handles high mark requirements (3 marks)", () => {
+    const formatDevice: ActionDefinition = {
+      ...hackOnTheFly,
+      id: "format-device",
+      prerequisites: [{ type: "resource", requirement: "marks", minimumValue: 3 }],
+    };
+    const result = actionDefinitionToMatrixAction(formatDevice);
+    expect(result!.marksRequired).toBe(3);
+  });
+});

--- a/lib/rules/matrix/action-mapper.ts
+++ b/lib/rules/matrix/action-mapper.ts
@@ -1,0 +1,103 @@
+/**
+ * Action Mapper
+ *
+ * Bridges the gap between ActionDefinition (ruleset data format) and
+ * MatrixAction (rule engine format). The ruleset stores matrix actions
+ * as ActionDefinition objects; the dice pool calculator and action
+ * validator expect MatrixAction objects.
+ */
+
+import type { ActionDefinition, ActionSubcategory } from "@/lib/types/action-definitions";
+import type { MatrixAction, MatrixActionCategory } from "@/lib/types/matrix";
+
+/**
+ * Map ActionDefinition subcategory to MatrixActionCategory.
+ *
+ * The mapping follows SR5 conventions:
+ * - "hacking" subcategory → "sleaze" (covert actions)
+ * - "cybercombat" → "attack" (offensive actions)
+ * - "electronic-warfare" → "device" (general/utility)
+ * - "technomancer" → "persona" (complex forms)
+ *
+ * Individual actions may override this via limitType when the mapping
+ * is ambiguous (e.g., Erase Mark is "hacking" subcategory but uses Attack limit).
+ */
+export function subcategoryToMatrixCategory(subcategory?: ActionSubcategory): MatrixActionCategory {
+  switch (subcategory) {
+    case "hacking":
+      return "sleaze";
+    case "cybercombat":
+      return "attack";
+    case "electronic-warfare":
+      return "device";
+    case "technomancer":
+      return "persona";
+    default:
+      return "persona";
+  }
+}
+
+/**
+ * Map a limitType display string to a typed ASDF attribute.
+ */
+export function limitTypeToAttribute(
+  limitType?: string
+): "attack" | "sleaze" | "dataProcessing" | "firewall" {
+  switch (limitType?.toLowerCase()) {
+    case "attack":
+      return "attack";
+    case "sleaze":
+      return "sleaze";
+    case "data processing":
+      return "dataProcessing";
+    case "firewall":
+      return "firewall";
+    default:
+      return "dataProcessing";
+  }
+}
+
+/**
+ * Convert an ActionDefinition (ruleset format) to a MatrixAction (rule engine format).
+ *
+ * Used to bridge the component's ActionDefinition data to the rule engine
+ * functions like calculateMatrixDicePool() and validateMatrixAction().
+ */
+export function actionDefinitionToMatrixAction(action: ActionDefinition): MatrixAction | null {
+  // Actions without rollConfig can't be converted to a meaningful MatrixAction
+  if (!action.rollConfig?.skill || !action.rollConfig?.attribute) {
+    return null;
+  }
+
+  // Extract marks required from prerequisites
+  const markPrereq = action.prerequisites?.find(
+    (p) => p.type === "resource" && p.requirement === "marks"
+  );
+  const marksRequired = markPrereq?.minimumValue ?? 0;
+
+  // Determine legality from tags
+  const legality = action.tags?.includes("illegal") ? "illegal" : "legal";
+
+  // Map category — use limitType as primary signal since it's more specific
+  const limitAttribute = limitTypeToAttribute(action.rollConfig.limitType);
+  let category: MatrixActionCategory;
+  if (action.subcategory) {
+    category = subcategoryToMatrixCategory(action.subcategory);
+  } else {
+    // Fallback: derive from limit attribute
+    category =
+      limitAttribute === "attack" ? "attack" : limitAttribute === "sleaze" ? "sleaze" : "device";
+  }
+
+  return {
+    id: action.id,
+    name: action.name,
+    description: action.description,
+    category,
+    legality,
+    marksRequired,
+    limitAttribute,
+    skill: action.rollConfig.skill,
+    attribute: action.rollConfig.attribute,
+  };
+}


### PR DESCRIPTION
## Summary

- **Populate 18 SR5 CRB matrix actions** in `core-rulebook.json` — actions from p.237-243 including Brute Force, Hack on the Fly, Data Spike, Matrix Perception, Edit File, Snoop, and more
- **Create `action-mapper.ts`** — bridges `ActionDefinition` (ruleset data format) to `MatrixAction` (rule engine format) for dice pool calculation and validation
- **Upgrade `MatrixActionsDisplay`** — session-aware dice pools with limits, program bonuses, hot-sim indicators; connection mode badges; OS warning display; device compatibility filtering (dims unsupported actions)

Closes #416

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (no new errors)
- [x] `pnpm verify-data` validates JSON
- [x] 19 MatrixActionsDisplay tests pass (7 new session-aware tests)
- [x] 21 action-mapper unit tests pass (new file)
- [x] 380 matrix rule tests pass (no regressions)
- [x] 651 sheet component tests pass (no regressions)
- [ ] Manual: load decker character — Matrix Actions card shows 18 grouped actions
- [ ] Manual: expand action row — shows formula, limit type, description
- [ ] Manual: if jacked in via MatrixSessionProvider, pool shows limit value and program bonuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)