### PR TITLE
feat: add archetype quick-build system for character creation (#449)

### DIFF
--- a/app/api/editions/[editionCode]/archetypes/route.ts
+++ b/app/api/editions/[editionCode]/archetypes/route.ts
@@ -1,0 +1,63 @@
+/**
+ * Archetypes API
+ *
+ * GET /api/editions/[editionCode]/archetypes - List character archetypes
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { getArchetypes, searchArchetypes } from "@/lib/storage/archetypes";
+import type { EditionCode } from "@/lib/types/edition";
+import type { CharacterArchetype, ArchetypeCategory } from "@/lib/types/archetype";
+
+interface ArchetypesResponse {
+  success: boolean;
+  archetypes: CharacterArchetype[];
+  error?: string;
+}
+
+/**
+ * GET /api/editions/[editionCode]/archetypes
+ *
+ * Query Parameters:
+ * - category: Filter by category (combat, magic, technology, social)
+ * - search: Search by name/description
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ editionCode: string }> }
+): Promise<NextResponse<ArchetypesResponse>> {
+  try {
+    const userId = await getSession();
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, archetypes: [], error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const { editionCode } = await params;
+
+    const searchParams = request.nextUrl.searchParams;
+    const categoryParam = searchParams.get("category") as ArchetypeCategory | null;
+    const searchQuery = searchParams.get("search");
+
+    let archetypes;
+    if (searchQuery) {
+      archetypes = await searchArchetypes(editionCode as EditionCode, searchQuery);
+    } else {
+      archetypes = await getArchetypes(editionCode as EditionCode, categoryParam ?? undefined);
+    }
+
+    return NextResponse.json({
+      success: true,
+      archetypes,
+    });
+  } catch (error) {
+    console.error("Get archetypes error:", error);
+    return NextResponse.json(
+      { success: false, archetypes: [], error: "An error occurred" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/characters/create/sheet/page.tsx
+++ b/app/characters/create/sheet/page.tsx
@@ -17,8 +17,10 @@ import { CreationBudgetProvider } from "@/lib/contexts";
 import { SheetCreationLayout } from "./components/SheetCreationLayout";
 import { EditionSelector } from "@/components/creation/EditionSelector";
 import { CreationSetup } from "@/components/creation/CreationSetup";
+import { ArchetypeSelector } from "@/components/creation/ArchetypeSelector";
 import { CreationErrorBoundary } from "@/components/creation/CreationErrorBoundary";
 import type { EditionCode, Campaign, CreationState, ID } from "@/lib/types";
+import type { CharacterArchetype } from "@/lib/types/archetype";
 import type { GameplayLevel } from "@/lib/types/campaign";
 import { Loader2, ArrowLeft } from "lucide-react";
 import Link from "next/link";
@@ -97,6 +99,9 @@ function SheetCreationContent({
     }
     return createInitialCreationState();
   });
+  const [selectedArchetype, setSelectedArchetype] = useState<CharacterArchetype | "skipped" | null>(
+    null
+  );
   const [characterId, setCharacterId] = useState<ID | null>(existingCharacter?.id || null);
   const [isSaving, setIsSaving] = useState(false);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
@@ -381,6 +386,32 @@ function SheetCreationContent({
     [updateState]
   );
 
+  // Handle archetype selection — pre-fill creation state with archetype data
+  const handleArchetypeSelect = useCallback(
+    (archetype: CharacterArchetype) => {
+      setSelectedArchetype(archetype);
+      updateState({
+        priorities: archetype.priorities,
+        selections: {
+          ...creationState.selections,
+          metatype: archetype.selections.metatype,
+          "magical-path": archetype.selections["magical-path"],
+          attributes: archetype.selections.attributes,
+          specialAttributes: archetype.selections.specialAttributes,
+          skills: archetype.selections.skills,
+        },
+      });
+    },
+    [creationState.selections, updateState]
+  );
+
+  const handleArchetypeSkip = useCallback(() => {
+    setSelectedArchetype("skipped");
+  }, []);
+
+  // Determine if archetype selection is needed
+  const needsArchetypeSelection = !existingCharacter && selectedArchetype === null && ready;
+
   // Determine if setup is needed (standalone characters without a gameplay level)
   const needsSetup = !campaign && !creationState.gameplayLevel;
 
@@ -440,6 +471,17 @@ function SheetCreationContent({
           </button>
         </div>
       </div>
+    );
+  }
+
+  // Show archetype selector after ruleset loads
+  if (needsArchetypeSelection) {
+    return (
+      <ArchetypeSelector
+        editionCode={editionCode || (selectedEdition as string)}
+        onSelect={handleArchetypeSelect}
+        onSkip={handleArchetypeSkip}
+      />
     );
   }
 

--- a/components/creation/ArchetypeSelector.tsx
+++ b/components/creation/ArchetypeSelector.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import type { CharacterArchetype, ArchetypeCategory } from "@/lib/types/archetype";
+import { Swords, Sparkles, Cpu, MessageCircle, ArrowRight, Wrench, Loader2 } from "lucide-react";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const CATEGORY_CONFIG: Record<
+  ArchetypeCategory,
+  { icon: typeof Swords; label: string; color: string; bg: string; border: string }
+> = {
+  combat: {
+    icon: Swords,
+    label: "Combat",
+    color: "text-red-500 dark:text-red-400",
+    bg: "bg-red-500/10",
+    border: "border-red-500/30",
+  },
+  magic: {
+    icon: Sparkles,
+    label: "Magic",
+    color: "text-violet-500 dark:text-violet-400",
+    bg: "bg-violet-500/10",
+    border: "border-violet-500/30",
+  },
+  technology: {
+    icon: Cpu,
+    label: "Technology",
+    color: "text-cyan-500 dark:text-cyan-400",
+    bg: "bg-cyan-500/10",
+    border: "border-cyan-500/30",
+  },
+  social: {
+    icon: MessageCircle,
+    label: "Social",
+    color: "text-amber-500 dark:text-amber-400",
+    bg: "bg-amber-500/10",
+    border: "border-amber-500/30",
+  },
+};
+
+const DIFFICULTY_LABELS: Record<string, { label: string; color: string }> = {
+  beginner: { label: "Beginner", color: "text-emerald-500 dark:text-emerald-400" },
+  intermediate: { label: "Intermediate", color: "text-amber-500 dark:text-amber-400" },
+  advanced: { label: "Advanced", color: "text-red-500 dark:text-red-400" },
+};
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+interface ArchetypeSelectorProps {
+  editionCode: string;
+  onSelect: (archetype: CharacterArchetype) => void;
+  onSkip: () => void;
+}
+
+export function ArchetypeSelector({ editionCode, onSelect, onSkip }: ArchetypeSelectorProps) {
+  const [archetypes, setArchetypes] = useState<CharacterArchetype[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [filterCategory, setFilterCategory] = useState<ArchetypeCategory | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/editions/${editionCode}/archetypes`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.success) {
+            setArchetypes(data.archetypes);
+          }
+        }
+      } catch (e) {
+        console.error("Failed to load archetypes:", e);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [editionCode]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[300px] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-emerald-500" />
+      </div>
+    );
+  }
+
+  if (archetypes.length === 0) {
+    // No archetypes available — skip silently
+    onSkip();
+    return null;
+  }
+
+  const filtered = filterCategory
+    ? archetypes.filter((a) => a.category === filterCategory)
+    : archetypes;
+
+  const selectedArchetype = archetypes.find((a) => a.id === selected);
+
+  return (
+    <div className="mx-auto max-w-4xl py-8">
+      {/* Header */}
+      <div className="mb-8 text-center">
+        <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-50">Choose an Archetype</h2>
+        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          Start with a pre-built concept or build from scratch. Archetypes pre-fill priorities,
+          attributes, and skills — you can customize everything afterward.
+        </p>
+      </div>
+
+      {/* Category Filter */}
+      <div className="mb-6 flex flex-wrap items-center justify-center gap-2">
+        <button
+          onClick={() => setFilterCategory(null)}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+            filterCategory === null
+              ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+              : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+          }`}
+        >
+          All
+        </button>
+        {(Object.keys(CATEGORY_CONFIG) as ArchetypeCategory[]).map((cat) => {
+          const config = CATEGORY_CONFIG[cat];
+          return (
+            <button
+              key={cat}
+              onClick={() => setFilterCategory(filterCategory === cat ? null : cat)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                filterCategory === cat
+                  ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+              }`}
+            >
+              {config.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Archetype Grid */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((archetype) => {
+          const catConfig = CATEGORY_CONFIG[archetype.category];
+          const diffConfig = DIFFICULTY_LABELS[archetype.difficulty];
+          const Icon = catConfig.icon;
+          const isSelected = selected === archetype.id;
+
+          return (
+            <button
+              key={archetype.id}
+              onClick={() => setSelected(isSelected ? null : archetype.id)}
+              className={`relative flex flex-col rounded-xl border p-5 text-left transition-all ${
+                isSelected
+                  ? `${catConfig.border} ${catConfig.bg} ring-2 ring-offset-1 ring-offset-white dark:ring-offset-zinc-900 ${catConfig.border.replace("border-", "ring-")}`
+                  : "border-zinc-200 hover:border-zinc-300 dark:border-zinc-700 dark:hover:border-zinc-600"
+              }`}
+            >
+              {/* Header */}
+              <div className="mb-3 flex items-center gap-2">
+                <div
+                  className={`flex h-8 w-8 items-center justify-center rounded-lg ${catConfig.bg}`}
+                >
+                  <Icon className={`h-4 w-4 ${catConfig.color}`} />
+                </div>
+                <div className="flex-1">
+                  <h3
+                    className={`text-sm font-semibold ${isSelected ? catConfig.color : "text-zinc-900 dark:text-zinc-100"}`}
+                  >
+                    {archetype.name}
+                  </h3>
+                </div>
+              </div>
+
+              {/* Badges */}
+              <div className="mb-3 flex flex-wrap gap-1.5">
+                <span
+                  className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${catConfig.bg} ${catConfig.color}`}
+                >
+                  {catConfig.label}
+                </span>
+                <span
+                  className={`rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-medium dark:bg-zinc-800 ${diffConfig?.color ?? ""}`}
+                >
+                  {diffConfig?.label ?? archetype.difficulty}
+                </span>
+                <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                  {archetype.suggestedMetatype}
+                </span>
+              </div>
+
+              {/* Description */}
+              <p className="mb-4 line-clamp-3 text-xs text-zinc-500 dark:text-zinc-400">
+                {archetype.description}
+              </p>
+
+              {/* Key Attributes */}
+              <div className="mt-auto">
+                <div className="flex flex-wrap gap-1">
+                  {archetype.keyAttributes.map((attr) => (
+                    <span
+                      key={attr}
+                      className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-mono font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+                    >
+                      {attr.slice(0, 3).toUpperCase()}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Action Buttons */}
+      <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+        <button
+          onClick={() => {
+            if (selectedArchetype) onSelect(selectedArchetype);
+          }}
+          disabled={!selectedArchetype}
+          className={`flex items-center gap-2 rounded-lg px-6 py-2.5 text-sm font-medium transition-colors ${
+            selectedArchetype
+              ? "bg-emerald-600 text-white hover:bg-emerald-700"
+              : "cursor-not-allowed bg-zinc-200 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-600"
+          }`}
+        >
+          Use Archetype
+          <ArrowRight className="h-4 w-4" />
+        </button>
+        <button
+          onClick={onSkip}
+          className="flex items-center gap-2 rounded-lg border border-zinc-300 px-6 py-2.5 text-sm font-medium text-zinc-600 transition-colors hover:bg-zinc-50 dark:border-zinc-600 dark:text-zinc-400 dark:hover:bg-zinc-800"
+        >
+          <Wrench className="h-4 w-4" />
+          Custom Build
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/data/editions/sr5/archetypes/adept.json
+++ b/data/editions/sr5/archetypes/adept.json
@@ -1,0 +1,54 @@
+{
+  "id": "adept",
+  "editionCode": "sr5",
+  "name": "Adept",
+  "description": "A physical adept who channels magical energy inward to enhance their body beyond mortal limits. Adepts don't cast spells — they become the weapon. Enhanced reflexes, killing hands, and supernatural martial arts make them devastating in close combat without sacrificing a single point of Essence to chrome.",
+  "category": "combat",
+  "difficulty": "intermediate",
+  "keyAttributes": ["agility", "body", "strength"],
+  "suggestedMetatype": "human",
+  "magicalPath": "adept",
+  "priorities": {
+    "attributes": "A",
+    "skills": "B",
+    "magic": "C",
+    "metatype": "D",
+    "resources": "E"
+  },
+  "selections": {
+    "metatype": "human",
+    "magical-path": "adept",
+    "attributes": {
+      "body": 5,
+      "agility": 5,
+      "reaction": 5,
+      "strength": 5,
+      "willpower": 3,
+      "logic": 3,
+      "intuition": 3,
+      "charisma": 3
+    },
+    "specialAttributes": {
+      "edge": 4,
+      "magic": 5
+    },
+    "skills": {
+      "unarmed-combat": 6,
+      "blades": 4,
+      "clubs": 4,
+      "gymnastics": 4,
+      "sneaking": 4,
+      "running": 4,
+      "swimming": 4,
+      "perception": 3,
+      "intimidation": 3,
+      "escape-artist": 3,
+      "throwing-weapons": 3,
+      "etiquette": 2,
+      "locksmith": 2,
+      "first-aid": 1,
+      "pilot-ground-craft": 1
+    }
+  },
+  "source": "SR5 Core Rulebook"
+}

--- a/data/editions/sr5/archetypes/combat-mage.json
+++ b/data/editions/sr5/archetypes/combat-mage.json
@@ -1,0 +1,49 @@
+{
+  "id": "combat-mage",
+  "editionCode": "sr5",
+  "name": "Combat Mage",
+  "description": "A full magician who channels arcane power into devastating combat spells and protective wards. Combat mages bring magical firepower to the team — fireballs, lightning bolts, and healing spells. They can also perceive the astral plane and summon spirits to fight alongside them.",
+  "category": "magic",
+  "difficulty": "advanced",
+  "keyAttributes": ["willpower", "logic", "body"],
+  "suggestedMetatype": "human",
+  "magicalPath": "magician",
+  "priorities": {
+    "magic": "A",
+    "attributes": "B",
+    "metatype": "C",
+    "skills": "D",
+    "resources": "E"
+  },
+  "selections": {
+    "metatype": "human",
+    "magical-path": "magician",
+    "attributes": {
+      "body": 5,
+      "agility": 3,
+      "reaction": 3,
+      "strength": 3,
+      "willpower": 4,
+      "logic": 5,
+      "intuition": 3,
+      "charisma": 2
+    },
+    "specialAttributes": {
+      "edge": 2,
+      "magic": 6
+    },
+    "skills": {
+      "spellcasting": 5,
+      "counterspelling": 5,
+      "summoning": 4,
+      "assensing": 3,
+      "astral-combat": 3,
+      "banishing": 3,
+      "perception": 3,
+      "pistols": 3,
+      "first-aid": 3,
+      "blades": 2
+    }
+  },
+  "source": "SR5 Core Rulebook"
+}

--- a/data/editions/sr5/archetypes/decker.json
+++ b/data/editions/sr5/archetypes/decker.json
@@ -1,0 +1,51 @@
+{
+  "id": "decker",
+  "editionCode": "sr5",
+  "name": "Decker",
+  "description": "A Matrix specialist who hacks through corporate security, manipulates data, and wages cybercombat. Deckers are the team's digital muscle — they crack hosts, disable alarms, and steal paydata. Armed with a cyberdeck and sharp mind, they turn the Matrix into their personal playground.",
+  "category": "technology",
+  "difficulty": "intermediate",
+  "keyAttributes": ["logic", "willpower", "intuition"],
+  "suggestedMetatype": "dwarf",
+  "magicalPath": "mundane",
+  "priorities": {
+    "skills": "A",
+    "attributes": "B",
+    "metatype": "C",
+    "resources": "D",
+    "magic": "E"
+  },
+  "selections": {
+    "metatype": "dwarf",
+    "magical-path": "mundane",
+    "attributes": {
+      "body": 3,
+      "agility": 2,
+      "reaction": 3,
+      "strength": 3,
+      "willpower": 5,
+      "logic": 5,
+      "intuition": 4,
+      "charisma": 2
+    },
+    "specialAttributes": {
+      "edge": 2
+    },
+    "skills": {
+      "hacking": 6,
+      "cybercombat": 6,
+      "electronic-warfare": 6,
+      "computer": 6,
+      "software": 6,
+      "hardware": 6,
+      "pistols": 4,
+      "automatics": 4,
+      "etiquette": 4,
+      "first-aid": 3,
+      "locksmith": 4,
+      "unarmed-combat": 3,
+      "pilot-ground-craft": 3
+    }
+  },
+  "source": "SR5 Core Rulebook"
+}

--- a/data/editions/sr5/archetypes/face.json
+++ b/data/editions/sr5/archetypes/face.json
@@ -1,0 +1,53 @@
+{
+  "id": "face",
+  "editionCode": "sr5",
+  "name": "Face",
+  "description": "The team's social expert, master of persuasion, deception, and negotiation. Faces talk their way past security, charm corporate contacts, and close deals that keep the team working. With a broad skill set covering social manipulation and electronics, they're the glue that holds a team together.",
+  "category": "social",
+  "difficulty": "intermediate",
+  "keyAttributes": ["charisma", "intuition", "logic"],
+  "suggestedMetatype": "elf",
+  "magicalPath": "mundane",
+  "priorities": {
+    "skills": "A",
+    "attributes": "B",
+    "metatype": "C",
+    "resources": "D",
+    "magic": "E"
+  },
+  "selections": {
+    "metatype": "elf",
+    "magical-path": "mundane",
+    "attributes": {
+      "body": 3,
+      "agility": 4,
+      "reaction": 3,
+      "strength": 2,
+      "willpower": 4,
+      "logic": 4,
+      "intuition": 4,
+      "charisma": 7
+    },
+    "specialAttributes": {
+      "edge": 4
+    },
+    "skills": {
+      "con": 4,
+      "etiquette": 5,
+      "negotiation": 5,
+      "impersonation": 4,
+      "leadership": 4,
+      "intimidation": 4,
+      "perception": 4,
+      "pistols": 4,
+      "computer": 4,
+      "electronic-warfare": 4,
+      "performance": 4,
+      "forgery": 4,
+      "sneaking": 2,
+      "palming": 2,
+      "pilot-ground-craft": 1
+    }
+  },
+  "source": "SR5 Core Rulebook"
+}

--- a/data/editions/sr5/archetypes/rigger.json
+++ b/data/editions/sr5/archetypes/rigger.json
@@ -1,0 +1,47 @@
+{
+  "id": "rigger",
+  "editionCode": "sr5",
+  "name": "Rigger",
+  "description": "A vehicle and drone specialist who merges with machines through a control rig. Riggers pilot everything from motorcycles to attack helicopters, commanding drone fleets and providing mobile firepower. When they jack in, the vehicle becomes their body — every sensor an eye, every weapon an arm.",
+  "category": "technology",
+  "difficulty": "intermediate",
+  "keyAttributes": ["reaction", "intuition", "logic"],
+  "suggestedMetatype": "troll",
+  "magicalPath": "mundane",
+  "priorities": {
+    "resources": "A",
+    "attributes": "B",
+    "metatype": "C",
+    "skills": "D",
+    "magic": "E"
+  },
+  "selections": {
+    "metatype": "troll",
+    "magical-path": "mundane",
+    "attributes": {
+      "body": 5,
+      "agility": 2,
+      "reaction": 5,
+      "strength": 5,
+      "willpower": 3,
+      "logic": 2,
+      "intuition": 5,
+      "charisma": 4
+    },
+    "specialAttributes": {
+      "edge": 1
+    },
+    "skills": {
+      "pilot-ground-craft": 6,
+      "pilot-aircraft": 5,
+      "gunnery": 5,
+      "negotiation": 3,
+      "pistols": 3,
+      "electronic-warfare": 2,
+      "etiquette": 2,
+      "pilot-watercraft": 2,
+      "navigation": 1
+    }
+  },
+  "source": "SR5 Core Rulebook"
+}

--- a/data/editions/sr5/archetypes/street-samurai.json
+++ b/data/editions/sr5/archetypes/street-samurai.json
@@ -1,0 +1,45 @@
+{
+  "id": "street-samurai",
+  "editionCode": "sr5",
+  "name": "Street Samurai",
+  "description": "A chrome warrior who augments their body with cyberware and bioware for combat superiority. Street samurai are the front-line fighters of the shadows, combining heavy weaponry with enhanced reflexes and toughened bodies. They live by a personal code and die by the sword — or the gun.",
+  "category": "combat",
+  "difficulty": "beginner",
+  "keyAttributes": ["body", "agility", "strength"],
+  "suggestedMetatype": "ork",
+  "magicalPath": "mundane",
+  "priorities": {
+    "resources": "A",
+    "attributes": "B",
+    "metatype": "C",
+    "skills": "D",
+    "magic": "E"
+  },
+  "selections": {
+    "metatype": "ork",
+    "magical-path": "mundane",
+    "attributes": {
+      "body": 7,
+      "agility": 6,
+      "reaction": 5,
+      "strength": 5,
+      "willpower": 3,
+      "logic": 2,
+      "intuition": 3,
+      "charisma": 2
+    },
+    "specialAttributes": {
+      "edge": 1
+    },
+    "skills": {
+      "automatics": 5,
+      "blades": 5,
+      "longarms": 3,
+      "pistols": 4,
+      "sneaking": 2,
+      "unarmed-combat": 2,
+      "pilot-ground-craft": 1
+    }
+  },
+  "source": "SR5 Core Rulebook"
+}

--- a/data/editions/sr5/archetypes/technomancer.json
+++ b/data/editions/sr5/archetypes/technomancer.json
@@ -1,0 +1,54 @@
+{
+  "id": "technomancer",
+  "editionCode": "sr5",
+  "name": "Technomancer",
+  "description": "A living Matrix interface who manipulates the digital world through Resonance rather than hardware. Technomancers don't need cyberdecks — they connect to the Matrix with their minds, compiling sprites and threading complex forms. Feared and misunderstood, they wield power that corps would kill to study.",
+  "category": "technology",
+  "difficulty": "advanced",
+  "keyAttributes": ["intuition", "logic", "willpower"],
+  "suggestedMetatype": "human",
+  "magicalPath": "technomancer",
+  "priorities": {
+    "resonance": "A",
+    "skills": "B",
+    "metatype": "C",
+    "attributes": "D",
+    "resources": "E"
+  },
+  "selections": {
+    "metatype": "human",
+    "magical-path": "technomancer",
+    "attributes": {
+      "body": 3,
+      "agility": 3,
+      "reaction": 3,
+      "strength": 3,
+      "willpower": 5,
+      "logic": 5,
+      "intuition": 6,
+      "charisma": 4
+    },
+    "specialAttributes": {
+      "edge": 3,
+      "resonance": 5
+    },
+    "skills": {
+      "compiling": 3,
+      "computer": 4,
+      "cybercombat": 4,
+      "decompiling": 2,
+      "electronic-warfare": 6,
+      "hacking": 4,
+      "software": 4,
+      "hardware": 2,
+      "etiquette": 4,
+      "leadership": 4,
+      "negotiation": 4,
+      "pistols": 2,
+      "sneaking": 2,
+      "first-aid": 1,
+      "pilot-ground-craft": 1
+    }
+  },
+  "source": "SR5 Core Rulebook"
+}

--- a/lib/storage/archetypes.ts
+++ b/lib/storage/archetypes.ts
@@ -1,0 +1,102 @@
+/**
+ * Archetype storage layer
+ *
+ * Loads character archetypes from edition data at /data/editions/{editionCode}/archetypes/
+ *
+ * Archetypes are read-only edition data that provide pre-filled character
+ * creation starting points for common character concepts.
+ */
+
+import path from "path";
+import type { ID } from "../types";
+import type { EditionCode } from "../types/edition";
+import type { CharacterArchetype, ArchetypeCategory } from "../types/archetype";
+import { readJsonFile, readAllJsonFiles, listJsonFiles, directoryExists } from "./base";
+
+// =============================================================================
+// PATH UTILITIES
+// =============================================================================
+
+const DATA_DIR = path.join(process.cwd(), "data");
+
+function getArchetypesDir(editionCode: EditionCode): string {
+  return path.join(DATA_DIR, "editions", editionCode, "archetypes");
+}
+
+function getArchetypePath(editionCode: EditionCode, archetypeId: ID): string {
+  return path.join(getArchetypesDir(editionCode), `${archetypeId}.json`);
+}
+
+// =============================================================================
+// QUERY OPERATIONS
+// =============================================================================
+
+/**
+ * Get all archetypes for an edition
+ *
+ * @param editionCode - Edition to query (e.g., "sr5")
+ * @param category - Optional filter by category
+ * @returns Array of archetypes sorted by difficulty then name
+ */
+export async function getArchetypes(
+  editionCode: EditionCode,
+  category?: ArchetypeCategory
+): Promise<CharacterArchetype[]> {
+  const dir = getArchetypesDir(editionCode);
+
+  const exists = await directoryExists(dir);
+  if (!exists) {
+    return [];
+  }
+
+  const archetypes = await readAllJsonFiles<CharacterArchetype>(dir);
+
+  const filtered = category ? archetypes.filter((a) => a.category === category) : archetypes;
+
+  const difficultyOrder: Record<string, number> = { beginner: 0, intermediate: 1, advanced: 2 };
+  return filtered.sort((a, b) => {
+    const diffA = difficultyOrder[a.difficulty] ?? 1;
+    const diffB = difficultyOrder[b.difficulty] ?? 1;
+    if (diffA !== diffB) return diffA - diffB;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/**
+ * Get a specific archetype by ID
+ */
+export async function getArchetype(
+  editionCode: EditionCode,
+  archetypeId: ID
+): Promise<CharacterArchetype | null> {
+  const filePath = getArchetypePath(editionCode, archetypeId);
+  return readJsonFile<CharacterArchetype>(filePath);
+}
+
+/**
+ * Search archetypes by name or description
+ */
+export async function searchArchetypes(
+  editionCode: EditionCode,
+  query: string
+): Promise<CharacterArchetype[]> {
+  const archetypes = await getArchetypes(editionCode);
+  const queryLower = query.toLowerCase();
+
+  return archetypes.filter(
+    (a) =>
+      a.name.toLowerCase().includes(queryLower) || a.description.toLowerCase().includes(queryLower)
+  );
+}
+
+/**
+ * Check if archetypes exist for an edition
+ */
+export async function hasArchetypes(editionCode: EditionCode): Promise<boolean> {
+  const dir = getArchetypesDir(editionCode);
+  const exists = await directoryExists(dir);
+  if (!exists) return false;
+
+  const files = await listJsonFiles(dir);
+  return files.length > 0;
+}

--- a/lib/types/archetype.ts
+++ b/lib/types/archetype.ts
@@ -1,0 +1,36 @@
+/**
+ * Character archetype types
+ *
+ * Archetypes provide pre-filled character creation starting points.
+ * Players can pick an archetype to begin with suggested priorities,
+ * attributes, and skills, then customize from there.
+ */
+
+import type { ID } from "./core";
+import type { EditionCode } from "./edition";
+import type { CreationSelections } from "./creation-selections";
+
+// =============================================================================
+// ARCHETYPE CATEGORY
+// =============================================================================
+
+export type ArchetypeCategory = "combat" | "magic" | "technology" | "social";
+
+// =============================================================================
+// CHARACTER ARCHETYPE
+// =============================================================================
+
+export interface CharacterArchetype {
+  id: ID;
+  editionCode: EditionCode;
+  name: string;
+  description: string;
+  category: ArchetypeCategory;
+  difficulty: "beginner" | "intermediate" | "advanced";
+  keyAttributes: string[];
+  suggestedMetatype: string;
+  magicalPath: string;
+  priorities: Record<string, string>;
+  selections: Partial<CreationSelections>;
+  source?: string;
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -883,3 +883,6 @@ export {
   isBlockedByExisting,
   getAffectedLocations,
 } from "./cyberlimb";
+
+// Archetype types
+export type { CharacterArchetype, ArchetypeCategory } from "./archetype";


### PR DESCRIPTION
## Summary

- Adds a complete archetype system that lets players start character creation with pre-filled priorities, attributes, and skills
- Implements 7 core SR5 archetypes: Street Samurai, Face, Combat Mage, Decker, Technomancer, Rigger, and Adept
- New archetype selection step appears between edition selection and gameplay level setup
- "Custom Build" option preserves existing blank-sheet creation workflow

## Changes

### New Files
- `lib/types/archetype.ts` — `CharacterArchetype` type with category, difficulty, selections
- `lib/storage/archetypes.ts` — Storage layer mirroring grunt-templates pattern
- `app/api/editions/[editionCode]/archetypes/route.ts` — GET endpoint with category/search filters
- `components/creation/ArchetypeSelector.tsx` — Card grid UI with category filtering and difficulty badges
- `data/editions/sr5/archetypes/*.json` — 7 archetype data files

### Modified Files
- `lib/types/index.ts` — Re-exports archetype types
- `app/characters/create/sheet/page.tsx` — Integrates archetype step into creation flow

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (390 files, 8467 tests)
- [x] `pnpm verify-data` — no new issues
- [x] `pnpm verify-naming` — no new violations
- [ ] Manual: `GET /api/editions/sr5/archetypes` returns 7 archetypes
- [ ] Manual: Start character creation → see archetype selector → pick Street Samurai → priorities and attributes pre-filled on sheet → can still edit everything
- [ ] Manual: Start creation → click "Custom Build" → proceeds to blank sheet as before
- [ ] Manual: Resume editing existing character → archetype step is skipped

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)