### PR TITLE
fix(wireless): show wireless indicators for all tracked equipment categories

### DIFF
--- a/components/character/sheet/ArmorDisplay.tsx
+++ b/components/character/sheet/ArmorDisplay.tsx
@@ -200,7 +200,7 @@ function ArmorRow({
     item.state?.readiness ?? (item.equipped ? "worn" : "stored");
 
   // Wireless state
-  const hasWireless = !!(item.wirelessBonus || catalogArmor?.wirelessBonus);
+  const hasWireless = true;
   const globalWireless = isGlobalWirelessEnabled(character);
   const wirelessEnabled = item.state?.wirelessEnabled ?? true;
   const isWirelessActive = hasWireless && globalWireless && wirelessEnabled;

--- a/components/character/sheet/AugmentationsDisplay.tsx
+++ b/components/character/sheet/AugmentationsDisplay.tsx
@@ -61,7 +61,7 @@ function AugmentationRow({
 }: AugmentationRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const hasWireless = !!item.wirelessBonus;
+  const hasWireless = true;
   const globalWireless = isGlobalWirelessEnabled(character);
   const wirelessEnabled = item.wirelessEnabled ?? true;
   const isWirelessActive = hasWireless && globalWireless && wirelessEnabled;

--- a/components/character/sheet/VehiclesDisplay.tsx
+++ b/components/character/sheet/VehiclesDisplay.tsx
@@ -217,8 +217,8 @@ function VehicleRow({
   // Condition and wireless state
   const condition = item.state?.condition;
   const conditionBadge = getConditionBadge(condition);
-  const hasWireless = isMatrixCapable(item) && item.state != null;
-  const wirelessEnabled = item.state?.wirelessEnabled ?? false;
+  const hasWireless = isMatrixCapable(item);
+  const wirelessEnabled = item.state?.wirelessEnabled ?? true;
   const globalWireless = character ? isGlobalWirelessEnabled(character) : true;
   const isWirelessActive = hasWireless && wirelessEnabled && globalWireless;
 

--- a/components/character/sheet/WeaponsDisplay.tsx
+++ b/components/character/sheet/WeaponsDisplay.tsx
@@ -217,7 +217,7 @@ function WeaponRow({
   const readiness: EquipmentReadiness = weapon.state?.readiness ?? "holstered";
 
   // Wireless state
-  const hasWireless = !!(weapon.wirelessBonus || catalogWeapon?.wirelessBonus);
+  const hasWireless = true;
   const globalWireless = isGlobalWirelessEnabled(character);
   const wirelessEnabled = weapon.state?.wirelessEnabled ?? true;
   const isWirelessActive = hasWireless && globalWireless && wirelessEnabled;

--- a/components/character/sheet/__tests__/ArmorDisplay.test.tsx
+++ b/components/character/sheet/__tests__/ArmorDisplay.test.tsx
@@ -282,11 +282,10 @@ describe("ArmorDisplay", () => {
     expect(screen.getByTestId("wireless-icon-off")).toBeInTheDocument();
   });
 
-  it("does not show wireless icons for armor without wirelessBonus", () => {
+  it("shows wireless icon for armor without explicit wirelessBonus", () => {
     const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
     render(<ArmorDisplay character={character} />);
-    expect(screen.queryByTestId("wireless-icon")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("wireless-icon-off")).not.toBeInTheDocument();
+    expect(screen.getByTestId("wireless-icon")).toBeInTheDocument();
   });
 
   // --- Expand/collapse ---
@@ -503,12 +502,12 @@ describe("ArmorDisplay", () => {
   // --- Wireless toggle (expanded, editable) ---
 
   describe("wireless toggle", () => {
-    it("hidden when armor has no wirelessBonus", () => {
+    it("shown when armor has no explicit wirelessBonus", () => {
       const onUpdate = vi.fn();
       const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
       render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
       fireEvent.click(screen.getByTestId("expand-button"));
-      expect(screen.queryByTestId("wireless-toggle")).not.toBeInTheDocument();
+      expect(screen.getByTestId("wireless-toggle")).toBeInTheDocument();
     });
 
     it("hidden when not editable", () => {

--- a/components/character/sheet/__tests__/AugmentationsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/AugmentationsDisplay.test.tsx
@@ -251,12 +251,11 @@ describe("AugmentationsDisplay", () => {
     expect(screen.getByTestId("wireless-icon-off")).toBeInTheDocument();
   });
 
-  it("shows no wifi icon when no wirelessBonus", () => {
+  it("shows wireless icon for augmentation without explicit wirelessBonus", () => {
     const noWireless = { ...MOCK_CYBERWARE, wirelessBonus: undefined, wirelessEffects: undefined };
     const character = createSheetCharacter({ cyberware: [noWireless] });
     render(<AugmentationsDisplay character={character} />);
-    expect(screen.queryByTestId("wireless-icon")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("wireless-icon-off")).not.toBeInTheDocument();
+    expect(screen.getByTestId("wireless-icon")).toBeInTheDocument();
   });
 
   it("shows wireless toggle in expanded section when editable", async () => {

--- a/components/character/sheet/__tests__/VehiclesDisplay.test.tsx
+++ b/components/character/sheet/__tests__/VehiclesDisplay.test.tsx
@@ -674,9 +674,9 @@ describe("VehiclesDisplay", () => {
     expect(screen.queryByTestId("wireless-icon-off")).not.toBeInTheDocument();
   });
 
-  it("does not show wireless icon for drone without state", () => {
+  it("shows active wireless icon for drone without explicit state (default enabled)", () => {
     render(<VehiclesDisplay drones={[MOCK_DRONE]} />);
-    expect(screen.queryByTestId("wireless-icon")).not.toBeInTheDocument();
+    expect(screen.getByTestId("wireless-icon")).toBeInTheDocument();
     expect(screen.queryByTestId("wireless-icon-off")).not.toBeInTheDocument();
   });
 

--- a/components/character/sheet/__tests__/WeaponsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/WeaponsDisplay.test.tsx
@@ -260,11 +260,10 @@ describe("WeaponsDisplay", () => {
     expect(screen.getByTestId("wireless-icon")).toBeInTheDocument();
   });
 
-  it("hides wireless icon for weapons without wirelessBonus", () => {
+  it("shows wireless icon for weapons without explicit wirelessBonus", () => {
     const character = createSheetCharacter({ weapons: [MOCK_MELEE_WEAPON] });
     render(<WeaponsDisplay character={character} />);
-    expect(screen.queryByTestId("wireless-icon")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("wireless-icon-off")).not.toBeInTheDocument();
+    expect(screen.getByTestId("wireless-icon")).toBeInTheDocument();
   });
 
   it("shows WifiOff icon when wireless is disabled for a weapon", () => {
@@ -720,12 +719,12 @@ describe("WeaponsDisplay", () => {
   // =========================================================================
 
   describe("wireless toggle", () => {
-    it("hidden when weapon has no wirelessBonus", () => {
+    it("shown when weapon has no explicit wirelessBonus", () => {
       const onUpdate = vi.fn();
       const character = createSheetCharacter({ weapons: [MOCK_MELEE_WEAPON] });
       render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
       fireEvent.click(screen.getByTestId("expand-button"));
-      expect(screen.queryByTestId("wireless-toggle")).not.toBeInTheDocument();
+      expect(screen.getByTestId("wireless-toggle")).toBeInTheDocument();
     });
 
     it("hidden when not editable", () => {

--- a/lib/rules/inventory/__tests__/state-manager.test.ts
+++ b/lib/rules/inventory/__tests__/state-manager.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { Weapon, ArmorItem, Character } from "@/lib/types";
+import type { Weapon, ArmorItem, Character, BiowareItem, CharacterDrone } from "@/lib/types";
 import type { DeviceCondition } from "@/lib/types/gear-state";
 import {
   getDefaultState,
@@ -555,6 +555,66 @@ describe("Equipment State Manager", () => {
             wirelessEnabled: false,
           },
         ] as Character["cyberware"],
+        bioware: [
+          {
+            id: "bio-1",
+            catalogId: "b1",
+            name: "Synaptic Booster",
+            category: "cultured",
+            grade: "standard",
+            baseEssenceCost: 0.5,
+            essenceCost: 0.5,
+            cost: 95000,
+            availability: 12,
+            wirelessEnabled: true,
+          },
+          {
+            id: "bio-2",
+            catalogId: "b2",
+            name: "Orthoskin",
+            category: "basic",
+            grade: "standard",
+            baseEssenceCost: 0.25,
+            essenceCost: 0.25,
+            cost: 6250,
+            availability: 8,
+            wirelessEnabled: false,
+          },
+        ] as BiowareItem[],
+        drones: [
+          {
+            id: "drone-1",
+            catalogId: "d1",
+            name: "MCT Fly-Spy",
+            size: "mini",
+            handling: 4,
+            speed: 3,
+            acceleration: 3,
+            body: 1,
+            armor: 0,
+            pilot: 3,
+            sensor: 3,
+            cost: 2000,
+            availability: 6,
+            state: { readiness: "stored", wirelessEnabled: true },
+          },
+          {
+            id: "drone-2",
+            catalogId: "d2",
+            name: "GM-Nissan Doberman",
+            size: "medium",
+            handling: 5,
+            speed: 3,
+            acceleration: 3,
+            body: 4,
+            armor: 4,
+            pilot: 3,
+            sensor: 3,
+            cost: 5000,
+            availability: 4,
+            state: { readiness: "stored", wirelessEnabled: false },
+          },
+        ] as CharacterDrone[],
       });
 
       const summary = getEquipmentStateSummary(character);
@@ -566,8 +626,10 @@ describe("Equipment State Manager", () => {
       expect(summary.wornArmor).toBe(1);
       expect(summary.storedArmor).toBe(1);
       expect(summary.stashedArmor).toBe(1);
-      expect(summary.wirelessEnabled).toBe(5); // 4 weapons + 1 cyberware
-      expect(summary.wirelessDisabled).toBe(1); // 1 cyberware disabled
+      // 4 weapons + 3 armor + 1 cyberware + 1 bioware + 1 drone = 10
+      expect(summary.wirelessEnabled).toBe(10);
+      // 1 cyberware + 1 bioware + 1 drone = 3
+      expect(summary.wirelessDisabled).toBe(3);
     });
 
     it("should count bricked devices", () => {

--- a/lib/rules/inventory/state-manager.ts
+++ b/lib/rules/inventory/state-manager.ts
@@ -493,10 +493,23 @@ export function getEquipmentStateSummary(character: Character): {
     if (state === "worn") wornArmor++;
     else if (state === "stashed") stashedArmor++;
     else storedArmor++;
+
+    if (item.state?.wirelessEnabled !== false) wirelessEnabled++;
+    else wirelessDisabled++;
   }
 
   for (const item of cyberware) {
     if (item.wirelessEnabled !== false) wirelessEnabled++;
+    else wirelessDisabled++;
+  }
+
+  for (const item of character.bioware || []) {
+    if (item.wirelessEnabled !== false) wirelessEnabled++;
+    else wirelessDisabled++;
+  }
+
+  for (const item of character.drones || []) {
+    if (item.state?.wirelessEnabled !== false) wirelessEnabled++;
     else wirelessDisabled++;
   }
 


### PR DESCRIPTION
## Summary
- Always show wireless indicators for weapons, armor, and augmentations (matching SR5 rules where all these categories inherently have wireless capabilities)
- Add armor, bioware, and drones to the wireless equipment counter in `state-manager.ts`
- Fix VehiclesDisplay to show wireless icons for drones without explicit state (default enabled)
- Resolves the mismatch where the counter reported more wireless items than the UI displayed

## Test plan
- [x] All 7889 unit tests pass
- [x] TypeScript type-check clean
- [x] Pre-commit hooks pass (lint, knip, type-check)
- [ ] Verify wireless icons appear on all weapons, armor, and augmentations in character sheet
- [ ] Verify wireless toggle controls appear in expanded rows for all equipment categories
- [ ] Verify wireless counter matches visible indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)