### PR TITLE
feat(effects): Add unified effects to cyberware and bioware catalog items (#112)

### DIFF
--- a/__tests__/lib/rules/effects/augmentation-effects-data.test.ts
+++ b/__tests__/lib/rules/effects/augmentation-effects-data.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Data validation tests for cyberware and bioware effects in the unified effect system.
+ *
+ * Validates that all `effects` arrays added to cyberware and bioware
+ * catalog items in core-rulebook.json conform to the unified effect schema.
+ *
+ * @see Issue #112
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { UNIFIED_TRIGGERS, UNIFIED_TYPES } from "@/lib/rules/effects/quality-adapter";
+import type { SpecificAction } from "@/lib/types/effects";
+
+// ---------------------------------------------------------------------------
+// Load catalog data
+// ---------------------------------------------------------------------------
+
+const VALID_SPECIFIC_ACTIONS: ReadonlySet<string> = new Set<SpecificAction>([
+  "locate-sound-source",
+  "detect-ambush",
+  "read-lips",
+  "spot-hidden",
+  "called-shot",
+  "suppressive-fire",
+  "full-auto",
+  "negotiate",
+  "intimidate",
+  "con",
+  "hack-on-the-fly",
+  "brute-force",
+  "data-spike",
+]);
+
+interface CatalogEffect {
+  id: string;
+  type: string;
+  triggers: string[];
+  target: Record<string, unknown>;
+  value: unknown;
+  description?: string;
+  stackingGroup?: string;
+  stackingPriority?: number;
+  requiresWireless?: boolean;
+  wirelessOverride?: Record<string, unknown>;
+  condition?: Record<string, unknown>;
+}
+
+interface CatalogItem {
+  id: string;
+  name: string;
+  effects?: CatalogEffect[];
+}
+
+function loadCoreRulebook(): Record<string, unknown> {
+  const filePath = join(process.cwd(), "data/editions/sr5/core-rulebook.json");
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+/**
+ * Collect catalog items with unified `effects` arrays from cyberware and bioware modules.
+ */
+function collectItemsWithEffects(modules: Record<string, unknown>): CatalogItem[] {
+  const items: CatalogItem[] = [];
+  const augmentationModules = ["cyberware", "bioware"];
+
+  function traverse(obj: unknown): void {
+    if (Array.isArray(obj)) {
+      for (const element of obj) {
+        traverse(element);
+      }
+    } else if (typeof obj === "object" && obj !== null) {
+      const record = obj as Record<string, unknown>;
+      if (
+        typeof record.id === "string" &&
+        typeof record.name === "string" &&
+        Array.isArray(record.effects)
+      ) {
+        // Only include items whose effects have the unified format (triggers array)
+        const unifiedEffects = (record.effects as Record<string, unknown>[]).filter((e) =>
+          Array.isArray(e.triggers)
+        );
+        if (unifiedEffects.length > 0) {
+          items.push({
+            id: record.id,
+            name: record.name,
+            effects: unifiedEffects as unknown as CatalogEffect[],
+          });
+        }
+      }
+      for (const value of Object.values(record)) {
+        traverse(value);
+      }
+    }
+  }
+
+  for (const moduleName of augmentationModules) {
+    if (modules[moduleName]) {
+      traverse(modules[moduleName]);
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Collect ALL items with unified effects from gear and modifications modules
+ * (for cross-module duplicate ID checking).
+ */
+function collectGearEffectIds(modules: Record<string, unknown>): Set<string> {
+  const ids = new Set<string>();
+  const gearModules = ["gear", "modifications"];
+
+  function traverse(obj: unknown): void {
+    if (Array.isArray(obj)) {
+      for (const element of obj) {
+        traverse(element);
+      }
+    } else if (typeof obj === "object" && obj !== null) {
+      const record = obj as Record<string, unknown>;
+      if (Array.isArray(record.effects)) {
+        for (const effect of record.effects as Record<string, unknown>[]) {
+          if (Array.isArray(effect.triggers) && typeof effect.id === "string") {
+            ids.add(effect.id);
+          }
+        }
+      }
+      for (const value of Object.values(record)) {
+        traverse(value);
+      }
+    }
+  }
+
+  for (const moduleName of gearModules) {
+    if (modules[moduleName]) {
+      traverse(modules[moduleName]);
+    }
+  }
+
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Augmentation effects data validation", () => {
+  const rulebook = loadCoreRulebook();
+  const modules = rulebook.modules as Record<string, unknown>;
+  const itemsWithEffects = collectItemsWithEffects(modules);
+
+  it("should find catalog items with effects arrays (≥35)", () => {
+    expect(itemsWithEffects.length).toBeGreaterThanOrEqual(35);
+  });
+
+  it("every effect has required fields: id, type, triggers, target, value", () => {
+    for (const item of itemsWithEffects) {
+      for (const effect of item.effects!) {
+        expect(effect.id, `${item.id}: missing id`).toBeDefined();
+        expect(typeof effect.id, `${item.id}: id not string`).toBe("string");
+        expect(effect.type, `${item.id}: missing type`).toBeDefined();
+        expect(effect.triggers, `${item.id}: missing triggers`).toBeDefined();
+        expect(Array.isArray(effect.triggers), `${item.id}: triggers not array`).toBe(true);
+        expect(effect.triggers.length, `${item.id}: triggers empty`).toBeGreaterThan(0);
+        expect(effect.target, `${item.id}: missing target`).toBeDefined();
+        expect(typeof effect.target, `${item.id}: target not object`).toBe("object");
+        expect(effect.value, `${item.id}: missing value`).toBeDefined();
+      }
+    }
+  });
+
+  it("every type value is in UNIFIED_TYPES", () => {
+    for (const item of itemsWithEffects) {
+      for (const effect of item.effects!) {
+        expect(UNIFIED_TYPES.has(effect.type), `${item.id}: unknown type "${effect.type}"`).toBe(
+          true
+        );
+      }
+    }
+  });
+
+  it("every trigger value is in UNIFIED_TRIGGERS", () => {
+    for (const item of itemsWithEffects) {
+      for (const effect of item.effects!) {
+        for (const trigger of effect.triggers) {
+          expect(UNIFIED_TRIGGERS.has(trigger), `${item.id}: unknown trigger "${trigger}"`).toBe(
+            true
+          );
+        }
+      }
+    }
+  });
+
+  it("no duplicate effect IDs within cyberware/bioware", () => {
+    const seenIds = new Set<string>();
+    for (const item of itemsWithEffects) {
+      for (const effect of item.effects!) {
+        expect(seenIds.has(effect.id), `Duplicate effect ID: "${effect.id}" in ${item.id}`).toBe(
+          false
+        );
+        seenIds.add(effect.id);
+      }
+    }
+  });
+
+  it("no effect ID collisions with gear/modifications modules", () => {
+    const gearIds = collectGearEffectIds(modules);
+    for (const item of itemsWithEffects) {
+      for (const effect of item.effects!) {
+        expect(
+          gearIds.has(effect.id),
+          `Effect ID "${effect.id}" in ${item.id} collides with gear/modifications`
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("wirelessOverride has only valid keys when present", () => {
+    const validKeys = new Set(["type", "bonusValue", "description"]);
+    for (const item of itemsWithEffects) {
+      for (const effect of item.effects!) {
+        if (effect.wirelessOverride) {
+          for (const key of Object.keys(effect.wirelessOverride)) {
+            expect(
+              validKeys.has(key),
+              `${item.id}/${effect.id}: invalid wirelessOverride key "${key}"`
+            ).toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  it("per-rating values have { perRating: number } shape", () => {
+    for (const item of itemsWithEffects) {
+      for (const effect of item.effects!) {
+        if (typeof effect.value === "object" && effect.value !== null) {
+          const val = effect.value as Record<string, unknown>;
+          expect(typeof val.perRating, `${item.id}/${effect.id}: perRating not a number`).toBe(
+            "number"
+          );
+          expect(
+            Object.keys(val).length,
+            `${item.id}/${effect.id}: perRating object has extra keys`
+          ).toBe(1);
+        }
+      }
+    }
+  });
+
+  it("specificAction values are valid SpecificAction enum values when present", () => {
+    for (const item of itemsWithEffects) {
+      for (const effect of item.effects!) {
+        const specificAction = effect.target.specificAction;
+        if (specificAction !== undefined) {
+          expect(
+            VALID_SPECIFIC_ACTIONS.has(specificAction as string),
+            `${item.id}/${effect.id}: invalid specificAction "${specificAction}"`
+          ).toBe(true);
+        }
+      }
+    }
+  });
+});

--- a/__tests__/lib/rules/effects/resolver.test.ts
+++ b/__tests__/lib/rules/effects/resolver.test.ts
@@ -1589,3 +1589,324 @@ describe("Resolver Integration", () => {
     expect(result.totalLimitModifier).toBe(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// AUGMENTATION GATHERING TESTS (Issue #112)
+// ---------------------------------------------------------------------------
+
+describe("Augmentation Gathering", () => {
+  it("should gather cyberware effects with correct source metadata", () => {
+    const character = createMockCharacter({
+      cyberware: [
+        {
+          catalogId: "wired-reflexes",
+          name: "Wired Reflexes",
+          category: "bodyware",
+          grade: "standard",
+          baseEssenceCost: 3,
+          essenceCost: 3,
+          rating: 2,
+          cost: 149000,
+          availability: 12,
+          wirelessEnabled: true,
+        },
+      ],
+      wirelessBonusesEnabled: true,
+    });
+    const ruleset = makeMockRuleset({
+      cyberware: {
+        items: [
+          {
+            id: "wired-reflexes",
+            name: "Wired Reflexes",
+            effects: [
+              {
+                id: "wired-reflexes-reaction",
+                type: "attribute-modifier",
+                triggers: ["always"],
+                target: { attribute: "reaction" },
+                value: { perRating: 1 },
+                stackingGroup: "reaction-augmentation",
+              },
+              {
+                id: "wired-reflexes-initiative",
+                type: "initiative-modifier",
+                triggers: ["always"],
+                target: {},
+                value: { perRating: 1 },
+                stackingGroup: "initiative-augmentation",
+                wirelessOverride: { bonusValue: 1 },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const sources = gatherEffectSources(character, ruleset);
+    expect(sources).toHaveLength(2);
+    expect(sources[0].effect.id).toBe("wired-reflexes-reaction");
+    expect(sources[0].effect.type).toBe("attribute-modifier");
+    expect(sources[1].effect.id).toBe("wired-reflexes-initiative");
+    expect(sources[1].effect.type).toBe("initiative-modifier");
+    expect(sources[0].source.type).toBe("cyberware");
+    expect(sources[0].source.rating).toBe(2);
+    expect(sources[0].source.wirelessEnabled).toBe(true);
+  });
+
+  it("should gather bioware effects (cerebral-booster → attribute-modifier)", () => {
+    const character = createMockCharacter({
+      bioware: [
+        {
+          catalogId: "cerebral-booster",
+          name: "Cerebral Booster",
+          category: "cultured",
+          grade: "standard",
+          baseEssenceCost: 0.4,
+          essenceCost: 0.4,
+          rating: 2,
+          cost: 63000,
+          availability: 14,
+          wirelessEnabled: true,
+        },
+      ],
+      wirelessBonusesEnabled: true,
+    });
+    const ruleset = makeMockRuleset({
+      bioware: {
+        items: [
+          {
+            id: "cerebral-booster",
+            name: "Cerebral Booster",
+            effects: [
+              {
+                id: "cerebral-booster-logic",
+                type: "attribute-modifier",
+                triggers: ["always"],
+                target: { attribute: "logic" },
+                value: { perRating: 1 },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const sources = gatherEffectSources(character, ruleset);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].effect.id).toBe("cerebral-booster-logic");
+    expect(sources[0].effect.type).toBe("attribute-modifier");
+    expect(sources[0].source.type).toBe("bioware");
+    expect(sources[0].source.rating).toBe(2);
+  });
+
+  it("should propagate wireless enabled from cyberware source", () => {
+    const character = createMockCharacter({
+      cyberware: [
+        {
+          catalogId: "cybereyes",
+          name: "Cybereyes",
+          category: "eyeware",
+          grade: "standard",
+          baseEssenceCost: 0.3,
+          essenceCost: 0.3,
+          rating: 2,
+          cost: 6000,
+          availability: 6,
+          wirelessEnabled: true,
+        },
+      ],
+      wirelessBonusesEnabled: true,
+    });
+    const ruleset = makeMockRuleset({
+      cyberware: {
+        items: [
+          {
+            id: "cybereyes",
+            name: "Cybereyes",
+            effects: [
+              {
+                id: "cybereyes-perception-limit",
+                type: "limit-modifier",
+                triggers: ["perception-visual"],
+                target: { limit: "mental", perceptionType: "visual" },
+                value: 1,
+                requiresWireless: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const sources = gatherEffectSources(character, ruleset);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].source.wirelessEnabled).toBe(true);
+    expect(sources[0].effect.requiresWireless).toBe(true);
+  });
+
+  it("should gracefully skip missing bioware catalog item", () => {
+    const character = createMockCharacter({
+      bioware: [
+        {
+          catalogId: "nonexistent-bioware",
+          name: "Ghost Bioware",
+          category: "basic",
+          grade: "standard",
+          baseEssenceCost: 0.5,
+          essenceCost: 0.5,
+          cost: 10000,
+          availability: 6,
+        },
+      ],
+    });
+    const ruleset = makeMockRuleset({ bioware: { items: [] } });
+
+    const sources = gatherEffectSources(character, ruleset);
+    expect(sources).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AUGMENTATION RESOLVER INTEGRATION TESTS (Issue #112)
+// ---------------------------------------------------------------------------
+
+describe("Augmentation Resolver Integration", () => {
+  it("should resolve per-rating cyberware: wired-reflexes R2 → attribute-modifier resolves to 2", () => {
+    const character = createMockCharacter({
+      cyberware: [
+        {
+          catalogId: "wired-reflexes",
+          name: "Wired Reflexes",
+          category: "bodyware",
+          grade: "standard",
+          baseEssenceCost: 3,
+          essenceCost: 3,
+          rating: 2,
+          cost: 149000,
+          availability: 12,
+          wirelessEnabled: false,
+        },
+      ],
+      wirelessBonusesEnabled: false,
+    });
+    const ruleset = makeMockRuleset({
+      cyberware: {
+        items: [
+          {
+            id: "wired-reflexes",
+            name: "Wired Reflexes",
+            effects: [
+              {
+                id: "wired-reflexes-initiative",
+                type: "initiative-modifier",
+                triggers: ["always"],
+                target: {},
+                value: { perRating: 1 },
+                wirelessOverride: { bonusValue: 1 },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const context = makeContext({ type: "initiative" });
+
+    const result = resolveEffects(character, context, ruleset);
+    // perRating 1 * rating 2 = 2, no wireless bonus
+    expect(result.totalInitiativeModifier).toBe(2);
+    expect(result.initiativeModifiers).toHaveLength(1);
+    expect(result.initiativeModifiers[0].appliedVariant).toBe("standard");
+  });
+
+  it("should apply wireless override: wired-reflexes R2 with wireless → initiative resolves to 3", () => {
+    const character = createMockCharacter({
+      cyberware: [
+        {
+          catalogId: "wired-reflexes",
+          name: "Wired Reflexes",
+          category: "bodyware",
+          grade: "standard",
+          baseEssenceCost: 3,
+          essenceCost: 3,
+          rating: 2,
+          cost: 149000,
+          availability: 12,
+          wirelessEnabled: true,
+        },
+      ],
+      wirelessBonusesEnabled: true,
+    });
+    const ruleset = makeMockRuleset({
+      cyberware: {
+        items: [
+          {
+            id: "wired-reflexes",
+            name: "Wired Reflexes",
+            effects: [
+              {
+                id: "wired-reflexes-initiative",
+                type: "initiative-modifier",
+                triggers: ["always"],
+                target: {},
+                value: { perRating: 1 },
+                wirelessOverride: { bonusValue: 1 },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const context = makeContext({ type: "initiative" });
+
+    const result = resolveEffects(character, context, ruleset);
+    // perRating 1 * rating 2 = 2 base + wireless bonusValue 1 = 3
+    expect(result.totalInitiativeModifier).toBe(3);
+    expect(result.initiativeModifiers[0].appliedVariant).toBe("wireless");
+  });
+
+  it("should gate requiresWireless: cybereyes perception limit with wireless off → value 0", () => {
+    const character = createMockCharacter({
+      cyberware: [
+        {
+          catalogId: "cybereyes",
+          name: "Cybereyes",
+          category: "eyeware",
+          grade: "standard",
+          baseEssenceCost: 0.3,
+          essenceCost: 0.3,
+          rating: 2,
+          cost: 6000,
+          availability: 6,
+          wirelessEnabled: false,
+        },
+      ],
+      wirelessBonusesEnabled: true,
+    });
+    const ruleset = makeMockRuleset({
+      cyberware: {
+        items: [
+          {
+            id: "cybereyes",
+            name: "Cybereyes",
+            effects: [
+              {
+                id: "cybereyes-perception-limit",
+                type: "limit-modifier",
+                triggers: ["perception-visual"],
+                target: { limit: "mental", perceptionType: "visual" },
+                value: 1,
+                requiresWireless: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const context = makeContext({ type: "skill-test", perceptionType: "visual" });
+
+    const result = resolveEffects(character, context, ruleset);
+    // Wireless is off on the item → requiresWireless effect resolves to 0
+    expect(result.totalLimitModifier).toBe(0);
+  });
+});

--- a/data/editions/sr5/core-rulebook.json
+++ b/data/editions/sr5/core-rulebook.json
@@ -10665,7 +10665,9 @@
                 "id": "smartlink-accuracy",
                 "type": "accuracy-modifier",
                 "triggers": ["ranged-attack"],
-                "target": { "limit": "accuracy" },
+                "target": {
+                  "limit": "accuracy"
+                },
                 "value": 2,
                 "description": "+2 Accuracy when used with smartgun"
               }
@@ -10697,8 +10699,14 @@
                 "id": "vision-enhancement-limit",
                 "type": "limit-modifier",
                 "triggers": ["perception-visual", "skill-test"],
-                "target": { "limit": "mental", "skill": "perception", "perceptionType": "visual" },
-                "value": { "perRating": 1 },
+                "target": {
+                  "limit": "mental",
+                  "skill": "perception",
+                  "perceptionType": "visual"
+                },
+                "value": {
+                  "perRating": 1
+                },
                 "description": "+[Rating] limit on visual Perception",
                 "wirelessOverride": {
                   "type": "dice-pool-modifier",
@@ -10752,8 +10760,14 @@
                 "id": "audio-enhancement-limit",
                 "type": "limit-modifier",
                 "triggers": ["perception-audio", "skill-test"],
-                "target": { "limit": "mental", "skill": "perception", "perceptionType": "audio" },
-                "value": { "perRating": 1 },
+                "target": {
+                  "limit": "mental",
+                  "skill": "perception",
+                  "perceptionType": "audio"
+                },
+                "value": {
+                  "perRating": 1
+                },
                 "description": "+[Rating] limit on audio Perception",
                 "wirelessOverride": {
                   "type": "dice-pool-modifier",
@@ -10804,8 +10818,13 @@
                 "id": "select-sound-filter-pool",
                 "type": "dice-pool-modifier",
                 "triggers": ["perception-audio"],
-                "target": { "skill": "perception", "perceptionType": "audio" },
-                "value": { "perRating": 1 },
+                "target": {
+                  "skill": "perception",
+                  "perceptionType": "audio"
+                },
+                "value": {
+                  "perRating": 1
+                },
                 "description": "+[Rating] dice to isolate specific sound",
                 "requiresWireless": true
               }
@@ -10853,7 +10872,10 @@
                 "id": "spatial-recognizer-limit",
                 "type": "limit-modifier",
                 "triggers": ["perception-audio"],
-                "target": { "limit": "mental", "specificAction": "locate-sound-source" },
+                "target": {
+                  "limit": "mental",
+                  "specificAction": "locate-sound-source"
+                },
                 "value": 2,
                 "description": "+2 limit to locate sound source",
                 "wirelessOverride": {
@@ -13429,7 +13451,9 @@
                 "id": "laser-sight-accuracy",
                 "type": "accuracy-modifier",
                 "triggers": ["ranged-attack"],
-                "target": { "limit": "accuracy" },
+                "target": {
+                  "limit": "accuracy"
+                },
                 "value": 1,
                 "description": "+1 Accuracy (not cumulative with smartlink)",
                 "stackingGroup": "smartlink-laser",
@@ -13700,7 +13724,9 @@
                 "id": "smartgun-internal-accuracy",
                 "type": "accuracy-modifier",
                 "triggers": ["ranged-attack"],
-                "target": { "limit": "accuracy" },
+                "target": {
+                  "limit": "accuracy"
+                },
                 "value": 2,
                 "description": "+2 Accuracy when used with smartlink",
                 "stackingGroup": "smartlink-laser",
@@ -13749,7 +13775,9 @@
                 "id": "smartgun-external-accuracy",
                 "type": "accuracy-modifier",
                 "triggers": ["ranged-attack"],
-                "target": { "limit": "accuracy" },
+                "target": {
+                  "limit": "accuracy"
+                },
                 "value": 2,
                 "description": "+2 Accuracy when used with smartlink",
                 "stackingGroup": "smartlink-laser",
@@ -14320,7 +14348,21 @@
                 "condition": "perception_test"
               }
             ],
-            "page": 453
+            "page": 453,
+            "effects": [
+              {
+                "id": "cybereyes-perception-limit",
+                "type": "limit-modifier",
+                "triggers": ["perception-visual"],
+                "target": {
+                  "limit": "mental",
+                  "perceptionType": "visual"
+                },
+                "value": 1,
+                "description": "+1 limit to visual Perception tests",
+                "requiresWireless": true
+              }
+            ]
           },
           {
             "id": "cyberears",
@@ -14366,7 +14408,21 @@
                 "description": "Audio Perception tests only."
               }
             ],
-            "page": 454
+            "page": 454,
+            "effects": [
+              {
+                "id": "cyberears-perception-limit",
+                "type": "limit-modifier",
+                "triggers": ["perception-audio"],
+                "target": {
+                  "limit": "mental",
+                  "perceptionType": "audio"
+                },
+                "value": 1,
+                "description": "+1 limit to audio Perception tests",
+                "requiresWireless": true
+              }
+            ]
           },
           {
             "id": "dermal-plating",
@@ -14428,7 +14484,20 @@
             "description": "Bonus Armor equal to Rating (cumulative with worn armor, no Encumbrance). Cannot be combined with orthoskin or other skin augmentations that provide armor.",
             "page": 456,
             "legality": "restricted",
-            "incompatibleWith": ["orthoskin"]
+            "incompatibleWith": ["orthoskin"],
+            "effects": [
+              {
+                "id": "dermal-plating-armor",
+                "type": "armor-modifier",
+                "triggers": ["always"],
+                "target": {},
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Armor",
+                "stackingGroup": "skin-armor-augmentation"
+              }
+            ]
           },
           {
             "id": "internal-air-tank",
@@ -14524,7 +14593,33 @@
             "description": "+Rating STR and AGI. Cannot be combined with muscle augmentation or muscle toner bioware.",
             "page": 456,
             "legality": "restricted",
-            "incompatibleWith": ["muscle-augmentation", "muscle-toner"]
+            "incompatibleWith": ["muscle-augmentation", "muscle-toner"],
+            "effects": [
+              {
+                "id": "muscle-replacement-strength",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "strength"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Strength"
+              },
+              {
+                "id": "muscle-replacement-agility",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "agility"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Agility"
+              }
+            ]
           },
           {
             "id": "reaction-enhancers",
@@ -14576,7 +14671,22 @@
             ],
             "page": 457,
             "legality": "restricted",
-            "incompatibleWith": ["wired-reflexes"]
+            "incompatibleWith": ["wired-reflexes"],
+            "effects": [
+              {
+                "id": "reaction-enhancers-reaction",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "reaction"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Reaction",
+                "stackingGroup": "reaction-augmentation"
+              }
+            ]
           },
           {
             "id": "wired-reflexes",
@@ -14617,7 +14727,37 @@
             },
             "initiativeDiceBonus": 1,
             "legality": "restricted",
-            "incompatibleWith": ["reaction-enhancers", "synaptic-booster"]
+            "incompatibleWith": ["reaction-enhancers", "synaptic-booster"],
+            "effects": [
+              {
+                "id": "wired-reflexes-reaction",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "reaction"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Reaction",
+                "stackingGroup": "reaction-augmentation"
+              },
+              {
+                "id": "wired-reflexes-initiative",
+                "type": "initiative-modifier",
+                "triggers": ["always"],
+                "target": {},
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating]D6 Initiative",
+                "stackingGroup": "initiative-augmentation",
+                "wirelessOverride": {
+                  "bonusValue": 1,
+                  "description": "+1 additional Initiative Die when wireless active"
+                }
+              }
+            ]
           },
           {
             "id": "datajack",
@@ -14712,7 +14852,21 @@
                 "baseValue": 0.2,
                 "perRating": false
               }
-            }
+            },
+            "effects": [
+              {
+                "id": "olfactory-booster-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["skill-test"],
+                "target": {
+                  "skill": "perception"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice to smell-based Perception tests"
+              }
+            ]
           },
           {
             "id": "taste-booster",
@@ -14744,7 +14898,21 @@
                 "baseValue": 0.2,
                 "perRating": false
               }
-            }
+            },
+            "effects": [
+              {
+                "id": "taste-booster-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["skill-test"],
+                "target": {
+                  "skill": "perception"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice to taste-based Perception/analysis tests"
+              }
+            ]
           },
           {
             "id": "tooth-compartment",
@@ -14819,7 +14987,21 @@
                 "baseValue": 0.2,
                 "perRating": false
               }
-            }
+            },
+            "effects": [
+              {
+                "id": "voice-modulator-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["social-test"],
+                "target": {
+                  "skill": "impersonation"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice to vocal impersonation tests"
+              }
+            ]
           },
           {
             "id": "skilljack",
@@ -14960,7 +15142,21 @@
             "capacityCost": 3,
             "description": "+2 accuracy with smartgun systems. Implanted version is more effective than external.",
             "page": 454,
-            "legality": "restricted"
+            "legality": "restricted",
+            "effects": [
+              {
+                "id": "eye-smartlink-accuracy",
+                "type": "accuracy-modifier",
+                "triggers": ["ranged-attack"],
+                "target": {
+                  "limit": "accuracy"
+                },
+                "value": 2,
+                "description": "+2 Accuracy with smartgun systems",
+                "stackingGroup": "smartlink-laser",
+                "stackingPriority": 3
+              }
+            ]
           },
           {
             "id": "eye-thermographic-vision",
@@ -15009,7 +15205,22 @@
                 "baseValue": 1,
                 "perRating": true
               }
-            }
+            },
+            "effects": [
+              {
+                "id": "eye-vision-enhancement-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["perception-visual"],
+                "target": {
+                  "skill": "perception",
+                  "perceptionType": "visual"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice to visual Perception tests"
+              }
+            ]
           },
           {
             "id": "eye-vision-magnification",
@@ -15107,7 +15318,22 @@
                 "baseValue": 1,
                 "perRating": true
               }
-            }
+            },
+            "effects": [
+              {
+                "id": "ear-audio-enhancement-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["perception-audio"],
+                "target": {
+                  "skill": "perception",
+                  "perceptionType": "audio"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice to audio Perception tests"
+              }
+            ]
           },
           {
             "id": "ear-balance-augmenter",
@@ -15118,7 +15344,19 @@
             "availability": 8,
             "capacityCost": 4,
             "description": "+1 dice to tests involving balance (climbing, narrow platforms, landing after jumps).",
-            "page": 455
+            "page": 455,
+            "effects": [
+              {
+                "id": "ear-balance-augmenter-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["skill-test"],
+                "target": {
+                  "skill": "gymnastics"
+                },
+                "value": 1,
+                "description": "+1 die to balance-related tests"
+              }
+            ]
           },
           {
             "id": "ear-damper",
@@ -15129,7 +15367,17 @@
             "availability": 6,
             "capacityCost": 1,
             "description": "Protection from loud noises. +2 dice pool to resist sonic attacks including flashbangs.",
-            "page": 455
+            "page": 455,
+            "effects": [
+              {
+                "id": "ear-damper-resistance",
+                "type": "resistance-modifier",
+                "triggers": ["resistance-test"],
+                "target": {},
+                "value": 2,
+                "description": "+2 dice to resist sonic attacks including flashbangs"
+              }
+            ]
           },
           {
             "id": "ear-select-sound-filter",
@@ -15178,7 +15426,19 @@
             "availability": 8,
             "capacityCost": 2,
             "description": "+2 dice to locate sounds.",
-            "page": 455
+            "page": 455,
+            "effects": [
+              {
+                "id": "ear-spatial-recognizer-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["perception-audio"],
+                "target": {
+                  "specificAction": "locate-sound-source"
+                },
+                "value": 2,
+                "description": "+2 dice to locate sound source"
+              }
+            ]
           },
           {
             "id": "bone-lacing-plastic",
@@ -15193,7 +15453,17 @@
             },
             "page": 456,
             "legality": "restricted",
-            "incompatibleWith": ["bone-density-augmentation"]
+            "incompatibleWith": ["bone-density-augmentation"],
+            "effects": [
+              {
+                "id": "bone-lacing-plastic-dr",
+                "type": "damage-resistance-modifier",
+                "triggers": ["damage-resistance"],
+                "target": {},
+                "value": 1,
+                "description": "+1 Body for damage resistance tests"
+              }
+            ]
           },
           {
             "id": "bone-lacing-aluminum",
@@ -15208,7 +15478,17 @@
             },
             "page": 456,
             "legality": "restricted",
-            "incompatibleWith": ["bone-density-augmentation"]
+            "incompatibleWith": ["bone-density-augmentation"],
+            "effects": [
+              {
+                "id": "bone-lacing-aluminum-dr",
+                "type": "damage-resistance-modifier",
+                "triggers": ["damage-resistance"],
+                "target": {},
+                "value": 2,
+                "description": "+2 Body for damage resistance tests"
+              }
+            ]
           },
           {
             "id": "bone-lacing-titanium",
@@ -15223,7 +15503,17 @@
             },
             "page": 456,
             "legality": "restricted",
-            "incompatibleWith": ["bone-density-augmentation"]
+            "incompatibleWith": ["bone-density-augmentation"],
+            "effects": [
+              {
+                "id": "bone-lacing-titanium-dr",
+                "type": "damage-resistance-modifier",
+                "triggers": ["damage-resistance"],
+                "target": {},
+                "value": 3,
+                "description": "+3 Body for damage resistance tests"
+              }
+            ]
           },
           {
             "id": "fingertip-compartment",
@@ -15616,7 +15906,17 @@
               }
             ],
             "page": 457,
-            "legality": "forbidden"
+            "legality": "forbidden",
+            "effects": [
+              {
+                "id": "cyberlimb-gyromount-rc",
+                "type": "recoil-compensation",
+                "triggers": ["ranged-attack"],
+                "target": {},
+                "value": 3,
+                "description": "Rating 3 recoil compensation"
+              }
+            ]
           },
           {
             "id": "cyberlimb-holster",
@@ -15699,7 +15999,30 @@
                 "baseValue": 1,
                 "perRating": true
               }
-            }
+            },
+            "effects": [
+              {
+                "id": "cyberlimb-hydraulic-jacks-limit",
+                "type": "limit-modifier",
+                "triggers": ["skill-test"],
+                "target": {
+                  "limit": "physical"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Physical limit for jumping/sprinting"
+              },
+              {
+                "id": "cyberlimb-hydraulic-jacks-wireless-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["skill-test"],
+                "target": {},
+                "value": 1,
+                "description": "+1 dice pool to jumping, sprinting, or lifting",
+                "requiresWireless": true
+              }
+            ]
           },
           {
             "id": "cyberlimb-large-smuggling-compartment",
@@ -16105,7 +16428,21 @@
               "strength": 1
             },
             "legality": "restricted",
-            "incompatibleWith": ["muscle-replacement"]
+            "incompatibleWith": ["muscle-replacement"],
+            "effects": [
+              {
+                "id": "muscle-augmentation-strength",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "strength"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Strength"
+              }
+            ]
           },
           {
             "id": "muscle-toner",
@@ -16150,7 +16487,25 @@
               "agility": 1
             },
             "legality": "restricted",
-            "incompatibleWith": ["muscle-replacement"]
+            "incompatibleWith": ["muscle-replacement"],
+            "effects": [
+              {
+                "id": "muscle-toner-agility",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "agility"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Agility",
+                "wirelessOverride": {
+                  "bonusValue": 1,
+                  "description": "+1 additional Agility when wireless active"
+                }
+              }
+            ]
           },
           {
             "id": "pathogenic-defense",
@@ -16192,7 +16547,19 @@
             },
             "category": "basic",
             "description": "+1 dice vs. pathogens and disease.",
-            "page": 460
+            "page": 460,
+            "effects": [
+              {
+                "id": "pathogenic-defense-resistance",
+                "type": "resistance-modifier",
+                "triggers": ["resistance-test"],
+                "target": {},
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice vs. pathogens and disease"
+              }
+            ]
           },
           {
             "id": "symbiotes",
@@ -16266,7 +16633,19 @@
             },
             "category": "basic",
             "description": "+1 dice vs. inhaled toxins.",
-            "page": 461
+            "page": 461,
+            "effects": [
+              {
+                "id": "tracheal-filter-resistance",
+                "type": "resistance-modifier",
+                "triggers": ["resistance-test"],
+                "target": {},
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice vs. inhaled toxins"
+              }
+            ]
           },
           {
             "id": "tailored-pheromones",
@@ -16297,7 +16676,31 @@
             "attributeBonuses": {
               "socialLimit": 1
             },
-            "legality": "restricted"
+            "legality": "restricted",
+            "effects": [
+              {
+                "id": "tailored-pheromones-social-limit",
+                "type": "limit-modifier",
+                "triggers": ["social-test"],
+                "target": {
+                  "limit": "social"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Social Limit"
+              },
+              {
+                "id": "tailored-pheromones-social-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["social-test"],
+                "target": {},
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice to social tests (Acting and Influence)"
+              }
+            ]
           },
           {
             "id": "bone-density-augmentation",
@@ -16376,7 +16779,19 @@
             },
             "category": "basic",
             "description": "+1 dice to Toxin Resistance tests.",
-            "page": 461
+            "page": 461,
+            "effects": [
+              {
+                "id": "toxin-extractor-resistance",
+                "type": "resistance-modifier",
+                "triggers": ["resistance-test"],
+                "target": {},
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice to Toxin Resistance tests"
+              }
+            ]
           },
           {
             "id": "cerebral-booster",
@@ -16406,7 +16821,21 @@
             "page": 461,
             "attributeBonuses": {
               "logic": 1
-            }
+            },
+            "effects": [
+              {
+                "id": "cerebral-booster-logic",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "logic"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Logic"
+              }
+            ]
           },
           {
             "id": "damage-compensators",
@@ -16448,7 +16877,19 @@
             },
             "category": "cultured",
             "description": "Ignore 1 wound modifier.",
-            "page": 461
+            "page": 461,
+            "effects": [
+              {
+                "id": "damage-compensators-wound",
+                "type": "wound-modifier",
+                "triggers": ["always"],
+                "target": {},
+                "value": {
+                  "perRating": 1
+                },
+                "description": "Ignore [Rating] wound modifier boxes"
+              }
+            ]
           },
           {
             "id": "mnemonic-enhancer",
@@ -16475,7 +16916,21 @@
             },
             "category": "cultured",
             "description": "+1 to memory tests. +1 to Knowledge skill maximums.",
-            "page": 461
+            "page": 461,
+            "effects": [
+              {
+                "id": "mnemonic-enhancer-memory",
+                "type": "dice-pool-modifier",
+                "triggers": ["skill-test"],
+                "target": {
+                  "testCategory": "memory"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice to memory tests"
+              }
+            ]
           },
           {
             "id": "synaptic-booster",
@@ -16522,7 +16977,33 @@
             "description": "Broadened and replicated spinal nerve cells allow faster reaction time. Provides +1 Reaction and +1D6 Initiative per rating. Cannot be combined with any other Reaction or Initiative enhancement.",
             "page": 462,
             "legality": "restricted",
-            "incompatibleWith": ["wired-reflexes", "reaction-enhancers"]
+            "incompatibleWith": ["wired-reflexes", "reaction-enhancers"],
+            "effects": [
+              {
+                "id": "synaptic-booster-reaction",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "reaction"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Reaction",
+                "stackingGroup": "reaction-augmentation"
+              },
+              {
+                "id": "synaptic-booster-initiative",
+                "type": "initiative-modifier",
+                "triggers": ["always"],
+                "target": {},
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating]D6 Initiative",
+                "stackingGroup": "initiative-augmentation"
+              }
+            ]
           },
           {
             "id": "cat-eyes",
@@ -16542,7 +17023,29 @@
             "cost": 24000,
             "availability": 12,
             "description": "+1 to Escape Artist tests and Physical Limit.",
-            "page": 460
+            "page": 460,
+            "effects": [
+              {
+                "id": "enhanced-articulation-escape-artist",
+                "type": "dice-pool-modifier",
+                "triggers": ["skill-test"],
+                "target": {
+                  "skill": "escape-artist"
+                },
+                "value": 1,
+                "description": "+1 die to Escape Artist tests"
+              },
+              {
+                "id": "enhanced-articulation-physical-limit",
+                "type": "limit-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "limit": "physical"
+                },
+                "value": 1,
+                "description": "+1 Physical Limit"
+              }
+            ]
           },
           {
             "id": "orthoskin",
@@ -16588,7 +17091,20 @@
             "description": "Bonus Armor equal to Rating (compatible with bone lacing). Cannot be combined with dermal plating or other skin augmentations that provide armor.",
             "page": 460,
             "legality": "restricted",
-            "incompatibleWith": ["dermal-plating"]
+            "incompatibleWith": ["dermal-plating"],
+            "effects": [
+              {
+                "id": "orthoskin-armor",
+                "type": "armor-modifier",
+                "triggers": ["always"],
+                "target": {},
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] Armor",
+                "stackingGroup": "skin-armor-augmentation"
+              }
+            ]
           },
           {
             "id": "platelet-factories",
@@ -16639,7 +17155,49 @@
               "strength": 1
             },
             "page": 461,
-            "legality": "forbidden"
+            "legality": "forbidden",
+            "effects": [
+              {
+                "id": "suprathyroid-gland-body",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "body"
+                },
+                "value": 1,
+                "description": "+1 Body"
+              },
+              {
+                "id": "suprathyroid-gland-agility",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "agility"
+                },
+                "value": 1,
+                "description": "+1 Agility"
+              },
+              {
+                "id": "suprathyroid-gland-reaction",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "reaction"
+                },
+                "value": 1,
+                "description": "+1 Reaction"
+              },
+              {
+                "id": "suprathyroid-gland-strength",
+                "type": "attribute-modifier",
+                "triggers": ["always"],
+                "target": {
+                  "attribute": "strength"
+                },
+                "value": 1,
+                "description": "+1 Strength"
+              }
+            ]
           },
           {
             "id": "synthacardium",
@@ -16675,7 +17233,21 @@
               }
             },
             "description": "+Rating dice to Cardiovascular tests (fatigue, holding breath, etc.).",
-            "page": 461
+            "page": 461,
+            "effects": [
+              {
+                "id": "synthacardium-pool",
+                "type": "dice-pool-modifier",
+                "triggers": ["skill-test"],
+                "target": {
+                  "testCategory": "cardiovascular"
+                },
+                "value": {
+                  "perRating": 1
+                },
+                "description": "+[Rating] dice to cardiovascular tests (fatigue, holding breath, etc.)"
+              }
+            ]
           },
           {
             "id": "pain-editor",
@@ -16686,7 +17258,17 @@
             "availability": 18,
             "description": "Ignore all wound modifiers. Requires Willpower (3) to activate.",
             "page": 461,
-            "legality": "forbidden"
+            "legality": "forbidden",
+            "effects": [
+              {
+                "id": "pain-editor-wound",
+                "type": "wound-modifier",
+                "triggers": ["always"],
+                "target": {},
+                "value": 99,
+                "description": "Ignore all wound modifiers (requires Willpower (3) test to activate)"
+              }
+            ]
           },
           {
             "id": "sleep-regulator",
@@ -23055,7 +23637,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "cybercombat",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "equipment",
@@ -23078,12 +23662,17 @@
               {
                 "type": "mark",
                 "targetType": "target",
-                "calculation": { "baseValue": 1 },
+                "calculation": {
+                  "baseValue": 1
+                },
                 "description": "Place 1 mark on target (2 marks with 4+ net hits)"
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 238 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 238
+            }
           },
           {
             "id": "hack-on-the-fly",
@@ -23092,7 +23681,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "hacking",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "equipment",
@@ -23115,12 +23706,17 @@
               {
                 "type": "mark",
                 "targetType": "target",
-                "calculation": { "baseValue": 1 },
+                "calculation": {
+                  "baseValue": 1
+                },
                 "description": "Place 1 mark on target (2 marks with 4+ net hits)"
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 240 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 240
+            }
           },
           {
             "id": "data-spike",
@@ -23129,7 +23725,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "cybercombat",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "equipment",
@@ -23161,7 +23759,10 @@
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 238 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 238
+            }
           },
           {
             "id": "crash-program",
@@ -23170,7 +23771,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "cybercombat",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "equipment",
@@ -23199,12 +23802,17 @@
               {
                 "type": "device_action",
                 "targetType": "device",
-                "calculation": { "baseValue": 1 },
+                "calculation": {
+                  "baseValue": 1
+                },
                 "description": "Target program stops running"
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 238 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 238
+            }
           },
           {
             "id": "matrix-perception",
@@ -23213,7 +23821,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "electronic-warfare",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [],
             "modifiers": [],
             "rollConfig": {
@@ -23228,12 +23838,17 @@
               {
                 "type": "state_change",
                 "targetType": "self",
-                "calculation": { "addNetHits": true },
+                "calculation": {
+                  "addNetHits": true
+                },
                 "description": "Each net hit reveals one piece of information about a Matrix object"
               }
             ],
             "tags": [],
-            "source": { "book": "SR5 Core", "page": 241 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 241
+            }
           },
           {
             "id": "matrix-search",
@@ -23242,7 +23857,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "electronic-warfare",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [],
             "modifiers": [],
             "rollConfig": {
@@ -23258,12 +23875,17 @@
               {
                 "type": "state_change",
                 "targetType": "self",
-                "calculation": { "addNetHits": true },
+                "calculation": {
+                  "addNetHits": true
+                },
                 "description": "Find information. Threshold depends on obscurity."
               }
             ],
             "tags": [],
-            "source": { "book": "SR5 Core", "page": 241 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 241
+            }
           },
           {
             "id": "trace-icon",
@@ -23272,7 +23894,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "electronic-warfare",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "resource",
@@ -23296,12 +23920,17 @@
               {
                 "type": "state_change",
                 "targetType": "self",
-                "calculation": { "addNetHits": true },
+                "calculation": {
+                  "addNetHits": true
+                },
                 "description": "Determine physical location of icon's device"
               }
             ],
             "tags": [],
-            "source": { "book": "SR5 Core", "page": 242 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 242
+            }
           },
           {
             "id": "edit-file",
@@ -23310,7 +23939,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "hacking",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "resource",
@@ -23334,12 +23965,17 @@
               {
                 "type": "device_action",
                 "targetType": "device",
-                "calculation": { "baseValue": 1 },
+                "calculation": {
+                  "baseValue": 1
+                },
                 "description": "File is created, changed, copied, deleted, or protected"
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 239 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 239
+            }
           },
           {
             "id": "erase-mark",
@@ -23348,7 +23984,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "hacking",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [],
             "modifiers": [],
             "rollConfig": {
@@ -23365,12 +24003,17 @@
               {
                 "type": "state_change",
                 "targetType": "self",
-                "calculation": { "baseValue": 1 },
+                "calculation": {
+                  "baseValue": 1
+                },
                 "description": "Remove one mark from your persona or device"
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 240 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 240
+            }
           },
           {
             "id": "snoop",
@@ -23379,7 +24022,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "hacking",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "resource",
@@ -23408,7 +24053,10 @@
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 241 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 241
+            }
           },
           {
             "id": "spoof-command",
@@ -23417,7 +24065,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "hacking",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "resource",
@@ -23441,12 +24091,17 @@
               {
                 "type": "device_action",
                 "targetType": "device",
-                "calculation": { "baseValue": 1 },
+                "calculation": {
+                  "baseValue": 1
+                },
                 "description": "Target device accepts the spoofed command"
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 241 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 241
+            }
           },
           {
             "id": "control-device",
@@ -23455,7 +24110,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "electronic-warfare",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "resource",
@@ -23482,7 +24139,10 @@
               }
             ],
             "tags": [],
-            "source": { "book": "SR5 Core", "page": 238 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 238
+            }
           },
           {
             "id": "format-device",
@@ -23491,7 +24151,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "hacking",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "resource",
@@ -23520,7 +24182,10 @@
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 239 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 239
+            }
           },
           {
             "id": "reboot-device",
@@ -23529,7 +24194,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "hacking",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [
               {
                 "type": "resource",
@@ -23558,7 +24225,10 @@
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 241 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 241
+            }
           },
           {
             "id": "jam-signals",
@@ -23567,7 +24237,9 @@
             "type": "complex",
             "domain": "matrix",
             "subcategory": "electronic-warfare",
-            "cost": { "actionType": "complex" },
+            "cost": {
+              "actionType": "complex"
+            },
             "prerequisites": [],
             "modifiers": [],
             "rollConfig": {
@@ -23582,12 +24254,17 @@
               {
                 "type": "pool_modifier",
                 "targetType": "area",
-                "calculation": { "addNetHits": true },
+                "calculation": {
+                  "addNetHits": true
+                },
                 "description": "Create noise equal to hits for all devices in area"
               }
             ],
             "tags": ["illegal"],
-            "source": { "book": "SR5 Core", "page": 240 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 240
+            }
           },
           {
             "id": "jack-out",
@@ -23596,7 +24273,9 @@
             "type": "simple",
             "domain": "matrix",
             "subcategory": "electronic-warfare",
-            "cost": { "actionType": "simple" },
+            "cost": {
+              "actionType": "simple"
+            },
             "prerequisites": [],
             "modifiers": [],
             "rollConfig": {
@@ -23618,7 +24297,10 @@
               }
             ],
             "tags": [],
-            "source": { "book": "SR5 Core", "page": 240 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 240
+            }
           },
           {
             "id": "send-message",
@@ -23627,12 +24309,17 @@
             "type": "simple",
             "domain": "matrix",
             "subcategory": "electronic-warfare",
-            "cost": { "actionType": "simple" },
+            "cost": {
+              "actionType": "simple"
+            },
             "prerequisites": [],
             "modifiers": [],
             "effects": [],
             "tags": [],
-            "source": { "book": "SR5 Core", "page": 241 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 241
+            }
           },
           {
             "id": "change-icon",
@@ -23641,12 +24328,17 @@
             "type": "simple",
             "domain": "matrix",
             "subcategory": "electronic-warfare",
-            "cost": { "actionType": "simple" },
+            "cost": {
+              "actionType": "simple"
+            },
             "prerequisites": [],
             "modifiers": [],
             "effects": [],
             "tags": [],
-            "source": { "book": "SR5 Core", "page": 237 }
+            "source": {
+              "book": "SR5 Core",
+              "page": 237
+            }
           }
         ],
         "social": [],


### PR DESCRIPTION
## Summary

- Added unified `effects` arrays to **35 augmentation catalog items** (20 cyberware, 15 bioware) with 44 total effects
- Created data validation test suite for augmentation effects (9 tests including cross-module duplicate ID checking)
- Extended resolver tests with augmentation-specific gathering and integration tests (7 tests)

### Cyberware (20 items, 23 effects)
Bodyware: wired-reflexes, muscle-replacement, reaction-enhancers, dermal-plating, bone-lacing (×3)
Headware: cybereyes, cyberears, olfactory-booster, taste-booster, voice-modulator
Eyeware: eye-smartlink, eye-vision-enhancement
Earware: ear-audio-enhancement, ear-balance-augmenter, ear-damper, ear-spatial-recognizer
Cyberlimb: cyberlimb-gyromount, cyberlimb-hydraulic-jacks

### Bioware (15 items, 21 effects)
Basic: muscle-augmentation, muscle-toner, tailored-pheromones, enhanced-articulation, orthoskin, suprathyroid-gland, synthacardium, pathogenic-defense, tracheal-filter, toxin-extractor
Cultured: cerebral-booster, synaptic-booster, damage-compensators, pain-editor, mnemonic-enhancer

### No code changes needed
The gathering pipeline (`gatherCyberwareEffects`, `gatherBiowareEffects`) already supports the unified effect format — only JSON data additions and test extensions.

Closes #112

## Test plan

- [x] `pnpm verify-data` — JSON valid, no new issues
- [x] `pnpm type-check` — no type errors
- [x] `pnpm lint` — no lint errors
- [x] `pnpm test __tests__/lib/rules/effects/augmentation-effects-data` — 9 data validation tests pass
- [x] `pnpm test __tests__/lib/rules/effects/resolver` — 81 tests pass (including 7 new augmentation tests)
- [x] `pnpm test` — full suite passes (7824 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)