### PR TITLE
feat: gate effect gathering by equipment readiness state (#487)

### DIFF
--- a/__tests__/lib/rules/effects/gathering.test.ts
+++ b/__tests__/lib/rules/effects/gathering.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for equipment readiness gating in effect gathering.
+ *
+ * Verifies that gatherEffectSources() only collects effects from items
+ * whose readiness state indicates they are actively in use.
+ *
+ * @see Issue #487
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Character, GearItem, Weapon, ArmorItem } from "@/lib/types";
+import type { MergedRuleset } from "@/lib/types/edition";
+import type { GearState, EquipmentReadiness } from "@/lib/types/gear-state";
+import type { Effect } from "@/lib/types/effects";
+import { createMockCharacter } from "@/__tests__/mocks/storage";
+import { gatherEffectSources } from "@/lib/rules/effects";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_EFFECT: Effect = {
+  id: "test-effect",
+  type: "dice-pool-modifier",
+  triggers: ["always"],
+  target: {},
+  value: 1,
+};
+
+function makeRuleset(modules: Record<string, unknown> = {}): MergedRuleset {
+  return {
+    snapshotId: "test-snapshot",
+    editionId: "test-edition",
+    editionCode: "sr5",
+    bookIds: ["sr5-core"],
+    modules: modules as MergedRuleset["modules"],
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function makeGearModule(itemId: string) {
+  return {
+    gear: {
+      items: [{ id: itemId, name: "Test Item", effects: [TEST_EFFECT] }],
+    },
+  };
+}
+
+function makeModificationsModule(modId: string) {
+  return {
+    modifications: {
+      items: [{ id: modId, name: "Test Mod", effects: [TEST_EFFECT] }],
+    },
+  };
+}
+
+function makeState(readiness: EquipmentReadiness): GearState {
+  return { readiness, wirelessEnabled: true };
+}
+
+function makeGearItem(overrides: Partial<GearItem> = {}): GearItem {
+  return {
+    id: "test-gear",
+    name: "Test Gear",
+    category: "gear",
+    quantity: 1,
+    cost: 100,
+    ...overrides,
+  } as GearItem;
+}
+
+function makeWeapon(overrides: Partial<Weapon> = {}): Weapon {
+  return {
+    id: "test-weapon",
+    catalogId: "test-weapon-catalog",
+    name: "Test Weapon",
+    type: "ranged",
+    subcategory: "pistols",
+    damage: "5P",
+    ap: -1,
+    accuracy: 5,
+    ...overrides,
+  } as Weapon;
+}
+
+function makeArmor(overrides: Partial<ArmorItem> = {}): ArmorItem {
+  return {
+    id: "test-armor",
+    catalogId: "test-armor-catalog",
+    name: "Test Armor",
+    armorRating: 12,
+    ...overrides,
+  } as ArmorItem;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Equipment readiness gating", () => {
+  describe("weapon readiness", () => {
+    const ruleset = makeRuleset(makeGearModule("test-weapon-catalog"));
+
+    it("should gather effects from readied weapons", () => {
+      const char = createMockCharacter({
+        weapons: [makeWeapon({ state: makeState("readied") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-weapon-catalog")).toBe(true);
+    });
+
+    it("should gather effects from holstered weapons", () => {
+      const char = createMockCharacter({
+        weapons: [makeWeapon({ state: makeState("holstered") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-weapon-catalog")).toBe(true);
+    });
+
+    it("should NOT gather effects from stashed weapons", () => {
+      const char = createMockCharacter({
+        weapons: [makeWeapon({ state: makeState("stashed") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-weapon-catalog")).toBe(false);
+    });
+
+    it("should NOT gather effects from carried weapons", () => {
+      const char = createMockCharacter({
+        weapons: [makeWeapon({ state: makeState("carried") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-weapon-catalog")).toBe(false);
+    });
+
+    it("should NOT gather effects from stored weapons", () => {
+      const char = createMockCharacter({
+        weapons: [makeWeapon({ state: makeState("stored") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-weapon-catalog")).toBe(false);
+    });
+  });
+
+  describe("armor readiness", () => {
+    const ruleset = makeRuleset(makeGearModule("test-armor-catalog"));
+
+    it("should gather effects from worn armor", () => {
+      const char = createMockCharacter({
+        armor: [makeArmor({ state: makeState("worn") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-armor-catalog")).toBe(true);
+    });
+
+    it("should NOT gather effects from carried armor", () => {
+      const char = createMockCharacter({
+        armor: [makeArmor({ state: makeState("carried") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-armor-catalog")).toBe(false);
+    });
+
+    it("should NOT gather effects from stashed armor", () => {
+      const char = createMockCharacter({
+        armor: [makeArmor({ state: makeState("stashed") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-armor-catalog")).toBe(false);
+    });
+  });
+
+  describe("gear readiness", () => {
+    const ruleset = makeRuleset(makeGearModule("test-gear"));
+
+    it.each(["worn", "holstered", "pocketed", "carried"] as EquipmentReadiness[])(
+      "should gather effects from %s gear",
+      (readiness) => {
+        const char = createMockCharacter({
+          gear: [makeGearItem({ state: makeState(readiness) })],
+        });
+        const effects = gatherEffectSources(char, ruleset);
+        expect(effects.some((e) => e.source.id === "test-gear")).toBe(true);
+      }
+    );
+
+    it("should NOT gather effects from stashed gear", () => {
+      const char = createMockCharacter({
+        gear: [makeGearItem({ state: makeState("stashed") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-gear")).toBe(false);
+    });
+  });
+
+  describe("weapon mods inherit parent readiness", () => {
+    const ruleset = makeRuleset(makeModificationsModule("test-mod"));
+
+    it("should gather weapon mod effects when weapon is readied", () => {
+      const char = createMockCharacter({
+        weapons: [
+          makeWeapon({
+            state: makeState("readied"),
+            modifications: [
+              {
+                catalogId: "test-mod",
+                name: "Test Mod",
+                cost: 0,
+                availability: 0,
+                capacityUsed: 0,
+              },
+            ],
+          }),
+        ],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-mod")).toBe(true);
+    });
+
+    it("should NOT gather weapon mod effects when weapon is stashed", () => {
+      const char = createMockCharacter({
+        weapons: [
+          makeWeapon({
+            state: makeState("stashed"),
+            modifications: [
+              {
+                catalogId: "test-mod",
+                name: "Test Mod",
+                cost: 0,
+                availability: 0,
+                capacityUsed: 0,
+              },
+            ],
+          }),
+        ],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-mod")).toBe(false);
+    });
+  });
+
+  describe("gear mods inherit parent readiness", () => {
+    const ruleset = makeRuleset(makeGearModule("test-mod"));
+
+    it("should gather gear mod effects when gear is carried", () => {
+      const char = createMockCharacter({
+        gear: [
+          makeGearItem({
+            state: makeState("carried"),
+            modifications: [
+              {
+                catalogId: "test-mod",
+                name: "Test Mod",
+                rating: 1,
+                capacityUsed: 0,
+                cost: 0,
+                availability: 0,
+              },
+            ],
+          }),
+        ],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-mod")).toBe(true);
+    });
+
+    it("should NOT gather gear mod effects when gear is stashed", () => {
+      const char = createMockCharacter({
+        gear: [
+          makeGearItem({
+            state: makeState("stashed"),
+            modifications: [
+              {
+                catalogId: "test-mod",
+                name: "Test Mod",
+                rating: 1,
+                capacityUsed: 0,
+                cost: 0,
+                availability: 0,
+              },
+            ],
+          }),
+        ],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-mod")).toBe(false);
+    });
+  });
+
+  describe("backward compatibility (undefined readiness)", () => {
+    it("should gather effects from weapons with no state", () => {
+      const ruleset = makeRuleset(makeGearModule("test-weapon-catalog"));
+      const char = createMockCharacter({
+        weapons: [makeWeapon({ state: undefined })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-weapon-catalog")).toBe(true);
+    });
+
+    it("should gather effects from armor with no state", () => {
+      const ruleset = makeRuleset(makeGearModule("test-armor-catalog"));
+      const char = createMockCharacter({
+        armor: [makeArmor({ state: undefined })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-armor-catalog")).toBe(true);
+    });
+
+    it("should gather effects from gear with no state", () => {
+      const ruleset = makeRuleset(makeGearModule("test-gear"));
+      const char = createMockCharacter({
+        gear: [makeGearItem({ state: undefined })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-gear")).toBe(true);
+    });
+  });
+
+  describe("stored readiness normalization", () => {
+    it("should NOT gather effects from stored weapons (weapon category)", () => {
+      const ruleset = makeRuleset(makeGearModule("test-weapon-catalog"));
+      const char = createMockCharacter({
+        weapons: [makeWeapon({ state: makeState("stored") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      expect(effects.some((e) => e.source.id === "test-weapon-catalog")).toBe(false);
+    });
+
+    it("should gather effects from stored gear (normalized to carried)", () => {
+      const ruleset = makeRuleset(makeGearModule("test-gear"));
+      const char = createMockCharacter({
+        gear: [makeGearItem({ state: makeState("stored") })],
+      });
+      const effects = gatherEffectSources(char, ruleset);
+      // "stored" normalizes to "carried", which is in gear's active list
+      expect(effects.some((e) => e.source.id === "test-gear")).toBe(true);
+    });
+  });
+});

--- a/lib/rules/effects/gathering.ts
+++ b/lib/rules/effects/gathering.ts
@@ -12,7 +12,32 @@ import type { Character } from "@/lib/types";
 import type { MergedRuleset } from "@/lib/types/edition";
 import type { Quality } from "@/lib/types/qualities";
 import type { Effect, EffectSource, EffectSourceType } from "@/lib/types/effects";
+import type { EquipmentReadiness } from "@/lib/types/gear-state";
+import { normalizeReadiness } from "@/lib/types/gear-state";
 import { resolveRatingBasedValue } from "./format";
+
+/**
+ * Which readiness states allow effects to be gathered per equipment category.
+ * Items not in an active readiness state are skipped during effect gathering.
+ */
+const EFFECT_ACTIVE_READINESS: Record<string, EquipmentReadiness[]> = {
+  weapon: ["readied", "holstered"],
+  armor: ["worn"],
+  clothing: ["worn"],
+  gear: ["worn", "holstered", "pocketed", "carried"],
+  electronics: ["worn", "holstered", "pocketed", "carried"],
+};
+
+/**
+ * Check if an item's readiness state allows its effects to be gathered.
+ * Items with no state (legacy data) are treated as active for backward compatibility.
+ */
+function isReadinessActive(category: string, readiness: EquipmentReadiness | undefined): boolean {
+  if (!readiness) return true;
+  const normalized = normalizeReadiness(readiness);
+  const validStates = EFFECT_ACTIVE_READINESS[category] ?? EFFECT_ACTIVE_READINESS.gear;
+  return validStates.includes(normalized);
+}
 
 /**
  * An effect paired with its source metadata for resolution.
@@ -149,6 +174,8 @@ function gatherGearEffects(character: Character, ruleset: MergedRuleset): Source
   const results: SourcedEffect[] = [];
 
   for (const item of character.gear || []) {
+    if (!isReadinessActive(item.category, item.state?.readiness)) continue;
+
     const itemId = item.id;
     if (!itemId) continue;
 
@@ -178,6 +205,8 @@ function gatherWeaponEffects(character: Character, ruleset: MergedRuleset): Sour
   const results: SourcedEffect[] = [];
 
   for (const weapon of character.weapons || []) {
+    if (!isReadinessActive("weapon", weapon.state?.readiness)) continue;
+
     const catalogId = weapon.catalogId;
     if (!catalogId) continue;
 
@@ -206,6 +235,8 @@ function gatherArmorEffects(character: Character, ruleset: MergedRuleset): Sourc
   const results: SourcedEffect[] = [];
 
   for (const armor of character.armor || []) {
+    if (!isReadinessActive("armor", armor.state?.readiness)) continue;
+
     const catalogId = armor.catalogId;
     if (!catalogId) continue;
 
@@ -339,6 +370,8 @@ function gatherGearModEffects(character: Character, ruleset: MergedRuleset): Sou
   const results: SourcedEffect[] = [];
 
   for (const item of character.gear || []) {
+    if (!isReadinessActive(item.category, item.state?.readiness)) continue;
+
     for (const mod of item.modifications || []) {
       const catalogItem = findCatalogItem("gear", mod.catalogId, ruleset);
       if (!catalogItem) continue;
@@ -368,6 +401,8 @@ function gatherWeaponModEffects(character: Character, ruleset: MergedRuleset): S
   const results: SourcedEffect[] = [];
 
   for (const weapon of character.weapons || []) {
+    if (!isReadinessActive("weapon", weapon.state?.readiness)) continue;
+
     for (const mod of weapon.modifications || []) {
       const catalogItem = findCatalogItem("modifications", mod.catalogId, ruleset);
       if (!catalogItem) continue;


### PR DESCRIPTION
## Summary
- Effects from gear, weapons, armor, and their modifications are now only gathered when the parent item is in an active readiness state
- `EFFECT_ACTIVE_READINESS` map defines which readiness states allow effects per equipment category (e.g., weapons: readied/holstered, armor: worn, gear: worn/holstered/pocketed/carried)
- Uses `normalizeReadiness()` so legacy `"stored"` maps to `"carried"` behavior; items with undefined state remain active for backward compatibility

## Test plan
- [x] `pnpm type-check` — no TypeScript errors
- [x] `pnpm test` — all 8434 tests pass, no regressions
- [x] 22 new tests covering weapon/armor/gear readiness gating, mod inheritance, backward compat, and stored normalization

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)