### PR TITLE
fix: wire AddictionTracker craving test button to dice roll (#489)

### DIFF
--- a/app/characters/[id]/components/DynamicStateModal.tsx
+++ b/app/characters/[id]/components/DynamicStateModal.tsx
@@ -67,6 +67,7 @@ export function DynamicStateModal({
     const props = {
       selection,
       onUpdate: handleUpdate,
+      character,
     };
 
     switch (type) {

--- a/app/characters/[id]/components/trackers/AddictionTracker.tsx
+++ b/app/characters/[id]/components/trackers/AddictionTracker.tsx
@@ -1,16 +1,32 @@
 "use client";
 
 import React, { useState } from "react";
-import { AlertCircle, Calendar, History, Activity, Plus } from "lucide-react";
-import type { QualitySelection, AddictionState } from "@/lib/types";
+import { AlertCircle, Calendar, History, Activity, Plus, Dice5 } from "lucide-react";
+import type { Character, QualitySelection, AddictionState } from "@/lib/types";
+import { executeRoll } from "@/lib/rules/action-resolution/dice-engine";
+
+const SEVERITY_THRESHOLD: Record<AddictionState["severity"], number> = {
+  mild: 2,
+  moderate: 3,
+  severe: 4,
+  burnout: 5,
+};
+
+interface CravingTestResult {
+  hits: number;
+  threshold: number;
+  resisted: boolean;
+}
 
 interface AddictionTrackerProps {
   selection: QualitySelection;
   onUpdate: (updates: Partial<AddictionState>) => Promise<void>;
+  character: Character;
 }
 
-export function AddictionTracker({ selection, onUpdate }: AddictionTrackerProps) {
+export function AddictionTracker({ selection, onUpdate, character }: AddictionTrackerProps) {
   const [isUpdating, setIsUpdating] = useState(false);
+  const [rollResult, setRollResult] = useState<CravingTestResult | null>(null);
 
   const dynamicState = selection.dynamicState;
   if (!dynamicState || dynamicState.type !== "addiction") return null;
@@ -45,6 +61,25 @@ export function AddictionTracker({ selection, onUpdate }: AddictionTrackerProps)
         withdrawalActive: false,
         daysClean: 0,
       });
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleCravingTest = async () => {
+    setIsUpdating(true);
+    setRollResult(null);
+    try {
+      const pool = (character.attributes.body || 1) + (character.attributes.willpower || 1);
+      const threshold = SEVERITY_THRESHOLD[state.severity];
+      const result = executeRoll(pool);
+      const resisted = result.hits >= threshold;
+      setRollResult({ hits: result.hits, threshold, resisted });
+      if (!resisted) {
+        await onUpdate({ cravingActive: true });
+      } else {
+        await onUpdate({ cravingActive: false });
+      }
     } finally {
       setIsUpdating(false);
     }
@@ -138,13 +173,32 @@ export function AddictionTracker({ selection, onUpdate }: AddictionTrackerProps)
           Log Dose
         </button>
         <button
+          onClick={handleCravingTest}
           disabled={isUpdating}
           className="flex-1 flex items-center justify-center gap-2 py-2.5 bg-muted hover:bg-muted-foreground/10 text-foreground border border-border rounded text-xs font-bold transition-colors shadow-sm"
         >
-          <Activity className="w-4 h-4" />
+          <Dice5 className="w-4 h-4" />
           Craving Test
         </button>
       </div>
+
+      {/* Roll Result */}
+      {rollResult && (
+        <div
+          className={`p-3 rounded border text-xs font-medium ${
+            rollResult.resisted
+              ? "bg-emerald-500/10 border-emerald-500/30 text-emerald-500"
+              : "bg-red-500/10 border-red-500/30 text-red-500"
+          }`}
+        >
+          <div className="flex items-center justify-between">
+            <span className="font-bold">{rollResult.resisted ? "Resisted!" : "Failed!"}</span>
+            <span className="font-mono">
+              {rollResult.hits} hits vs {rollResult.threshold} threshold
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/characters/[id]/components/trackers/AllergyTracker.tsx
+++ b/app/characters/[id]/components/trackers/AllergyTracker.tsx
@@ -2,11 +2,12 @@
 
 import React, { useState } from "react";
 import { AlertCircle, Wind, ShieldAlert, Zap } from "lucide-react";
-import type { QualitySelection, AllergyState } from "@/lib/types";
+import type { Character, QualitySelection, AllergyState } from "@/lib/types";
 
 interface AllergyTrackerProps {
   selection: QualitySelection;
   onUpdate: (updates: Partial<AllergyState>) => Promise<void>;
+  character?: Character;
 }
 
 export function AllergyTracker({ selection, onUpdate }: AllergyTrackerProps) {

--- a/app/characters/[id]/components/trackers/CodeOfHonorTracker.tsx
+++ b/app/characters/[id]/components/trackers/CodeOfHonorTracker.tsx
@@ -11,11 +11,12 @@ import {
   MinusCircle,
   Calendar,
 } from "lucide-react";
-import type { QualitySelection, CodeOfHonorState } from "@/lib/types";
+import type { Character, QualitySelection, CodeOfHonorState } from "@/lib/types";
 
 interface CodeOfHonorTrackerProps {
   selection: QualitySelection;
   onUpdate: (updates: Partial<CodeOfHonorState>) => Promise<void>;
+  character?: Character;
 }
 
 export function CodeOfHonorTracker({ selection, onUpdate }: CodeOfHonorTrackerProps) {

--- a/app/characters/[id]/components/trackers/DependentTracker.tsx
+++ b/app/characters/[id]/components/trackers/DependentTracker.tsx
@@ -2,11 +2,12 @@
 
 import React, { useState } from "react";
 import { Heart, ShieldCheck, ShieldAlert, HelpCircle, Clock, Coins, UserCheck } from "lucide-react";
-import type { QualitySelection, DependentState } from "@/lib/types";
+import type { Character, QualitySelection, DependentState } from "@/lib/types";
 
 interface DependentTrackerProps {
   selection: QualitySelection;
   onUpdate: (updates: Partial<DependentState>) => Promise<void>;
+  character?: Character;
 }
 
 export function DependentTracker({ selection, onUpdate }: DependentTrackerProps) {

--- a/app/characters/[id]/components/trackers/__tests__/AddictionTracker.test.tsx
+++ b/app/characters/[id]/components/trackers/__tests__/AddictionTracker.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AddictionTracker } from "../AddictionTracker";
+import type { Character, QualitySelection, AddictionState } from "@/lib/types";
+
+// Mock dice engine
+const mockExecuteRoll = vi.fn();
+vi.mock("@/lib/rules/action-resolution/dice-engine", () => ({
+  executeRoll: (...args: unknown[]) => mockExecuteRoll(...args),
+}));
+
+// Mock lucide-react icons
+vi.mock("lucide-react", () => ({
+  AlertCircle: () => <span data-testid="alert-circle-icon" />,
+  Calendar: () => <span data-testid="calendar-icon" />,
+  History: () => <span data-testid="history-icon" />,
+  Activity: () => <span data-testid="activity-icon" />,
+  Plus: () => <span data-testid="plus-icon" />,
+  Dice5: () => <span data-testid="dice5-icon" />,
+}));
+
+const mockCharacter = {
+  id: "char-1",
+  ownerId: "user-1",
+  name: "Test Runner",
+  editionCode: "sr5",
+  creationMethod: "priority",
+  metatype: "human",
+  state: "active",
+  attributes: {
+    body: 4,
+    agility: 5,
+    reaction: 4,
+    strength: 3,
+    willpower: 3,
+    logic: 4,
+    intuition: 4,
+    charisma: 3,
+    edge: 3,
+  },
+  skills: {},
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-01T00:00:00Z",
+} as unknown as Character;
+
+const mockSelection: QualitySelection = {
+  qualityId: "addiction-bliss",
+  name: "Addiction (Bliss)",
+  category: "negative",
+  karmaCost: -4,
+  source: "core",
+  dynamicState: {
+    type: "addiction",
+    state: {
+      substance: "Bliss",
+      substanceType: "physiological",
+      severity: "moderate",
+      originalSeverity: "moderate",
+      lastDose: "2024-06-01T10:00:00Z",
+      nextCravingCheck: "2024-06-02T10:00:00Z",
+      cravingActive: false,
+      withdrawalActive: false,
+      withdrawalPenalty: 2,
+      daysClean: 5,
+      dosesLogged: 12,
+    },
+  },
+} as unknown as QualitySelection;
+
+describe("AddictionTracker", () => {
+  let mockOnUpdate: ReturnType<typeof vi.fn<(updates: Partial<AddictionState>) => Promise<void>>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnUpdate = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it("calls onUpdate with cravingActive: true on failed roll", async () => {
+    // 1 hit vs threshold 3 (moderate) = fail
+    mockExecuteRoll.mockReturnValue({
+      hits: 1,
+      dice: [],
+      rawHits: 1,
+      ones: 0,
+      isGlitch: false,
+      isCriticalGlitch: false,
+      limitApplied: false,
+      poolSize: 7,
+    });
+
+    render(
+      <AddictionTracker
+        selection={mockSelection}
+        onUpdate={mockOnUpdate}
+        character={mockCharacter}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Craving Test"));
+
+    await waitFor(() => {
+      expect(mockOnUpdate).toHaveBeenCalledWith({ cravingActive: true });
+    });
+
+    // Pool should be body(4) + willpower(3) = 7
+    expect(mockExecuteRoll).toHaveBeenCalledWith(7);
+  });
+
+  it("calls onUpdate with cravingActive: false on successful roll", async () => {
+    // 4 hits vs threshold 3 (moderate) = success
+    mockExecuteRoll.mockReturnValue({
+      hits: 4,
+      dice: [],
+      rawHits: 4,
+      ones: 0,
+      isGlitch: false,
+      isCriticalGlitch: false,
+      limitApplied: false,
+      poolSize: 7,
+    });
+
+    render(
+      <AddictionTracker
+        selection={mockSelection}
+        onUpdate={mockOnUpdate}
+        character={mockCharacter}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Craving Test"));
+
+    await waitFor(() => {
+      expect(mockOnUpdate).toHaveBeenCalledWith({ cravingActive: false });
+    });
+  });
+
+  it("disables button while isUpdating", async () => {
+    // Make onUpdate hang to keep isUpdating true
+    mockOnUpdate = vi.fn().mockReturnValue(new Promise(() => {}));
+    mockExecuteRoll.mockReturnValue({
+      hits: 1,
+      dice: [],
+      rawHits: 1,
+      ones: 0,
+      isGlitch: false,
+      isCriticalGlitch: false,
+      limitApplied: false,
+      poolSize: 7,
+    });
+
+    render(
+      <AddictionTracker
+        selection={mockSelection}
+        onUpdate={mockOnUpdate}
+        character={mockCharacter}
+      />
+    );
+
+    const button = screen.getByText("Craving Test");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+  });
+
+  it("shows roll result UI after clicking", async () => {
+    mockExecuteRoll.mockReturnValue({
+      hits: 1,
+      dice: [],
+      rawHits: 1,
+      ones: 0,
+      isGlitch: false,
+      isCriticalGlitch: false,
+      limitApplied: false,
+      poolSize: 7,
+    });
+
+    render(
+      <AddictionTracker
+        selection={mockSelection}
+        onUpdate={mockOnUpdate}
+        character={mockCharacter}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Craving Test"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed!")).toBeInTheDocument();
+      expect(screen.getByText("1 hits vs 3 threshold")).toBeInTheDocument();
+    });
+  });
+
+  it("shows Resisted for successful roll result", async () => {
+    mockExecuteRoll.mockReturnValue({
+      hits: 4,
+      dice: [],
+      rawHits: 4,
+      ones: 0,
+      isGlitch: false,
+      isCriticalGlitch: false,
+      limitApplied: false,
+      poolSize: 7,
+    });
+
+    render(
+      <AddictionTracker
+        selection={mockSelection}
+        onUpdate={mockOnUpdate}
+        character={mockCharacter}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Craving Test"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Resisted!")).toBeInTheDocument();
+      expect(screen.getByText("4 hits vs 3 threshold")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Wire the no-op "Craving Test" button in AddictionTracker to roll Body + Willpower vs severity threshold using `executeRoll()` from the dice engine
- Display inline pass/fail result banner with hits and threshold
- Pass `character` from DynamicStateModal to all tracker components (required for AddictionTracker, optional for others)

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` — all 8502 tests pass (5 new AddictionTracker tests)
- [ ] Manual: open an addiction quality tracker, click "Craving Test", verify dice roll result appears and craving state updates

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)