### PR TITLE
feat: sourcebook configuration UI with metadata and content badges (#451)

### DIFF
--- a/app/api/editions/[editionCode]/route.ts
+++ b/app/api/editions/[editionCode]/route.ts
@@ -15,6 +15,7 @@ import {
   getAllBooks,
   getAllCreationMethods,
   getEditionContentSummary,
+  getBookSummary,
 } from "@/lib/storage/editions";
 import type { EditionCode } from "@/lib/types";
 
@@ -61,6 +62,14 @@ export async function GET(
     if (include.includes("summary")) {
       const contentSummary = await getEditionContentSummary(editionCode as EditionCode);
       response.contentSummary = contentSummary;
+    }
+
+    // Optionally include book summaries with content contribution counts
+    if (include.includes("bookSummaries")) {
+      const bookSummaries = await Promise.all(
+        edition.bookIds.map((bookId) => getBookSummary(editionCode as EditionCode, bookId))
+      );
+      response.bookSummaries = bookSummaries.filter(Boolean);
     }
 
     return NextResponse.json(response);

--- a/app/campaigns/[id]/settings/page.tsx
+++ b/app/campaigns/[id]/settings/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import type {
   Campaign,
   Book,
+  BookSummary,
   CreationMethod,
   GameplayLevel,
   CampaignVisibility,
@@ -85,6 +86,7 @@ export default function CampaignSettingsPage({ params }: SettingsPageProps) {
 
   // Edition data
   const [books, setBooks] = useState<Book[]>([]);
+  const [bookSummaries, setBookSummaries] = useState<BookSummary[]>([]);
   const [creationMethods, setCreationMethods] = useState<CreationMethod[]>([]);
 
   // Fetch campaign and edition data
@@ -126,11 +128,12 @@ export default function CampaignSettingsPage({ params }: SettingsPageProps) {
           setAdvancementSettings(c.advancementSettings);
         }
 
-        // Fetch edition data
-        const editionRes = await fetch(`/api/editions/${c.editionCode}`);
+        // Fetch edition data with book summaries
+        const editionRes = await fetch(`/api/editions/${c.editionCode}?include=bookSummaries`);
         const editionData = await editionRes.json();
         if (editionData.success) {
           setBooks(editionData.books || []);
+          setBookSummaries(editionData.bookSummaries || []);
           setCreationMethods(editionData.creationMethods || []);
         }
       } catch {
@@ -468,26 +471,62 @@ export default function CampaignSettingsPage({ params }: SettingsPageProps) {
               <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
                 Enabled Books
               </label>
-              <div className="mt-2 space-y-2">
-                {books.map((book) => (
-                  <label key={book.id} className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={enabledBookIds.includes(book.id)}
-                      onChange={() => toggleBookId(book.id)}
-                      disabled={book.isCore} // Core book cannot be disabled
-                      className="rounded border-zinc-300 text-indigo-600 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
-                    />
-                    <span className="text-sm text-zinc-700 dark:text-zinc-300">
-                      {book.title}
-                      {book.isCore && (
-                        <span className="ml-1 text-xs text-indigo-600 dark:text-indigo-400">
-                          (Core - Required)
-                        </span>
-                      )}
-                    </span>
-                  </label>
-                ))}
+              <div className="mt-2 space-y-3">
+                {books.map((book) => {
+                  const summary = bookSummaries.find((s) => s.id === book.id);
+                  return (
+                    <label
+                      key={book.id}
+                      className="flex cursor-pointer gap-3 rounded-lg border border-zinc-200 p-3 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/50"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={enabledBookIds.includes(book.id)}
+                        onChange={() => toggleBookId(book.id)}
+                        disabled={book.isCore}
+                        className="mt-0.5 rounded border-zinc-300 text-indigo-600 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          {book.abbreviation && (
+                            <span className="rounded bg-indigo-100 px-1.5 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+                              {book.abbreviation}
+                            </span>
+                          )}
+                          <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                            {book.title}
+                          </span>
+                          {book.isCore && (
+                            <span className="text-xs text-indigo-600 dark:text-indigo-400">
+                              (Core - Required)
+                            </span>
+                          )}
+                        </div>
+                        {summary && (
+                          <>
+                            {summary.role && (
+                              <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                                {summary.role}
+                              </p>
+                            )}
+                            {summary.contentContributions.length > 0 && (
+                              <div className="mt-2 flex flex-wrap gap-1.5">
+                                {summary.contentContributions.map((c) => (
+                                  <span
+                                    key={c.id}
+                                    className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+                                  >
+                                    {c.name}: {c.itemCount}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    </label>
+                  );
+                })}
               </div>
             </div>
 

--- a/app/characters/create/sheet/components/SheetCreationLayout.tsx
+++ b/app/characters/create/sheet/components/SheetCreationLayout.tsx
@@ -20,7 +20,15 @@ import { useMemo } from "react";
 import dynamic from "next/dynamic";
 import { useCreationBudgets } from "@/lib/contexts";
 import type { CreationState, Campaign, SelectedQuality } from "@/lib/types";
-import { CheckCircle2, AlertCircle, AlertTriangle, Loader2, Clock, Save } from "lucide-react";
+import {
+  CheckCircle2,
+  AlertCircle,
+  AlertTriangle,
+  Loader2,
+  Clock,
+  Save,
+  BookOpen,
+} from "lucide-react";
 import { InfoTooltip } from "@/components/ui";
 import { useQualities, useSkills, useGameplayLevelModifiers } from "@/lib/rules/RulesetContext";
 
@@ -807,8 +815,8 @@ export function SheetCreationLayout({
   lastSaved,
   saveError,
   onRetry,
-  campaignId: _campaignId, // Used in Phase 5+
-  campaign: _campaign, // Used in Phase 5+
+  campaignId: _campaignId,
+  campaign,
   serverValidation,
 }: SheetCreationLayoutProps) {
   // Determine what sections are available based on selections
@@ -854,6 +862,20 @@ export function SheetCreationLayout({
           )}
         </div>
       </div>
+
+      {/* Active Books Banner */}
+      {campaign && (
+        <div className="rounded-md bg-blue-50 px-4 py-3 dark:bg-blue-900/20">
+          <div className="flex items-center gap-2 text-sm">
+            <BookOpen className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+            <span className="font-medium text-blue-800 dark:text-blue-200">{campaign.title}</span>
+            <span className="text-blue-600 dark:text-blue-400">
+              — {campaign.enabledBookIds.length} book
+              {campaign.enabledBookIds.length !== 1 ? "s" : ""} active
+            </span>
+          </div>
+        </div>
+      )}
 
       {/* Three Column Grid */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/data/editions/sr5/core-rulebook.json
+++ b/data/editions/sr5/core-rulebook.json
@@ -6,7 +6,9 @@
     "version": "1.0.0",
     "category": "core",
     "publisher": "Catalyst Game Labs",
-    "releaseYear": 2013
+    "releaseYear": 2013,
+    "abbreviation": "SR5",
+    "description": "The complete core rules for Shadowrun 5th Edition, including character creation, combat, magic, the Matrix, and rigging."
   },
   "modules": {
     "advancement": {

--- a/lib/storage/editions.ts
+++ b/lib/storage/editions.ts
@@ -116,6 +116,9 @@ export async function getAllBooks(editionCode: EditionCode): Promise<Book[]> {
         id: bookPayload.meta.bookId,
         editionId: edition.id,
         title: bookPayload.meta.title,
+        abbreviation: bookPayload.meta.abbreviation,
+        publisher: bookPayload.meta.publisher,
+        releaseYear: bookPayload.meta.releaseYear,
         version: bookPayload.meta.version || "1.0.0",
         isCore: bookPayload.meta.category === "core",
         categories: [bookPayload.meta.category],
@@ -405,6 +408,8 @@ export async function getBookSummary(
   return {
     id: payload.meta.bookId,
     title: payload.meta.title,
+    abbreviation: payload.meta.abbreviation,
+    releaseYear: payload.meta.releaseYear,
     category: payload.meta.category,
     role: payload.meta.category === "core" ? "Core rules foundation" : "Content expansion",
     contentContributions: contributions,

--- a/lib/types/edition.ts
+++ b/lib/types/edition.ts
@@ -279,6 +279,10 @@ export interface BookPayload {
     edition: EditionCode;
     version: string;
     category: BookCategory;
+    abbreviation?: string;
+    description?: string;
+    publisher?: string;
+    releaseYear?: number;
   };
 
   /**


### PR DESCRIPTION
## Summary

- Enrich `BookPayload.meta` type and SR5 core-rulebook JSON with `abbreviation`, `description`, `publisher`, `releaseYear`
- Add `?include=bookSummaries` support to the editions API endpoint for per-book content contribution counts
- Enhance campaign settings book toggles from flat checkboxes to card-style UI with abbreviation badges, role descriptions, and content contribution pills (e.g., "Metatypes: 8", "Skills: 42")
- Add active books info banner in character creation for campaign-linked characters showing campaign name and book count

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (390 files, 8467 tests)
- [ ] **Manual — campaign settings:** Navigate to campaign settings, verify book cards show abbreviation badge, description, content contribution counts. Toggle a book off/on, save, verify changes persist.
- [ ] **Manual — character creation:** Create character from campaign, verify info banner shows campaign name and active book count.
- [ ] **Manual — API:** `GET /api/editions/sr5?include=bookSummaries` returns `bookSummaries` array with content counts.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)