### PR TITLE
feat(magic): add MagicSummaryDisplay component (#92)

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -35,6 +35,7 @@ import {
   EncumbranceDisplay,
   FociDisplay,
   GearDisplay,
+  MagicSummaryDisplay,
   IdentitiesDisplay,
   CharacterInfoDisplay,
   KnowledgeLanguagesDisplay,
@@ -396,6 +397,9 @@ function CharacterSheet({
                 openDiceRoller(pool, context);
               }}
             />
+
+            {/* Magic Operations */}
+            {character.magicalPath !== "mundane" && <MagicSummaryDisplay character={character} />}
 
             {character.spells && character.spells.length > 0 && (
               <SpellsDisplay

--- a/components/character/sheet/MagicSummaryDisplay.tsx
+++ b/components/character/sheet/MagicSummaryDisplay.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useMemo } from "react";
+import type { Character } from "@/lib/types";
+import type { MagicalPath } from "@/lib/types/core";
+import { DisplayCard } from "./DisplayCard";
+import { Sparkles } from "lucide-react";
+import { useTraditions } from "@/lib/rules";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ATTR_ABBREV: Record<string, string> = {
+  body: "BOD",
+  agility: "AGI",
+  reaction: "REA",
+  strength: "STR",
+  willpower: "WIL",
+  logic: "LOG",
+  intuition: "INT",
+  charisma: "CHA",
+};
+
+const PATH_LABELS: Record<MagicalPath, string> = {
+  mundane: "Mundane",
+  "full-mage": "Full Mage",
+  "aspected-mage": "Aspected Mage",
+  "mystic-adept": "Mystic Adept",
+  adept: "Adept",
+  technomancer: "Technomancer",
+  explorer: "Explorer",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface MagicSummaryDisplayProps {
+  character: Character;
+}
+
+export function MagicSummaryDisplay({ character }: MagicSummaryDisplayProps) {
+  const traditions = useTraditions();
+  const isTechnomancer = character.magicalPath === "technomancer";
+
+  const tradition = useMemo(() => {
+    if (!character.tradition) return null;
+    return traditions.find((t) => t.id === character.tradition) ?? null;
+  }, [traditions, character.tradition]);
+
+  const magicRating = useMemo(
+    () =>
+      isTechnomancer
+        ? (character.specialAttributes.resonance ?? 0)
+        : (character.specialAttributes.magic ?? 0),
+    [character.specialAttributes, isTechnomancer]
+  );
+
+  const initiateGrade = character.initiateGrade ?? 0;
+
+  const sustainedCount = character.sustainedSpells?.length ?? 0;
+  const sustainedPenalty = sustainedCount > 0 ? sustainedCount * -2 : 0;
+
+  const boundSpirits = useMemo(
+    () => (character.spirits ?? []).filter((s) => s.bound),
+    [character.spirits]
+  );
+  const totalServices = useMemo(
+    () => boundSpirits.reduce((sum, s) => sum + s.services, 0),
+    [boundSpirits]
+  );
+
+  const activeFociCount = character.activeFoci?.length ?? 0;
+
+  const powerPointsSpent = useMemo(
+    () => (character.adeptPowers ?? []).reduce((sum, p) => sum + p.powerPointCost, 0),
+    [character.adeptPowers]
+  );
+
+  const hasAdeptPowers =
+    character.magicalPath === "adept" || character.magicalPath === "mystic-adept";
+
+  // Counts for bottom row
+  const spellCount = character.spells?.length ?? 0;
+  const adeptPowerCount = character.adeptPowers?.length ?? 0;
+  const complexFormCount = character.complexForms?.length ?? 0;
+  const fociCount = character.foci?.length ?? 0;
+
+  const hasActiveEffects = sustainedCount > 0 || boundSpirits.length > 0 || activeFociCount > 0;
+  const hasResourceCounts =
+    spellCount > 0 || adeptPowerCount > 0 || complexFormCount > 0 || fociCount > 0;
+
+  if (character.magicalPath === "mundane") return null;
+
+  const drainFormula = tradition
+    ? tradition.drainAttributes.map((a) => ATTR_ABBREV[a] ?? a.toUpperCase()).join(" + ")
+    : null;
+
+  return (
+    <DisplayCard
+      id="sheet-magic-summary"
+      title={isTechnomancer ? "Resonance" : "Magic"}
+      icon={<Sparkles className="h-4 w-4 text-violet-400" />}
+      collapsible
+    >
+      <div className="space-y-3">
+        {/* Magical Ability */}
+        <div data-testid="magic-ability-section">
+          <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+            {isTechnomancer ? "Resonance Ability" : "Magical Ability"}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              data-testid="magic-path"
+              className="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-400"
+            >
+              {PATH_LABELS[character.magicalPath]}
+            </span>
+            <span
+              data-testid="magic-rating"
+              className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+            >
+              {isTechnomancer ? "RES" : "MAG"} {magicRating}
+            </span>
+            {initiateGrade > 0 && (
+              <span
+                data-testid="initiate-grade"
+                className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+              >
+                {isTechnomancer ? "Submersion" : "Grade"} {initiateGrade}
+              </span>
+            )}
+          </div>
+          {/* Tradition / Stream */}
+          {tradition && (
+            <div
+              data-testid="tradition-info"
+              className="mt-1.5 text-[11px] text-zinc-500 dark:text-zinc-400"
+            >
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">{tradition.name}</span>
+              {drainFormula && (
+                <span className="ml-1">
+                  — Drain: <span className="font-mono font-semibold">{drainFormula}</span>
+                </span>
+              )}
+            </div>
+          )}
+          {isTechnomancer && character.stream && (
+            <div
+              data-testid="stream-info"
+              className="mt-1.5 text-[11px] text-zinc-500 dark:text-zinc-400"
+            >
+              Stream:{" "}
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                {character.stream}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Metamagics */}
+        {initiateGrade > 0 && character.metamagics && character.metamagics.length > 0 && (
+          <div data-testid="metamagics-section">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Metamagics
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {character.metamagics.map((m) => (
+                <span
+                  key={m}
+                  className="rounded-full px-2 py-0.5 text-[10px] font-medium bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                >
+                  {m.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Active Effects */}
+        {hasActiveEffects && (
+          <div data-testid="active-effects-section">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+              Active Effects
+            </div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-zinc-500 dark:text-zinc-400">
+              {sustainedCount > 0 && (
+                <span data-testid="sustained-spells" className="font-mono">
+                  {sustainedCount} Sustained{" "}
+                  <span className="font-semibold text-amber-600 dark:text-amber-400">
+                    ({sustainedPenalty})
+                  </span>
+                </span>
+              )}
+              {boundSpirits.length > 0 && (
+                <span data-testid="bound-spirits" className="font-mono">
+                  {boundSpirits.length} Bound Spirit{boundSpirits.length !== 1 ? "s" : ""}{" "}
+                  <span className="font-semibold text-zinc-700 dark:text-zinc-300">
+                    ({totalServices} service{totalServices !== 1 ? "s" : ""})
+                  </span>
+                </span>
+              )}
+              {activeFociCount > 0 && (
+                <span data-testid="active-foci" className="font-mono">
+                  {activeFociCount} Active {activeFociCount !== 1 ? "Foci" : "Focus"}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Power Points */}
+        {hasAdeptPowers && (
+          <div data-testid="power-points-section" className="flex items-center justify-between">
+            <span className="text-xs text-zinc-500 dark:text-zinc-400">Power Points</span>
+            <span
+              data-testid="power-points-value"
+              className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50"
+            >
+              {powerPointsSpent} / {magicRating} PP
+            </span>
+          </div>
+        )}
+
+        {/* Resource Counts */}
+        {hasResourceCounts && (
+          <div
+            data-testid="resource-counts"
+            className="flex flex-wrap gap-x-2 text-[11px] text-zinc-500 dark:text-zinc-400"
+          >
+            {spellCount > 0 && (
+              <span>
+                {spellCount} Spell{spellCount !== 1 ? "s" : ""}
+              </span>
+            )}
+            {spellCount > 0 && adeptPowerCount > 0 && <span>·</span>}
+            {adeptPowerCount > 0 && (
+              <span>
+                {adeptPowerCount} Power{adeptPowerCount !== 1 ? "s" : ""}
+              </span>
+            )}
+            {(spellCount > 0 || adeptPowerCount > 0) && complexFormCount > 0 && <span>·</span>}
+            {complexFormCount > 0 && (
+              <span>
+                {complexFormCount} Complex Form{complexFormCount !== 1 ? "s" : ""}
+              </span>
+            )}
+            {(spellCount > 0 || adeptPowerCount > 0 || complexFormCount > 0) && fociCount > 0 && (
+              <span>·</span>
+            )}
+            {fociCount > 0 && (
+              <span>
+                {fociCount} {fociCount !== 1 ? "Foci" : "Focus"}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </DisplayCard>
+  );
+}

--- a/components/character/sheet/__tests__/MagicSummaryDisplay.test.tsx
+++ b/components/character/sheet/__tests__/MagicSummaryDisplay.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { setupDisplayCardMock, LUCIDE_MOCK, createSheetCharacter } from "./test-helpers";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+const mockUseTraditions = vi.fn();
+
+vi.mock("@/lib/rules", () => ({
+  useTraditions: (...args: unknown[]) => mockUseTraditions(...args),
+}));
+
+import { MagicSummaryDisplay } from "../MagicSummaryDisplay";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const HERMETIC_TRADITION = {
+  id: "hermetic",
+  name: "Hermetic",
+  drainAttributes: ["logic", "willpower"] as [string, string],
+  spiritTypes: {},
+  description: "Hermetic tradition",
+};
+
+const SHAMAN_TRADITION = {
+  id: "shamanic",
+  name: "Shamanic",
+  drainAttributes: ["charisma", "willpower"] as [string, string],
+  spiritTypes: {},
+  description: "Shamanic tradition",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MagicSummaryDisplay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTraditions.mockReturnValue([HERMETIC_TRADITION, SHAMAN_TRADITION]);
+  });
+
+  it("returns null for mundane characters", () => {
+    const character = createSheetCharacter({ magicalPath: "mundane" });
+    const { container } = render(<MagicSummaryDisplay character={character} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders full mage with tradition, drain formula, and Magic rating", () => {
+    const character = createSheetCharacter({
+      magicalPath: "full-mage",
+      tradition: "hermetic",
+      specialAttributes: { edge: 3, essence: 6, magic: 6 },
+      spells: ["manabolt", "heal", "invisibility"],
+      foci: [
+        {
+          catalogId: "power-focus",
+          name: "Power Focus",
+          type: "power" as never,
+          force: 3,
+          bonded: true,
+          karmaToBond: 18,
+          cost: 18000,
+          availability: 12,
+        },
+      ],
+    });
+
+    render(<MagicSummaryDisplay character={character} />);
+
+    // Path pill
+    expect(screen.getByTestId("magic-path")).toHaveTextContent("Full Mage");
+    // Magic rating
+    expect(screen.getByTestId("magic-rating")).toHaveTextContent("MAG 6");
+    // Tradition and drain formula
+    expect(screen.getByTestId("tradition-info")).toHaveTextContent("Hermetic");
+    expect(screen.getByTestId("tradition-info")).toHaveTextContent("LOG + WIL");
+    // Resource counts
+    expect(screen.getByTestId("resource-counts")).toHaveTextContent("3 Spells");
+    expect(screen.getByTestId("resource-counts")).toHaveTextContent("1 Focus");
+  });
+
+  it("renders adept with power points section", () => {
+    const character = createSheetCharacter({
+      magicalPath: "adept",
+      specialAttributes: { edge: 3, essence: 6, magic: 6 },
+      adeptPowers: [
+        {
+          id: "imp-reflexes",
+          catalogId: "improved-reflexes",
+          name: "Improved Reflexes",
+          rating: 2,
+          powerPointCost: 3.5,
+        },
+        {
+          id: "killing-hands",
+          catalogId: "killing-hands",
+          name: "Killing Hands",
+          powerPointCost: 0.5,
+        },
+      ],
+    });
+
+    render(<MagicSummaryDisplay character={character} />);
+
+    expect(screen.getByTestId("magic-path")).toHaveTextContent("Adept");
+    expect(screen.getByTestId("magic-rating")).toHaveTextContent("MAG 6");
+    // Power points
+    expect(screen.getByTestId("power-points-section")).toBeInTheDocument();
+    expect(screen.getByTestId("power-points-value")).toHaveTextContent("4 / 6 PP");
+    // Resource counts
+    expect(screen.getByTestId("resource-counts")).toHaveTextContent("2 Powers");
+  });
+
+  it("renders technomancer with Resonance title, stream, and complex forms", () => {
+    const character = createSheetCharacter({
+      magicalPath: "technomancer",
+      stream: "Cyberadept",
+      specialAttributes: { edge: 3, essence: 6, resonance: 5 },
+      complexForms: ["cleaner", "resonance-spike", "puppeteer"],
+    });
+
+    render(<MagicSummaryDisplay character={character} />);
+
+    // Title should be "Resonance" (checked via display-card mock)
+    expect(screen.getByText("Resonance")).toBeInTheDocument();
+    expect(screen.getByTestId("magic-path")).toHaveTextContent("Technomancer");
+    expect(screen.getByTestId("magic-rating")).toHaveTextContent("RES 5");
+    // Stream info
+    expect(screen.getByTestId("stream-info")).toHaveTextContent("Cyberadept");
+    // Resource counts
+    expect(screen.getByTestId("resource-counts")).toHaveTextContent("3 Complex Forms");
+  });
+
+  it("renders initiate grade and metamagics when present", () => {
+    const character = createSheetCharacter({
+      magicalPath: "full-mage",
+      tradition: "hermetic",
+      specialAttributes: { edge: 3, essence: 6, magic: 7 },
+      initiateGrade: 2,
+      metamagics: ["centering", "shielding"],
+    });
+
+    render(<MagicSummaryDisplay character={character} />);
+
+    expect(screen.getByTestId("initiate-grade")).toHaveTextContent("Grade 2");
+    expect(screen.getByTestId("metamagics-section")).toBeInTheDocument();
+    expect(screen.getByText("Centering")).toBeInTheDocument();
+    expect(screen.getByText("Shielding")).toBeInTheDocument();
+  });
+
+  it("renders active effects with sustained spells, bound spirits, and active foci", () => {
+    const character = createSheetCharacter({
+      magicalPath: "full-mage",
+      tradition: "shamanic",
+      specialAttributes: { edge: 3, essence: 6, magic: 6 },
+      sustainedSpells: [
+        { spellId: "invisibility", hits: 3, force: 5 },
+        { spellId: "armor", hits: 4, force: 6 },
+      ],
+      spirits: [
+        { type: "fire" as never, force: 6, services: 3, bound: true },
+        { type: "water" as never, force: 5, services: 2, bound: true },
+        { type: "air" as never, force: 4, services: 0, bound: false },
+      ],
+      activeFoci: [{ id: "focus-1", type: "power", rating: 3 }],
+    });
+
+    render(<MagicSummaryDisplay character={character} />);
+
+    expect(screen.getByTestId("active-effects-section")).toBeInTheDocument();
+    // Sustained spells with penalty
+    expect(screen.getByTestId("sustained-spells")).toHaveTextContent("2 Sustained");
+    expect(screen.getByTestId("sustained-spells")).toHaveTextContent("(-4)");
+    // Bound spirits (only bound=true count)
+    expect(screen.getByTestId("bound-spirits")).toHaveTextContent("2 Bound Spirits");
+    expect(screen.getByTestId("bound-spirits")).toHaveTextContent("(5 services)");
+    // Active foci
+    expect(screen.getByTestId("active-foci")).toHaveTextContent("1 Active Focus");
+  });
+
+  it("does not render active effects section when none exist", () => {
+    const character = createSheetCharacter({
+      magicalPath: "full-mage",
+      tradition: "hermetic",
+      specialAttributes: { edge: 3, essence: 6, magic: 6 },
+    });
+
+    render(<MagicSummaryDisplay character={character} />);
+
+    expect(screen.queryByTestId("active-effects-section")).not.toBeInTheDocument();
+  });
+
+  it("does not render power points for non-adept mages", () => {
+    const character = createSheetCharacter({
+      magicalPath: "full-mage",
+      tradition: "hermetic",
+      specialAttributes: { edge: 3, essence: 6, magic: 6 },
+    });
+
+    render(<MagicSummaryDisplay character={character} />);
+
+    expect(screen.queryByTestId("power-points-section")).not.toBeInTheDocument();
+  });
+});

--- a/components/character/sheet/index.ts
+++ b/components/character/sheet/index.ts
@@ -18,6 +18,7 @@ export { EffectsSummaryDisplay } from "./EffectsSummaryDisplay";
 export { EncumbranceDisplay } from "./EncumbranceDisplay";
 export { FociDisplay } from "./FociDisplay";
 export { GearDisplay } from "./GearDisplay";
+export { MagicSummaryDisplay } from "./MagicSummaryDisplay";
 export { IdentitiesDisplay } from "./IdentitiesDisplay";
 export { KnowledgeLanguagesDisplay } from "./KnowledgeLanguagesDisplay";
 export { QualitiesDisplay } from "./QualitiesDisplay";


### PR DESCRIPTION
## Summary

- Add `MagicSummaryDisplay` component — a read-only overview panel for the magic/resonance section of the character sheet
- Shows magical path, tradition/stream, Magic/Resonance rating, initiate grade, metamagics, active effects (sustained spells with penalty, bound spirits with services, active foci), power points for adepts, and resource counts
- Integrates into the character sheet page before SpellsDisplay/AdeptPowersDisplay as the magic section overview header (mirrors MatrixSummaryDisplay pattern for matrix section)

Closes #92

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (7897 tests, 354 files)
- [x] 8 new unit tests covering: mundane null render, full mage, adept with power points, technomancer with Resonance title/stream, initiation + metamagics, active effects, and negative cases
- [ ] Manual: verify panel renders on character sheet for mage/adept/technomancer characters
- [ ] Manual: verify panel does not appear for mundane characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)