### PR TITLE
feat: group active effects by source item with parent attribution (#486)

### DIFF
--- a/components/character/sheet/EffectsSummaryDisplay.tsx
+++ b/components/character/sheet/EffectsSummaryDisplay.tsx
@@ -5,14 +5,16 @@
  *
  * Collapsible DisplayCard showing all active effects on a character,
  * grouped by source type (Qualities, Cyberware, Bioware, Gear, Adept Powers,
- * Active Modifiers). Each row shows source name, effect type badge,
- * value pill, and wireless indicator.
+ * Active Modifiers) and sub-grouped by source item. Each source item shows
+ * its name (with parent attribution for mods) and colored effect badges.
  *
- * @see Issue #113
+ * @see Issue #113, #486
  */
 
 import type { EffectSourceType } from "@/lib/types/effects";
 import type { SourcedEffect } from "@/lib/rules/effects";
+import { formatEffectBadge } from "@/lib/rules/effects";
+import type { EffectBadge } from "@/lib/rules/effects";
 import { DisplayCard } from "./DisplayCard";
 import { Zap, Wifi } from "lucide-react";
 
@@ -22,6 +24,14 @@ import { Zap, Wifi } from "lucide-react";
 
 interface EffectsSummaryDisplayProps {
   sources: SourcedEffect[];
+}
+
+interface GroupedSourceItem {
+  id: string;
+  name: string;
+  parentName?: string;
+  hasWireless: boolean;
+  effects: SourcedEffect[];
 }
 
 // ---------------------------------------------------------------------------
@@ -40,10 +50,6 @@ const SOURCE_SECTIONS: Array<{ key: EffectSourceType; label: string }> = [
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatEffectType(type: string): string {
-  return type.replace(/-/g, " ");
-}
 
 function resolveDisplayValue(source: SourcedEffect): number {
   const { effect, source: src } = source;
@@ -67,49 +73,86 @@ function resolveDisplayValue(source: SourcedEffect): number {
   return value;
 }
 
+/**
+ * Sub-group effects by source.id within a source-type section.
+ * Preserves insertion order.
+ */
+function groupBySourceId(effects: SourcedEffect[]): GroupedSourceItem[] {
+  const map = new Map<string, GroupedSourceItem>();
+
+  for (const s of effects) {
+    const existing = map.get(s.source.id);
+    if (existing) {
+      existing.effects.push(s);
+      if (isWirelessEffect(s)) {
+        existing.hasWireless = true;
+      }
+    } else {
+      map.set(s.source.id, {
+        id: s.source.id,
+        name: s.source.name,
+        parentName: s.source.parentName,
+        hasWireless: isWirelessEffect(s),
+        effects: [s],
+      });
+    }
+  }
+
+  return Array.from(map.values());
+}
+
+function isWirelessEffect(s: SourcedEffect): boolean {
+  return !!(
+    s.source.wirelessEnabled &&
+    (s.effect.wirelessOverride !== undefined || s.effect.requiresWireless === true)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
 
-function EffectRow({ sourced }: { sourced: SourcedEffect }) {
-  const { effect, source } = sourced;
-  const value = resolveDisplayValue(sourced);
-  const isWireless =
-    source.wirelessEnabled &&
-    (effect.wirelessOverride !== undefined || effect.requiresWireless === true);
+function SourceItemRow({ item }: { item: GroupedSourceItem }) {
+  const badges: Array<EffectBadge & { value: number }> = [];
+
+  for (const s of item.effects) {
+    const value = resolveDisplayValue(s);
+    const badge = formatEffectBadge(s.effect, { resolvedValue: value });
+    if (badge) {
+      badges.push({ ...badge, value });
+    }
+  }
 
   return (
-    <div className="flex min-w-0 items-center gap-1.5 px-3 py-1.5 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50">
-      {/* Source name */}
+    <div className="flex min-w-0 flex-wrap items-center gap-1.5 px-3 py-1.5 [&+&]:border-t [&+&]:border-zinc-200 dark:[&+&]:border-zinc-800/50">
+      {/* Source name with optional parent attribution */}
       <span className="truncate text-[13px] font-medium text-zinc-800 dark:text-zinc-200">
-        {source.name}
-      </span>
-
-      {/* Effect type badge */}
-      <span className="shrink-0 rounded-full border border-blue-500/20 bg-blue-500/10 px-1.5 py-px font-mono text-[9px] uppercase text-blue-400">
-        {formatEffectType(effect.type)}
+        {item.name}
+        {item.parentName && <span className="text-zinc-500"> ({item.parentName})</span>}
       </span>
 
       {/* Wireless indicator */}
-      {isWireless && (
+      {item.hasWireless && (
         <span title="Wireless bonus active">
           <Wifi className="h-3 w-3 shrink-0 text-cyan-400" />
         </span>
       )}
 
-      {/* Value pill */}
-      <span
-        className={`ml-auto shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px] font-semibold ${
-          value > 0
-            ? "border-emerald-500/20 bg-emerald-500/12 text-emerald-600 dark:text-emerald-300"
-            : value < 0
-              ? "border-red-500/20 bg-red-500/12 text-red-600 dark:text-red-300"
-              : "border-zinc-500/20 bg-zinc-500/12 text-zinc-500"
-        }`}
-      >
-        {value > 0 ? "+" : ""}
-        {value}
-      </span>
+      {/* Effect badges */}
+      {badges.map((badge, idx) => (
+        <span
+          key={idx}
+          data-testid="effect-badge"
+          className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium ${badge.colorClass}`}
+        >
+          {badge.label}
+          {badge.trigger && (
+            <span className={badge.triggerActive ? "font-semibold text-red-400" : "opacity-50"}>
+              · {badge.trigger}
+            </span>
+          )}
+        </span>
+      ))}
     </div>
   );
 }
@@ -143,14 +186,15 @@ export function EffectsSummaryDisplay({ sources }: EffectsSummaryDisplayProps) {
       <div className="space-y-3">
         {SOURCE_SECTIONS.filter((section) => grouped.has(section.key)).map((section) => {
           const sectionSources = grouped.get(section.key)!;
+          const items = groupBySourceId(sectionSources);
           return (
             <div key={section.key}>
               <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
                 {section.label}
               </div>
               <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
-                {sectionSources.map((s, idx) => (
-                  <EffectRow key={`${s.source.id}-${s.effect.id}-${idx}`} sourced={s} />
+                {items.map((item) => (
+                  <SourceItemRow key={item.id} item={item} />
                 ))}
               </div>
             </div>

--- a/components/character/sheet/__tests__/EffectsSummaryDisplay.test.tsx
+++ b/components/character/sheet/__tests__/EffectsSummaryDisplay.test.tsx
@@ -1,10 +1,11 @@
 /**
  * EffectsSummaryDisplay Component Tests
  *
- * Tests the effects summary panel rendering. Verifies grouping by source type,
- * effect rows with type badges, value pills, and wireless indicators.
+ * Tests the effects summary panel rendering. Verifies grouping by source type
+ * and source ID, effect badge rendering via formatEffectBadge, value display,
+ * wireless indicators, and parent attribution.
  *
- * @see Issue #113
+ * @see Issue #113, #486
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -12,6 +13,7 @@ import { render, screen } from "@testing-library/react";
 import { LUCIDE_MOCK } from "./test-helpers";
 import type { Effect, EffectSource } from "@/lib/types/effects";
 import type { SourcedEffect } from "@/lib/rules/effects";
+import type { EffectBadge } from "@/lib/rules/effects";
 
 vi.mock("../DisplayCard", () => ({
   DisplayCard: ({
@@ -32,6 +34,24 @@ vi.mock("../DisplayCard", () => ({
 }));
 
 vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+vi.mock("@/lib/rules/effects", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/rules/effects")>("@/lib/rules/effects");
+  return {
+    ...actual,
+    formatEffectBadge: vi.fn(
+      (effect: Effect, context?: { resolvedValue?: number }): EffectBadge | null => {
+        const value =
+          context?.resolvedValue ?? (typeof effect.value === "number" ? effect.value : 0);
+        const sign = value >= 0 ? "+" : "";
+        return {
+          label: `${sign}${value} Mock`,
+          colorClass: "bg-emerald-100 text-emerald-700",
+        };
+      }
+    ),
+  };
+});
 
 import { EffectsSummaryDisplay } from "../EffectsSummaryDisplay";
 
@@ -88,7 +108,7 @@ describe("EffectsSummaryDisplay", () => {
   it("renders multiple effects from different source types", () => {
     const sources = [
       makeSourced({}, { name: "Catlike" }),
-      makeSourced({ id: "eff-2" }, { name: "Audio Enhancement", type: "gear" }),
+      makeSourced({ id: "eff-2" }, { name: "Audio Enhancement", type: "gear", id: "audio-enh" }),
     ];
     render(<EffectsSummaryDisplay sources={sources} />);
     expect(screen.getByText("Catlike")).toBeInTheDocument();
@@ -98,43 +118,41 @@ describe("EffectsSummaryDisplay", () => {
   it("renders source names", () => {
     const sources = [
       makeSourced({}, { name: "Catlike" }),
-      makeSourced({ id: "eff-2" }, { name: "Cybereyes Rating 3", type: "cyberware" }),
+      makeSourced(
+        { id: "eff-2" },
+        { name: "Cybereyes Rating 3", type: "cyberware", id: "cybereyes" }
+      ),
     ];
     render(<EffectsSummaryDisplay sources={sources} />);
     expect(screen.getByText("Catlike")).toBeInTheDocument();
     expect(screen.getByText("Cybereyes Rating 3")).toBeInTheDocument();
   });
 
-  it("renders effect type badges", () => {
-    const sources = [
-      makeSourced({ type: "dice-pool-modifier" }, { name: "Catlike" }),
-      makeSourced(
-        { id: "eff-2", type: "limit-modifier" },
-        { name: "Cybereyes", type: "cyberware" }
-      ),
-    ];
+  it("renders effect badges via formatEffectBadge", () => {
+    const sources = [makeSourced({ type: "dice-pool-modifier", value: 2 }, { name: "Catlike" })];
     render(<EffectsSummaryDisplay sources={sources} />);
-    expect(screen.getByText("dice pool modifier")).toBeInTheDocument();
-    expect(screen.getByText("limit modifier")).toBeInTheDocument();
+    const badges = screen.getAllByTestId("effect-badge");
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toHaveTextContent("+2 Mock");
   });
 
-  it("renders positive value pills with plus sign", () => {
+  it("renders positive value in badge with plus sign", () => {
     const sources = [makeSourced({ value: 2 }, { name: "Catlike" })];
     render(<EffectsSummaryDisplay sources={sources} />);
-    expect(screen.getByText("+2")).toBeInTheDocument();
+    expect(screen.getByTestId("effect-badge")).toHaveTextContent("+2");
   });
 
-  it("renders negative value pills without plus sign", () => {
+  it("renders negative value in badge without plus sign", () => {
     const sources = [makeSourced({ value: -1 }, { name: "Bad Quality" })];
     render(<EffectsSummaryDisplay sources={sources} />);
-    expect(screen.getByText("-1")).toBeInTheDocument();
+    expect(screen.getByTestId("effect-badge")).toHaveTextContent("-1");
   });
 
   it("groups effects by source type", () => {
     const sources = [
       makeSourced({}, { name: "Quality A", type: "quality" }),
-      makeSourced({ id: "eff-2" }, { name: "Cyberware A", type: "cyberware" }),
-      makeSourced({ id: "eff-3" }, { name: "Quality B", type: "quality" }),
+      makeSourced({ id: "eff-2" }, { name: "Cyberware A", type: "cyberware", id: "cyber-a" }),
+      makeSourced({ id: "eff-3" }, { name: "Quality B", type: "quality", id: "quality-b" }),
     ];
     render(<EffectsSummaryDisplay sources={sources} />);
 
@@ -158,7 +176,7 @@ describe("EffectsSummaryDisplay", () => {
       makeSourced({ value: { perRating: 1 } }, { name: "Wired Reflexes", rating: 3 }),
     ];
     render(<EffectsSummaryDisplay sources={sources} />);
-    expect(screen.getByText("+3")).toBeInTheDocument();
+    expect(screen.getByTestId("effect-badge")).toHaveTextContent("+3");
   });
 
   it("shows wireless bonus value when source has wireless enabled and wirelessOverride", () => {
@@ -170,6 +188,62 @@ describe("EffectsSummaryDisplay", () => {
     ];
     render(<EffectsSummaryDisplay sources={sources} />);
     // 1 base + 1 wireless bonus = 2
-    expect(screen.getByText("+2")).toBeInTheDocument();
+    expect(screen.getByTestId("effect-badge")).toHaveTextContent("+2");
+  });
+
+  // --- New tests for #486 ---
+
+  it("groups multiple effects from the same source under one name", () => {
+    const sources = [
+      makeSourced(
+        { id: "eff-1", type: "dice-pool-modifier", value: -1 },
+        { name: "Addiction", type: "quality", id: "addiction" }
+      ),
+      makeSourced(
+        { id: "eff-2", type: "attribute-modifier", value: -2 },
+        { name: "Addiction", type: "quality", id: "addiction" }
+      ),
+      makeSourced(
+        { id: "eff-3", type: "limit-modifier", value: -1 },
+        { name: "Addiction", type: "quality", id: "addiction" }
+      ),
+    ];
+    render(<EffectsSummaryDisplay sources={sources} />);
+
+    // Should only render the name once
+    const nameElements = screen.getAllByText("Addiction");
+    expect(nameElements).toHaveLength(1);
+
+    // Should render 3 badges
+    const badges = screen.getAllByTestId("effect-badge");
+    expect(badges).toHaveLength(3);
+  });
+
+  it("renders parent attribution for mod effects", () => {
+    const sources = [
+      makeSourced(
+        { id: "laser-sight-eff", type: "accuracy-modifier", value: 1 },
+        {
+          name: "Laser Sight",
+          type: "gear",
+          id: "laser-sight",
+          parentName: "Ares Predator V",
+          parentId: "ares-predator-v",
+        }
+      ),
+    ];
+    render(<EffectsSummaryDisplay sources={sources} />);
+
+    expect(screen.getByText("Laser Sight")).toBeInTheDocument();
+    expect(screen.getByText("(Ares Predator V)")).toBeInTheDocument();
+  });
+
+  it("renders badge with colorClass from formatEffectBadge", () => {
+    const sources = [makeSourced({ value: 1 }, { name: "Test Quality" })];
+    render(<EffectsSummaryDisplay sources={sources} />);
+
+    const badge = screen.getByTestId("effect-badge");
+    expect(badge.className).toContain("bg-emerald-100");
+    expect(badge.className).toContain("text-emerald-700");
   });
 });

--- a/lib/rules/effects/gathering.ts
+++ b/lib/rules/effects/gathering.ts
@@ -382,6 +382,8 @@ function gatherGearModEffects(character: Character, ruleset: MergedRuleset): Sou
         id: mod.catalogId,
         name: mod.name,
         rating: mod.rating,
+        parentName: item.name,
+        parentId: item.id,
       };
 
       for (const effect of effects) {
@@ -413,6 +415,8 @@ function gatherWeaponModEffects(character: Character, ruleset: MergedRuleset): S
         id: mod.catalogId,
         name: mod.name,
         rating: mod.rating,
+        parentName: weapon.name,
+        parentId: weapon.id,
       };
 
       for (const effect of effects) {

--- a/lib/types/effects.ts
+++ b/lib/types/effects.ts
@@ -260,6 +260,12 @@ export interface EffectSource {
 
   /** Whether wireless is enabled on source item */
   wirelessEnabled?: boolean;
+
+  /** Parent item name (for mods installed on weapons/gear) */
+  parentName?: string;
+
+  /** Parent item ID (for mods installed on weapons/gear) */
+  parentId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Group by source item**: Effects from the same source (e.g., 3 Addiction effects) now render under a single name row with multiple badge pills instead of 3 separate rows
- **Parent attribution**: Mod effects (weapon accessories, gear mods) show their parent item in parentheses, e.g., "Laser Sight (Ares Predator V)"
- **Badge rendering**: Replaced raw effect type text (e.g., "dice pool modifier") with colored `formatEffectBadge()` badge pills matching the QualitiesDisplay pattern

## Changes
- `lib/types/effects.ts` — Added `parentName?` and `parentId?` to `EffectSource`
- `lib/rules/effects/gathering.ts` — Set parent fields in `gatherWeaponModEffects()` and `gatherGearModEffects()`
- `components/character/sheet/EffectsSummaryDisplay.tsx` — Rewrote grouping logic and badge rendering
- `components/character/sheet/__tests__/EffectsSummaryDisplay.test.tsx` — Updated + expanded tests (14 tests)

## Test plan
- [x] `pnpm type-check` — no errors
- [x] `pnpm test` — all 8437 tests pass (388 files)
- [x] EffectsSummaryDisplay tests cover grouping, parent attribution, badge rendering
- [x] Gathering tests unchanged and passing

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)