### PR TITLE
feat: server-side edition validation for campaign character creation (#462)

### DIFF
--- a/app/api/characters/__tests__/route.test.ts
+++ b/app/api/characters/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import { NextRequest } from "next/server";
 import * as sessionModule from "@/lib/auth/session";
 import * as userStorageModule from "@/lib/storage/users";
 import * as characterStorageModule from "@/lib/storage/characters";
+import * as campaignStorageModule from "@/lib/storage/campaigns";
 
 import type { Character, CharacterDraft, UserRole } from "@/lib/types";
 import type { CharacterSearchResult } from "@/lib/storage/characters";
@@ -19,6 +20,9 @@ import type { CharacterSearchResult } from "@/lib/storage/characters";
 vi.mock("@/lib/auth/session");
 vi.mock("@/lib/storage/users");
 vi.mock("@/lib/storage/characters");
+vi.mock("@/lib/storage/campaigns");
+vi.mock("@/lib/storage/activity");
+vi.mock("@/lib/storage/notifications");
 
 // Helper to create a NextRequest with JSON body
 function createMockRequest(url: string, body?: unknown, method = "GET"): NextRequest {
@@ -637,5 +641,108 @@ describe("POST /api/characters", () => {
 
     // Restore console.error
     consoleErrorSpy.mockRestore();
+  });
+
+  it("should reject draft creation with nonexistent campaign", async () => {
+    const requestBody = {
+      editionId: "sr5",
+      editionCode: "sr5",
+      creationMethodId: "priority",
+      name: "New Character",
+      campaignId: "nonexistent-campaign",
+    };
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-user-id");
+    vi.mocked(userStorageModule.getUserById).mockResolvedValue(mockUser);
+    vi.mocked(campaignStorageModule.getCampaignById).mockResolvedValue(null);
+
+    const request = createMockRequest("http://localhost:3000/api/characters", requestBody, "POST");
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Campaign not found");
+    expect(characterStorageModule.createCharacterDraft).not.toHaveBeenCalled();
+  });
+
+  it("should reject draft creation with mismatched campaign edition", async () => {
+    const requestBody = {
+      editionId: "sr5",
+      editionCode: "sr5",
+      creationMethodId: "priority",
+      name: "New Character",
+      campaignId: "campaign-1",
+    };
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-user-id");
+    vi.mocked(userStorageModule.getUserById).mockResolvedValue(mockUser);
+    vi.mocked(campaignStorageModule.getCampaignById).mockResolvedValue({
+      id: "campaign-1",
+      gmId: "gm-user",
+      title: "Test Campaign",
+      status: "active",
+      editionId: "sr6",
+      editionCode: "sr6",
+      enabledBookIds: ["core-rulebook"],
+      enabledCreationMethodIds: ["priority"],
+      gameplayLevel: "experienced",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as import("@/lib/types").Campaign);
+
+    const request = createMockRequest("http://localhost:3000/api/characters", requestBody, "POST");
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toContain("does not match campaign edition");
+    expect(characterStorageModule.createCharacterDraft).not.toHaveBeenCalled();
+  });
+
+  it("should allow draft creation when edition matches campaign", async () => {
+    const requestBody = {
+      editionId: "sr5",
+      editionCode: "sr5",
+      creationMethodId: "priority",
+      name: "New Character",
+      campaignId: "campaign-1",
+    };
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-user-id");
+    vi.mocked(userStorageModule.getUserById).mockResolvedValue(mockUser);
+    vi.mocked(campaignStorageModule.getCampaignById).mockResolvedValue({
+      id: "campaign-1",
+      gmId: "gm-user",
+      title: "Test Campaign",
+      status: "active",
+      editionId: "sr5",
+      editionCode: "sr5",
+      enabledBookIds: ["core-rulebook"],
+      enabledCreationMethodIds: ["priority"],
+      gameplayLevel: "experienced",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as import("@/lib/types").Campaign);
+    vi.mocked(characterStorageModule.createCharacterDraft).mockResolvedValue(mockDraft);
+
+    const request = createMockRequest("http://localhost:3000/api/characters", requestBody, "POST");
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(characterStorageModule.createCharacterDraft).toHaveBeenCalledWith(
+      "test-user-id",
+      "sr5",
+      "sr5",
+      "priority",
+      "New Character",
+      "campaign-1"
+    );
   });
 });

--- a/app/api/characters/route.ts
+++ b/app/api/characters/route.ts
@@ -232,6 +232,27 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Validate campaign edition match
+    let campaignForNotification: Awaited<
+      ReturnType<typeof import("@/lib/storage/campaigns").getCampaignById>
+    > = null;
+    if (campaignId) {
+      const { getCampaignById } = await import("@/lib/storage/campaigns");
+      campaignForNotification = await getCampaignById(campaignId);
+      if (!campaignForNotification) {
+        return NextResponse.json({ success: false, error: "Campaign not found" }, { status: 404 });
+      }
+      if (editionCode !== campaignForNotification.editionCode) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: `Character edition (${editionCode}) does not match campaign edition (${campaignForNotification.editionCode})`,
+          },
+          { status: 400 }
+        );
+      }
+    }
+
     // Create draft
     const draft = await createCharacterDraft(
       user.id,
@@ -243,11 +264,10 @@ export async function POST(request: NextRequest) {
     );
 
     // Log activity and notify GM asynchronously if campaignId is present
-    if (campaignId) {
+    if (campaignId && campaignForNotification) {
       try {
         const { logActivity } = await import("@/lib/storage/activity");
         const { createNotification } = await import("@/lib/storage/notifications");
-        const { getCampaignById } = await import("@/lib/storage/campaigns");
 
         await logActivity({
           campaignId: campaignId,
@@ -259,17 +279,14 @@ export async function POST(request: NextRequest) {
           description: `${user.username} created a character for the campaign: "${draft.name || "Unnamed"}".`,
         });
 
-        const campaign = await getCampaignById(campaignId);
-        if (campaign) {
-          await createNotification({
-            userId: campaign.gmId,
-            campaignId: campaignId,
-            type: "character_approval_requested",
-            title: "New Character",
-            message: `${user.username} created a new character "${draft.name || "Unnamed"}" for your campaign "${campaign.title}".`,
-            actionUrl: `/campaigns/${campaignId}?tab=approvals`,
-          });
-        }
+        await createNotification({
+          userId: campaignForNotification.gmId,
+          campaignId: campaignId,
+          type: "character_approval_requested",
+          title: "New Character",
+          message: `${user.username} created a new character "${draft.name || "Unnamed"}" for your campaign "${campaignForNotification.title}".`,
+          actionUrl: `/campaigns/${campaignId}?tab=approvals`,
+        });
       } catch (activityError) {
         console.error("Failed to log character creation activity:", activityError);
       }

--- a/lib/rules/validation/__tests__/character-validator.test.ts
+++ b/lib/rules/validation/__tests__/character-validator.test.ts
@@ -1265,6 +1265,31 @@ describe("Character Validator", () => {
       );
     });
 
+    it("should report edition mismatch", async () => {
+      const character = createMinimalCharacter({
+        campaignId: "campaign-1",
+        editionCode: "sr5",
+      });
+      const ruleset = createMinimalRuleset();
+      const campaign = createMinimalCampaign({
+        editionCode: "sr6",
+      });
+
+      const result = await validateCharacter({
+        character,
+        ruleset,
+        campaign,
+        mode: "finalization",
+      });
+
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "CAMPAIGN_EDITION_MISMATCH",
+          field: "editionCode",
+        })
+      );
+    });
+
     it("should pass when all books are enabled", async () => {
       const character = createMinimalCharacter({
         campaignId: "campaign-1",

--- a/lib/rules/validation/character-validator.ts
+++ b/lib/rules/validation/character-validator.ts
@@ -1448,6 +1448,17 @@ const campaignValidator: ValidatorDefinition = {
       return issues;
     }
 
+    // Check edition mismatch
+    if (character.editionCode !== campaign.editionCode) {
+      issues.push({
+        code: "CAMPAIGN_EDITION_MISMATCH",
+        message: `Character edition (${character.editionCode}) does not match campaign edition (${campaign.editionCode})`,
+        field: "editionCode",
+        severity: "error",
+        suggestion: "Create a new character using the campaign's edition",
+      });
+    }
+
     // Check if character uses only enabled books
     if (campaign.enabledBookIds && character.attachedBookIds) {
       const disabledBooks = character.attachedBookIds.filter(


### PR DESCRIPTION
## Summary
- **POST /api/characters**: Validates that the character's edition matches the campaign edition before creating a draft. Returns 404 for nonexistent campaigns, 400 for mismatched editions.
- **Finalization validator**: Adds `CAMPAIGN_EDITION_MISMATCH` error code to `campaignValidator` so finalization also catches edition mismatches.
- Reuses fetched campaign object in activity logging to avoid a redundant fetch.

Closes #462

## Test plan
- [x] 3 new tests in `app/api/characters/__tests__/route.test.ts` (nonexistent campaign, mismatched edition, matching edition)
- [x] 1 new test in `lib/rules/validation/__tests__/character-validator.test.ts` (edition mismatch in finalization)
- [x] All 18 route tests pass
- [x] All 168 validator tests pass
- [x] `pnpm type-check` clean