### PR TITLE
feat: add in-app rule quick-reference system (#450)

### DIFF
--- a/app/api/editions/[editionCode]/rule-reference/__tests__/route.test.ts
+++ b/app/api/editions/[editionCode]/rule-reference/__tests__/route.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for /api/editions/[editionCode]/rule-reference endpoint
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "../route";
+import { NextRequest } from "next/server";
+import * as editionsStorage from "@/lib/storage/editions";
+import type { Edition, EditionCode, RuleReferenceData } from "@/lib/types";
+
+vi.mock("@/lib/storage/editions");
+
+function createMockRequest(url: string): NextRequest {
+  return new NextRequest(url);
+}
+
+describe("GET /api/editions/[editionCode]/rule-reference", () => {
+  const mockEdition: Edition = {
+    id: "sr5",
+    name: "Shadowrun 5th Edition",
+    shortCode: "sr5" as EditionCode,
+    version: "1.0.0",
+    releaseYear: 2013,
+    bookIds: ["core-rulebook"],
+    creationMethodIds: ["priority"],
+    createdAt: new Date().toISOString(),
+  };
+
+  const mockRuleReference: RuleReferenceData = {
+    version: "1.0.0",
+    editionCode: "sr5",
+    entries: [
+      {
+        id: "defense-modifiers",
+        title: "Defense Modifiers",
+        category: "combat",
+        subcategory: "ranged",
+        tags: ["defense", "dodge"],
+        summary: "Dice pool modifiers for defense tests.",
+        tables: [
+          {
+            headers: ["Situation", "Modifier"],
+            rows: [["Defender prone", "-2"]],
+          },
+        ],
+        source: { book: "SR5 Core", page: 188 },
+      },
+      {
+        id: "noise-table",
+        title: "Noise Table",
+        category: "matrix",
+        tags: ["noise", "distance"],
+        summary: "Noise levels based on distance.",
+        tables: [
+          {
+            headers: ["Distance", "Noise"],
+            rows: [["Up to 100m", "0"]],
+          },
+        ],
+        source: { book: "SR5 Core", page: 230 },
+      },
+      {
+        id: "assensing-table",
+        title: "Assensing Table",
+        category: "magic",
+        tags: ["assensing", "astral"],
+        summary: "Information gained from assensing.",
+        tables: [
+          {
+            headers: ["Hits", "Info"],
+            rows: [["1", "General health"]],
+          },
+        ],
+        source: { book: "SR5 Core", page: 312 },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return all rule reference entries", async () => {
+    vi.mocked(editionsStorage.getEdition).mockResolvedValue(mockEdition);
+    vi.mocked(editionsStorage.getRuleReference).mockResolvedValue(mockRuleReference);
+
+    const request = createMockRequest("http://localhost:3000/api/editions/sr5/rule-reference");
+    const response = await GET(request, {
+      params: Promise.resolve({ editionCode: "sr5" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.entries).toHaveLength(3);
+    expect(data.data.version).toBe("1.0.0");
+  });
+
+  it("should filter entries by category", async () => {
+    vi.mocked(editionsStorage.getEdition).mockResolvedValue(mockEdition);
+    vi.mocked(editionsStorage.getRuleReference).mockResolvedValue(mockRuleReference);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/editions/sr5/rule-reference?category=combat"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ editionCode: "sr5" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.entries).toHaveLength(1);
+    expect(data.data.entries[0].id).toBe("defense-modifiers");
+  });
+
+  it("should return 404 for unknown edition", async () => {
+    vi.mocked(editionsStorage.getEdition).mockResolvedValue(null);
+
+    const request = createMockRequest("http://localhost:3000/api/editions/invalid/rule-reference");
+    const response = await GET(request, {
+      params: Promise.resolve({ editionCode: "invalid" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+  });
+
+  it("should return 400 for invalid category", async () => {
+    vi.mocked(editionsStorage.getEdition).mockResolvedValue(mockEdition);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/editions/sr5/rule-reference?category=invalid"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({ editionCode: "sr5" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toContain("Invalid category");
+  });
+
+  it("should return 404 when no rule reference data exists", async () => {
+    vi.mocked(editionsStorage.getEdition).mockResolvedValue(mockEdition);
+    vi.mocked(editionsStorage.getRuleReference).mockResolvedValue(null);
+
+    const request = createMockRequest("http://localhost:3000/api/editions/sr5/rule-reference");
+    const response = await GET(request, {
+      params: Promise.resolve({ editionCode: "sr5" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error).toContain("No rule reference data found");
+  });
+
+  it("should return 500 on storage error", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.mocked(editionsStorage.getEdition).mockRejectedValue(new Error("Storage error"));
+
+    const request = createMockRequest("http://localhost:3000/api/editions/sr5/rule-reference");
+    const response = await GET(request, {
+      params: Promise.resolve({ editionCode: "sr5" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/app/api/editions/[editionCode]/rule-reference/route.ts
+++ b/app/api/editions/[editionCode]/rule-reference/route.ts
@@ -1,0 +1,74 @@
+/**
+ * API Route: GET /api/editions/[editionCode]/rule-reference
+ *
+ * Returns curated rule reference data for an edition.
+ * Supports optional category filtering via query param.
+ *
+ * Query params:
+ *   - category: Filter entries by category (combat, magic, matrix, etc.)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getEdition, getRuleReference } from "@/lib/storage/editions";
+import type { EditionCode, RuleReferenceCategory } from "@/lib/types";
+
+const VALID_CATEGORIES: RuleReferenceCategory[] = [
+  "combat",
+  "magic",
+  "matrix",
+  "rigging",
+  "social",
+  "environment",
+  "tests",
+  "equipment",
+];
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ editionCode: string }> }
+) {
+  try {
+    const { editionCode } = await params;
+    const { searchParams } = new URL(request.url);
+    const category = searchParams.get("category") as RuleReferenceCategory | null;
+
+    const edition = await getEdition(editionCode as EditionCode);
+    if (!edition) {
+      return NextResponse.json(
+        { success: false, error: `Edition not found: ${editionCode}` },
+        { status: 404 }
+      );
+    }
+
+    if (category && !VALID_CATEGORIES.includes(category)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Invalid category: ${category}. Valid options: ${VALID_CATEGORIES.join(", ")}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    const data = await getRuleReference(editionCode as EditionCode);
+    if (!data) {
+      return NextResponse.json(
+        { success: false, error: `No rule reference data found for edition: ${editionCode}` },
+        { status: 404 }
+      );
+    }
+
+    const entries = category ? data.entries.filter((e) => e.category === category) : data.entries;
+
+    return NextResponse.json({
+      success: true,
+      data: { ...data, entries },
+    });
+  } catch (error) {
+    console.error("Failed to fetch rule reference:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch rule reference data" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/users/AuthenticatedLayout.tsx
+++ b/app/users/AuthenticatedLayout.tsx
@@ -9,6 +9,9 @@ import { NotificationBell } from "@/components/NotificationBell";
 import { EnvironmentBadge } from "@/components/EnvironmentBadge";
 import { EmailVerificationBanner } from "@/components/auth/EmailVerificationBanner";
 import { Tooltip } from "@/components/ui/Tooltip";
+import { RuleReferenceProvider } from "@/lib/contexts/RuleReferenceContext";
+import { RuleReferenceTrigger } from "@/components/rule-reference/RuleReferenceTrigger";
+import { RuleReferencePalette } from "@/components/rule-reference/RuleReferencePalette";
 
 // =============================================================================
 // TYPES
@@ -342,260 +345,266 @@ export default function AuthenticatedLayout({
   ];
 
   return (
-    <div className="flex min-h-screen flex-col bg-white font-sans dark:bg-zinc-950">
-      {/* Skip Link for keyboard users */}
-      <a
-        href={`#${mainContentId}`}
-        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-emerald-500 focus:px-4 focus:py-2 focus:text-white focus:outline-none"
-      >
-        Skip to main content
-      </a>
-
-      {/* Screen reader announcements */}
-      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
-        {isOpen ? "Navigation sidebar opened" : ""}
-      </div>
-
-      {/* Header */}
-      <header className="neon-header fixed top-0 z-50 w-full border-b border-zinc-200 bg-white/95 backdrop-blur-sm dark:border-zinc-800/50 dark:bg-zinc-950/95">
-        <div className="flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center gap-4">
-            {/* Mobile hamburger menu */}
-            <Button
-              ref={toggleButtonRef}
-              onPress={toggle}
-              className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-600 transition-colors hover:bg-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 dark:text-zinc-400 dark:hover:bg-zinc-900 dark:focus:ring-emerald-400 dark:focus:ring-offset-zinc-950 lg:hidden"
-              aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
-              aria-expanded={isOpen}
-              aria-controls={sidebarId}
-            >
-              {isOpen ? <CloseIcon className="h-6 w-6" /> : <HamburgerIcon className="h-6 w-6" />}
-            </Button>
-            <div className="flex flex-col">
-              {/* Accessible heading - visually hidden but available to screen readers */}
-              <h1 className="sr-only">Shadow Master</h1>
-              <Link
-                href="/"
-                className="logo-text text-xl font-semibold text-black transition-colors hover:text-zinc-700 dark:text-zinc-50 dark:hover:text-emerald-400"
-                aria-label="Shadow Master - Go to home page"
-              >
-                Shadow Master
-              </Link>
-              <EnvironmentBadge />
-            </div>
-          </div>
-          <div className="flex items-center gap-3">
-            {/* Notifications */}
-            <NotificationBell />
-            {/* User Menu */}
-            <MenuTrigger>
-              <Button
-                className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 dark:text-zinc-50 dark:hover:bg-zinc-900"
-                aria-label={`User menu for ${user.username}`}
-              >
-                <div className="avatar-glow flex h-8 w-8 items-center justify-center rounded-full bg-zinc-200 dark:border dark:border-emerald-500/20 dark:bg-zinc-800">
-                  <span className="text-xs font-medium text-zinc-700 dark:text-emerald-400">
-                    {user.username.charAt(0).toUpperCase()}
-                  </span>
-                </div>
-                <span className="hidden sm:inline">{user.username}</span>
-                <ChevronDownIcon className="h-4 w-4" />
-              </Button>
-              <Popover className="min-w-[200px] rounded-lg border border-zinc-200 bg-white shadow-lg dark:border-zinc-800 dark:bg-zinc-900">
-                <Menu className="p-1">
-                  <MenuItem className="flex flex-col items-start rounded-md px-3 py-2 text-sm text-zinc-900 outline-none focus:bg-zinc-100 dark:text-zinc-50 dark:focus:bg-zinc-800">
-                    <div className="font-medium">{user.username}</div>
-                    <div className="text-xs text-zinc-600 dark:text-zinc-400">{user.email}</div>
-                    <div className="text-xs text-zinc-600 dark:text-zinc-400">
-                      {Array.isArray(user.role) ? user.role.join(", ") : user.role}
-                    </div>
-                  </MenuItem>
-                  <MenuItem
-                    onAction={() => router.push("/settings/profile")}
-                    className="cursor-pointer rounded-md px-3 py-2 text-sm text-zinc-900 outline-none focus:bg-zinc-100 dark:text-zinc-50 dark:focus:bg-zinc-800"
-                  >
-                    Profile
-                  </MenuItem>
-                  <MenuItem
-                    onAction={() => router.push("/settings")}
-                    className="cursor-pointer rounded-md px-3 py-2 text-sm text-zinc-900 outline-none focus:bg-zinc-100 dark:text-zinc-50 dark:focus:bg-zinc-800"
-                  >
-                    Settings
-                  </MenuItem>
-                  <MenuItem
-                    onAction={handleSignOut}
-                    className="cursor-pointer rounded-md px-3 py-2 text-sm text-red-600 outline-none focus:bg-zinc-100 dark:text-red-400 dark:focus:bg-zinc-800"
-                  >
-                    Sign Out
-                  </MenuItem>
-                </Menu>
-              </Popover>
-            </MenuTrigger>
-          </div>
-        </div>
-      </header>
-
-      <div className="flex flex-1">
-        {/* Sidebar */}
-        <aside
-          ref={sidebarRef}
-          id={sidebarId}
-          role="complementary"
-          aria-label="Main navigation sidebar"
-          className={`neon-sidebar fixed left-0 top-0 z-40 h-screen border-r border-zinc-200 bg-white/95 pt-16 transition-[transform,width] duration-300 ease-in-out dark:border-zinc-800/50 dark:bg-zinc-950/95 lg:translate-x-0 ${
-            isOpen ? "translate-x-0" : "-translate-x-full"
-          } ${isCollapsed ? "w-16" : "w-64"}`}
+    <RuleReferenceProvider>
+      <div className="flex min-h-screen flex-col bg-white font-sans dark:bg-zinc-950">
+        {/* Skip Link for keyboard users */}
+        <a
+          href={`#${mainContentId}`}
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-emerald-500 focus:px-4 focus:py-2 focus:text-white focus:outline-none"
         >
-          <div className="flex h-full flex-col">
-            {/* Collapse toggle (desktop only) */}
-            <div className="flex items-center justify-end border-b border-zinc-100 p-2 dark:border-zinc-800/30">
-              <Tooltip
-                content={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-                placement="right"
-                delay={300}
+          Skip to main content
+        </a>
+
+        {/* Screen reader announcements */}
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {isOpen ? "Navigation sidebar opened" : ""}
+        </div>
+
+        {/* Header */}
+        <header className="neon-header fixed top-0 z-50 w-full border-b border-zinc-200 bg-white/95 backdrop-blur-sm dark:border-zinc-800/50 dark:bg-zinc-950/95">
+          <div className="flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center gap-4">
+              {/* Mobile hamburger menu */}
+              <Button
+                ref={toggleButtonRef}
+                onPress={toggle}
+                className="flex h-10 w-10 items-center justify-center rounded-md text-zinc-600 transition-colors hover:bg-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 dark:text-zinc-400 dark:hover:bg-zinc-900 dark:focus:ring-emerald-400 dark:focus:ring-offset-zinc-950 lg:hidden"
+                aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
+                aria-expanded={isOpen}
+                aria-controls={sidebarId}
               >
-                <button
-                  onClick={toggleCollapse}
-                  className="collapse-btn hidden h-6 w-6 items-center justify-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 dark:text-zinc-500 dark:hover:bg-zinc-900 lg:flex"
-                  aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-                  aria-expanded={!isCollapsed}
+                {isOpen ? <CloseIcon className="h-6 w-6" /> : <HamburgerIcon className="h-6 w-6" />}
+              </Button>
+              <div className="flex flex-col">
+                {/* Accessible heading - visually hidden but available to screen readers */}
+                <h1 className="sr-only">Shadow Master</h1>
+                <Link
+                  href="/"
+                  className="logo-text text-xl font-semibold text-black transition-colors hover:text-zinc-700 dark:text-zinc-50 dark:hover:text-emerald-400"
+                  aria-label="Shadow Master - Go to home page"
                 >
-                  {isCollapsed ? (
-                    <ChevronRightIcon className="h-4 w-4" />
-                  ) : (
-                    <ChevronLeftIcon className="h-4 w-4" />
-                  )}
-                </button>
-              </Tooltip>
+                  Shadow Master
+                </Link>
+                <EnvironmentBadge />
+              </div>
             </div>
+            <div className="flex items-center gap-3">
+              {/* Notifications */}
+              <NotificationBell />
+              {/* User Menu */}
+              <MenuTrigger>
+                <Button
+                  className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 dark:text-zinc-50 dark:hover:bg-zinc-900"
+                  aria-label={`User menu for ${user.username}`}
+                >
+                  <div className="avatar-glow flex h-8 w-8 items-center justify-center rounded-full bg-zinc-200 dark:border dark:border-emerald-500/20 dark:bg-zinc-800">
+                    <span className="text-xs font-medium text-zinc-700 dark:text-emerald-400">
+                      {user.username.charAt(0).toUpperCase()}
+                    </span>
+                  </div>
+                  <span className="hidden sm:inline">{user.username}</span>
+                  <ChevronDownIcon className="h-4 w-4" />
+                </Button>
+                <Popover className="min-w-[200px] rounded-lg border border-zinc-200 bg-white shadow-lg dark:border-zinc-800 dark:bg-zinc-900">
+                  <Menu className="p-1">
+                    <MenuItem className="flex flex-col items-start rounded-md px-3 py-2 text-sm text-zinc-900 outline-none focus:bg-zinc-100 dark:text-zinc-50 dark:focus:bg-zinc-800">
+                      <div className="font-medium">{user.username}</div>
+                      <div className="text-xs text-zinc-600 dark:text-zinc-400">{user.email}</div>
+                      <div className="text-xs text-zinc-600 dark:text-zinc-400">
+                        {Array.isArray(user.role) ? user.role.join(", ") : user.role}
+                      </div>
+                    </MenuItem>
+                    <MenuItem
+                      onAction={() => router.push("/settings/profile")}
+                      className="cursor-pointer rounded-md px-3 py-2 text-sm text-zinc-900 outline-none focus:bg-zinc-100 dark:text-zinc-50 dark:focus:bg-zinc-800"
+                    >
+                      Profile
+                    </MenuItem>
+                    <MenuItem
+                      onAction={() => router.push("/settings")}
+                      className="cursor-pointer rounded-md px-3 py-2 text-sm text-zinc-900 outline-none focus:bg-zinc-100 dark:text-zinc-50 dark:focus:bg-zinc-800"
+                    >
+                      Settings
+                    </MenuItem>
+                    <MenuItem
+                      onAction={handleSignOut}
+                      className="cursor-pointer rounded-md px-3 py-2 text-sm text-red-600 outline-none focus:bg-zinc-100 dark:text-red-400 dark:focus:bg-zinc-800"
+                    >
+                      Sign Out
+                    </MenuItem>
+                  </Menu>
+                </Popover>
+              </MenuTrigger>
+            </div>
+          </div>
+        </header>
 
-            {/* Navigation */}
-            <nav
-              aria-label="Main navigation"
-              className={`flex-1 overflow-y-auto p-2 ${isCollapsed ? "items-center" : ""}`}
-            >
-              <ul role="list" className="space-y-1">
-                {navItems.map((item) => {
-                  const Icon = item.icon;
-                  const isActive = item.href === currentPath;
-                  const isDisabled = item.disabled;
+        <div className="flex flex-1">
+          {/* Sidebar */}
+          <aside
+            ref={sidebarRef}
+            id={sidebarId}
+            role="complementary"
+            aria-label="Main navigation sidebar"
+            className={`neon-sidebar fixed left-0 top-0 z-40 h-screen border-r border-zinc-200 bg-white/95 pt-16 transition-[transform,width] duration-300 ease-in-out dark:border-zinc-800/50 dark:bg-zinc-950/95 lg:translate-x-0 ${
+              isOpen ? "translate-x-0" : "-translate-x-full"
+            } ${isCollapsed ? "w-16" : "w-64"}`}
+          >
+            <div className="flex h-full flex-col">
+              {/* Collapse toggle (desktop only) */}
+              <div className="flex items-center justify-end border-b border-zinc-100 p-2 dark:border-zinc-800/30">
+                <Tooltip
+                  content={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+                  placement="right"
+                  delay={300}
+                >
+                  <button
+                    onClick={toggleCollapse}
+                    className="collapse-btn hidden h-6 w-6 items-center justify-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 dark:text-zinc-500 dark:hover:bg-zinc-900 lg:flex"
+                    aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+                    aria-expanded={!isCollapsed}
+                  >
+                    {isCollapsed ? (
+                      <ChevronRightIcon className="h-4 w-4" />
+                    ) : (
+                      <ChevronLeftIcon className="h-4 w-4" />
+                    )}
+                  </button>
+                </Tooltip>
+              </div>
 
-                  // Render disabled items as non-interactive elements
-                  if (isDisabled) {
-                    const disabledContent = (
-                      <div
-                        className={`flex cursor-not-allowed items-center rounded-md px-3 py-2 text-sm font-medium text-zinc-400 dark:text-zinc-600 ${
-                          isCollapsed ? "justify-center" : "gap-3"
+              {/* Navigation */}
+              <nav
+                aria-label="Main navigation"
+                className={`flex-1 overflow-y-auto p-2 ${isCollapsed ? "items-center" : ""}`}
+              >
+                <ul role="list" className="space-y-1">
+                  {navItems.map((item) => {
+                    const Icon = item.icon;
+                    const isActive = item.href === currentPath;
+                    const isDisabled = item.disabled;
+
+                    // Render disabled items as non-interactive elements
+                    if (isDisabled) {
+                      const disabledContent = (
+                        <div
+                          className={`flex cursor-not-allowed items-center rounded-md px-3 py-2 text-sm font-medium text-zinc-400 dark:text-zinc-600 ${
+                            isCollapsed ? "justify-center" : "gap-3"
+                          }`}
+                          aria-disabled="true"
+                        >
+                          <Icon className="h-5 w-5 shrink-0" />
+                          {!isCollapsed && (
+                            <>
+                              <span className="truncate">{item.label}</span>
+                              <span className="ml-auto rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium uppercase text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500">
+                                Soon
+                              </span>
+                            </>
+                          )}
+                        </div>
+                      );
+
+                      return (
+                        <li key={item.id}>
+                          {isCollapsed ? (
+                            <Tooltip
+                              content={`${item.label} (Coming soon)`}
+                              placement="right"
+                              delay={300}
+                            >
+                              <div role="button" tabIndex={0} aria-disabled="true">
+                                {disabledContent}
+                              </div>
+                            </Tooltip>
+                          ) : (
+                            <div title="Coming soon">{disabledContent}</div>
+                          )}
+                        </li>
+                      );
+                    }
+
+                    const linkContent = (
+                      <Link
+                        href={item.href}
+                        aria-current={isActive ? "page" : undefined}
+                        className={`nav-item flex items-center rounded-md py-2 text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-emerald-500/50 ${
+                          isCollapsed ? "justify-center px-2" : "gap-3 px-3"
+                        } ${
+                          isActive
+                            ? "nav-item-active bg-zinc-100 text-black dark:bg-emerald-500/10 dark:text-emerald-400"
+                            : "text-zinc-600 hover:bg-zinc-100 hover:text-black dark:text-zinc-400 dark:hover:bg-zinc-800/50 dark:hover:text-emerald-400"
                         }`}
-                        aria-disabled="true"
                       >
-                        <Icon className="h-5 w-5 shrink-0" />
+                        <Icon
+                          className={`h-5 w-5 shrink-0 ${isActive ? "dark:text-emerald-400" : ""}`}
+                        />
                         {!isCollapsed && (
                           <>
                             <span className="truncate">{item.label}</span>
-                            <span className="ml-auto rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium uppercase text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500">
-                              Soon
-                            </span>
+                            {"badge" in item &&
+                              (item as { badge?: string | number | null }).badge != null && (
+                                <span className="ml-auto rounded-full bg-zinc-200 px-2 py-0.5 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+                                  {(item as { badge?: string | number | null }).badge}
+                                </span>
+                              )}
                           </>
                         )}
-                      </div>
+                      </Link>
                     );
 
                     return (
                       <li key={item.id}>
                         {isCollapsed ? (
-                          <Tooltip
-                            content={`${item.label} (Coming soon)`}
-                            placement="right"
-                            delay={300}
-                          >
-                            <div role="button" tabIndex={0} aria-disabled="true">
-                              {disabledContent}
-                            </div>
+                          <Tooltip content={item.label} placement="right" delay={300}>
+                            {linkContent}
                           </Tooltip>
                         ) : (
-                          <div title="Coming soon">{disabledContent}</div>
+                          linkContent
                         )}
                       </li>
                     );
-                  }
+                  })}
+                </ul>
+              </nav>
+            </div>
+          </aside>
 
-                  const linkContent = (
-                    <Link
-                      href={item.href}
-                      aria-current={isActive ? "page" : undefined}
-                      className={`nav-item flex items-center rounded-md py-2 text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-emerald-500/50 ${
-                        isCollapsed ? "justify-center px-2" : "gap-3 px-3"
-                      } ${
-                        isActive
-                          ? "nav-item-active bg-zinc-100 text-black dark:bg-emerald-500/10 dark:text-emerald-400"
-                          : "text-zinc-600 hover:bg-zinc-100 hover:text-black dark:text-zinc-400 dark:hover:bg-zinc-800/50 dark:hover:text-emerald-400"
-                      }`}
-                    >
-                      <Icon
-                        className={`h-5 w-5 shrink-0 ${isActive ? "dark:text-emerald-400" : ""}`}
-                      />
-                      {!isCollapsed && (
-                        <>
-                          <span className="truncate">{item.label}</span>
-                          {"badge" in item &&
-                            (item as { badge?: string | number | null }).badge != null && (
-                              <span className="ml-auto rounded-full bg-zinc-200 px-2 py-0.5 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
-                                {(item as { badge?: string | number | null }).badge}
-                              </span>
-                            )}
-                        </>
-                      )}
-                    </Link>
-                  );
+          {/* Sidebar overlay for mobile */}
+          {isOpen && (
+            <div
+              className="fixed inset-0 z-30 bg-black/50 lg:hidden"
+              onClick={close}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  close();
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              aria-label="Close sidebar overlay"
+            />
+          )}
 
-                  return (
-                    <li key={item.id}>
-                      {isCollapsed ? (
-                        <Tooltip content={item.label} placement="right" delay={300}>
-                          {linkContent}
-                        </Tooltip>
-                      ) : (
-                        linkContent
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            </nav>
-          </div>
-        </aside>
+          {/* Main Content - margin only on lg+ screens where sidebar is visible */}
+          <main
+            id={mainContentId}
+            tabIndex={-1}
+            className={`flex-1 min-h-screen bg-white pt-16 transition-[margin] duration-300 ease-in-out dark:bg-zinc-950 ${
+              isCollapsed ? "lg:ml-16" : "lg:ml-64"
+            }`}
+          >
+            {/* Email Verification Banner - in document flow, spans full width */}
+            <EmailVerificationBanner />
+            <div className="px-4 py-6 sm:px-6 lg:px-8">{children}</div>
+          </main>
+        </div>
 
-        {/* Sidebar overlay for mobile */}
-        {isOpen && (
-          <div
-            className="fixed inset-0 z-30 bg-black/50 lg:hidden"
-            onClick={close}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                close();
-              }
-            }}
-            role="button"
-            tabIndex={0}
-            aria-label="Close sidebar overlay"
-          />
-        )}
-
-        {/* Main Content - margin only on lg+ screens where sidebar is visible */}
-        <main
-          id={mainContentId}
-          tabIndex={-1}
-          className={`flex-1 min-h-screen bg-white pt-16 transition-[margin] duration-300 ease-in-out dark:bg-zinc-950 ${
-            isCollapsed ? "lg:ml-16" : "lg:ml-64"
-          }`}
-        >
-          {/* Email Verification Banner - in document flow, spans full width */}
-          <EmailVerificationBanner />
-          <div className="px-4 py-6 sm:px-6 lg:px-8">{children}</div>
-        </main>
+        {/* Rule Quick-Reference */}
+        <RuleReferenceTrigger />
+        <RuleReferencePalette />
       </div>
-    </div>
+    </RuleReferenceProvider>
   );
 }

--- a/components/rule-reference/RuleReferenceCard.tsx
+++ b/components/rule-reference/RuleReferenceCard.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { RuleReferenceEntry } from "@/lib/types";
+import { RuleReferenceTable } from "./RuleReferenceTable";
+
+interface RuleReferenceCardProps {
+  entry: RuleReferenceEntry;
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  combat: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  magic: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400",
+  matrix: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400",
+  rigging: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
+  social: "bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400",
+  environment: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  tests: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  equipment: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+};
+
+export function RuleReferenceCard({ entry }: RuleReferenceCardProps) {
+  const colorClass =
+    CATEGORY_COLORS[entry.category] ??
+    "bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-400";
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div>
+        <div className="mb-2 flex items-center gap-2">
+          <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${colorClass}`}>
+            {entry.category}
+          </span>
+          {entry.subcategory && (
+            <span className="text-xs text-zinc-500 dark:text-zinc-500">{entry.subcategory}</span>
+          )}
+        </div>
+        <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{entry.title}</h3>
+        <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{entry.summary}</p>
+      </div>
+
+      {/* Tables */}
+      {entry.tables.map((table, i) => (
+        <RuleReferenceTable key={i} table={table} />
+      ))}
+
+      {/* Notes */}
+      {entry.notes && entry.notes.length > 0 && (
+        <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800/50">
+          <p className="mb-1 text-xs font-medium text-zinc-500 dark:text-zinc-500">Notes</p>
+          <ul className="space-y-1">
+            {entry.notes.map((note, i) => (
+              <li key={i} className="text-sm text-zinc-600 dark:text-zinc-400">
+                {note}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Source */}
+      <p className="text-xs text-zinc-400 dark:text-zinc-600">
+        {entry.source.book}, p. {entry.source.page}
+      </p>
+    </div>
+  );
+}

--- a/components/rule-reference/RuleReferenceCategoryTabs.tsx
+++ b/components/rule-reference/RuleReferenceCategoryTabs.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { RuleReferenceCategory } from "@/lib/types";
+
+interface RuleReferenceCategoryTabsProps {
+  categories: RuleReferenceCategory[];
+  selected: RuleReferenceCategory | null;
+  onSelect: (category: RuleReferenceCategory | null) => void;
+}
+
+const CATEGORY_LABELS: Record<RuleReferenceCategory, string> = {
+  combat: "Combat",
+  magic: "Magic",
+  matrix: "Matrix",
+  rigging: "Rigging",
+  social: "Social",
+  environment: "Environment",
+  tests: "Tests",
+  equipment: "Equipment",
+};
+
+export function RuleReferenceCategoryTabs({
+  categories,
+  selected,
+  onSelect,
+}: RuleReferenceCategoryTabsProps) {
+  return (
+    <div
+      className="flex gap-1.5 overflow-x-auto pb-1"
+      role="tablist"
+      aria-label="Filter by category"
+    >
+      <button
+        role="tab"
+        aria-selected={selected === null}
+        onClick={() => onSelect(null)}
+        className={`shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+          selected === null
+            ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
+            : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+        }`}
+      >
+        All
+      </button>
+      {categories.map((cat) => (
+        <button
+          key={cat}
+          role="tab"
+          aria-selected={selected === cat}
+          onClick={() => onSelect(cat)}
+          className={`shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+            selected === cat
+              ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
+              : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+          }`}
+        >
+          {CATEGORY_LABELS[cat]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/rule-reference/RuleReferenceList.tsx
+++ b/components/rule-reference/RuleReferenceList.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useRef, useCallback } from "react";
+import type { RuleReferenceEntry } from "@/lib/types";
+
+interface RuleReferenceListProps {
+  entries: RuleReferenceEntry[];
+  selectedEntry: RuleReferenceEntry | null;
+  onSelect: (entry: RuleReferenceEntry) => void;
+}
+
+const CATEGORY_DOT_COLORS: Record<string, string> = {
+  combat: "bg-red-400",
+  magic: "bg-purple-400",
+  matrix: "bg-cyan-400",
+  rigging: "bg-orange-400",
+  social: "bg-pink-400",
+  environment: "bg-green-400",
+  tests: "bg-blue-400",
+  equipment: "bg-amber-400",
+};
+
+export function RuleReferenceList({ entries, selectedEntry, onSelect }: RuleReferenceListProps) {
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!entries.length) return;
+
+      const currentIndex = selectedEntry ? entries.indexOf(selectedEntry) : -1;
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        const next = Math.min(currentIndex + 1, entries.length - 1);
+        onSelect(entries[next]);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        const prev = Math.max(currentIndex - 1, 0);
+        onSelect(entries[prev]);
+      }
+    },
+    [entries, selectedEntry, onSelect]
+  );
+
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-40 items-center justify-center text-sm text-zinc-400 dark:text-zinc-500">
+        No matching rules found
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      ref={listRef}
+      role="listbox"
+      aria-label="Rule reference entries"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      className="space-y-0.5 outline-none"
+    >
+      {entries.map((entry) => {
+        const isSelected = selectedEntry?.id === entry.id;
+        const dotColor = CATEGORY_DOT_COLORS[entry.category] ?? "bg-zinc-400";
+
+        return (
+          <li
+            key={entry.id}
+            role="option"
+            aria-selected={isSelected}
+            onClick={() => onSelect(entry)}
+            className={`cursor-pointer rounded-lg px-3 py-2 transition-colors ${
+              isSelected
+                ? "bg-emerald-50 dark:bg-emerald-900/20"
+                : "hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+            }`}
+          >
+            <div className="flex items-center gap-2">
+              <span className={`h-2 w-2 shrink-0 rounded-full ${dotColor}`} aria-hidden="true" />
+              <span className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                {entry.title}
+              </span>
+            </div>
+            <p className="ml-4 truncate text-xs text-zinc-500 dark:text-zinc-500">
+              {entry.summary}
+            </p>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/components/rule-reference/RuleReferencePalette.tsx
+++ b/components/rule-reference/RuleReferencePalette.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useRuleReferenceContext } from "@/lib/contexts/RuleReferenceContext";
+import { BaseModalRoot, ModalHeader, ModalBody } from "@/components/ui/BaseModal";
+import { useRuleReference } from "./useRuleReference";
+import { RuleReferenceSearch } from "./RuleReferenceSearch";
+import { RuleReferenceCategoryTabs } from "./RuleReferenceCategoryTabs";
+import { RuleReferenceList } from "./RuleReferenceList";
+import { RuleReferenceCard } from "./RuleReferenceCard";
+
+export function RuleReferencePalette() {
+  const { isOpen, close, defaultCategory } = useRuleReferenceContext();
+  const {
+    filteredEntries,
+    searchQuery,
+    setSearchQuery,
+    selectedCategory,
+    setSelectedCategory,
+    selectedEntry,
+    setSelectedEntry,
+    isLoading,
+    error,
+    categories,
+  } = useRuleReference(defaultCategory);
+
+  if (!isOpen) return null;
+
+  return (
+    <BaseModalRoot isOpen={isOpen} onClose={close} size="2xl" zIndex={60}>
+      {({ close: modalClose }) => (
+        <>
+          <ModalHeader title="Rule Quick-Reference" onClose={modalClose} />
+          <ModalBody className="flex min-h-0 flex-col p-0">
+            {/* Search + Filters */}
+            <div className="space-y-3 border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
+              <RuleReferenceSearch value={searchQuery} onChange={setSearchQuery} />
+              <RuleReferenceCategoryTabs
+                categories={categories}
+                selected={selectedCategory}
+                onSelect={setSelectedCategory}
+              />
+            </div>
+
+            {/* Content area */}
+            <div className="flex min-h-0 flex-1">
+              {isLoading ? (
+                <div className="flex w-full items-center justify-center py-12">
+                  <div className="h-6 w-6 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
+                </div>
+              ) : error ? (
+                <div className="flex w-full items-center justify-center py-12 text-sm text-red-500">
+                  {error}
+                </div>
+              ) : (
+                <>
+                  {/* Entry list */}
+                  <div className="w-2/5 shrink-0 overflow-y-auto border-r border-zinc-200 p-2 dark:border-zinc-700">
+                    <RuleReferenceList
+                      entries={filteredEntries}
+                      selectedEntry={selectedEntry}
+                      onSelect={setSelectedEntry}
+                    />
+                  </div>
+
+                  {/* Detail view */}
+                  <div className="flex-1 overflow-y-auto p-6">
+                    {selectedEntry ? (
+                      <RuleReferenceCard entry={selectedEntry} />
+                    ) : (
+                      <div className="flex h-full items-center justify-center text-sm text-zinc-400 dark:text-zinc-500">
+                        Select a rule to view details
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Footer hint */}
+            <div className="border-t border-zinc-200 px-6 py-2 dark:border-zinc-700">
+              <p className="text-xs text-zinc-400 dark:text-zinc-600">
+                <kbd className="rounded border border-zinc-300 px-1 py-0.5 font-mono text-[10px] dark:border-zinc-600">
+                  Cmd+/
+                </kbd>{" "}
+                to toggle &middot;{" "}
+                <kbd className="rounded border border-zinc-300 px-1 py-0.5 font-mono text-[10px] dark:border-zinc-600">
+                  Esc
+                </kbd>{" "}
+                to close &middot;{" "}
+                <kbd className="rounded border border-zinc-300 px-1 py-0.5 font-mono text-[10px] dark:border-zinc-600">
+                  &uarr;&darr;
+                </kbd>{" "}
+                to navigate
+              </p>
+            </div>
+          </ModalBody>
+        </>
+      )}
+    </BaseModalRoot>
+  );
+}

--- a/components/rule-reference/RuleReferenceSearch.tsx
+++ b/components/rule-reference/RuleReferenceSearch.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import { X, Search } from "lucide-react";
+
+interface RuleReferenceSearchProps {
+  value: string;
+  onChange: (value: string) => void;
+  autoFocus?: boolean;
+}
+
+export function RuleReferenceSearch({
+  value,
+  onChange,
+  autoFocus = true,
+}: RuleReferenceSearchProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (autoFocus && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [autoFocus]);
+
+  return (
+    <div className="relative">
+      <Search
+        className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400"
+        aria-hidden="true"
+      />
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Search rules... (e.g. barrier, defense, range)"
+        className="w-full rounded-lg border border-zinc-200 bg-white py-2.5 pl-10 pr-10 text-sm text-zinc-900 placeholder-zinc-400 outline-none focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder-zinc-500 dark:focus:border-emerald-400"
+        aria-label="Search rule references"
+      />
+      {value && (
+        <button
+          onClick={() => onChange("")}
+          className="absolute right-3 top-1/2 -translate-y-1/2 rounded p-0.5 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+          aria-label="Clear search"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/rule-reference/RuleReferenceTable.tsx
+++ b/components/rule-reference/RuleReferenceTable.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { RuleReferenceTable as RuleReferenceTableType } from "@/lib/types";
+
+interface RuleReferenceTableProps {
+  table: RuleReferenceTableType;
+}
+
+export function RuleReferenceTable({ table }: RuleReferenceTableProps) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-zinc-200 dark:border-zinc-700">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/50">
+            {table.headers.map((header, i) => (
+              <th
+                key={i}
+                className="whitespace-nowrap px-3 py-2 text-left font-medium text-zinc-700 dark:text-zinc-300"
+              >
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.map((row, rowIndex) => (
+            <tr
+              key={rowIndex}
+              className="border-b border-zinc-100 last:border-0 dark:border-zinc-800"
+            >
+              {row.map((cell, cellIndex) => (
+                <td
+                  key={cellIndex}
+                  className="whitespace-nowrap px-3 py-1.5 text-zinc-600 dark:text-zinc-400"
+                >
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/rule-reference/RuleReferenceTrigger.tsx
+++ b/components/rule-reference/RuleReferenceTrigger.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { BookOpen } from "lucide-react";
+import { useRuleReferenceContext } from "@/lib/contexts/RuleReferenceContext";
+import { Tooltip } from "@/components/ui/Tooltip";
+
+export function RuleReferenceTrigger() {
+  const { isOpen, open, close } = useRuleReferenceContext();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "/") {
+        e.preventDefault();
+        if (isOpen) {
+          close();
+        } else {
+          open();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, open, close]);
+
+  return (
+    <Tooltip content="Rule Reference (Cmd+/)" placement="left" delay={300}>
+      <button
+        onClick={() => open()}
+        className="fixed bottom-6 right-6 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500 text-white shadow-lg transition-all hover:bg-emerald-600 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 dark:bg-emerald-600 dark:hover:bg-emerald-500 dark:focus:ring-offset-zinc-950"
+        aria-label="Open rule reference"
+      >
+        <BookOpen className="h-5 w-5" />
+      </button>
+    </Tooltip>
+  );
+}

--- a/components/rule-reference/__tests__/RuleReferenceCard.test.tsx
+++ b/components/rule-reference/__tests__/RuleReferenceCard.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for RuleReferenceCard component
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RuleReferenceCard } from "../RuleReferenceCard";
+import type { RuleReferenceEntry } from "@/lib/types";
+
+describe("RuleReferenceCard", () => {
+  const entry: RuleReferenceEntry = {
+    id: "defense-modifiers",
+    title: "Defense Modifiers",
+    category: "combat",
+    subcategory: "ranged",
+    tags: ["defense", "dodge"],
+    summary: "Dice pool modifiers for defense tests in combat.",
+    tables: [
+      {
+        headers: ["Situation", "Modifier"],
+        rows: [
+          ["Defender prone", "-2"],
+          ["Defender running", "+2"],
+        ],
+      },
+    ],
+    notes: ["Wound modifiers stack with defense modifiers."],
+    source: { book: "SR5 Core", page: 188 },
+  };
+
+  it("should render the entry title", () => {
+    render(<RuleReferenceCard entry={entry} />);
+    expect(screen.getByText("Defense Modifiers")).toBeInTheDocument();
+  });
+
+  it("should render the category badge", () => {
+    render(<RuleReferenceCard entry={entry} />);
+    expect(screen.getByText("combat")).toBeInTheDocument();
+  });
+
+  it("should render the subcategory", () => {
+    render(<RuleReferenceCard entry={entry} />);
+    expect(screen.getByText("ranged")).toBeInTheDocument();
+  });
+
+  it("should render the summary", () => {
+    render(<RuleReferenceCard entry={entry} />);
+    expect(
+      screen.getByText("Dice pool modifiers for defense tests in combat.")
+    ).toBeInTheDocument();
+  });
+
+  it("should render table data", () => {
+    render(<RuleReferenceCard entry={entry} />);
+    expect(screen.getByText("Defender prone")).toBeInTheDocument();
+    expect(screen.getByText("-2")).toBeInTheDocument();
+  });
+
+  it("should render notes", () => {
+    render(<RuleReferenceCard entry={entry} />);
+    expect(screen.getByText("Wound modifiers stack with defense modifiers.")).toBeInTheDocument();
+  });
+
+  it("should render source reference", () => {
+    render(<RuleReferenceCard entry={entry} />);
+    expect(screen.getByText("SR5 Core, p. 188")).toBeInTheDocument();
+  });
+
+  it("should not render notes section when no notes", () => {
+    const entryWithoutNotes: RuleReferenceEntry = {
+      ...entry,
+      notes: undefined,
+    };
+
+    render(<RuleReferenceCard entry={entryWithoutNotes} />);
+    expect(screen.queryByText("Notes")).not.toBeInTheDocument();
+  });
+
+  it("should not render subcategory when not present", () => {
+    const entryWithoutSubcategory: RuleReferenceEntry = {
+      ...entry,
+      subcategory: undefined,
+    };
+
+    render(<RuleReferenceCard entry={entryWithoutSubcategory} />);
+    expect(screen.queryByText("ranged")).not.toBeInTheDocument();
+  });
+});

--- a/components/rule-reference/__tests__/RuleReferencePalette.test.tsx
+++ b/components/rule-reference/__tests__/RuleReferencePalette.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for RuleReferencePalette component
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RuleReferencePalette } from "../RuleReferencePalette";
+
+const mockClose = vi.fn();
+
+vi.mock("@/lib/contexts/RuleReferenceContext", () => ({
+  useRuleReferenceContext: vi.fn(() => ({
+    isOpen: true,
+    close: mockClose,
+    defaultCategory: null,
+  })),
+}));
+
+vi.mock("react-aria-components", () => ({
+  Dialog: ({ children }: { children: (props: { close: () => void }) => React.ReactNode }) => (
+    <div data-testid="dialog">{children({ close: mockClose })}</div>
+  ),
+  Modal: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="modal" className={className}>
+      {children}
+    </div>
+  ),
+  ModalOverlay: ({
+    children,
+    isOpen,
+  }: {
+    children: React.ReactNode;
+    isOpen: boolean;
+    isDismissable?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    className?: string;
+    style?: React.CSSProperties;
+  }) => (isOpen ? <div data-testid="overlay">{children}</div> : null),
+  Heading: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+describe("RuleReferencePalette", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            version: "1.0.0",
+            editionCode: "sr5",
+            entries: [
+              {
+                id: "test-entry",
+                title: "Test Entry",
+                category: "combat",
+                tags: ["test"],
+                summary: "A test entry",
+                tables: [],
+                source: { book: "SR5", page: 1 },
+              },
+            ],
+          },
+        }),
+    });
+  });
+
+  it("should render the palette when open", () => {
+    render(<RuleReferencePalette />);
+    expect(screen.getByText("Rule Quick-Reference")).toBeInTheDocument();
+  });
+
+  it("should render search input", () => {
+    render(<RuleReferencePalette />);
+    expect(screen.getByLabelText("Search rule references")).toBeInTheDocument();
+  });
+
+  it("should render the All category tab", () => {
+    render(<RuleReferencePalette />);
+    expect(screen.getByText("All")).toBeInTheDocument();
+  });
+
+  it("should not render when closed", async () => {
+    const { useRuleReferenceContext } = await import("@/lib/contexts/RuleReferenceContext");
+    vi.mocked(useRuleReferenceContext).mockReturnValue({
+      isOpen: false,
+      close: mockClose,
+      open: vi.fn(),
+      defaultCategory: null,
+    });
+
+    const { container } = render(<RuleReferencePalette />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/components/rule-reference/__tests__/RuleReferenceTable.test.tsx
+++ b/components/rule-reference/__tests__/RuleReferenceTable.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Tests for RuleReferenceTable component
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RuleReferenceTable } from "../RuleReferenceTable";
+import type { RuleReferenceTable as TableType } from "@/lib/types";
+
+describe("RuleReferenceTable", () => {
+  const table: TableType = {
+    headers: ["Situation", "Modifier", "Notes"],
+    rows: [
+      ["Defender prone", "-2", ""],
+      ["Defender running", "+2", "Applies to ranged only"],
+      ["Good Cover", "+4", ""],
+    ],
+  };
+
+  it("should render table headers", () => {
+    render(<RuleReferenceTable table={table} />);
+
+    expect(screen.getByText("Situation")).toBeInTheDocument();
+    expect(screen.getByText("Modifier")).toBeInTheDocument();
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+  });
+
+  it("should render table rows", () => {
+    render(<RuleReferenceTable table={table} />);
+
+    expect(screen.getByText("Defender prone")).toBeInTheDocument();
+    expect(screen.getByText("-2")).toBeInTheDocument();
+    expect(screen.getByText("Good Cover")).toBeInTheDocument();
+    expect(screen.getByText("+4")).toBeInTheDocument();
+  });
+
+  it("should render all rows", () => {
+    render(<RuleReferenceTable table={table} />);
+
+    const rows = screen.getAllByRole("row");
+    // 1 header row + 3 data rows
+    expect(rows).toHaveLength(4);
+  });
+
+  it("should render an empty table", () => {
+    const emptyTable: TableType = {
+      headers: ["Col A"],
+      rows: [],
+    };
+
+    render(<RuleReferenceTable table={emptyTable} />);
+    expect(screen.getByText("Col A")).toBeInTheDocument();
+    expect(screen.getAllByRole("row")).toHaveLength(1); // header only
+  });
+});

--- a/components/rule-reference/__tests__/useRuleReference.test.ts
+++ b/components/rule-reference/__tests__/useRuleReference.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for useRuleReference hook
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useRuleReference } from "../useRuleReference";
+import type { RuleReferenceData } from "@/lib/types";
+
+const mockData: RuleReferenceData = {
+  version: "1.0.0",
+  editionCode: "sr5",
+  entries: [
+    {
+      id: "defense-modifiers",
+      title: "Defense Modifiers",
+      category: "combat",
+      subcategory: "ranged",
+      tags: ["defense", "dodge", "cover"],
+      summary: "Dice pool modifiers for defense.",
+      tables: [{ headers: ["Situation", "Mod"], rows: [["Prone", "-2"]] }],
+      source: { book: "SR5 Core", page: 188 },
+    },
+    {
+      id: "noise-table",
+      title: "Noise Table",
+      category: "matrix",
+      tags: ["noise", "distance"],
+      summary: "Noise levels based on distance.",
+      tables: [{ headers: ["Distance", "Noise"], rows: [["100m", "0"]] }],
+      source: { book: "SR5 Core", page: 230 },
+    },
+    {
+      id: "healing-modifiers",
+      title: "Healing Modifiers",
+      category: "tests",
+      tags: ["healing", "first aid"],
+      summary: "Modifiers for healing tests.",
+      tables: [{ headers: ["Situation", "Mod"], rows: [["Good conditions", "+0"]] }],
+      source: { book: "SR5 Core", page: 205 },
+    },
+  ],
+};
+
+describe("useRuleReference", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: mockData }),
+    });
+  });
+
+  it("should load entries from API", async () => {
+    const { result } = renderHook(() => useRuleReference(null));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.entries).toHaveLength(3);
+    expect(result.current.filteredEntries).toHaveLength(3);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should filter entries by category", async () => {
+    const { result } = renderHook(() => useRuleReference(null));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setSelectedCategory("combat");
+    });
+
+    expect(result.current.filteredEntries).toHaveLength(1);
+    expect(result.current.filteredEntries[0].id).toBe("defense-modifiers");
+  });
+
+  it("should filter entries by search query", async () => {
+    const { result } = renderHook(() => useRuleReference(null));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setSearchQuery("noise");
+    });
+
+    expect(result.current.filteredEntries).toHaveLength(1);
+    expect(result.current.filteredEntries[0].id).toBe("noise-table");
+  });
+
+  it("should search tags", async () => {
+    const { result } = renderHook(() => useRuleReference(null));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setSearchQuery("cover");
+    });
+
+    expect(result.current.filteredEntries).toHaveLength(1);
+    expect(result.current.filteredEntries[0].id).toBe("defense-modifiers");
+  });
+
+  it("should apply default category", async () => {
+    const { result } = renderHook(() => useRuleReference("matrix"));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.selectedCategory).toBe("matrix");
+    expect(result.current.filteredEntries).toHaveLength(1);
+  });
+
+  it("should extract unique categories", async () => {
+    const { result } = renderHook(() => useRuleReference(null));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.categories).toEqual(["combat", "matrix", "tests"]);
+  });
+
+  it("should handle fetch error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const { result } = renderHook(() => useRuleReference(null));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.entries).toHaveLength(0);
+  });
+
+  it("should clear selected entry when search changes", async () => {
+    const { result } = renderHook(() => useRuleReference(null));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setSelectedEntry(result.current.entries[0]);
+    });
+
+    expect(result.current.selectedEntry).not.toBeNull();
+
+    act(() => {
+      result.current.setSearchQuery("noise");
+    });
+
+    expect(result.current.selectedEntry).toBeNull();
+  });
+});

--- a/components/rule-reference/useRuleReference.ts
+++ b/components/rule-reference/useRuleReference.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState, useEffect, useMemo, useCallback } from "react";
+import type { RuleReferenceEntry, RuleReferenceCategory, RuleReferenceData } from "@/lib/types";
+
+const DEFAULT_EDITION = "sr5";
+
+interface UseRuleReferenceReturn {
+  entries: RuleReferenceEntry[];
+  filteredEntries: RuleReferenceEntry[];
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  selectedCategory: RuleReferenceCategory | null;
+  setSelectedCategory: (category: RuleReferenceCategory | null) => void;
+  selectedEntry: RuleReferenceEntry | null;
+  setSelectedEntry: (entry: RuleReferenceEntry | null) => void;
+  isLoading: boolean;
+  error: string | null;
+  categories: RuleReferenceCategory[];
+}
+
+export function useRuleReference(
+  defaultCategory: RuleReferenceCategory | null,
+  editionCode: string = DEFAULT_EDITION
+): UseRuleReferenceReturn {
+  const [data, setData] = useState<RuleReferenceData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<RuleReferenceCategory | null>(
+    defaultCategory
+  );
+  const [selectedEntry, setSelectedEntry] = useState<RuleReferenceEntry | null>(null);
+
+  useEffect(() => {
+    setSelectedCategory(defaultCategory);
+  }, [defaultCategory]);
+
+  useEffect(() => {
+    if (!editionCode) return;
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    fetch(`/api/editions/${editionCode}/rule-reference`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to load rule reference data");
+        return res.json();
+      })
+      .then((json) => {
+        if (!cancelled) {
+          setData(json.data);
+          setIsLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err.message);
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [editionCode]);
+
+  const entries = data?.entries ?? [];
+
+  const categories = useMemo(() => {
+    const cats = new Set<RuleReferenceCategory>();
+    for (const entry of entries) {
+      cats.add(entry.category);
+    }
+    return Array.from(cats).sort();
+  }, [entries]);
+
+  const filteredEntries = useMemo(() => {
+    let result = entries;
+
+    if (selectedCategory) {
+      result = result.filter((e) => e.category === selectedCategory);
+    }
+
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase().trim();
+      result = result.filter(
+        (e) =>
+          e.title.toLowerCase().includes(query) ||
+          e.summary.toLowerCase().includes(query) ||
+          e.tags.some((t) => t.toLowerCase().includes(query)) ||
+          (e.subcategory && e.subcategory.toLowerCase().includes(query))
+      );
+    }
+
+    return result;
+  }, [entries, selectedCategory, searchQuery]);
+
+  const wrappedSetSearchQuery = useCallback((query: string) => {
+    setSearchQuery(query);
+    setSelectedEntry(null);
+  }, []);
+
+  const wrappedSetCategory = useCallback((category: RuleReferenceCategory | null) => {
+    setSelectedCategory(category);
+    setSelectedEntry(null);
+  }, []);
+
+  return {
+    entries,
+    filteredEntries,
+    searchQuery,
+    setSearchQuery: wrappedSetSearchQuery,
+    selectedCategory,
+    setSelectedCategory: wrappedSetCategory,
+    selectedEntry,
+    setSelectedEntry,
+    isLoading,
+    error,
+    categories,
+  };
+}

--- a/data/editions/sr5/rule-reference.json
+++ b/data/editions/sr5/rule-reference.json
@@ -1,0 +1,1105 @@
+{
+  "version": "1.0.0",
+  "editionCode": "sr5",
+  "entries": [
+    {
+      "id": "defense-modifiers",
+      "title": "Defense Modifiers",
+      "category": "combat",
+      "subcategory": "ranged",
+      "tags": ["defense", "dodge", "cover", "prone", "modifiers"],
+      "summary": "Dice pool modifiers applied to a defender's defense test in ranged and melee combat.",
+      "tables": [
+        {
+          "headers": ["Situation", "Dice Pool Modifier"],
+          "rows": [
+            ["Defender inside a moving vehicle", "+3"],
+            ["Defender prone", "-2"],
+            ["Defender unaware of attack", "No defense possible"],
+            ["Defender wounded", "-wound modifiers"],
+            ["Attacker has longer Reach", "-1 per point of net Reach"],
+            ["Defender has longer Reach", "+1 per point of net Reach"],
+            ["Defender receiving a charge", "+1"],
+            ["Defender has defended against previous attack", "-1 per previous attack"]
+          ]
+        },
+        {
+          "headers": ["Attacker Firing Situation", "Dice Pool Modifier"],
+          "rows": [
+            ["Flechette shotgun narrow spread", "-1"],
+            ["Flechette shotgun medium spread", "-3"],
+            ["Flechette shotgun wide spread", "-5"],
+            ["Full-auto (Complex)", "-9"],
+            ["Long burst or full-auto (Simple)", "-5"],
+            ["Burst or semi-auto burst", "-2"],
+            ["Defender in melee targeted by ranged attack", "-3"],
+            ["Defender running", "+2"],
+            ["Defender/Target has Good Cover", "+4"],
+            ["Defender/Target has Partial Cover", "+2"],
+            ["Targeted by area-effect attack", "-2"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 188 }
+    },
+    {
+      "id": "melee-modifiers",
+      "title": "Melee Modifiers",
+      "category": "combat",
+      "subcategory": "melee",
+      "tags": ["melee", "close combat", "reach", "modifiers", "called shot"],
+      "summary": "Dice pool modifiers for melee combat attacks and defense.",
+      "tables": [
+        {
+          "headers": ["Situation", "Dice Pool Modifier"],
+          "rows": [
+            ["Attacker making charging attack", "+2"],
+            ["Attacker prone", "-1"],
+            ["Attacker making a Called Shot", "-4"],
+            ["Character attacking multiple targets", "Split dice pool"],
+            ["Character has superior position", "+2"],
+            ["Character using off-hand weapon", "-2"],
+            ["Attacker wounded", "-wound modifier"],
+            ["Defender receiving a charge", "+1"],
+            ["Environmental modifiers", "Use Light and Visibility"],
+            ["Attacker has friends in melee", "+1 or Teamwork"],
+            ["Opponent prone", "+1"],
+            ["Touch-only attack", "+2"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 187 }
+    },
+    {
+      "id": "firing-modes",
+      "title": "Firing Modes",
+      "category": "combat",
+      "subcategory": "ranged",
+      "tags": ["firing mode", "burst", "auto", "semi-auto", "suppressive fire", "recoil", "rounds"],
+      "summary": "Weapon firing modes with defense modifiers, rounds consumed, and recoil notes.",
+      "tables": [
+        {
+          "headers": ["Mode", "Defense Modifier", "Rounds Used", "Notes"],
+          "rows": [
+            ["Single-Shot (SS)", "0", "1", "No Recoil"],
+            ["Semi-Automatic (SA)", "0", "1", ""],
+            ["Semi-Automatic Burst (SB)", "-2", "3", ""],
+            ["Burst Fire (BF)", "-2", "3", ""],
+            ["Long Burst / Full Auto (Simple)", "-5", "6", ""],
+            ["Full Auto (Complex)", "-9", "10", ""],
+            ["Suppressive Fire", "Duck or Cover", "20", "No Recoil"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 178 }
+    },
+    {
+      "id": "range-table",
+      "title": "Range Table",
+      "category": "combat",
+      "subcategory": "ranged",
+      "tags": [
+        "range",
+        "short",
+        "medium",
+        "long",
+        "extreme",
+        "distance",
+        "pistol",
+        "rifle",
+        "shotgun"
+      ],
+      "summary": "Range bands by weapon type and dice pool modifiers for each range category.",
+      "tables": [
+        {
+          "headers": ["Range", "Modifier"],
+          "rows": [
+            ["Short", "+0"],
+            ["Medium", "-1"],
+            ["Long", "-3"],
+            ["Extreme", "-6"]
+          ]
+        },
+        {
+          "headers": ["Weapon", "Short", "Medium", "Long", "Extreme"],
+          "rows": [
+            ["Taser", "0-5", "6-10", "11-15", "16-20"],
+            ["Hold-Out Pistol", "0-5", "6-15", "16-30", "31-50"],
+            ["Light Pistol", "0-5", "6-15", "16-30", "31-50"],
+            ["Heavy Pistol", "0-5", "6-20", "21-40", "41-60"],
+            ["Machine Pistol", "0-5", "6-15", "16-30", "31-50"],
+            ["SMG", "0-10", "11-40", "41-80", "81-150"],
+            ["Assault Rifle", "0-25", "26-150", "151-350", "351-550"],
+            ["Shotgun (flechette)", "0-15", "16-30", "31-45", "45-60"],
+            ["Shotgun (slug)", "0-10", "11-40", "41-80", "81-150"],
+            ["Sniper Rifle", "0-50", "51-350", "351-800", "801-1,500"],
+            ["Light Machinegun", "0-25", "26-200", "201-400", "401-800"],
+            ["Medium/Heavy Machinegun", "0-40", "41-250", "251-750", "751-1,200"],
+            ["Assault Cannon", "0-50", "51-300", "301-750", "751-1,500"]
+          ]
+        }
+      ],
+      "notes": [
+        "Ranges in meters.",
+        "See Launcher Minimum Range, p. 182 for grenade/missile launchers."
+      ],
+      "source": { "book": "SR5 Core", "page": 185 }
+    },
+    {
+      "id": "barrier-ratings",
+      "title": "Barrier Ratings",
+      "category": "combat",
+      "subcategory": "barriers",
+      "tags": ["barrier", "structure", "armor", "cover", "destruction", "wall", "door"],
+      "summary": "Structure and armor ratings for common barrier materials, used when attacking through or destroying barriers.",
+      "tables": [
+        {
+          "headers": ["Barrier", "Examples", "Structure", "Armor"],
+          "rows": [
+            ["Fragile", "Standard glass", "1", "2"],
+            ["Cheap Material", "Drywall, plaster, door, regular tire", "2", "4"],
+            ["Average Material", "Furniture, plastiboard, ballistic glass", "4", "6"],
+            ["Heavy Material", "Tree, hardwood, dataterm, light post, chain link", "6", "8"],
+            [
+              "Reinforced Material",
+              "Densiplast, security door, armored glass, Kevlar wallboard",
+              "8",
+              "12"
+            ],
+            ["Structural Material", "Brick, plascrete", "10", "16"],
+            ["Heavy Structural Material", "Concrete, metal beam", "12", "20"],
+            ["Armored/Reinforced Material", "Reinforced concrete", "14", "24"],
+            ["Hardened Material", "Blast bunkers", "16+", "32+"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 197 }
+    },
+    {
+      "id": "combat-actions",
+      "title": "Combat Actions",
+      "category": "combat",
+      "subcategory": "actions",
+      "tags": ["action", "free", "simple", "complex", "interrupt", "initiative", "turn"],
+      "summary": "Available combat actions organized by action type: Free, Simple, Complex, and Interrupt.",
+      "tables": [
+        {
+          "headers": ["Free Actions"],
+          "rows": [
+            ["Call a Shot"],
+            ["Change Linked Device Mode"],
+            ["Drop Object"],
+            ["Drop Prone"],
+            ["Eject Smartgun Clip"],
+            ["Multiple Attacks"],
+            ["Run"],
+            ["Speak/Text/Transmit Phrase"]
+          ]
+        },
+        {
+          "headers": ["Simple Actions"],
+          "rows": [
+            ["Activate Focus"],
+            ["Call Spirit"],
+            ["Change Device Mode"],
+            ["Command Spirit"],
+            ["Dismiss Spirit"],
+            ["Fire Bow"],
+            ["Fire Weapon (SA, SS, BF, FA)"],
+            ["Insert Clip"],
+            ["Observe in Detail"],
+            ["Pick Up/Put Down Object"],
+            ["Quick Draw"],
+            ["Ready/Draw Weapon"],
+            ["Reckless Spellcasting"],
+            ["Reload Weapon (see table)"],
+            ["Remove Clip"],
+            ["Shift Perception"],
+            ["Take Aim"],
+            ["Take Cover"],
+            ["Throw Weapon"],
+            ["Use Simple Device"]
+          ]
+        },
+        {
+          "headers": ["Complex Actions"],
+          "rows": [
+            ["Astral Projection"],
+            ["Banish Spirit"],
+            ["Cast Spell"],
+            ["Fire Weapon (FA)"],
+            ["Fire Long or Semi-Auto Burst"],
+            ["Fire Mounted or Vehicle Weapon"],
+            ["Melee Attack"],
+            ["Reload Weapon (see table)"],
+            ["Rigger Jump In"],
+            ["Sprint"],
+            ["Summoning"],
+            ["Use Skill"]
+          ]
+        },
+        {
+          "headers": ["Interrupt Actions"],
+          "rows": [
+            ["Block"],
+            ["Dodge"],
+            ["Full Defense"],
+            ["Hit the Dirt"],
+            ["Intercept"],
+            ["Parry"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 163 }
+    },
+    {
+      "id": "scatter-table",
+      "title": "Scatter Table",
+      "category": "combat",
+      "subcategory": "ranged",
+      "tags": ["scatter", "grenade", "rocket", "missile", "launcher", "miss"],
+      "summary": "Scatter distance formulas for grenades, launchers, and missiles. Roll 2D6 for direction.",
+      "tables": [
+        {
+          "headers": ["Type", "Scatter"],
+          "rows": [
+            ["Standard Grenade", "(1D6 - Hits) meters"],
+            ["Aerodynamic Grenade", "(2D6 - Hits) meters"],
+            ["Grenade Launcher", "(3D6 - Hits) meters"],
+            ["Missile Launcher", "(4D6 - Hits) meters"],
+            ["Rocket Launcher", "(5D6 - Hits) meters"]
+          ]
+        }
+      ],
+      "notes": ["Roll 2D6 for direction (2/12=Down, 7=Up, etc.). Minimum scatter is 0 meters."],
+      "source": { "book": "SR5 Core", "page": 182 }
+    },
+    {
+      "id": "reloading-weapons",
+      "title": "Reloading Weapons",
+      "category": "combat",
+      "subcategory": "ranged",
+      "tags": ["reload", "clip", "magazine", "ammunition", "ammo", "action"],
+      "summary": "Reloading methods for different weapon types and the action type required.",
+      "tables": [
+        {
+          "headers": ["Reloading Method", "Result", "Action Type"],
+          "rows": [
+            ["Removable Clip (c)", "Remove or insert clip", "Simple"],
+            ["Speed Loader", "Completely load gun", "Complex"],
+            ["Fill Clip", "Insert (Agility) rounds into clip", "Complex"],
+            ["Break Action (b)", "Insert 2 rounds", "Complex"],
+            ["Belt Fed (belt)", "Remove or insert belt", "Complex"],
+            ["Fill Belt/Drum", "Insert (Agility) rounds", "Complex"],
+            ["Internal Magazine (m)", "Insert (Agility) rounds", "Complex"],
+            ["Muzzle-Loader (ml)", "Load 1 muzzle tube", "Complex"],
+            ["Cylinder (cy)", "Insert (Agility) rounds", "Complex"],
+            ["Drum (d)", "Remove or insert drum", "Complex"],
+            ["Bow", "Nock 1 arrow", "Simple"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 163 }
+    },
+    {
+      "id": "damaging-barriers",
+      "title": "Damaging Barriers",
+      "category": "combat",
+      "subcategory": "barriers",
+      "tags": ["barrier", "damage", "penetration", "explosive", "combat spell"],
+      "summary": "Damage value modifiers when attacking barriers with different weapon types.",
+      "tables": [
+        {
+          "headers": ["Weapon", "DV Modifier"],
+          "rows": [
+            ["Melee or unarmed", "No change"],
+            ["Projectiles and bullets", "See Penetration Weapons"],
+            ["Explosive in contact with barrier", "Base DV x 2"],
+            ["AV rocket/missile", "Base DV x 2"],
+            ["Combat spell", "No change"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 197 }
+    },
+    {
+      "id": "environmental-modifiers",
+      "title": "Environmental Modifiers",
+      "category": "environment",
+      "tags": ["visibility", "light", "glare", "wind", "rain", "fog", "smoke", "darkness"],
+      "summary": "Dice pool modifiers from visibility, light/glare, wind, and range conditions. Conditions in the same row stack.",
+      "tables": [
+        {
+          "headers": ["Visibility", "Light/Glare", "Wind", "Range", "Modifier"],
+          "rows": [
+            ["Clear", "Full Light/No Glare", "None or Light Breeze", "Short", "--"],
+            ["Light Rain/Fog/Smoke", "Partial Light/Weak Glare", "Light Winds", "Medium", "-1"],
+            ["Moderate Rain/Fog/Smoke", "Dim Light/Moderate Glare", "Moderate Winds", "Long", "-3"],
+            [
+              "Heavy Rain/Fog/Smoke",
+              "Total Darkness/Blinding Glare",
+              "Strong Winds",
+              "Extreme",
+              "-6"
+            ],
+            ["Two or more conditions at -6 level", "", "", "", "-10"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 173 }
+    },
+    {
+      "id": "terrain-modifiers",
+      "title": "Terrain Modifiers",
+      "category": "environment",
+      "tags": ["terrain", "driving", "vehicle", "open", "tight", "restricted"],
+      "summary": "Threshold modifiers for vehicle tests based on terrain difficulty.",
+      "tables": [
+        {
+          "headers": ["Terrain", "Modifier", "Examples"],
+          "rows": [
+            ["Open", "0", "Highways, flat plains, open sea, clear sky"],
+            ["Light", "+1", "Main streets, rolling hills, dock areas"],
+            ["Restricted", "+2", "Side streets, light woods, rocky slopes, shallow waters"],
+            ["Tight", "+4", "Back alleys, heavy woods, steep slopes, swamp, street-level flying"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 201 }
+    },
+    {
+      "id": "environmental-compensation",
+      "title": "Environmental Compensation",
+      "category": "environment",
+      "tags": [
+        "compensation",
+        "flare",
+        "low-light",
+        "thermographic",
+        "ultrasound",
+        "smartlink",
+        "vision"
+      ],
+      "summary": "Gear and abilities that reduce environmental modifiers, and which conditions each compensates.",
+      "tables": [
+        {
+          "headers": ["Compensation", "Effect"],
+          "rows": [
+            ["Flare Compensation", "Glare conditions shift two rows up"],
+            ["Image Magnification", "Reduce Range conditions by one category"],
+            ["Low-Light Vision", "Treat Partial/Dim Light as Full Light"],
+            ["Thermographic Vision", "Visibility and Light shift one row up"],
+            ["Tracer Rounds (FA)", "Wind below Light Winds and Range below Short shift one row up"],
+            ["Smartlink", "Wind shifts one row up"],
+            ["Sunglasses", "Glare shifts one row up / Light shifts one row down"],
+            ["Ultrasound", "Visibility shifts one row up, ignore Light (within 50m)"]
+          ]
+        },
+        {
+          "headers": ["Condition", "How to Compensate"],
+          "rows": [
+            ["Visibility", "Ultrasound, Thermographic"],
+            ["Light", "Low-Light, Sunglasses, Thermographic, Ultrasound"],
+            ["Wind", "Tracer Rounds, Smartlink"],
+            ["Range", "Image Magnification, Tracer Rounds"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 175 }
+    },
+    {
+      "id": "perception-thresholds",
+      "title": "Perception Thresholds",
+      "category": "tests",
+      "tags": ["perception", "threshold", "notice", "spot", "hear", "detect"],
+      "summary": "Thresholds for Perception tests based on how obvious or hidden the target is.",
+      "tables": [
+        {
+          "headers": ["Item/Event Is", "Threshold", "Examples"],
+          "rows": [
+            ["Obvious/Large/Loud", "1", "Neon sign, running crowd, yelling, gunfire"],
+            ["Normal", "2", "Street sign, pedestrian, conversation, silenced gunfire"],
+            ["Obscured/Small/Muffled", "3", "Item dropped under table, contact lens, whispering"],
+            ["Hidden/Micro/Silent", "4", "Secret door, needle in haystack, subvocal speech"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 135 }
+    },
+    {
+      "id": "perception-test-modifiers",
+      "title": "Perception Test Modifiers",
+      "category": "tests",
+      "tags": ["perception", "modifiers", "distracted", "enhancements", "looking"],
+      "summary": "Dice pool modifiers for Perception tests based on situational factors.",
+      "tables": [
+        {
+          "headers": ["Situation", "Dice Pool Modifier"],
+          "rows": [
+            ["Perceiver is distracted", "-2"],
+            ["Perceiver is specifically looking/listening for it", "+3"],
+            ["Object/sound not in immediate vicinity", "-2"],
+            ["Object/sound far away", "-3"],
+            ["Object/sound stands out in some way", "+2"],
+            ["Interfering sight/odor/sound", "-2"],
+            ["Perceiver has active enhancements", "+(Rating)"]
+          ]
+        }
+      ],
+      "notes": ["Visibility and Light: See Environmental Factors, p. 173"],
+      "source": { "book": "SR5 Core", "page": 135 }
+    },
+    {
+      "id": "success-test-thresholds",
+      "title": "Success Test Thresholds",
+      "category": "tests",
+      "tags": ["threshold", "difficulty", "success", "easy", "hard", "extreme"],
+      "summary": "Standard threshold values for success tests by difficulty level.",
+      "tables": [
+        {
+          "headers": ["Difficulty", "Threshold"],
+          "rows": [
+            ["Easy", "1"],
+            ["Average", "2"],
+            ["Hard", "4"],
+            ["Very Hard", "6"],
+            ["Extreme", "8-10"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 45 }
+    },
+    {
+      "id": "extended-test-thresholds",
+      "title": "Extended Test Thresholds",
+      "category": "tests",
+      "tags": ["extended test", "threshold", "cumulative", "time"],
+      "summary": "Threshold values for extended tests where hits accumulate across multiple rolls.",
+      "tables": [
+        {
+          "headers": ["Difficulty", "Threshold"],
+          "rows": [
+            ["Easy", "6"],
+            ["Average", "12"],
+            ["Hard", "18"],
+            ["Very Hard", "24"],
+            ["Extreme", "30+"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 48 }
+    },
+    {
+      "id": "healing-modifiers",
+      "title": "Healing Modifiers",
+      "category": "tests",
+      "tags": ["healing", "first aid", "medicine", "medkit", "wounds", "recovery"],
+      "summary": "Dice pool modifiers for First Aid and Medicine tests based on conditions and equipment.",
+      "tables": [
+        {
+          "headers": ["Situation", "Modifier"],
+          "rows": [
+            ["Good conditions (sterilized med facility)", "+0"],
+            ["Average conditions (indoors)", "-1"],
+            ["Poor conditions (street or wilderness)", "-2"],
+            ["Bad conditions (combat, bad weather, swamp)", "-3"],
+            ["Terrible conditions (fire, severe storm)", "-4"],
+            ["No medical supplies", "-3"],
+            ["Improvised medical supplies", "-1"],
+            ["Wireless medkit/autodoc", "+Rating"],
+            ["Applying care remotely through medkit/autodoc", "-2"],
+            ["Assistance", "As Teamwork Test (p. 49)"],
+            ["Uncooperative patient", "-2"],
+            ["Patient is Awakened or Emerged", "-2"],
+            ["Patient has implants", "-1 per 2 full points of lost Essence"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 205 }
+    },
+    {
+      "id": "assensing-table",
+      "title": "Assensing Table",
+      "category": "magic",
+      "tags": ["assensing", "astral", "aura", "perception", "magic", "awakened", "cyberware"],
+      "summary": "Information gained from Assensing based on number of hits. Each level includes all previous information.",
+      "tables": [
+        {
+          "headers": ["Hits", "Information Gained"],
+          "rows": [
+            ["0", "None"],
+            ["1", "General health, emotional state, mundane or Awakened"],
+            ["2", "Cyberware presence/location, magical class, aura recognition"],
+            ["3", "Alphaware, Essence/Magic/Force comparison, malady diagnosis, astral signatures"],
+            ["4", "Bioware/betaware, exact Essence/Magic/Force, astral signature cause"],
+            ["5+", "Deltaware/gene treatments/nanotech, accurate diagnosis, technomancer detection"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 312 }
+    },
+    {
+      "id": "spirit-services",
+      "title": "Spirit Services",
+      "category": "magic",
+      "tags": ["spirit", "summoning", "binding", "services", "command"],
+      "summary": "Available services for unbound and bound spirits.",
+      "tables": [
+        {
+          "headers": ["Unbound Spirit Services", "Bound Spirit Services"],
+          "rows": [
+            ["Combat", "Any Unbound Spirit Service"],
+            ["Power Use", "Aid Alchemy"],
+            ["Physical Task", "Aid Sorcery"],
+            ["Remote Service", "Spell Binding"],
+            ["", "Spell Sustaining"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 301 }
+    },
+    {
+      "id": "object-resistance",
+      "title": "Object Resistance Table",
+      "category": "magic",
+      "tags": ["object resistance", "spell", "magic", "target", "threshold"],
+      "summary": "Dice pool for objects resisting magical effects, based on level of processing/technology.",
+      "tables": [
+        {
+          "headers": ["Object Type", "Dice Pool"],
+          "rows": [
+            ["Natural Objects (trees, soil, hand-carved wood)", "3"],
+            ["Manufactured Low-Tech (brick, leather, simple plastics)", "6"],
+            ["Manufactured High-Tech (advanced plastics, alloys, electronics)", "9"],
+            ["Highly Processed (computers, drones, vehicles)", "15+"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 295 }
+    },
+    {
+      "id": "astral-combat",
+      "title": "Astral Combat",
+      "category": "magic",
+      "tags": ["astral", "combat", "spirit", "weapon focus", "damage"],
+      "summary": "Attack and defense tests for astral combat, plus damage values by source type.",
+      "tables": [
+        {
+          "headers": ["Attack Type", "Attack Test", "Defense Test"],
+          "rows": [
+            ["Unarmed", "Astral Combat + Willpower [Astral]", "Intuition + Logic"],
+            ["Weapon Focus", "Astral Combat + Willpower [Accuracy]", "Intuition + Logic"]
+          ]
+        },
+        {
+          "headers": ["Source", "Damage"],
+          "rows": [
+            ["Magician", "Charisma"],
+            ["Weapon Focus", "By weapon (uses Charisma instead of Strength)"],
+            ["Spirit", "Force"],
+            ["Watcher", "1"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 315 }
+    },
+    {
+      "id": "focus-bonding",
+      "title": "Focus Bonding Costs",
+      "category": "magic",
+      "tags": ["focus", "bonding", "karma", "enchanting", "power", "weapon", "spell"],
+      "summary": "Karma costs for bonding different types of foci.",
+      "tables": [
+        {
+          "headers": ["Focus Type", "Bonding Cost (Karma)"],
+          "rows": [
+            ["Enchanting Focus", "Force x 3"],
+            ["Metamagic Focus", "Force x 3"],
+            ["Power Focus", "Force x 6"],
+            ["Qi Focus", "Force x 2"],
+            ["Spell Focus", "Force x 2"],
+            ["Spirit Focus", "Force x 2"],
+            ["Weapon Focus", "Force x 3"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 318 }
+    },
+    {
+      "id": "matrix-actions",
+      "title": "Matrix Actions",
+      "category": "matrix",
+      "tags": ["matrix", "hacking", "decker", "technomancer", "actions", "brute force", "hack"],
+      "summary": "All matrix actions organized by action type: Free, Simple, Complex, and Variable.",
+      "tables": [
+        {
+          "headers": ["Free Actions"],
+          "rows": [
+            ["Load Program"],
+            ["Switch Two Matrix Attributes"],
+            ["Swap Two Programs"],
+            ["Unload Program"]
+          ]
+        },
+        {
+          "headers": ["Simple Actions"],
+          "rows": [
+            ["Call/Dismiss Sprite"],
+            ["Change Icon"],
+            ["Command Sprite"],
+            ["Jack Out"],
+            ["Invite Mark"],
+            ["Send Message"],
+            ["Switch Interface Mode"]
+          ]
+        },
+        {
+          "headers": ["Complex Actions"],
+          "rows": [
+            ["Brute Force"],
+            ["Check Overwatch Score"],
+            ["Crack File"],
+            ["Crash Program"],
+            ["Data Spike"],
+            ["Disarm Data Bomb"],
+            ["Edit File"],
+            ["Enter/Exit Host"],
+            ["Erase Mark"],
+            ["Format Device"],
+            ["Hack on the Fly"],
+            ["Hide"],
+            ["Jam Signals"],
+            ["Jump Into Rigged Device"],
+            ["Matrix Perception"],
+            ["Reboot Device"],
+            ["Set Data Bomb"],
+            ["Snoop"],
+            ["Spoof Command"],
+            ["Trace Icon"],
+            ["Compile Sprite"],
+            ["Decompile Sprite"],
+            ["Register Sprite"],
+            ["Thread Complex Form"]
+          ]
+        },
+        {
+          "headers": ["Variable Actions"],
+          "rows": [["Control Device"], ["Matrix Search"]]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 237 }
+    },
+    {
+      "id": "noise-table",
+      "title": "Noise Table",
+      "category": "matrix",
+      "tags": ["noise", "distance", "signal", "jamming", "matrix", "wireless"],
+      "summary": "Noise levels based on physical distance and situational factors that affect matrix signal quality.",
+      "tables": [
+        {
+          "headers": ["Distance", "Noise Level"],
+          "rows": [
+            ["Directly connected (any distance)", "0"],
+            ["Up to 100 meters", "0"],
+            ["101-1,000 meters (1 km)", "1"],
+            ["1,001-10,000 meters (10 km)", "3"],
+            ["10,001-100,000 meters (100 km)", "5"],
+            ["Greater than 100 km", "8"]
+          ]
+        },
+        {
+          "headers": ["Situation", "Noise Level"],
+          "rows": [
+            ["Dense foliage", "1 per 5 meters"],
+            ["Faraday cage", "No signal (actions blocked)"],
+            ["Fresh water", "1 per 10 cm"],
+            ["Jamming", "1 per hit on Jam Signals"],
+            ["Metal-laced earth or wall", "1 per 5 meters"],
+            ["Salt water", "1 per centimeter"],
+            ["Spam/static zone", "Rating"],
+            ["Wireless negation (wallpaper/paint)", "Rating"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 230 }
+    },
+    {
+      "id": "host-ratings",
+      "title": "Sample Host Ratings",
+      "category": "matrix",
+      "tags": ["host", "rating", "security", "corporate", "government", "hacking"],
+      "summary": "Example host ratings for different types of matrix hosts, from personal sites to megacorp HQs.",
+      "tables": [
+        {
+          "headers": ["Examples", "Host Rating"],
+          "rows": [
+            ["Personal sites, pirate archives, public education", "1-2"],
+            ["Low-end commercial, private businesses, public libraries", "3-4"],
+            ["Social media, small universities, local police networks", "5-6"],
+            ["Matrix games, local corporate hosts, large universities", "7-8"],
+            ["Regional corporate hosts, major government systems", "9-10"],
+            ["Megacorporate HQs, military command centers", "11-12"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 247 }
+    },
+    {
+      "id": "user-modes",
+      "title": "User Modes",
+      "category": "matrix",
+      "tags": ["AR", "VR", "cold-sim", "hot-sim", "augmented reality", "initiative", "matrix mode"],
+      "summary": "Matrix user modes with initiative values and special bonuses.",
+      "tables": [
+        {
+          "headers": ["User Mode", "Initiative", "Initiative Dice", "Notes"],
+          "rows": [
+            [
+              "Augmented Reality",
+              "Physical Initiative",
+              "Physical Initiative Dice",
+              "Can be distracting"
+            ],
+            ["Cold-Sim VR", "Data Processing + Intuition", "3D6", ""],
+            [
+              "Hot-Sim VR",
+              "Data Processing + Intuition",
+              "4D6",
+              "+2 dice pool bonus to Matrix actions"
+            ]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 229 }
+    },
+    {
+      "id": "social-modifiers",
+      "title": "Social Modifiers",
+      "category": "social",
+      "tags": [
+        "social",
+        "con",
+        "etiquette",
+        "intimidation",
+        "negotiation",
+        "leadership",
+        "charisma"
+      ],
+      "summary": "Dice pool modifiers for social skill tests including general, con, etiquette, intimidation, leadership, and negotiation modifiers.",
+      "tables": [
+        {
+          "headers": ["General Modifier", "Dice Pool Modifier"],
+          "rows": [
+            ["NPC attitude: Friendly", "+2"],
+            ["NPC attitude: Neutral", "+0"],
+            ["NPC attitude: Suspicious", "-1"],
+            ["NPC attitude: Prejudiced", "-2"],
+            ["NPC attitude: Hostile", "-3"],
+            ["NPC attitude: Enemy", "-4"],
+            ["Result advantageous to NPC", "+1"],
+            ["Result of no value to NPC", "+0"],
+            ["Result annoying to NPC", "-1"],
+            ["Result harmful to NPC", "-3"],
+            ["Result disastrous to NPC", "-4"],
+            ["Character has street reputation", "+(Street Cred)"],
+            ["Subject has romantic attraction", "+2"],
+            ["Character is intoxicated", "-1"]
+          ]
+        },
+        {
+          "headers": ["Skill-Specific Modifier", "Dice Pool Modifier"],
+          "rows": [
+            ["Con: Plausible-seeming evidence", "+1 or +2"],
+            ["Con: Subject has time to evaluate", "-1"],
+            ["Etiquette: Wrong attire/look", "-2"],
+            ["Etiquette: Obviously nervous/agitated", "-2"],
+            ["Intimidation: Physically imposing", "+1 to +3"],
+            ["Intimidation: Characters outnumber subject", "+2"],
+            ["Intimidation: Wielding weapon/obvious magic", "+2"],
+            ["Negotiation: Lacks background knowledge", "-2"],
+            ["Negotiation: Has blackmail/heavy bargaining chip", "+2"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 140 }
+    },
+    {
+      "id": "social-skill-tests",
+      "title": "Social Skill Tests",
+      "category": "social",
+      "tags": [
+        "social",
+        "opposed test",
+        "con",
+        "etiquette",
+        "intimidation",
+        "negotiation",
+        "impersonation"
+      ],
+      "summary": "Opposed test pools for social skill tests - what both the character and target roll.",
+      "tables": [
+        {
+          "headers": ["Skill", "Character Roll", "Target Roll"],
+          "rows": [
+            ["Con", "Con + Charisma [Social]", "Con + Charisma [Social]"],
+            ["Etiquette", "Etiquette + Charisma [Social]", "Perception + Charisma [Social]"],
+            [
+              "Impersonation",
+              "Impersonation + Charisma [Social]",
+              "Perception + Intuition [Mental]"
+            ],
+            [
+              "Intimidation",
+              "Intimidation + Charisma [Social]",
+              "Intimidation + Willpower [Social]"
+            ],
+            ["Leadership", "Leadership + Charisma [Social]", "Leadership + Willpower [Social]"],
+            ["Negotiation", "Negotiation + Charisma [Social]", "Negotiation + Charisma [Social]"],
+            ["Performance", "Performance + Charisma [Social]", "Charisma + Willpower"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 141 }
+    },
+    {
+      "id": "connection-rating",
+      "title": "Connection Rating Table",
+      "category": "social",
+      "tags": ["contact", "connection", "rating", "influence", "network"],
+      "summary": "What each Connection rating level means in terms of a contact's social influence and reach.",
+      "tables": [
+        {
+          "headers": ["Rating", "Description"],
+          "rows": [
+            ["1", "No social influence; useful only for Knowledge skills"],
+            ["2", "One or two friends, some minor social influence"],
+            ["3", "A few friends, not much social influence"],
+            ["4", "Knows several people in a neighborhood; gang leader, borough mayor"],
+            ["5", "Moderate social influence; city councilman, low-level corporate exec"],
+            ["6", "Connected across state; city mayor, notable fixer, mid-level corp exec"],
+            ["7", "Considerable influence over large area; national corp leadership"],
+            ["8", "Multi-state connections; state government or national corp exec"],
+            ["9", "Continental connections; AA megacorp or small national government"],
+            ["10", "Worldwide connections; senior exec in government or AA megacorp"],
+            ["11", "Extreme worldwide connections; mid-level AAA megacorp or major government"],
+            ["12", "Global power-player; key exec in AAA megacorp or major government"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 387 }
+    },
+    {
+      "id": "loyalty-rating",
+      "title": "Loyalty Rating Table",
+      "category": "social",
+      "tags": ["contact", "loyalty", "rating", "relationship", "trust"],
+      "summary": "What each Loyalty rating level means for a contact's willingness to help.",
+      "tables": [
+        {
+          "headers": ["Rating", "Level", "Description"],
+          "rows": [
+            ["1", "Just Biz", "Purely mercenary, based solely on economics"],
+            ["2", "Regular", "All business, but with mutual respect"],
+            ["3", "Acquaintance", "Friendly but won't take a fall for you"],
+            ["4", "Buddy", "Actual friendship; will go out of their way"],
+            ["5", "Got Your Back", "Trust each other; will back you in risky situations"],
+            ["6", "Friend for Life", "Will go to the wall for each other"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 389 }
+    },
+    {
+      "id": "karma-rewards",
+      "title": "Karma Rewards",
+      "category": "social",
+      "subcategory": "rewards",
+      "tags": ["karma", "reward", "experience", "session", "adventure"],
+      "summary": "Karma awarded at the end of a session or adventure based on survival, objectives, and run type.",
+      "tables": [
+        {
+          "headers": ["Situation", "Karma"],
+          "rows": [
+            ["Character survived", "2"],
+            ["Group completed all objectives", "2"],
+            ["Group completed some objectives", "1"],
+            ["Overall adventure challenge", "Highest opposed Dice Pool / 6 (round down)"]
+          ]
+        },
+        {
+          "headers": ["Run Type", "Modifier"],
+          "rows": [
+            ["Standard run", "0"],
+            ["Cold-hearted bastard run", "-2"],
+            ["Good feelings run", "+2"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 375 }
+    },
+    {
+      "id": "cash-rewards",
+      "title": "Cash Rewards",
+      "category": "social",
+      "subcategory": "rewards",
+      "tags": ["nuyen", "payment", "reward", "run", "money", "cash"],
+      "summary": "Base payment and modifiers for shadowruns. Base cost is 3,000 nuyen.",
+      "tables": [
+        {
+          "headers": ["Situation", "Modifier"],
+          "rows": [
+            ["Highest opposing Dice Pool", "+(Dice Pool/4)"],
+            ["Outnumbered 3:1 in combat", "+1"],
+            ["Outnumbered 2:1 by PR4+ NPCs", "+1"],
+            ["Faced pack of 6+ critters", "+1"],
+            ["Encountered 3+ spirits in one encounter", "+1"],
+            ["Impressive speed/subtlety", "+1"],
+            ["Risked public exposure", "+1"],
+            ["Direct contact with dangerous Sixth World element", "+1"]
+          ]
+        },
+        {
+          "headers": ["Run Description", "Cost Modifier"],
+          "rows": [
+            ["Standard run", "0%"],
+            ["Cold-hearted bastard run (wetwork, etc.)", "+10-20%"],
+            ["Good feelings run (hooding, etc.)", "-10-20%"]
+          ]
+        }
+      ],
+      "notes": ["Base cost: 3,000 nuyen. Multiply base by total situational modifiers."],
+      "source": { "book": "SR5 Core", "page": 376 }
+    },
+    {
+      "id": "htr-response-time",
+      "title": "HTR Response Time",
+      "category": "social",
+      "subcategory": "security",
+      "tags": ["security", "response", "HTR", "police", "knight errant", "lone star"],
+      "summary": "High Threat Response team arrival times based on area security rating.",
+      "tables": [
+        {
+          "headers": ["Security Level", "Example", "Response Time"],
+          "rows": [
+            ["AAA", "Downtown Seattle, megacorp HQ, military", "1D6 minutes"],
+            ["AA", "Luxury residential area", "1D6 + 4 minutes"],
+            ["A", "Mid/high residential, common corporations", "2D6 + 3 minutes"],
+            ["B", "Mid-level residential, industrial", "1D6 x 5 minutes"],
+            ["C", "Low-end residential, storage areas", "1D6 x 10 minutes"],
+            ["Z", "Redmond Barrens, Chicago CZ", "2D6 hours"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 370 }
+    },
+    {
+      "id": "delivery-times",
+      "title": "Delivery Times",
+      "category": "equipment",
+      "tags": ["gear", "delivery", "purchase", "availability", "shopping", "time"],
+      "summary": "How long gear takes to arrive based on purchase cost.",
+      "tables": [
+        {
+          "headers": ["Gear Cost", "Delivery Time"],
+          "rows": [
+            ["Up to 100 nuyen", "6 hours"],
+            ["101-1,000 nuyen", "1 day"],
+            ["1,001-10,000 nuyen", "2 days"],
+            ["10,001-100,000 nuyen", "1 week"],
+            ["More than 100,000 nuyen", "1 month"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 418 }
+    },
+    {
+      "id": "favor-rating",
+      "title": "Favor Rating Table",
+      "category": "social",
+      "tags": ["favor", "contact", "rating", "risk", "services"],
+      "summary": "What each Favor rating level represents in terms of risk, value, and access provided.",
+      "tables": [
+        {
+          "headers": ["Rating", "Description"],
+          "rows": [
+            ["1", "Minor: Deliver a message, access to low-level restricted area"],
+            ["2", "Low Risk: Loan equipment up to 5,000 nuyen, first-line supervisor signature"],
+            ["3", "Medium: Access to mid-level restricted security area"],
+            ["4", "Moderate Risk: Loan equipment up to 50,000 nuyen, middle manager signature"],
+            ["5", "Serious: Access to high-level security area (FBI, AA/AAA megacorp HQ)"],
+            ["6", "Major Risk: Loan equipment up to 500,000 nuyen, senior manager signature"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 389 }
+    },
+    {
+      "id": "initiative-chart",
+      "title": "Initiative Types",
+      "category": "combat",
+      "subcategory": "initiative",
+      "tags": ["initiative", "astral", "matrix", "physical", "dice", "passes"],
+      "summary": "Initiative formulas for physical, astral, and matrix combat.",
+      "tables": [
+        {
+          "headers": ["Type", "Initiative", "Initiative Dice"],
+          "rows": [
+            ["Physical", "Reaction + Intuition", "1D6"],
+            ["Astral", "Intuition x 2", "2D6"],
+            ["Matrix AR", "Physical Initiative", "Physical Initiative Dice"],
+            ["Matrix Cold-Sim VR", "Data Processing + Intuition", "3D6"],
+            ["Matrix Hot-Sim VR", "Data Processing + Intuition", "4D6"]
+          ]
+        }
+      ],
+      "notes": [
+        "Each additional Initiative Die grants +1D6 (e.g., wired reflexes). Multiple initiative passes when total exceeds 10."
+      ],
+      "source": { "book": "SR5 Core", "page": 159 }
+    },
+    {
+      "id": "mana-barriers",
+      "title": "Mana Barriers",
+      "category": "magic",
+      "tags": ["mana barrier", "ward", "lodge", "circle of protection", "astral", "physical"],
+      "summary": "Types of mana barriers and whether they exist on the astral plane, physical plane, or both.",
+      "tables": [
+        {
+          "headers": ["Mana Barrier", "Astral or Physical", "Reference"],
+          "rows": [
+            ["Circle of Protection ritual", "Both", "p. 298"],
+            ["Magical Lodge", "Both", "p. 280"],
+            ["Mana Barrier spell", "Either", "p. 294"],
+            ["Ward ritual", "Both", "p. 297"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 315 }
+    },
+    {
+      "id": "situational-modifiers",
+      "title": "Situational Modifiers",
+      "category": "tests",
+      "tags": ["modifiers", "situational", "attacker", "defender", "general"],
+      "summary": "General situational modifiers that apply to various types of tests.",
+      "tables": [
+        {
+          "headers": ["Situation", "Dice Pool Modifier"],
+          "rows": [
+            ["Attacker running", "-2"],
+            ["Attacker in melee combat", "-3"],
+            ["Attacker firing from moving vehicle", "-2"],
+            ["Attacker firing from full cover (blind fire)", "-6"],
+            ["Attacker using off-hand weapon", "-2"],
+            ["Attacker using image link", "+1"],
+            ["Attacker using smartlink", "+2"],
+            ["Attacker using laser sight", "+1"],
+            ["Attacker wounded", "-wound modifier"],
+            ["Called Shot", "-4"]
+          ]
+        }
+      ],
+      "source": { "book": "SR5 Core", "page": 174 }
+    }
+  ]
+}

--- a/lib/contexts/RuleReferenceContext.tsx
+++ b/lib/contexts/RuleReferenceContext.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import type { RuleReferenceCategory } from "@/lib/types";
+
+interface RuleReferenceContextValue {
+  isOpen: boolean;
+  open: (context?: RuleReferenceCategory) => void;
+  close: () => void;
+  defaultCategory: RuleReferenceCategory | null;
+}
+
+const RuleReferenceContext = createContext<RuleReferenceContextValue | null>(null);
+
+export function RuleReferenceProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [defaultCategory, setDefaultCategory] = useState<RuleReferenceCategory | null>(null);
+
+  const open = useCallback((context?: RuleReferenceCategory) => {
+    setDefaultCategory(context ?? null);
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setDefaultCategory(null);
+  }, []);
+
+  return (
+    <RuleReferenceContext.Provider value={{ isOpen, open, close, defaultCategory }}>
+      {children}
+    </RuleReferenceContext.Provider>
+  );
+}
+
+export function useRuleReferenceContext(): RuleReferenceContextValue {
+  const ctx = useContext(RuleReferenceContext);
+  if (!ctx) {
+    throw new Error("useRuleReferenceContext must be used within RuleReferenceProvider");
+  }
+  return ctx;
+}

--- a/lib/storage/editions.ts
+++ b/lib/storage/editions.ts
@@ -233,6 +233,22 @@ export async function getDefaultCreationMethod(
 }
 
 // =============================================================================
+// RULE REFERENCE OPERATIONS
+// =============================================================================
+
+import type { RuleReferenceData } from "../types/rule-reference";
+
+/**
+ * Get rule reference data for an edition
+ */
+export async function getRuleReference(
+  editionCode: EditionCode
+): Promise<RuleReferenceData | null> {
+  const filePath = path.join(getEditionDir(editionCode), "rule-reference.json");
+  return readJsonFile<RuleReferenceData>(filePath);
+}
+
+// =============================================================================
 // DISCOVERY OPERATIONS (Content Summarization)
 // =============================================================================
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -886,3 +886,11 @@ export {
 
 // Archetype types
 export type { CharacterArchetype, ArchetypeCategory } from "./archetype";
+
+// Rule Reference types
+export type {
+  RuleReferenceCategory,
+  RuleReferenceTable,
+  RuleReferenceEntry,
+  RuleReferenceData,
+} from "./rule-reference";

--- a/lib/types/rule-reference.ts
+++ b/lib/types/rule-reference.ts
@@ -1,0 +1,40 @@
+/**
+ * Rule Reference types
+ *
+ * Types for the in-app rule quick-reference system.
+ * Supports structured reference entries with tables, searchable tags,
+ * and category-based filtering.
+ */
+
+export type RuleReferenceCategory =
+  | "combat"
+  | "magic"
+  | "matrix"
+  | "rigging"
+  | "social"
+  | "environment"
+  | "tests"
+  | "equipment";
+
+export interface RuleReferenceTable {
+  headers: string[];
+  rows: string[][];
+}
+
+export interface RuleReferenceEntry {
+  id: string;
+  title: string;
+  category: RuleReferenceCategory;
+  subcategory?: string;
+  tags: string[];
+  summary: string;
+  tables: RuleReferenceTable[];
+  notes?: string[];
+  source: { book: string; page: number | string };
+}
+
+export interface RuleReferenceData {
+  version: string;
+  editionCode: string;
+  entries: RuleReferenceEntry[];
+}


### PR DESCRIPTION
## Summary

- Add a **Cmd+/ triggered command palette** for searchable in-app rule reference, accessible from any authenticated page
- Curate **38 structured reference entries** across 7 categories (combat, magic, matrix, social, environment, tests, equipment) from existing `/docs/data_tables/` markdown files
- Split-pane UI with search, category filter pills, entry list with keyboard navigation, and detail view with rendered tables

## Key Changes

### New files (13)
- **Types**: `lib/types/rule-reference.ts` — `RuleReferenceEntry`, `RuleReferenceTable`, `RuleReferenceData`
- **Data**: `data/editions/sr5/rule-reference.json` — 38 curated entries with tables, tags, sources
- **API**: `app/api/editions/[editionCode]/rule-reference/route.ts` — GET with optional `?category=` filter
- **Context**: `lib/contexts/RuleReferenceContext.tsx` — open/close state, default category
- **Components**: 7 files in `components/rule-reference/` — Palette, Search, CategoryTabs, List, Card, Table, Trigger

### Modified files (3)
- `lib/types/index.ts` — re-export rule-reference types
- `lib/storage/editions.ts` — add `getRuleReference()` function
- `app/users/AuthenticatedLayout.tsx` — wrap in `RuleReferenceProvider`, add trigger + palette

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 31 new tests pass (API route, hook, palette, card, table)
- [x] No regressions in existing edition tests (83/83 pass)
- [ ] Manual: Press Cmd+/ on any authenticated page, verify palette opens
- [ ] Manual: Type "barrier" in search, verify barrier ratings table renders
- [ ] Manual: Click category filter pills, verify entries filter correctly
- [ ] Manual: Press Escape or click outside, verify palette closes
- [ ] Manual: Click floating book icon button, verify palette opens
- [ ] Manual: Use arrow keys to navigate entry list

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)