### PR TITLE
feat: implement specialization +2 dice bonus in dice pools (#447)

### DIFF
--- a/app/characters/[id]/components/CombatQuickReference.tsx
+++ b/app/characters/[id]/components/CombatQuickReference.tsx
@@ -211,6 +211,22 @@ function getWeaponPools(
       modifiers.push({ label: "Smartgun", value: smartgunBonus, type: "gear" });
     }
 
+    // Check for specialization bonus (+2 for matching spec)
+    let matchedSpecialization: string | undefined;
+    const specs = character.skillSpecializations?.[skillId] || [];
+    if (specs.length > 0) {
+      const weaponName = weapon.name.toLowerCase();
+      const weaponSubcat = (weapon.subcategory || "").toLowerCase().replace(/-/g, " ");
+      matchedSpecialization = specs.find((spec) => {
+        const normalizedSpec = spec.toLowerCase();
+        return weaponName.includes(normalizedSpec) || weaponSubcat.includes(normalizedSpec);
+      });
+      if (matchedSpecialization) {
+        modifiers.push({ label: `Spec: ${matchedSpecialization}`, value: 2, type: "other" });
+        pool += 2;
+      }
+    }
+
     // Armor encumbrance (agility penalty)
     if (armorAgilityPenalty < 0) {
       modifiers.push({

--- a/app/characters/[id]/components/__tests__/CombatQuickReference.test.tsx
+++ b/app/characters/[id]/components/__tests__/CombatQuickReference.test.tsx
@@ -547,6 +547,92 @@ describe("CombatQuickReference", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Specialization bonuses
+  // -----------------------------------------------------------------------
+
+  describe("specialization bonuses on weapons", () => {
+    it("adds +2 when weapon matches a specialization", () => {
+      const char = baseCharacter({
+        skillSpecializations: { pistols: ["Heavy Pistols"] },
+        gear: [
+          {
+            id: "weapon-1",
+            name: "Ares Predator V",
+            category: "weapons",
+            subcategory: "heavy-pistols",
+            accuracy: 5,
+            damage: "8P",
+            ap: -1,
+            mode: ["SA"],
+            quantity: 1,
+            availability: 5,
+            cost: 725,
+          } satisfies Weapon,
+        ] as unknown as Character["gear"],
+      });
+
+      renderComponent(char);
+      const weapon = getPoolProps("Ares Predator V");
+      // agility(5) + pistols(3) + spec(2) = 10
+      expect(weapon.pool).toBe(10);
+      const specMod = hasModifier(weapon.modifiers, "Spec: Heavy Pistols");
+      expect(specMod).toBeDefined();
+      expect(specMod!.value).toBe(2);
+    });
+
+    it("does not add spec bonus when weapon does not match any specialization", () => {
+      const char = baseCharacter({
+        skillSpecializations: { pistols: ["Light Pistols"] },
+        gear: [
+          {
+            id: "weapon-1",
+            name: "Ares Predator V",
+            category: "weapons",
+            subcategory: "heavy-pistols",
+            accuracy: 5,
+            damage: "8P",
+            ap: -1,
+            mode: ["SA"],
+            quantity: 1,
+            availability: 5,
+            cost: 725,
+          } satisfies Weapon,
+        ] as unknown as Character["gear"],
+      });
+
+      renderComponent(char);
+      const weapon = getPoolProps("Ares Predator V");
+      // agility(5) + pistols(3) = 8 (no spec)
+      expect(weapon.pool).toBe(8);
+      expect(hasModifier(weapon.modifiers, "Spec: Light Pistols")).toBeUndefined();
+    });
+
+    it("does not add spec bonus when character has no specializations", () => {
+      const char = baseCharacter({
+        gear: [
+          {
+            id: "weapon-1",
+            name: "Ares Predator V",
+            category: "weapons",
+            subcategory: "heavy-pistols",
+            accuracy: 5,
+            damage: "8P",
+            ap: -1,
+            mode: ["SA"],
+            quantity: 1,
+            availability: 5,
+            cost: 725,
+          } satisfies Weapon,
+        ] as unknown as Character["gear"],
+      });
+
+      renderComponent(char);
+      const weapon = getPoolProps("Ares Predator V");
+      expect(weapon.pool).toBe(8);
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Common Tests (no encumbrance/wireless)
   // -----------------------------------------------------------------------
 

--- a/components/character/sheet/SkillsDisplay.tsx
+++ b/components/character/sheet/SkillsDisplay.tsx
@@ -38,6 +38,7 @@ interface PoolBreakdown {
   skillRating: number;
   augBonuses: Array<{ source: string; value: number }>;
   effectBonuses?: Array<{ source: string; value: number; isWireless: boolean }>;
+  specBonuses?: Array<{ name: string; value: number }>;
 }
 
 interface EnrichedSkill {
@@ -114,7 +115,7 @@ function SkillRow({
         )}
         {skill.poolBreakdown ? (
           <span
-            className="ml-auto shrink-0"
+            className="ml-auto flex shrink-0 items-center gap-1"
             onClick={(e) => {
               e.stopPropagation();
               onSelect?.(skill.id, skill.dicePool, skill.attrAbbr);
@@ -138,6 +139,14 @@ function SkillRow({
                 {skill.dicePool}
               </AriaButton>
             </Tooltip>
+            {skill.specs.length > 0 && (
+              <span
+                data-testid="spec-bonus-indicator"
+                className="font-mono text-[10px] font-semibold text-amber-500 dark:text-amber-400"
+              >
+                [+2]
+              </span>
+            )}
           </span>
         ) : (
           <button
@@ -257,6 +266,14 @@ function PoolTooltipContent({ breakdown }: { breakdown: PoolBreakdown }) {
           </span>
         </div>
       ))}
+      {(breakdown.specBonuses || []).map((b, i) => (
+        <div key={`spec-${i}`} className="flex items-center justify-between gap-4">
+          <span className="text-amber-400">
+            {b.name} <span className="text-amber-400/60">(contextual)</span>
+          </span>
+          <span className="font-mono font-semibold text-amber-400">+{b.value}</span>
+        </div>
+      ))}
       <div className="border-t border-zinc-600" />
       <div className="flex items-center justify-between gap-4">
         <span className="text-[10px] font-semibold uppercase tracking-wide text-zinc-200">
@@ -325,6 +342,7 @@ export function SkillsDisplay({ character, onSelect, resolveEffects }: SkillsDis
             skillRating: rating,
             augBonuses,
             effectBonuses: effectBonuses.length > 0 ? effectBonuses : undefined,
+            specBonuses: specs.length > 0 ? specs.map((s) => ({ name: s, value: 2 })) : undefined,
           }
         : undefined,
     };

--- a/components/character/sheet/__tests__/SkillsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/SkillsDisplay.test.tsx
@@ -139,8 +139,9 @@ describe("SkillsDisplay", () => {
     expect(screen.getByText("(Semi-Automatics, Revolvers)")).toBeInTheDocument();
     // Also visible as tags in expanded section
     fireEvent.click(screen.getByTestId("expand-button"));
-    expect(screen.getByText("Semi-Automatics")).toBeInTheDocument();
-    expect(screen.getByText("Revolvers")).toBeInTheDocument();
+    const expandedContent = screen.getByTestId("expanded-content");
+    expect(within(expandedContent).getByText("Semi-Automatics")).toBeInTheDocument();
+    expect(within(expandedContent).getByText("Revolvers")).toBeInTheDocument();
   });
 
   it("does not render specialization placeholder for skills without specs", () => {
@@ -149,6 +150,56 @@ describe("SkillsDisplay", () => {
     });
     render(<SkillsDisplay character={character} />);
     expect(screen.queryByText("__________")).not.toBeInTheDocument();
+  });
+
+  it("shows [+2] indicator when skill has specializations", () => {
+    const character = createSheetCharacter({
+      skills: { pistols: 5 },
+      skillSpecializations: { pistols: ["Semi-Automatics"] },
+    });
+    render(<SkillsDisplay character={character} />);
+    expect(screen.getByTestId("spec-bonus-indicator")).toHaveTextContent("[+2]");
+  });
+
+  it("does not show [+2] indicator when skill has no specializations", () => {
+    const character = createSheetCharacter({
+      skills: { pistols: 5 },
+    });
+    render(<SkillsDisplay character={character} />);
+    expect(screen.queryByTestId("spec-bonus-indicator")).not.toBeInTheDocument();
+  });
+
+  it("does not include +2 in base dice pool number", () => {
+    const character = createSheetCharacter({
+      attributes: {
+        body: 5,
+        agility: 6,
+        reaction: 5,
+        strength: 4,
+        willpower: 3,
+        logic: 3,
+        intuition: 4,
+        charisma: 2,
+      },
+      skills: { pistols: 5 },
+      skillSpecializations: { pistols: ["Semi-Automatics"] },
+    });
+    const { container } = render(<SkillsDisplay character={character} />);
+    // Pool = pistols(5) + agility(6) = 11 (no +2 baked in)
+    const poolPill = container.querySelector('[data-testid="dice-pool-pill"]');
+    expect(poolPill!.textContent).toBe("11");
+  });
+
+  it("shows specialization in tooltip with contextual label", () => {
+    const character = createSheetCharacter({
+      skills: { pistols: 5 },
+      skillSpecializations: { pistols: ["Semi-Automatics"] },
+    });
+    render(<SkillsDisplay character={character} />);
+
+    const tooltipContent = screen.getByTestId("tooltip-content");
+    expect(tooltipContent.textContent).toContain("Semi-Automatics");
+    expect(tooltipContent.textContent).toContain("(contextual)");
   });
 
   it("calls onSelect with skillId, dicePool, and attrAbbr", () => {

--- a/lib/rules/action-resolution/__tests__/pool-builder.test.ts
+++ b/lib/rules/action-resolution/__tests__/pool-builder.test.ts
@@ -31,6 +31,7 @@ import {
   getAttributeValue,
   getSkillRating,
   hasSpecialization,
+  getSkillSpecializations,
   calculateLimit,
   buildActionPool,
   buildSimplePool,
@@ -314,9 +315,59 @@ describe("getSkillRating", () => {
 // =============================================================================
 
 describe("hasSpecialization", () => {
-  it("should return false (placeholder implementation)", () => {
+  it("should return true when character has matching skill+spec", () => {
+    const character = createMockCharacter({
+      skillSpecializations: { pistols: ["Semi-Automatics", "Revolvers"] },
+    });
+    expect(hasSpecialization(character, "pistols", "Revolvers")).toBe(true);
+  });
+
+  it("should return false for non-matching spec", () => {
+    const character = createMockCharacter({
+      skillSpecializations: { pistols: ["Semi-Automatics"] },
+    });
+    expect(hasSpecialization(character, "pistols", "Revolvers")).toBe(false);
+  });
+
+  it("should be case-insensitive", () => {
+    const character = createMockCharacter({
+      skillSpecializations: { pistols: ["Semi-Automatics"] },
+    });
+    expect(hasSpecialization(character, "pistols", "semi-automatics")).toBe(true);
+    expect(hasSpecialization(character, "pistols", "SEMI-AUTOMATICS")).toBe(true);
+  });
+
+  it("should handle missing skillSpecializations", () => {
     const character = createMockCharacter();
-    expect(hasSpecialization(character, "firearms", "pistols")).toBe(false);
+    expect(hasSpecialization(character, "pistols", "Revolvers")).toBe(false);
+  });
+
+  it("should return false when skill has no specs", () => {
+    const character = createMockCharacter({
+      skillSpecializations: { blades: ["Swords"] },
+    });
+    expect(hasSpecialization(character, "pistols", "Revolvers")).toBe(false);
+  });
+});
+
+describe("getSkillSpecializations", () => {
+  it("should return specs for a skill", () => {
+    const character = createMockCharacter({
+      skillSpecializations: { pistols: ["Semi-Automatics", "Revolvers"] },
+    });
+    expect(getSkillSpecializations(character, "pistols")).toEqual(["Semi-Automatics", "Revolvers"]);
+  });
+
+  it("should return empty array for skill with no specs", () => {
+    const character = createMockCharacter({
+      skillSpecializations: { blades: ["Swords"] },
+    });
+    expect(getSkillSpecializations(character, "pistols")).toEqual([]);
+  });
+
+  it("should return empty array when skillSpecializations is undefined", () => {
+    const character = createMockCharacter();
+    expect(getSkillSpecializations(character, "pistols")).toEqual([]);
   });
 });
 
@@ -550,6 +601,38 @@ describe("buildActionPool", () => {
 
     expect(pool.basePool).toBe(4);
     expect(pool.totalDice).toBe(4);
+  });
+
+  it("should add +2 specialization bonus when spec matches", () => {
+    const character = createMockCharacter({
+      skillSpecializations: { firearms: ["Pistols"] },
+    });
+    const pool = buildActionPool(character, {
+      attribute: "agility",
+      skill: "firearms",
+      specialization: "Pistols",
+    });
+
+    // 5 AGI + 4 Firearms + 2 spec = 11
+    expect(pool.totalDice).toBe(11);
+    expect(pool.modifiers).toContainEqual(
+      expect.objectContaining({ source: "other", value: 2, description: "Specialization: Pistols" })
+    );
+  });
+
+  it("should not add spec bonus when spec does not match", () => {
+    const character = createMockCharacter({
+      skillSpecializations: { firearms: ["Shotguns"] },
+    });
+    const pool = buildActionPool(character, {
+      attribute: "agility",
+      skill: "firearms",
+      specialization: "Pistols",
+    });
+
+    // 5 AGI + 4 Firearms, no spec bonus
+    expect(pool.totalDice).toBe(9);
+    expect(pool.modifiers.find((m) => m.description?.includes("Specialization"))).toBeUndefined();
   });
 });
 

--- a/lib/rules/action-resolution/pool-builder.ts
+++ b/lib/rules/action-resolution/pool-builder.ts
@@ -124,14 +124,27 @@ export function getSkillRating(character: Character, skillName: string): number 
  * Check if character has a specialization for a skill
  */
 export function hasSpecialization(
-  _character: Character,
-  _skillName: string,
-  _specialization: string
+  character: Character,
+  skillName: string,
+  specialization: string
 ): boolean {
-  // Specializations would typically be stored in character data
-  // This is a placeholder - implement based on actual data structure
-  // For now, return false (no specialization bonus)
-  return false;
+  const specs =
+    character.skillSpecializations?.[skillName] ||
+    character.skillSpecializations?.[skillName.toLowerCase()];
+  if (!specs || !Array.isArray(specs)) return false;
+  const normalizedSpec = specialization.toLowerCase();
+  return specs.some((s) => s.toLowerCase() === normalizedSpec);
+}
+
+/**
+ * Get all specializations for a skill
+ */
+export function getSkillSpecializations(character: Character, skillName: string): string[] {
+  const specs =
+    character.skillSpecializations?.[skillName] ||
+    character.skillSpecializations?.[skillName.toLowerCase()];
+  if (!specs) return [];
+  return Array.isArray(specs) ? specs : [specs];
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Implement `hasSpecialization()` in pool-builder.ts (was a placeholder returning `false`) with case-insensitive matching against `character.skillSpecializations`
- Add `getSkillSpecializations()` helper function
- Add contextual `[+2]` indicator in amber on SkillsDisplay for skills with specializations (does NOT inflate base pool number)
- Add specialization lines in tooltip with "(contextual)" label
- Auto-match weapon subcategory/name to specializations in CombatQuickReference, adding +2 to weapon attack pools when matched

Closes #447

## Test plan

- [x] `pnpm type-check` — no TypeScript errors
- [x] `pnpm test` — all 8341 tests pass (80 pool-builder, 29 SkillsDisplay, 17 CombatQuickReference)
- [x] `pnpm lint` — no new lint issues
- [x] Manual: character sheet skill list shows `[+2]` next to skills with specializations
- [x] Manual: combat quick reference shows +2 bonus on matching weapons
- [x] Manual: tooltip breakdowns show specialization line with "(contextual)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)