### PR TITLE
feat(combat): wire ammunition consumption into combat action API (#453)

### DIFF
--- a/app/api/combat/[sessionId]/actions/__tests__/ammo-consumption.test.ts
+++ b/app/api/combat/[sessionId]/actions/__tests__/ammo-consumption.test.ts
@@ -1,0 +1,631 @@
+/**
+ * Tests for ammunition consumption in combat actions
+ *
+ * Tests ammo validation, consumption, thrown weapon handling,
+ * reload actions, and magazine swaps during combat.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+import * as sessionModule from "@/lib/auth/session";
+import * as usersModule from "@/lib/storage/users";
+import * as combatModule from "@/lib/storage/combat";
+import * as charactersModule from "@/lib/storage/characters";
+import * as loaderModule from "@/lib/rules/loader";
+import * as actionResolutionModule from "@/lib/rules/action-resolution";
+import type {
+  User,
+  CombatSession,
+  CombatParticipant,
+  Character,
+  ActionDefinition,
+  Weapon,
+} from "@/lib/types";
+import type { LoadedRuleset } from "@/lib/rules/loader-types";
+
+// Mock dependencies
+vi.mock("@/lib/auth/session");
+vi.mock("@/lib/storage/users");
+vi.mock("@/lib/storage/combat");
+vi.mock("@/lib/storage/characters");
+vi.mock("@/lib/rules/loader");
+vi.mock("@/lib/rules/action-resolution");
+
+// Helper to create a NextRequest with JSON body
+function createMockRequest(url: string, body: unknown): NextRequest {
+  const headers = new Headers();
+  headers.set("Content-Type", "application/json");
+
+  const request = new NextRequest(url, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers,
+  });
+
+  (request as { json: () => Promise<unknown> }).json = async () => body;
+
+  return request;
+}
+
+// Route params helper
+function createRouteParams(sessionId: string) {
+  return { params: Promise.resolve({ sessionId }) };
+}
+
+// Mock data factories
+function createMockUser(overrides?: Partial<User>): User {
+  return {
+    id: "test-user-id",
+    email: "test@example.com",
+    username: "testuser",
+    passwordHash: "mock-hash",
+    role: ["user"],
+    createdAt: new Date().toISOString(),
+    lastLogin: null,
+    characters: [],
+    failedLoginAttempts: 0,
+    lockoutUntil: null,
+    sessionVersion: 1,
+    sessionSecretHash: null,
+    preferences: { theme: "system", navigationCollapsed: false },
+    accountStatus: "active",
+    statusChangedAt: null,
+    statusChangedBy: null,
+    statusReason: null,
+    lastRoleChangeAt: null,
+    lastRoleChangeBy: null,
+    emailVerified: true,
+    emailVerifiedAt: null,
+    emailVerificationTokenHash: null,
+    emailVerificationTokenExpiresAt: null,
+    emailVerificationTokenPrefix: null,
+    passwordResetTokenHash: null,
+    passwordResetTokenExpiresAt: null,
+    passwordResetTokenPrefix: null,
+    magicLinkTokenHash: null,
+    magicLinkTokenExpiresAt: null,
+    magicLinkTokenPrefix: null,
+    ...overrides,
+  };
+}
+
+function createMockParticipant(overrides?: Partial<CombatParticipant>): CombatParticipant {
+  return {
+    id: "test-participant-id",
+    type: "character",
+    entityId: "test-character-id",
+    name: "Test Character",
+    initiativeScore: 10,
+    initiativeDice: [4],
+    actionsRemaining: { free: 999, simple: 2, complex: 1, interrupt: true },
+    interruptsPending: [],
+    status: "active",
+    controlledBy: "test-user-id",
+    isGMControlled: false,
+    woundModifier: 0,
+    conditions: [],
+    ...overrides,
+  };
+}
+
+function createMockCombatSession(overrides?: Partial<CombatSession>): CombatSession {
+  return {
+    id: "test-session-id",
+    ownerId: "test-user-id",
+    editionCode: "sr5",
+    participants: [],
+    initiativeOrder: [],
+    currentTurn: 0,
+    currentPhase: "action",
+    round: 1,
+    status: "active",
+    environment: {},
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createMockWeapon(overrides?: Partial<Weapon>): Weapon {
+  return {
+    id: "weapon-1",
+    name: "Ares Predator V",
+    category: "weapon",
+    subcategory: "heavy-pistol",
+    damage: "8P",
+    ap: -1,
+    mode: ["SA", "BF"],
+    quantity: 1,
+    cost: 725,
+    ammoState: {
+      loadedAmmoTypeId: "regular-ammo",
+      currentRounds: 15,
+      magazineCapacity: 15,
+    },
+    ...overrides,
+  };
+}
+
+function createMockCharacter(overrides?: Partial<Character>): Character {
+  return {
+    id: "test-character-id",
+    ownerId: "test-user-id",
+    editionId: "test-edition-id",
+    editionCode: "sr5",
+    creationMethodId: "test-creation-method-id",
+    rulesetSnapshotId: "test-snapshot-id",
+    attachedBookIds: [],
+    name: "Test Character",
+    metatype: "Human",
+    status: "active",
+    attributes: {
+      agility: 4,
+      reaction: 4,
+      intuition: 3,
+      strength: 3,
+      body: 3,
+      willpower: 3,
+      logic: 3,
+      charisma: 3,
+    },
+    specialAttributes: { edge: 1, essence: 6 },
+    skills: { firearms: 4 },
+    positiveQualities: [],
+    negativeQualities: [],
+    magicalPath: "mundane",
+    nuyen: 0,
+    startingNuyen: 0,
+    gear: [],
+    contacts: [],
+    derivedStats: {},
+    condition: { physicalDamage: 0, stunDamage: 0 },
+    karmaTotal: 0,
+    karmaCurrent: 0,
+    karmaSpentAtCreation: 0,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createMockAction(overrides?: Partial<ActionDefinition>): ActionDefinition {
+  return {
+    id: "test-action",
+    name: "Test Action",
+    description: "A test action",
+    type: "simple",
+    domain: "combat",
+    cost: { actionType: "simple" },
+    prerequisites: [],
+    modifiers: [],
+    ...overrides,
+  } as ActionDefinition;
+}
+
+function createFireWeaponAction(
+  id: string,
+  ammoCount: number,
+  overrides?: Partial<ActionDefinition>
+): ActionDefinition {
+  return createMockAction({
+    id,
+    name: `Fire Weapon (${id})`,
+    type: "simple",
+    cost: {
+      actionType: "simple",
+      resourceCosts: [
+        { type: "ammunition", amount: ammoCount, description: `${ammoCount} round(s)` },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+function createRulesetWithActions(actions: ActionDefinition[]): LoadedRuleset {
+  return {
+    edition: {
+      id: "sr5",
+      code: "sr5",
+      name: "Shadowrun 5th Edition",
+      version: "1.0.0",
+      releaseYear: 2013,
+      supportLevel: "active",
+      books: ["sr5-core"],
+      creationMethods: [],
+    },
+    books: [
+      {
+        id: "sr5-core",
+        title: "Core Rulebook",
+        isCore: true,
+        loadOrder: 1,
+        payload: {
+          modules: {
+            actions: {
+              payload: {
+                combat: actions,
+              },
+            },
+          },
+        },
+      },
+    ],
+    creationMethods: [],
+  } as unknown as LoadedRuleset;
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("Ammunition consumption in combat actions", () => {
+  const mockUser = createMockUser();
+  const mockParticipant = createMockParticipant();
+  const mockWeapon = createMockWeapon();
+  const mockCharacter = createMockCharacter({ weapons: [mockWeapon] });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mock implementations
+    vi.mocked(sessionModule.getSession).mockResolvedValue(mockUser.id);
+    vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
+    vi.mocked(combatModule.updateParticipantActions).mockResolvedValue(mockParticipant);
+    vi.mocked(charactersModule.updateCharacter).mockResolvedValue(mockCharacter);
+
+    vi.mocked(actionResolutionModule.validateAction).mockReturnValue({
+      valid: true,
+      errors: [],
+      warnings: [],
+    });
+    vi.mocked(actionResolutionModule.consumeAction).mockReturnValue({
+      free: 999,
+      simple: 1,
+      complex: 1,
+      interrupt: true,
+    });
+  });
+
+  function setupSession(
+    character: Character,
+    actions: ActionDefinition[],
+    participant?: CombatParticipant
+  ) {
+    const part = participant ?? mockParticipant;
+    const session = createMockCombatSession({
+      participants: [part],
+      status: "active",
+    });
+
+    vi.mocked(combatModule.getCombatSession).mockResolvedValue(session);
+    vi.mocked(combatModule.getCurrentParticipant).mockResolvedValue(part);
+    vi.mocked(loaderModule.loadRuleset).mockResolvedValue({
+      success: true,
+      ruleset: createRulesetWithActions(actions),
+    });
+    vi.mocked(charactersModule.getCharacterById).mockResolvedValue(character);
+
+    return session;
+  }
+
+  describe("fire weapon actions", () => {
+    it("should decrement ammo by action resourceCosts amount (SS = 1 round)", async () => {
+      const fireSSAction = createFireWeaponAction("fire-weapon-ss", 1);
+      setupSession(mockCharacter, [fireSSAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "fire-weapon-ss", weaponId: "weapon-1" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.ammoConsumed).toBe(1);
+      expect(data.ammoRemaining).toBe(14);
+      expect(data.weaponId).toBe("weapon-1");
+      expect(charactersModule.updateCharacter).toHaveBeenCalledWith(
+        "test-user-id",
+        "test-character-id",
+        expect.objectContaining({
+          weapons: expect.arrayContaining([
+            expect.objectContaining({
+              id: "weapon-1",
+              ammoState: expect.objectContaining({ currentRounds: 14 }),
+            }),
+          ]),
+        })
+      );
+    });
+
+    it("should decrement ammo by 3 for burst fire", async () => {
+      const fireBFAction = createFireWeaponAction("fire-weapon-bf", 3);
+      setupSession(mockCharacter, [fireBFAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "fire-weapon-bf", weaponId: "weapon-1" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ammoConsumed).toBe(3);
+      expect(data.ammoRemaining).toBe(12);
+    });
+
+    it("should decrement ammo by 6 for full auto", async () => {
+      const fireFAAction = createFireWeaponAction("fire-weapon-fa", 6, {
+        cost: {
+          actionType: "complex",
+          resourceCosts: [{ type: "ammunition", amount: 6, description: "6 rounds" }],
+        },
+      });
+      setupSession(mockCharacter, [fireFAAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "fire-weapon-fa", weaponId: "weapon-1" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ammoConsumed).toBe(6);
+      expect(data.ammoRemaining).toBe(9);
+    });
+
+    it("should return 400 when insufficient ammo", async () => {
+      const fireFAAction = createFireWeaponAction("fire-weapon-fa", 6, {
+        cost: {
+          actionType: "complex",
+          resourceCosts: [{ type: "ammunition", amount: 6, description: "6 rounds" }],
+        },
+      });
+      const lowAmmoWeapon = createMockWeapon({
+        ammoState: { loadedAmmoTypeId: "regular-ammo", currentRounds: 3, magazineCapacity: 15 },
+      });
+      const characterWithLowAmmo = createMockCharacter({ weapons: [lowAmmoWeapon] });
+      setupSession(characterWithLowAmmo, [fireFAAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "fire-weapon-fa", weaponId: "weapon-1" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("Insufficient ammunition");
+      // Should NOT have consumed action economy
+      expect(combatModule.updateParticipantActions).not.toHaveBeenCalled();
+    });
+
+    it("should return 404 when weapon not found", async () => {
+      const fireSSAction = createFireWeaponAction("fire-weapon-ss", 1);
+      setupSession(mockCharacter, [fireSSAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "fire-weapon-ss", weaponId: "nonexistent-weapon" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("Weapon not found");
+    });
+  });
+
+  describe("actions without weapon", () => {
+    it("should work normally without weaponId (no ammo change)", async () => {
+      const shootAction = createMockAction({
+        id: "shoot",
+        name: "Shoot",
+        type: "simple",
+        cost: { actionType: "simple" },
+      });
+      setupSession(mockCharacter, [shootAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "shoot" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.ammoConsumed).toBeUndefined();
+      expect(data.ammoRemaining).toBeUndefined();
+      expect(data.weaponId).toBeUndefined();
+    });
+
+    it("should ignore ammo logic for non-firearm actions", async () => {
+      const meleeAction = createMockAction({
+        id: "melee-attack",
+        name: "Melee Attack",
+        type: "complex",
+        cost: { actionType: "complex" },
+      });
+      setupSession(mockCharacter, [meleeAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "melee-attack" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.ammoConsumed).toBeUndefined();
+    });
+  });
+
+  describe("thrown weapons", () => {
+    it("should decrement quantity when throwing a weapon with quantity > 1", async () => {
+      const throwAction = createMockAction({
+        id: "throw-weapon",
+        name: "Throw Weapon",
+        type: "simple",
+        cost: { actionType: "simple" },
+      });
+      const grenades = createMockWeapon({
+        id: "grenade-1",
+        name: "Fragmentation Grenade",
+        subcategory: "grenade",
+        quantity: 3,
+        ammoState: undefined,
+        ammoCapacity: 0,
+      });
+      const charWithGrenades = createMockCharacter({ weapons: [grenades] });
+      setupSession(charWithGrenades, [throwAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "throw-weapon", weaponId: "grenade-1" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.consumableUsed).toBe(true);
+      expect(charactersModule.updateCharacter).toHaveBeenCalledWith(
+        "test-user-id",
+        "test-character-id",
+        expect.objectContaining({
+          weapons: expect.arrayContaining([
+            expect.objectContaining({
+              id: "grenade-1",
+              quantity: 2,
+            }),
+          ]),
+        })
+      );
+    });
+
+    it("should remove weapon when throwing last one", async () => {
+      const throwAction = createMockAction({
+        id: "throw-weapon",
+        name: "Throw Weapon",
+        type: "simple",
+        cost: { actionType: "simple" },
+      });
+      const lastGrenade = createMockWeapon({
+        id: "grenade-1",
+        name: "Fragmentation Grenade",
+        subcategory: "grenade",
+        quantity: 1,
+        ammoState: undefined,
+        ammoCapacity: 0,
+      });
+      const charWithOneGrenade = createMockCharacter({ weapons: [lastGrenade] });
+      setupSession(charWithOneGrenade, [throwAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "throw-weapon", weaponId: "grenade-1" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.consumableUsed).toBe(true);
+      expect(charactersModule.updateCharacter).toHaveBeenCalledWith(
+        "test-user-id",
+        "test-character-id",
+        expect.objectContaining({
+          weapons: [],
+        })
+      );
+    });
+  });
+
+  describe("reload actions", () => {
+    it("should swap magazine with insert-clip + magazineId", async () => {
+      const insertClipAction = createMockAction({
+        id: "insert-clip",
+        name: "Insert Clip",
+        type: "simple",
+        cost: { actionType: "simple" },
+      });
+      const weaponWithSpares = createMockWeapon({
+        ammoState: {
+          loadedAmmoTypeId: "regular-ammo",
+          currentRounds: 2,
+          magazineCapacity: 15,
+        },
+        spareMagazines: [
+          {
+            id: "spare-mag-1",
+            weaponCompatibility: ["heavy-pistol"],
+            capacity: 15,
+            loadedAmmoTypeId: "apds-ammo",
+            currentRounds: 15,
+            cost: 5,
+          },
+        ],
+      });
+      const charWithSpares = createMockCharacter({ weapons: [weaponWithSpares] });
+      setupSession(charWithSpares, [insertClipAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "insert-clip", weaponId: "weapon-1", magazineId: "spare-mag-1" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.reloadResult).toBeDefined();
+      expect(data.reloadResult.magazineSwapped).toBe(true);
+      expect(data.weaponId).toBe("weapon-1");
+      expect(charactersModule.updateCharacter).toHaveBeenCalled();
+    });
+
+    it("should unload weapon with remove-clip", async () => {
+      const removeClipAction = createMockAction({
+        id: "remove-clip",
+        name: "Remove Clip",
+        type: "simple",
+        cost: { actionType: "simple" },
+      });
+      const loadedWeapon = createMockWeapon({
+        ammoState: {
+          loadedAmmoTypeId: "regular-ammo",
+          currentRounds: 8,
+          magazineCapacity: 15,
+        },
+      });
+      const charWithLoaded = createMockCharacter({ weapons: [loadedWeapon] });
+      setupSession(charWithLoaded, [removeClipAction]);
+
+      const request = createMockRequest(
+        "http://localhost:3000/api/combat/test-session-id/actions",
+        { actionId: "remove-clip", weaponId: "weapon-1" }
+      );
+      const response = await POST(request, createRouteParams("test-session-id"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.reloadResult).toBeDefined();
+      expect(data.weaponId).toBe("weapon-1");
+      expect(charactersModule.updateCharacter).toHaveBeenCalledWith(
+        "test-user-id",
+        "test-character-id",
+        expect.objectContaining({
+          weapons: expect.arrayContaining([
+            expect.objectContaining({
+              ammoState: expect.objectContaining({ currentRounds: 0 }),
+            }),
+          ]),
+        })
+      );
+    });
+  });
+});

--- a/app/api/combat/[sessionId]/actions/route.ts
+++ b/app/api/combat/[sessionId]/actions/route.ts
@@ -31,13 +31,23 @@ import {
   type ValidationResult,
 } from "@/lib/rules/action-resolution";
 import { processDamageApplication } from "@/lib/rules/action-resolution/combat";
+import {
+  getWeaponAmmoState,
+  updateWeaponAmmoState,
+  loadWeapon,
+  unloadWeapon,
+  swapMagazine,
+  weaponUsesAmmo,
+} from "@/lib/rules/action-resolution/combat/ammunition-manager";
 import type {
   ActionDefinition,
   Character,
   EditionCode,
   ActionType,
   ActionAllocation,
+  Weapon,
 } from "@/lib/types";
+import type { MagazineItem, AmmunitionItem } from "@/lib/types/gear-state";
 
 interface RouteParams {
   params: Promise<{ sessionId: string }>;
@@ -260,7 +270,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     // Parse body
     const body = await request.json();
-    const { actionId, participantId, targetId, modifiers } = body;
+    const { actionId, participantId, targetId, modifiers, weaponId, magazineId, ammoItemId } = body;
 
     // Validate required fields
     if (!actionId) {
@@ -332,6 +342,34 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       character = await getCharacterById(participant.entityId);
     }
 
+    // Validate ammunition for weapon-based actions
+    const ammoResourceCost = getAmmoResourceCost(action);
+    let targetWeapon: Weapon | undefined;
+
+    if (weaponId && character?.weapons) {
+      targetWeapon = character.weapons.find((w) => w.id === weaponId);
+      if (!targetWeapon) {
+        return NextResponse.json(
+          { success: false, error: `Weapon not found: ${weaponId}` },
+          { status: 404 }
+        );
+      }
+
+      // Check ammo for fire actions
+      if (ammoResourceCost !== null && weaponUsesAmmo(targetWeapon)) {
+        const ammoState = getWeaponAmmoState(targetWeapon);
+        if (ammoState.currentRounds < ammoResourceCost) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: `Insufficient ammunition (need ${ammoResourceCost}, have ${ammoState.currentRounds})`,
+            },
+            { status: 400 }
+          );
+        }
+      }
+    }
+
     // Validate action
     let validation: ValidationResult | null = null;
     if (character) {
@@ -369,6 +407,80 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Update participant's remaining actions
     await updateParticipantActions(sessionId, participant.id, newActionsRemaining);
 
+    // Consume ammunition after action economy deduction
+    if (ammoResourceCost !== null && targetWeapon && character && weaponUsesAmmo(targetWeapon)) {
+      const ammoState = getWeaponAmmoState(targetWeapon);
+      const newRounds = ammoState.currentRounds - ammoResourceCost;
+      const updatedWeapon = updateWeaponAmmoState(targetWeapon, {
+        ...ammoState,
+        currentRounds: newRounds,
+      });
+
+      const updatedWeapons = character.weapons!.map((w) => (w.id === weaponId ? updatedWeapon : w));
+      await updateCharacter(character.ownerId, character.id, { weapons: updatedWeapons });
+      // Update local reference for response
+      targetWeapon = updatedWeapon;
+    }
+
+    // Handle thrown weapons/grenades
+    if (isThrowAction(actionId) && targetWeapon && character?.weapons) {
+      let updatedWeapons: Weapon[];
+      if (targetWeapon.quantity > 1) {
+        updatedWeapons = character.weapons.map((w) =>
+          w.id === weaponId ? { ...w, quantity: w.quantity - 1 } : w
+        );
+      } else {
+        updatedWeapons = character.weapons.filter((w) => w.id !== weaponId);
+      }
+      await updateCharacter(character.ownerId, character.id, { weapons: updatedWeapons });
+    }
+
+    // Handle reload actions
+    let reloadResult: { roundsLoaded?: number; magazineSwapped?: boolean } | undefined;
+    if (isReloadAction(actionId) && targetWeapon && character?.weapons) {
+      if (actionId === "insert-clip" && magazineId && targetWeapon.spareMagazines) {
+        // Magazine swap
+        const magazine = targetWeapon.spareMagazines.find((m: MagazineItem) => m.id === magazineId);
+        if (magazine) {
+          const swapResult = swapMagazine(targetWeapon, magazine);
+          if (swapResult.success) {
+            const updatedSpares = targetWeapon.spareMagazines
+              .filter((m: MagazineItem) => m.id !== magazineId)
+              .concat(swapResult.oldMagazine ? [swapResult.oldMagazine] : []);
+            const updatedWeapon = { ...swapResult.weapon, spareMagazines: updatedSpares };
+            const updatedWeapons = character.weapons.map((w) =>
+              w.id === weaponId ? updatedWeapon : w
+            );
+            await updateCharacter(character.ownerId, character.id, { weapons: updatedWeapons });
+            reloadResult = { magazineSwapped: true };
+          }
+        }
+      } else if (actionId === "insert-clip" && ammoItemId) {
+        // Load from ammo inventory
+        const ammoItem = findAmmoItem(character, ammoItemId);
+        if (ammoItem) {
+          const loadResult = loadWeapon(targetWeapon, ammoItem);
+          if (loadResult.success) {
+            const updatedWeapons = character.weapons.map((w) =>
+              w.id === weaponId ? loadResult.weapon : w
+            );
+            await updateCharacter(character.ownerId, character.id, { weapons: updatedWeapons });
+            reloadResult = { roundsLoaded: loadResult.roundsLoaded };
+          }
+        }
+      } else if (actionId === "remove-clip") {
+        // Unload weapon
+        const unloadResult = unloadWeapon(targetWeapon);
+        if (unloadResult.success && unloadResult.roundsUnloaded > 0) {
+          const updatedWeapons = character.weapons.map((w) =>
+            w.id === weaponId ? unloadResult.weapon : w
+          );
+          await updateCharacter(character.ownerId, character.id, { weapons: updatedWeapons });
+          reloadResult = { roundsLoaded: 0 };
+        }
+      }
+    }
+
     // Build response
     const result: {
       success: boolean;
@@ -390,6 +502,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       damage?: unknown;
       validation?: ValidationResult;
       warnings?: ValidationResult["warnings"];
+      ammoConsumed?: number;
+      ammoRemaining?: number;
+      weaponId?: string;
+      consumableUsed?: boolean;
+      reloadResult?: { roundsLoaded?: number; magazineSwapped?: boolean };
     } = {
       success: true,
       action,
@@ -505,6 +622,26 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
+    // Add ammo consumption info to response
+    if (ammoResourceCost !== null && targetWeapon && weaponUsesAmmo(targetWeapon)) {
+      const finalAmmoState = getWeaponAmmoState(targetWeapon);
+      result.ammoConsumed = ammoResourceCost;
+      result.ammoRemaining = finalAmmoState.currentRounds;
+      result.weaponId = weaponId;
+    }
+
+    // Add thrown weapon info
+    if (isThrowAction(actionId) && weaponId) {
+      result.consumableUsed = true;
+      result.weaponId = weaponId;
+    }
+
+    // Add reload info
+    if (reloadResult) {
+      result.reloadResult = reloadResult;
+      result.weaponId = weaponId;
+    }
+
     return NextResponse.json(result);
   } catch (error) {
     console.error("Failed to execute action:", error);
@@ -535,4 +672,55 @@ function checkActionConsumed(
     default:
       return true;
   }
+}
+
+/**
+ * Get the ammunition cost from an action's resourceCosts.
+ * Returns the amount if found, null otherwise.
+ */
+function getAmmoResourceCost(action: ActionDefinition): number | null {
+  if (!action.cost?.resourceCosts) return null;
+  const ammoCost = action.cost.resourceCosts.find((rc) => rc.type === "ammunition");
+  if (!ammoCost) return null;
+  return typeof ammoCost.amount === "number" ? ammoCost.amount : null;
+}
+
+/**
+ * Check if action is a thrown weapon action.
+ */
+function isThrowAction(actionId: string): boolean {
+  return actionId === "throw-weapon";
+}
+
+/**
+ * Check if action is a reload/magazine action.
+ */
+function isReloadAction(actionId: string): boolean {
+  return actionId === "insert-clip" || actionId === "remove-clip";
+}
+
+/**
+ * Find an ammunition item from character's weapon purchasedAmmunition.
+ * Converts PurchasedAmmunitionItem to the AmmunitionItem format
+ * expected by ammunition-manager.
+ */
+function findAmmoItem(character: Character, ammoItemId: string): AmmunitionItem | null {
+  for (const weapon of character.weapons ?? []) {
+    const purchased = weapon.purchasedAmmunition?.find((a) => a.catalogId === ammoItemId);
+    if (purchased && purchased.quantity > 0) {
+      return {
+        id: ammoItemId,
+        catalogId: purchased.catalogId,
+        name: purchased.name,
+        caliber: weapon.subcategory as AmmunitionItem["caliber"],
+        ammoType: "regular",
+        quantity: purchased.quantity * (purchased.roundsPerBox ?? 10),
+        damageModifier: purchased.apModifier ? 0 : 0,
+        apModifier: purchased.apModifier ?? 0,
+        cost: purchased.cost,
+        availability: purchased.availability,
+      };
+    }
+  }
+  return null;
 }

--- a/lib/combat/CombatSessionContext.tsx
+++ b/lib/combat/CombatSessionContext.tsx
@@ -46,7 +46,11 @@ export interface CombatSessionActions {
   /** Refresh session state from server */
   refreshSession: () => Promise<void>;
   /** Execute an action in combat */
-  executeAction: (actionId: string, targetId?: string) => Promise<boolean>;
+  executeAction: (
+    actionId: string,
+    targetId?: string,
+    options?: { weaponId?: string; firingMode?: string; magazineId?: string; ammoItemId?: string }
+  ) => Promise<boolean>;
   /** Delay turn */
   delayTurn: () => Promise<boolean>;
   /** End turn */
@@ -220,7 +224,11 @@ export function CombatSessionProvider({
 
   // Execute an action
   const executeAction = useCallback(
-    async (actionId: string, targetId?: string): Promise<boolean> => {
+    async (
+      actionId: string,
+      targetId?: string,
+      options?: { weaponId?: string; firingMode?: string; magazineId?: string; ammoItemId?: string }
+    ): Promise<boolean> => {
       if (!session || !participant) {
         setError("Not in combat");
         return false;
@@ -237,6 +245,7 @@ export function CombatSessionProvider({
             participantId: participant.id,
             actionId,
             targetId,
+            ...options,
           }),
         });
 

--- a/lib/rules/action-resolution/__tests__/action-validator.test.ts
+++ b/lib/rules/action-resolution/__tests__/action-validator.test.ts
@@ -20,6 +20,7 @@ import {
   validateCombatContext,
   validateAction,
   validateActionEligibility,
+  validateActionCost,
   calculateStateModifiers,
   canPerformAction,
   getActionBlockers,
@@ -776,6 +777,169 @@ describe("validateActionEligibility with combat context", () => {
 
     const result = validateActionEligibility(character, action, session, participant.id);
 
+    expect(result.valid).toBe(true);
+  });
+});
+
+// =============================================================================
+// AMMUNITION RESOURCE COST VALIDATION
+// =============================================================================
+
+describe("validateActionCost - ammunition", () => {
+  it("should pass when weapon has enough ammo", () => {
+    const character = createMockCharacter({
+      weapons: [
+        {
+          id: "pistol",
+          name: "Ares Predator V",
+          category: "weapon",
+          subcategory: "heavy-pistol",
+          damage: "8P",
+          ap: -1,
+          mode: ["SA"],
+          quantity: 1,
+          cost: 725,
+          ammoState: {
+            loadedAmmoTypeId: "regular",
+            currentRounds: 15,
+            magazineCapacity: 15,
+          },
+        },
+      ],
+    });
+    const action = createMockActionDefinition({
+      cost: {
+        actionType: "simple",
+        resourceCosts: [{ type: "ammunition", amount: 1 }],
+      },
+    });
+
+    const result = validateActionCost(character, action);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should fail when no weapon has enough ammo", () => {
+    const character = createMockCharacter({
+      weapons: [
+        {
+          id: "pistol",
+          name: "Ares Predator V",
+          category: "weapon",
+          subcategory: "heavy-pistol",
+          damage: "8P",
+          ap: -1,
+          mode: ["SA"],
+          quantity: 1,
+          cost: 725,
+          ammoState: {
+            loadedAmmoTypeId: "regular",
+            currentRounds: 0,
+            magazineCapacity: 15,
+          },
+        },
+      ],
+    });
+    const action = createMockActionDefinition({
+      cost: {
+        actionType: "simple",
+        resourceCosts: [{ type: "ammunition", amount: 1 }],
+      },
+    });
+
+    const result = validateActionCost(character, action);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: ValidationErrorCodes.INSUFFICIENT_RESOURCE,
+          message: expect.stringContaining("Insufficient ammunition"),
+        }),
+      ])
+    );
+  });
+
+  it("should fail when ammo required exceeds available", () => {
+    const character = createMockCharacter({
+      weapons: [
+        {
+          id: "pistol",
+          name: "Ares Predator V",
+          category: "weapon",
+          subcategory: "heavy-pistol",
+          damage: "8P",
+          ap: -1,
+          mode: ["SA", "BF"],
+          quantity: 1,
+          cost: 725,
+          ammoState: {
+            loadedAmmoTypeId: "regular",
+            currentRounds: 2,
+            magazineCapacity: 15,
+          },
+        },
+      ],
+    });
+    const action = createMockActionDefinition({
+      cost: {
+        actionType: "complex",
+        resourceCosts: [{ type: "ammunition", amount: 6, description: "6 rounds for full auto" }],
+      },
+    });
+
+    const result = validateActionCost(character, action);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].message).toContain("need 6 rounds");
+  });
+
+  it("should pass when character has no weapons but ammo cost is optional", () => {
+    const character = createMockCharacter({ weapons: [] });
+    const action = createMockActionDefinition({
+      cost: {
+        actionType: "simple",
+        resourceCosts: [{ type: "ammunition", amount: 1, optional: true }],
+      },
+    });
+
+    const result = validateActionCost(character, action);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should pass when action has no resourceCosts", () => {
+    const character = createMockCharacter();
+    const action = createMockActionDefinition({
+      cost: { actionType: "simple" },
+    });
+
+    const result = validateActionCost(character, action);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should support legacy currentAmmo field", () => {
+    const character = createMockCharacter({
+      weapons: [
+        {
+          id: "pistol",
+          name: "Old Pistol",
+          category: "weapon",
+          subcategory: "light-pistol",
+          damage: "6P",
+          ap: 0,
+          mode: ["SA"],
+          quantity: 1,
+          cost: 200,
+          currentAmmo: 10,
+          ammoCapacity: 12,
+        },
+      ],
+    });
+    const action = createMockActionDefinition({
+      cost: {
+        actionType: "simple",
+        resourceCosts: [{ type: "ammunition", amount: 3 }],
+      },
+    });
+
+    const result = validateActionCost(character, action);
     expect(result.valid).toBe(true);
   });
 });

--- a/lib/rules/action-resolution/action-validator.ts
+++ b/lib/rules/action-resolution/action-validator.ts
@@ -523,8 +523,13 @@ function validateSinglePrerequisite(
       if (requirement === "edge") {
         hasMet = (character.attributes?.edge ?? 0) >= (minimumValue ?? 1);
       } else if (requirement === "ammunition") {
-        // Would need ammo tracking
-        hasMet = true;
+        // Check if any readied ranged weapon has enough ammo
+        hasMet =
+          character.weapons?.some((w) => {
+            if (!w.ammoState && !w.currentAmmo) return false;
+            const current = w.ammoState?.currentRounds ?? w.currentAmmo ?? 0;
+            return current >= (minimumValue ?? 1);
+          }) ?? false;
       }
       break;
 
@@ -930,9 +935,24 @@ export function validateActionCost(
         }
         break;
 
-      case "ammunition":
-        // Would need to check weapon ammo
+      case "ammunition": {
+        const ammoCost = typeof resourceCost.amount === "number" ? resourceCost.amount : 1;
+        const hasEnoughAmmo =
+          character.weapons?.some((w) => {
+            const current = w.ammoState?.currentRounds ?? w.currentAmmo ?? 0;
+            return current >= ammoCost;
+          }) ?? false;
+        if (!hasEnoughAmmo) {
+          errors.push(
+            createError(
+              ValidationErrorCodes.INSUFFICIENT_RESOURCE,
+              `Insufficient ammunition (need ${ammoCost} rounds)`,
+              "ammunition"
+            )
+          );
+        }
         break;
+      }
 
       // Add other resource types as needed
     }


### PR DESCRIPTION
## Summary

- Wire the existing `ammunition-manager.ts` infrastructure into the combat action execution flow
- Fire-weapon actions now validate ammo availability and consume rounds based on the action definition's `resourceCosts` amount (SS=1, SA=2, BF=3, FA=6)
- Thrown weapon actions (`throw-weapon`) decrement weapon quantity or remove the weapon entirely
- Reload actions (`insert-clip`, `remove-clip`) handle magazine swaps and weapon loading/unloading
- Replace stubbed `ammunition` prerequisite and resource cost checks in `action-validator.ts` with real weapon ammo state validation
- Add `options` parameter to `CombatSessionContext.executeAction()` for passing `weaponId`, `firingMode`, `magazineId`, `ammoItemId`
- Response now includes `ammoConsumed`, `ammoRemaining`, `weaponId`, `consumableUsed`, `reloadResult` fields

## Test plan

- [x] 11 new API integration tests for ammo consumption (`ammo-consumption.test.ts`)
- [x] 6 new validator tests for ammunition resource prerequisite checking
- [x] All 127 affected tests pass (5 test files)
- [x] `pnpm type-check` passes
- [x] `pnpm lint` clean (no new warnings)
- [x] Manual: fire `fire-weapon-ss` with weaponId, verify ammo decrements by 1
- [ ] Manual: fire until empty, verify 400 insufficient ammo response
- [x] Manual: `insert-clip` with magazineId, verify magazine swap persists

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)