### PR TITLE
feat(campaigns): add GM-triggered Edge refresh for sessions (#458)

### DIFF
--- a/app/api/campaigns/[id]/sessions/[sessionId]/edge-refresh/route.ts
+++ b/app/api/campaigns/[id]/sessions/[sessionId]/edge-refresh/route.ts
@@ -1,0 +1,218 @@
+import { NextRequest, NextResponse } from "next/server";
+import { v4 as uuidv4 } from "uuid";
+import { getSession } from "@/lib/auth/session";
+import { getCampaignById, updateCampaign } from "@/lib/storage/campaigns";
+import {
+  getCharacterById,
+  getUserCharacters,
+  getCurrentEdge,
+  getMaxEdge,
+  restoreFullEdge,
+} from "@/lib/storage/characters";
+import type { EdgeRefreshEvent } from "@/lib/types/campaign";
+import type { Character } from "@/lib/types";
+
+/**
+ * POST /api/campaigns/[id]/sessions/[sessionId]/edge-refresh
+ * Refreshes Edge for all party characters or an individual character.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; sessionId: string }> }
+): Promise<NextResponse> {
+  try {
+    const userId = await getSession();
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const { id: campaignId, sessionId } = await params;
+    const campaign = await getCampaignById(campaignId);
+
+    if (!campaign) {
+      return NextResponse.json({ success: false, error: "Campaign not found" }, { status: 404 });
+    }
+
+    // Only GM can refresh Edge
+    if (campaign.gmId !== userId) {
+      return NextResponse.json(
+        { success: false, error: "Only the GM can refresh Edge" },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const { scope, characterId, reason } = body as {
+      scope: "party" | "individual";
+      characterId?: string;
+      reason: string;
+    };
+
+    // Validate scope
+    if (scope !== "party" && scope !== "individual") {
+      return NextResponse.json(
+        { success: false, error: "Scope must be 'party' or 'individual'" },
+        { status: 400 }
+      );
+    }
+
+    // Validate reason
+    if (!reason || reason.trim().length === 0) {
+      return NextResponse.json({ success: false, error: "Reason is required" }, { status: 400 });
+    }
+
+    // Find the session
+    const sessions = campaign.sessions || [];
+    const sessionIndex = sessions.findIndex((s) => s.id === sessionId);
+
+    if (sessionIndex === -1) {
+      return NextResponse.json({ success: false, error: "Session not found" }, { status: 404 });
+    }
+
+    const session = sessions[sessionIndex];
+
+    // Reject if session is completed or cancelled
+    if (session.status === "completed" || session.status === "cancelled") {
+      return NextResponse.json(
+        { success: false, error: "Cannot refresh Edge during a completed or cancelled session" },
+        { status: 400 }
+      );
+    }
+
+    // Determine target characters
+    let targets: Character[] = [];
+
+    if (scope === "party") {
+      // Fetch all campaign characters
+      const allMemberIds = [campaign.gmId, ...campaign.playerIds];
+      const characterPromises = allMemberIds.map((memberId) => getUserCharacters(memberId));
+      const allCharacterArrays = await Promise.all(characterPromises);
+      targets = allCharacterArrays
+        .flat()
+        .filter((char) => char.campaignId === campaignId && char.status === "active");
+    } else {
+      // Individual scope
+      if (!characterId) {
+        return NextResponse.json(
+          { success: false, error: "characterId is required for individual scope" },
+          { status: 400 }
+        );
+      }
+      const character = await getCharacterById(characterId);
+      if (!character) {
+        return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
+      }
+      targets = [character];
+    }
+
+    if (targets.length === 0) {
+      return NextResponse.json(
+        { success: false, error: "No eligible characters found" },
+        { status: 400 }
+      );
+    }
+
+    // Refresh Edge for each character and collect results
+    const results: {
+      characterId: string;
+      characterName: string;
+      previousEdge: number;
+      newEdge: number;
+      maxEdge: number;
+    }[] = [];
+
+    for (const character of targets) {
+      const previousEdge = getCurrentEdge(character);
+      const maxEdge = getMaxEdge(character);
+
+      await restoreFullEdge(character.ownerId, character.id);
+
+      results.push({
+        characterId: character.id,
+        characterName: character.name,
+        previousEdge,
+        newEdge: maxEdge,
+        maxEdge,
+      });
+    }
+
+    // Build the Edge refresh record
+    const edgeRefresh: EdgeRefreshEvent = {
+      id: uuidv4(),
+      scope,
+      characterIds: targets.map((c) => c.id),
+      characterNames: targets.map((c) => c.name),
+      reason: reason.trim(),
+      refreshedBy: userId,
+      refreshedAt: new Date().toISOString(),
+    };
+
+    // Append to session's edgeRefreshes
+    const existingRefreshes = session.edgeRefreshes || [];
+    const updatedSession = {
+      ...session,
+      edgeRefreshes: [...existingRefreshes, edgeRefresh],
+      updatedAt: new Date().toISOString(),
+    };
+
+    const updatedSessions = [...sessions];
+    updatedSessions[sessionIndex] = updatedSession;
+
+    // Save campaign
+    const updatedCampaign = await updateCampaign(campaignId, {
+      sessions: updatedSessions,
+    });
+
+    // Log activity and notify asynchronously
+    try {
+      const { logActivity } = await import("@/lib/storage/activity");
+      const { createNotification } = await import("@/lib/storage/notifications");
+
+      const namesStr = targets.map((c) => c.name).join(", ");
+      await logActivity({
+        campaignId,
+        type: "edge_refresh",
+        actorId: userId,
+        targetId: sessionId,
+        targetType: "session",
+        targetName: session.title,
+        description: `Edge Refresh: ${scope === "party" ? "All characters" : namesStr} — ${reason.trim()}`,
+      });
+
+      // Notify each affected character's owner
+      const notifiedOwnerIds = new Set<string>();
+      for (const character of targets) {
+        if (notifiedOwnerIds.has(character.ownerId)) continue;
+        notifiedOwnerIds.add(character.ownerId);
+
+        const ownerChars = targets.filter((c) => c.ownerId === character.ownerId);
+        const charNames = ownerChars.map((c) => c.name).join(", ");
+
+        await createNotification({
+          userId: character.ownerId,
+          campaignId,
+          type: "edge_refreshed",
+          title: "Edge Refreshed",
+          message: `${charNames} had Edge restored to maximum — ${reason.trim()}`,
+          actionUrl: `/characters/${ownerChars[0].id}`,
+        });
+      }
+    } catch (activityError) {
+      console.error("Failed to log edge refresh activity:", activityError);
+    }
+
+    return NextResponse.json({
+      success: true,
+      campaign: updatedCampaign,
+      session: updatedSession,
+      edgeRefresh,
+      results,
+    });
+  } catch (error) {
+    console.error("Edge refresh error:", error);
+    return NextResponse.json({ success: false, error: "An error occurred" }, { status: 500 });
+  }
+}

--- a/app/campaigns/[id]/components/CampaignCalendarTab.tsx
+++ b/app/campaigns/[id]/components/CampaignCalendarTab.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import type { Campaign, CampaignEvent } from "@/lib/types";
-import { Plus, Clock, Trophy, CheckCircle2, Gift, Coins } from "lucide-react";
+import { Plus, Clock, Trophy, CheckCircle2, Gift, Coins, RefreshCw } from "lucide-react";
 import SessionRewardDialog from "./SessionRewardDialog";
 import MidSessionAwardDialog from "./MidSessionAwardDialog";
+import EdgeRefreshDialog from "./EdgeRefreshDialog";
 import type { CampaignSession } from "@/lib/types";
 
 interface CampaignCalendarTabProps {
@@ -36,6 +37,10 @@ export default function CampaignCalendarTab({ campaign, userRole }: CampaignCale
   const [awardSession, setAwardSession] = useState<CampaignSession | null>(null);
   const [isAwardDialogOpen, setIsAwardDialogOpen] = useState(false);
 
+  // Edge Refresh Dialog State
+  const [edgeRefreshSession, setEdgeRefreshSession] = useState<CampaignSession | null>(null);
+  const [isEdgeRefreshDialogOpen, setIsEdgeRefreshDialogOpen] = useState(false);
+
   const handleCompleteSession = (session: CampaignSession) => {
     setSelectedSession(session);
     setIsRewardDialogOpen(true);
@@ -46,7 +51,16 @@ export default function CampaignCalendarTab({ campaign, userRole }: CampaignCale
     setIsAwardDialogOpen(true);
   };
 
+  const handleEdgeRefresh = (session: CampaignSession) => {
+    setEdgeRefreshSession(session);
+    setIsEdgeRefreshDialogOpen(true);
+  };
+
   const handleAwardSuccess = () => {
+    window.location.reload();
+  };
+
+  const handleEdgeRefreshSuccess = () => {
     window.location.reload();
   };
 
@@ -308,6 +322,13 @@ export default function CampaignCalendarTab({ campaign, userRole }: CampaignCale
                             Quick Award
                           </button>
                           <button
+                            onClick={() => handleEdgeRefresh(event)}
+                            className="inline-flex items-center gap-1.5 text-xs font-semibold text-cyan-600 hover:text-cyan-700 dark:text-cyan-400 dark:hover:text-cyan-300"
+                          >
+                            <RefreshCw className="h-3.5 w-3.5" />
+                            Edge Refresh
+                          </button>
+                          <button
                             onClick={() => handleCompleteSession(event)}
                             className="inline-flex items-center gap-1.5 text-xs font-semibold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
                           >
@@ -372,6 +393,32 @@ export default function CampaignCalendarTab({ campaign, userRole }: CampaignCale
                           </div>
                         </div>
                       )}
+                    {isSession(event) && event.edgeRefreshes && event.edgeRefreshes.length > 0 && (
+                      <div className="mt-3 rounded-md border border-cyan-200 bg-cyan-50 p-3 dark:border-cyan-900/40 dark:bg-cyan-900/10">
+                        <p className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-cyan-700 dark:text-cyan-400">
+                          <RefreshCw className="h-3.5 w-3.5" />
+                          {event.edgeRefreshes.length} Edge Refresh
+                          {event.edgeRefreshes.length !== 1 ? "es" : ""}
+                        </p>
+                        <div className="space-y-1">
+                          {event.edgeRefreshes.map((refresh) => (
+                            <div
+                              key={refresh.id}
+                              className="flex items-center justify-between text-xs text-zinc-600 dark:text-zinc-300"
+                            >
+                              <span className="font-medium">
+                                {refresh.scope === "party"
+                                  ? "All Characters"
+                                  : refresh.characterNames.join(", ")}
+                              </span>
+                              <span className="text-zinc-500 dark:text-zinc-400">
+                                {refresh.reason}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </div>
               ))}
@@ -422,6 +469,17 @@ export default function CampaignCalendarTab({ campaign, userRole }: CampaignCale
           campaign={campaign}
           session={awardSession}
           onSuccess={handleAwardSuccess}
+        />
+      )}
+
+      {/* Edge Refresh Dialog */}
+      {edgeRefreshSession && (
+        <EdgeRefreshDialog
+          isOpen={isEdgeRefreshDialogOpen}
+          onClose={() => setIsEdgeRefreshDialogOpen(false)}
+          campaign={campaign}
+          session={edgeRefreshSession}
+          onSuccess={handleEdgeRefreshSuccess}
         />
       )}
     </div>

--- a/app/campaigns/[id]/components/EdgeRefreshDialog.tsx
+++ b/app/campaigns/[id]/components/EdgeRefreshDialog.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Modal, ModalOverlay, Dialog, Heading, Button, Form } from "react-aria-components";
+import { Loader2, RefreshCw, X, Users, User } from "lucide-react";
+import type { Campaign, CampaignSession, Character } from "@/lib/types";
+
+interface EdgeRefreshDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  campaign: Campaign;
+  session: CampaignSession;
+  onSuccess: (updatedCampaign: Campaign) => void;
+}
+
+const REASON_PRESETS = [
+  { value: "session-start", label: "Session Start" },
+  { value: "scene-change", label: "Scene Change" },
+  { value: "custom", label: "Custom..." },
+];
+
+export default function EdgeRefreshDialog({
+  isOpen,
+  onClose,
+  campaign,
+  session,
+  onSuccess,
+}: EdgeRefreshDialogProps) {
+  const [loading, setLoading] = useState(false);
+  const [characters, setCharacters] = useState<Character[]>([]);
+  const [fetchingCharacters, setFetchingCharacters] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form state
+  const [scope, setScope] = useState<"party" | "individual">("party");
+  const [selectedCharacterId, setSelectedCharacterId] = useState("");
+  const [reasonPreset, setReasonPreset] = useState("session-start");
+  const [customReason, setCustomReason] = useState("");
+
+  // Fetch characters in campaign
+  useEffect(() => {
+    if (isOpen) {
+      const fetchCharacters = async () => {
+        setFetchingCharacters(true);
+        try {
+          const res = await fetch(`/api/campaigns/${campaign.id}/characters`);
+          const data = await res.json();
+          if (data.success) {
+            setCharacters(data.characters);
+          }
+        } catch {
+          // Ignore errors
+        } finally {
+          setFetchingCharacters(false);
+        }
+      };
+      fetchCharacters();
+      // Reset form on open
+      setScope("party");
+      setSelectedCharacterId("");
+      setReasonPreset("session-start");
+      setCustomReason("");
+      setError(null);
+    }
+  }, [isOpen, campaign.id]);
+
+  const effectiveReason =
+    reasonPreset === "custom"
+      ? customReason
+      : REASON_PRESETS.find((p) => p.value === reasonPreset)?.label || reasonPreset;
+
+  const isValid =
+    effectiveReason.trim().length > 0 &&
+    (scope === "party" || (scope === "individual" && selectedCharacterId));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/campaigns/${campaign.id}/sessions/${session.id}/edge-refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scope,
+          characterId: scope === "individual" ? selectedCharacterId : undefined,
+          reason: effectiveReason,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (data.success) {
+        onSuccess(data.campaign);
+        onClose();
+      } else {
+        setError(data.error || "Failed to refresh Edge");
+      }
+    } catch {
+      setError("An unexpected error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ModalOverlay
+      isOpen={isOpen}
+      onOpenChange={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+    >
+      <Modal className="w-full max-w-md overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-zinc-900">
+        <Dialog className="relative outline-none">
+          {({ close }) => (
+            <div className="flex flex-col">
+              {/* Header */}
+              <div className="flex items-center justify-between border-b border-zinc-100 bg-zinc-50/50 px-6 py-4 dark:border-zinc-800 dark:bg-zinc-900/50">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-cyan-100 text-cyan-600 dark:bg-cyan-900/40 dark:text-cyan-400">
+                    <RefreshCw className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <Heading
+                      slot="title"
+                      className="text-lg font-bold text-zinc-900 dark:text-zinc-50"
+                    >
+                      Edge Refresh
+                    </Heading>
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400">{session.title}</p>
+                  </div>
+                </div>
+                <Button
+                  onPress={close}
+                  className="rounded-full p-2 text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                >
+                  <X className="h-5 w-5" />
+                </Button>
+              </div>
+
+              <Form onSubmit={handleSubmit} className="p-6">
+                <div className="space-y-5">
+                  {/* Scope toggle */}
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                      Scope
+                    </label>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setScope("party")}
+                        className={`flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                          scope === "party"
+                            ? "bg-cyan-600 text-white shadow-md"
+                            : "border border-zinc-200 text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        }`}
+                      >
+                        <Users className="h-4 w-4" />
+                        All Characters
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setScope("individual")}
+                        className={`flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                          scope === "individual"
+                            ? "bg-cyan-600 text-white shadow-md"
+                            : "border border-zinc-200 text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                        }`}
+                      >
+                        <User className="h-4 w-4" />
+                        Individual
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Character selector (individual only) */}
+                  {scope === "individual" && (
+                    <div className="flex flex-col gap-1">
+                      <label className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                        Character
+                      </label>
+                      {fetchingCharacters ? (
+                        <div className="flex items-center gap-2 py-2 text-sm text-zinc-400">
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Loading characters...
+                        </div>
+                      ) : (
+                        <select
+                          value={selectedCharacterId}
+                          onChange={(e) => setSelectedCharacterId(e.target.value)}
+                          required
+                          className="w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm focus:border-cyan-500 focus:ring-1 focus:ring-cyan-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                        >
+                          <option value="">Select a character...</option>
+                          {characters.map((char) => (
+                            <option key={char.id} value={char.id}>
+                              {char.name} ({char.metatype})
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Reason selector */}
+                  <div className="flex flex-col gap-1">
+                    <label className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                      Reason
+                    </label>
+                    <select
+                      value={reasonPreset}
+                      onChange={(e) => setReasonPreset(e.target.value)}
+                      className="w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm focus:border-cyan-500 focus:ring-1 focus:ring-cyan-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                    >
+                      {REASON_PRESETS.map((preset) => (
+                        <option key={preset.value} value={preset.value}>
+                          {preset.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {/* Custom reason input */}
+                  {reasonPreset === "custom" && (
+                    <div className="flex flex-col gap-1">
+                      <label className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                        Custom Reason
+                      </label>
+                      <input
+                        type="text"
+                        value={customReason}
+                        onChange={(e) => setCustomReason(e.target.value)}
+                        placeholder="Enter reason for Edge refresh..."
+                        required
+                        className="w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm focus:border-cyan-500 focus:ring-1 focus:ring-cyan-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {error && (
+                  <div className="mt-4 rounded-md bg-red-50 p-3 text-xs text-red-600 dark:bg-red-900/20 dark:text-red-400">
+                    {error}
+                  </div>
+                )}
+
+                <div className="mt-6 flex justify-end gap-3 border-t border-zinc-100 pt-5 dark:border-zinc-800">
+                  <Button
+                    onPress={close}
+                    className="rounded-md px-4 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    isDisabled={loading || !isValid}
+                    className="flex items-center gap-2 rounded-md bg-cyan-600 px-6 py-2 text-sm font-bold text-white shadow-lg hover:bg-cyan-700 disabled:opacity-50"
+                  >
+                    {loading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-4 w-4" />
+                    )}
+                    Refresh Edge
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          )}
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}

--- a/lib/types/campaign.ts
+++ b/lib/types/campaign.ts
@@ -258,6 +258,8 @@ export interface CampaignSession {
   nuyenAwarded?: number;
   /** Mid-session individual awards (Quick Awards from GM) */
   midSessionAwards?: MidSessionAward[];
+  /** Edge refresh events triggered by the GM */
+  edgeRefreshes?: EdgeRefreshEvent[];
   createdAt: ISODateString;
   updatedAt: ISODateString;
 }
@@ -274,6 +276,19 @@ export interface MidSessionAward {
   reason: string;
   awardedBy: ID;
   awardedAt: ISODateString;
+}
+
+/**
+ * An Edge refresh event triggered by the GM
+ */
+export interface EdgeRefreshEvent {
+  id: ID;
+  scope: "party" | "individual";
+  characterIds: ID[];
+  characterNames: string[];
+  reason: string;
+  refreshedBy: ID;
+  refreshedAt: ISODateString;
 }
 
 /**
@@ -345,7 +360,8 @@ export type CampaignActivityType =
   | "grunt_team_deleted"
   | "grunt_casualties"
   | "grunt_morale_break"
-  | "grunt_morale_rally";
+  | "grunt_morale_rally"
+  | "edge_refresh";
 
 /**
  * Campaign activity feed entry
@@ -388,7 +404,8 @@ export type NotificationType =
   | "advancement_rejected"
   | "karma_awarded"
   | "post_created"
-  | "mentioned";
+  | "mentioned"
+  | "edge_refreshed";
 
 /**
  * User notification

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -372,6 +372,7 @@ export type {
   CampaignTemplate,
   SessionRewardData,
   MidSessionAward,
+  EdgeRefreshEvent,
   CampaignActivityType,
   CampaignActivityEvent,
   NotificationType,


### PR DESCRIPTION
## Summary
- Add `EdgeRefreshEvent` type and extend `CampaignSession` with `edgeRefreshes` tracking
- New POST endpoint at `/api/campaigns/[id]/sessions/[sessionId]/edge-refresh` supporting party-wide and individual Edge refresh
- New `EdgeRefreshDialog` component (React Aria modal, cyan-themed) with scope toggle, character picker, and reason presets
- Integrate Edge Refresh button into `CampaignCalendarTab` between Quick Award and Complete & Award, with cyan-themed history display on session cards

Closes #458

## Test plan
- [ ] `pnpm type-check` passes (verified)
- [ ] `pnpm test` passes — 8105 tests (verified)
- [ ] `pnpm lint` passes (verified)
- [ ] Open campaign calendar as GM, click "Edge Refresh" on a scheduled session
- [ ] Test party-wide refresh — all active campaign characters get Edge restored to max
- [ ] Test individual refresh — select single character, verify only that character is refreshed
- [ ] Verify Edge refresh history appears as cyan-themed box on session cards
- [ ] Verify burnt Edge (permanent max reduction) is NOT recovered (restoreFullEdge restores to current max)

🤖 Generated with [Claude Code](https://claude.ai/code)