### PR TITLE
fix: standardize quality state PATCH API to direct format (#491)

### DIFF
--- a/app/api/characters/[characterId]/qualities/[qualityId]/state/__tests__/route.test.ts
+++ b/app/api/characters/[characterId]/qualities/[qualityId]/state/__tests__/route.test.ts
@@ -170,8 +170,7 @@ describe("PATCH /api/characters/[characterId]/qualities/[qualityId]/state", () =
       expect(response.status).toBe(200);
     });
 
-    it("should return 500 if body is null (crashes accessing data.updates)", async () => {
-      // Note: null body causes error when accessing data.updates in the route
+    it("should return 400 if body is null", async () => {
       const request = createMockRequest(
         `http://localhost/api/characters/${TEST_CHARACTER_ID}/qualities/${qualityId}/state`,
         null,
@@ -182,8 +181,8 @@ describe("PATCH /api/characters/[characterId]/qualities/[qualityId]/state", () =
         params: Promise.resolve({ characterId: TEST_CHARACTER_ID, qualityId }),
       });
 
-      // Accessing null.updates throws, caught by outer try-catch -> 500
-      expect(response.status).toBe(500);
+      // null is not a valid object, caught by validation -> 400
+      expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.success).toBe(false);
     });
@@ -194,32 +193,7 @@ describe("PATCH /api/characters/[characterId]/qualities/[qualityId]/state", () =
   // ===========================================================================
 
   describe("Request Format Support", () => {
-    it("should accept { updates: {...} } format", async () => {
-      const updatedCharacter = { ...mockCharacter };
-      vi.mocked(characterStorageModule.updateQualityDynamicState).mockResolvedValue(
-        updatedCharacter
-      );
-
-      const request = createMockRequest(
-        `http://localhost/api/characters/${TEST_CHARACTER_ID}/qualities/${qualityId}/state`,
-        { updates: { severity: "severe" } },
-        "PATCH"
-      );
-
-      const response = await PATCH(request, {
-        params: Promise.resolve({ characterId: TEST_CHARACTER_ID, qualityId }),
-      });
-
-      expect(response.status).toBe(200);
-      expect(characterStorageModule.updateQualityDynamicState).toHaveBeenCalledWith(
-        TEST_USER_ID,
-        TEST_CHARACTER_ID,
-        qualityId,
-        { severity: "severe" }
-      );
-    });
-
-    it("should accept direct {...} format without wrapper", async () => {
+    it("should accept direct state update format", async () => {
       const updatedCharacter = { ...mockCharacter };
       vi.mocked(characterStorageModule.updateQualityDynamicState).mockResolvedValue(
         updatedCharacter

--- a/app/api/characters/[characterId]/qualities/[qualityId]/state/route.ts
+++ b/app/api/characters/[characterId]/qualities/[qualityId]/state/route.ts
@@ -39,7 +39,7 @@ export async function PATCH(
 
     // Parse body for state updates
     const data = await request.json();
-    const updates = data.updates || data; // Flexible: handle both {updates: {...}} and {...}
+    const updates = data;
 
     if (!updates || typeof updates !== "object") {
       return NextResponse.json(

--- a/app/characters/[id]/components/DynamicStateModal.tsx
+++ b/app/characters/[id]/components/DynamicStateModal.tsx
@@ -43,7 +43,7 @@ export function DynamicStateModal({
         {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ updates }),
+          body: JSON.stringify(updates),
         }
       );
 


### PR DESCRIPTION
## Summary

- **DynamicStateModal**: Remove `{ updates }` wrapper — now sends state updates directly like the toggle pill
- **API route**: Remove fragile `data.updates || data` fallback — accepts only direct `{ field: value }` format
- **Tests**: Remove wrapped format test, update null body test expectation (400 instead of 500)

Closes #491

## Test plan

- [x] `pnpm type-check` passes
- [x] Quality state API tests pass (17/17)
- [x] Full test suite passes (8497 tests)
- [ ] Manual: toggle quality state pill on character sheet
- [ ] Manual: update quality state via DynamicStateModal tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)