### PR TITLE
refactor: centralize duplicated magic and attribute constants (#306)

### DIFF
--- a/app/characters/[id]/advancement/components/AttributesTab.tsx
+++ b/app/characters/[id]/advancement/components/AttributesTab.tsx
@@ -9,6 +9,11 @@ import {
   getAttributeMaximum,
 } from "@/lib/rules/advancement/validation";
 import { calculateAttributeCost, calculateEdgeCost } from "@/lib/rules/advancement/costs";
+import {
+  CORE_ATTRIBUTE_NAMES,
+  PHYSICAL_ATTRIBUTES,
+  MENTAL_ATTRIBUTES,
+} from "@/lib/constants/attributes";
 import { X, ArrowUp } from "lucide-react";
 
 interface AttributesTabProps {
@@ -17,20 +22,11 @@ interface AttributesTabProps {
   onCharacterUpdate: (updatedCharacter: Character) => void;
 }
 
+/** Core attributes plus Edge for the advancement UI */
 const ATTRIBUTE_NAMES: Record<string, string> = {
-  body: "Body",
-  agility: "Agility",
-  reaction: "Reaction",
-  strength: "Strength",
-  willpower: "Willpower",
-  logic: "Logic",
-  intuition: "Intuition",
-  charisma: "Charisma",
+  ...CORE_ATTRIBUTE_NAMES,
   edge: "Edge",
 };
-
-const PHYSICAL_ATTRIBUTES = ["body", "agility", "reaction", "strength"];
-const MENTAL_ATTRIBUTES = ["willpower", "logic", "intuition", "charisma"];
 
 export function AttributesTab({ character, ruleset, onCharacterUpdate }: AttributesTabProps) {
   const [selectedAttribute, setSelectedAttribute] = useState<string | null>(null);

--- a/components/character/sheet/AdeptPowersDisplay.tsx
+++ b/components/character/sheet/AdeptPowersDisplay.tsx
@@ -6,17 +6,11 @@ import { ChevronDown, ChevronRight, Zap } from "lucide-react";
 import type { AdeptPower } from "@/lib/types";
 import { useAdeptPowers } from "@/lib/rules";
 import type { AdeptPowerCatalogItem } from "@/lib/rules/loader-types";
+import { ACTIVATION_LABELS } from "@/lib/constants/magic";
 
 interface AdeptPowersDisplayProps {
   adeptPowers: AdeptPower[];
 }
-
-const ACTIVATION_LABELS: Record<string, string> = {
-  free: "Free Action",
-  simple: "Simple Action",
-  complex: "Complex Action",
-  interrupt: "Interrupt",
-};
 
 function PowerRow({
   power,

--- a/components/creation/AdeptPowersCard.tsx
+++ b/components/creation/AdeptPowersCard.tsx
@@ -22,6 +22,7 @@ import type { AdeptPowerCatalogItem } from "@/lib/rules/loader-types";
 import { useCreationBudgets } from "@/lib/contexts";
 import { CreationCard, BudgetIndicator, SummaryFooter } from "./shared";
 import { AdeptPowerModal, AdeptPowerListItem } from "./adept-powers";
+import { ACTIVATION_ORDER, ACTIVATION_LABELS } from "@/lib/constants/magic";
 import { Lock, Plus, AlertTriangle } from "lucide-react";
 
 // =============================================================================
@@ -32,18 +33,6 @@ const POWER_POINT_KARMA_COST = 5;
 
 // Paths that can have adept powers
 const ADEPT_PATHS = ["adept", "mystic-adept"];
-
-/** Display order for activation types */
-const ACTIVATION_ORDER = ["free", "simple", "complex", "interrupt", "other"] as const;
-
-/** Human-readable activation type labels */
-const ACTIVATION_LABELS: Record<string, string> = {
-  free: "Free Action",
-  simple: "Simple Action",
-  complex: "Complex Action",
-  interrupt: "Interrupt Action",
-  other: "Passive / Other",
-};
 
 // =============================================================================
 // TYPES

--- a/components/creation/SpellsCard.tsx
+++ b/components/creation/SpellsCard.tsx
@@ -21,6 +21,8 @@ import type { CreationState, SpellSelection } from "@/lib/types";
 import { getSpellId, isSpellSelectionObject } from "@/lib/types";
 import type { SpellData } from "@/lib/rules";
 import { useCreationBudgets } from "@/lib/contexts";
+import { SPELL_KARMA_COST, SPELL_CATEGORIES } from "@/lib/constants/magic";
+import { getCoreAttributeName } from "@/lib/constants/attributes";
 import { CreationCard, BudgetIndicator, SummaryFooter } from "./shared";
 import { SpellModal, SpellListItem } from "./spells";
 import { Lock, Plus } from "lucide-react";
@@ -29,32 +31,8 @@ import { Lock, Plus } from "lucide-react";
 // CONSTANTS
 // =============================================================================
 
-const SPELL_KARMA_COST = 5;
-
-type SpellCategory = "combat" | "detection" | "health" | "illusion" | "manipulation";
-
-const SPELL_CATEGORIES: { id: SpellCategory; name: string }[] = [
-  { id: "combat", name: "Combat" },
-  { id: "detection", name: "Detection" },
-  { id: "health", name: "Health" },
-  { id: "illusion", name: "Illusion" },
-  { id: "manipulation", name: "Manipulation" },
-];
-
 // Paths that can have spells
 const SPELL_PATHS = ["magician", "mystic-adept", "aspected-mage"];
-
-// Attribute display names
-const ATTRIBUTE_NAMES: Record<string, string> = {
-  body: "Body",
-  agility: "Agility",
-  reaction: "Reaction",
-  strength: "Strength",
-  willpower: "Willpower",
-  logic: "Logic",
-  intuition: "Intuition",
-  charisma: "Charisma",
-};
 
 // =============================================================================
 // TYPES
@@ -75,7 +53,7 @@ interface SpellsCardProps {
 function getSpellDisplayName(spell: SpellData, selectedAttribute?: string): string {
   if (spell.requiresAttributeSelection && selectedAttribute) {
     // Replace [Attribute] with the selected attribute name
-    const attrName = ATTRIBUTE_NAMES[selectedAttribute] || selectedAttribute;
+    const attrName = getCoreAttributeName(selectedAttribute);
     return spell.name.replace("[Attribute]", `[${attrName}]`);
   }
   return spell.name;

--- a/components/creation/adept-powers/AdeptPowerListItem.tsx
+++ b/components/creation/adept-powers/AdeptPowerListItem.tsx
@@ -15,6 +15,7 @@
  */
 
 import { X, Zap, Minus, Plus, ChevronDown } from "lucide-react";
+import { getCoreAttributeName } from "@/lib/constants/attributes";
 
 // =============================================================================
 // CONSTANTS
@@ -47,18 +48,6 @@ const ACTIVATION_BADGES: Record<string, { letter: string; bg: string; text: stri
     bg: "bg-zinc-100 dark:bg-zinc-800",
     text: "text-zinc-600 dark:text-zinc-400",
   },
-};
-
-/** Attribute display names */
-const ATTRIBUTE_NAMES: Record<string, string> = {
-  body: "Body",
-  agility: "Agility",
-  reaction: "Reaction",
-  strength: "Strength",
-  willpower: "Willpower",
-  logic: "Logic",
-  intuition: "Intuition",
-  charisma: "Charisma",
 };
 
 // =============================================================================
@@ -236,7 +225,7 @@ export function AdeptPowerListItem({
               <option value="">-- Select --</option>
               {validSpecs.map((spec) => (
                 <option key={spec} value={spec}>
-                  {specType === "skill" ? formatSkillName(spec) : ATTRIBUTE_NAMES[spec] || spec}
+                  {specType === "skill" ? formatSkillName(spec) : getCoreAttributeName(spec)}
                 </option>
               ))}
             </select>

--- a/components/creation/adept-powers/AdeptPowerModal.tsx
+++ b/components/creation/adept-powers/AdeptPowerModal.tsx
@@ -21,35 +21,9 @@ import { useMemo, useState, useCallback } from "react";
 import type { AdeptPower } from "@/lib/types";
 import type { AdeptPowerCatalogItem } from "@/lib/rules/loader-types";
 import { BaseModalRoot, ModalHeader, ModalBody, ModalFooter } from "@/components/ui";
+import { ACTIVATION_ORDER, ACTIVATION_LABELS } from "@/lib/constants/magic";
+import { getCoreAttributeName } from "@/lib/constants/attributes";
 import { Search, Check, ChevronDown, Zap } from "lucide-react";
-
-// =============================================================================
-// CONSTANTS
-// =============================================================================
-
-/** Display order for activation types */
-const ACTIVATION_ORDER = ["free", "simple", "complex", "interrupt", "other"] as const;
-
-/** Human-readable activation type labels */
-const ACTIVATION_LABELS: Record<string, string> = {
-  free: "Free Action",
-  simple: "Simple Action",
-  complex: "Complex Action",
-  interrupt: "Interrupt Action",
-  other: "Passive / Other",
-};
-
-/** Attribute display names */
-const ATTRIBUTE_NAMES: Record<string, string> = {
-  body: "Body",
-  agility: "Agility",
-  reaction: "Reaction",
-  strength: "Strength",
-  willpower: "Willpower",
-  logic: "Logic",
-  intuition: "Intuition",
-  charisma: "Charisma",
-};
 
 // =============================================================================
 // TYPES
@@ -76,7 +50,7 @@ export interface AdeptPowerModalProps {
 function getPowerDisplayName(power: AdeptPowerCatalogItem, selectedSpec?: string): string {
   if (selectedSpec) {
     if (power.requiresAttribute) {
-      const attrName = ATTRIBUTE_NAMES[selectedSpec] || selectedSpec;
+      const attrName = getCoreAttributeName(selectedSpec);
       return `${power.name} (${attrName})`;
     }
     if (power.requiresSkill) {
@@ -384,7 +358,7 @@ export function AdeptPowerModal({
                             <option value="">-- Select Attribute --</option>
                             {selectedPowerData.validAttributes.map((attr) => (
                               <option key={attr} value={attr}>
-                                {ATTRIBUTE_NAMES[attr] || attr}
+                                {getCoreAttributeName(attr)}
                               </option>
                             ))}
                           </select>
@@ -393,7 +367,7 @@ export function AdeptPowerModal({
                         <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
                           Valid attributes:{" "}
                           {selectedPowerData.validAttributes
-                            .map((a) => ATTRIBUTE_NAMES[a] || a)
+                            .map((a) => getCoreAttributeName(a))
                             .join(", ")}
                         </p>
                       </div>

--- a/components/creation/spells/SpellListItem.tsx
+++ b/components/creation/spells/SpellListItem.tsx
@@ -14,21 +14,7 @@
  */
 
 import { X, Sparkles, ChevronDown } from "lucide-react";
-
-// =============================================================================
-// CONSTANTS
-// =============================================================================
-
-const ATTRIBUTE_NAMES: Record<string, string> = {
-  body: "Body",
-  agility: "Agility",
-  reaction: "Reaction",
-  strength: "Strength",
-  willpower: "Willpower",
-  logic: "Logic",
-  intuition: "Intuition",
-  charisma: "Charisma",
-};
+import { getCoreAttributeName } from "@/lib/constants/attributes";
 
 // =============================================================================
 // TYPES
@@ -155,7 +141,7 @@ export function SpellListItem({
               <option value="">-- Select --</option>
               {validAttributes.map((attr) => (
                 <option key={attr} value={attr}>
-                  {ATTRIBUTE_NAMES[attr] || attr}
+                  {getCoreAttributeName(attr)}
                 </option>
               ))}
             </select>

--- a/components/creation/spells/SpellModal.tsx
+++ b/components/creation/spells/SpellModal.tsx
@@ -16,39 +16,22 @@
 
 import { useMemo, useState, useCallback } from "react";
 import type { SpellData } from "@/lib/rules";
-import type { SpellSelection } from "@/lib/types";
+import type { SpellCategory, SpellSelection } from "@/lib/types";
 import { getSpellId, isSpellSelectionObject } from "@/lib/types";
 import { BaseModalRoot, ModalHeader, ModalBody, ModalFooter } from "@/components/ui";
+import { SPELL_KARMA_COST, SPELL_CATEGORIES } from "@/lib/constants/magic";
+import { getCoreAttributeName } from "@/lib/constants/attributes";
 import { Search, Check, ChevronDown, Sparkles } from "lucide-react";
 
 // =============================================================================
 // CONSTANTS
 // =============================================================================
 
-const SPELL_KARMA_COST = 5;
-
-type SpellCategory = "combat" | "detection" | "health" | "illusion" | "manipulation";
-
-const SPELL_CATEGORIES: { id: SpellCategory | "all"; name: string }[] = [
+/** Spell filter categories: base categories plus "all" for the modal filter */
+const SPELL_FILTER_CATEGORIES: { id: SpellCategory | "all"; name: string }[] = [
   { id: "all", name: "All" },
-  { id: "combat", name: "Combat" },
-  { id: "detection", name: "Detection" },
-  { id: "health", name: "Health" },
-  { id: "illusion", name: "Illusion" },
-  { id: "manipulation", name: "Manipulation" },
+  ...SPELL_CATEGORIES,
 ];
-
-// Attribute display names
-const ATTRIBUTE_NAMES: Record<string, string> = {
-  body: "Body",
-  agility: "Agility",
-  reaction: "Reaction",
-  strength: "Strength",
-  willpower: "Willpower",
-  logic: "Logic",
-  intuition: "Intuition",
-  charisma: "Charisma",
-};
 
 // =============================================================================
 // TYPES
@@ -73,7 +56,7 @@ export interface SpellModalProps {
  */
 function getSpellDisplayName(spell: SpellData, selectedAttribute?: string): string {
   if (spell.requiresAttributeSelection && selectedAttribute) {
-    const attrName = ATTRIBUTE_NAMES[selectedAttribute] || selectedAttribute;
+    const attrName = getCoreAttributeName(selectedAttribute);
     return spell.name.replace("[Attribute]", `[${attrName}]`);
   }
   return spell.name;
@@ -214,7 +197,7 @@ export function SpellModal({
 
             {/* Category Filter */}
             <div className="mt-3 flex flex-wrap gap-2">
-              {SPELL_CATEGORIES.map((cat) => (
+              {SPELL_FILTER_CATEGORIES.map((cat) => (
                 <button
                   key={cat.id}
                   onClick={() => setSelectedCategory(cat.id)}
@@ -380,7 +363,7 @@ export function SpellModal({
                             <option value="">-- Select --</option>
                             {selectedSpell.validAttributes.map((attr) => (
                               <option key={attr} value={attr}>
-                                {ATTRIBUTE_NAMES[attr] || attr}
+                                {getCoreAttributeName(attr)}
                               </option>
                             ))}
                           </select>
@@ -389,7 +372,7 @@ export function SpellModal({
                         <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
                           Valid attributes:{" "}
                           {selectedSpell.validAttributes
-                            .map((a) => ATTRIBUTE_NAMES[a] || a)
+                            .map((a) => getCoreAttributeName(a))
                             .join(", ")}
                         </p>
                       </div>

--- a/lib/constants/__tests__/attributes.test.ts
+++ b/lib/constants/__tests__/attributes.test.ts
@@ -9,6 +9,8 @@ import {
   SPECIAL_ATTRIBUTES,
   CORE_ATTRIBUTES,
   ALL_ATTRIBUTES,
+  CORE_ATTRIBUTE_NAMES,
+  getCoreAttributeName,
   ATTRIBUTE_ABBREVIATION_MAP,
   normalizeAttributeKey,
   isValidAttribute,
@@ -36,6 +38,45 @@ describe("Attribute Constants", () => {
 
     it("should have ALL_ATTRIBUTES as core + special", () => {
       expect(ALL_ATTRIBUTES).toEqual([...CORE_ATTRIBUTES, ...SPECIAL_ATTRIBUTES]);
+    });
+  });
+
+  describe("CORE_ATTRIBUTE_NAMES", () => {
+    it("should have a display name for every core attribute", () => {
+      for (const attr of CORE_ATTRIBUTES) {
+        expect(CORE_ATTRIBUTE_NAMES[attr]).toBeDefined();
+        expect(typeof CORE_ATTRIBUTE_NAMES[attr]).toBe("string");
+      }
+    });
+
+    it("should have capitalized display names", () => {
+      for (const attr of CORE_ATTRIBUTES) {
+        const name = CORE_ATTRIBUTE_NAMES[attr];
+        expect(name[0]).toBe(name[0].toUpperCase());
+      }
+    });
+
+    it("should have exactly 8 entries (no special attributes)", () => {
+      expect(Object.keys(CORE_ATTRIBUTE_NAMES)).toHaveLength(8);
+    });
+
+    it("should not include special attributes", () => {
+      const keys = Object.keys(CORE_ATTRIBUTE_NAMES);
+      expect(keys).not.toContain("edge");
+      expect(keys).not.toContain("magic");
+      expect(keys).not.toContain("resonance");
+    });
+  });
+
+  describe("getCoreAttributeName", () => {
+    it("should return display name for known core attributes", () => {
+      expect(getCoreAttributeName("body")).toBe("Body");
+      expect(getCoreAttributeName("charisma")).toBe("Charisma");
+    });
+
+    it("should return the key itself for unknown attributes", () => {
+      expect(getCoreAttributeName("edge")).toBe("edge");
+      expect(getCoreAttributeName("unknown")).toBe("unknown");
     });
   });
 

--- a/lib/constants/__tests__/magic.test.ts
+++ b/lib/constants/__tests__/magic.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for magic constants
+ */
+
+import { describe, it, expect } from "vitest";
+import { ACTIVATION_ORDER, ACTIVATION_LABELS, SPELL_KARMA_COST, SPELL_CATEGORIES } from "../magic";
+
+describe("Magic Constants", () => {
+  describe("ACTIVATION_ORDER", () => {
+    it("should contain all five activation types in order", () => {
+      expect(ACTIVATION_ORDER).toEqual(["free", "simple", "complex", "interrupt", "other"]);
+    });
+  });
+
+  describe("ACTIVATION_LABELS", () => {
+    it("should have a label for every activation type", () => {
+      for (const type of ACTIVATION_ORDER) {
+        expect(ACTIVATION_LABELS[type]).toBeDefined();
+        expect(typeof ACTIVATION_LABELS[type]).toBe("string");
+      }
+    });
+
+    it("should use 'Interrupt Action' (not 'Interrupt')", () => {
+      expect(ACTIVATION_LABELS.interrupt).toBe("Interrupt Action");
+    });
+
+    it("should have expected labels", () => {
+      expect(ACTIVATION_LABELS.free).toBe("Free Action");
+      expect(ACTIVATION_LABELS.simple).toBe("Simple Action");
+      expect(ACTIVATION_LABELS.complex).toBe("Complex Action");
+      expect(ACTIVATION_LABELS.other).toBe("Passive / Other");
+    });
+  });
+
+  describe("SPELL_KARMA_COST", () => {
+    it("should be 5", () => {
+      expect(SPELL_KARMA_COST).toBe(5);
+    });
+  });
+
+  describe("SPELL_CATEGORIES", () => {
+    it("should have 5 base categories", () => {
+      expect(SPELL_CATEGORIES).toHaveLength(5);
+    });
+
+    it("should contain all spell categories", () => {
+      const ids = SPELL_CATEGORIES.map((c) => c.id);
+      expect(ids).toEqual(["combat", "detection", "health", "illusion", "manipulation"]);
+    });
+
+    it("should not include 'all' filter category", () => {
+      const ids = SPELL_CATEGORIES.map((c) => c.id);
+      expect(ids).not.toContain("all");
+    });
+
+    it("should have human-readable names", () => {
+      for (const cat of SPELL_CATEGORIES) {
+        expect(cat.name).toBeTruthy();
+        // Name should be capitalized
+        expect(cat.name[0]).toBe(cat.name[0].toUpperCase());
+      }
+    });
+  });
+});

--- a/lib/constants/attributes.ts
+++ b/lib/constants/attributes.ts
@@ -22,6 +22,26 @@ export type SpecialAttribute = (typeof SPECIAL_ATTRIBUTES)[number];
 export type CoreAttribute = (typeof CORE_ATTRIBUTES)[number];
 export type Attribute = (typeof ALL_ATTRIBUTES)[number];
 
+/** Human-readable display names for the 8 core attributes */
+export const CORE_ATTRIBUTE_NAMES: Record<CoreAttribute, string> = {
+  body: "Body",
+  agility: "Agility",
+  reaction: "Reaction",
+  strength: "Strength",
+  willpower: "Willpower",
+  logic: "Logic",
+  intuition: "Intuition",
+  charisma: "Charisma",
+};
+
+/**
+ * Look up the display name for a core attribute, with fallback for unknown keys.
+ * Use this when the key comes from data typed as `string` rather than `CoreAttribute`.
+ */
+export function getCoreAttributeName(key: string): string {
+  return (CORE_ATTRIBUTE_NAMES as Record<string, string | undefined>)[key] ?? key;
+}
+
 // =============================================================================
 // ABBREVIATION MAPPING
 // =============================================================================

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from "./attributes";
+export * from "./magic";

--- a/lib/constants/magic.ts
+++ b/lib/constants/magic.ts
@@ -1,0 +1,43 @@
+/**
+ * Magic Constants
+ *
+ * Centralized definitions for magic-related constants used across
+ * spell and adept power components.
+ */
+
+import type { SpellCategory } from "@/lib/types";
+
+// =============================================================================
+// ACTIVATION TYPES (Adept Powers)
+// =============================================================================
+
+/** Display order for activation types */
+export const ACTIVATION_ORDER = ["free", "simple", "complex", "interrupt", "other"] as const;
+
+/** Activation type union derived from ACTIVATION_ORDER */
+export type ActivationType = (typeof ACTIVATION_ORDER)[number];
+
+/** Human-readable activation type labels */
+export const ACTIVATION_LABELS: Record<ActivationType, string> = {
+  free: "Free Action",
+  simple: "Simple Action",
+  complex: "Complex Action",
+  interrupt: "Interrupt Action",
+  other: "Passive / Other",
+};
+
+// =============================================================================
+// SPELLS
+// =============================================================================
+
+/** Karma cost to learn one spell beyond free allocation */
+export const SPELL_KARMA_COST = 5;
+
+/** Base spell categories (without "all" filter option) */
+export const SPELL_CATEGORIES: readonly { id: SpellCategory; name: string }[] = [
+  { id: "combat", name: "Combat" },
+  { id: "detection", name: "Detection" },
+  { id: "health", name: "Health" },
+  { id: "illusion", name: "Illusion" },
+  { id: "manipulation", name: "Manipulation" },
+];


### PR DESCRIPTION
## Summary

Closes #306

- Extract `ACTIVATION_ORDER`, `ACTIVATION_LABELS`, `SPELL_KARMA_COST`, and `SPELL_CATEGORIES` into `lib/constants/magic.ts`
- Add `CORE_ATTRIBUTE_NAMES` (`Record<CoreAttribute, string>`) and `getCoreAttributeName()` helper to `lib/constants/attributes.ts`
- Update 8 consumer files to import from shared constants instead of defining locally
- Fix inconsistency where `AdeptPowersDisplay` used "Interrupt" while creation components used "Interrupt Action"

## Test plan

- [x] `pnpm type-check` passes (Record<CoreAttribute, string> catches missing attrs)
- [x] All 7912 tests pass (355 test files)
- [x] `pnpm lint` — no new warnings
- [x] `pnpm knip` — no new dead exports
- [x] New tests: 9 tests in `magic.test.ts`, 6 new tests in `attributes.test.ts`
- [ ] Verify AdeptPowersDisplay shows "Interrupt Action" (not "Interrupt") in expanded power rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)