### PR TITLE
feat: add visual feedback for quality state toggles and effect preview (#493, #492)

### DIFF
--- a/__tests__/components/DynamicStateModal-effects.test.tsx
+++ b/__tests__/components/DynamicStateModal-effects.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * Tests for DynamicStateModal active effects preview (#492)
+ *
+ * Covers: effect badges render, reactive updates, no-effects case
+ */
+
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Character, QualitySelection } from "@/lib/types";
+import type { EffectBadge } from "@/lib/rules/effects";
+import { DynamicStateModal } from "@/app/characters/[id]/components/DynamicStateModal";
+
+// Track the mock's return values so we can change per-test
+let mockEffectBadges: EffectBadge[] = [];
+
+// Mock useQualities to return catalog data
+vi.mock("@/lib/rules", () => ({
+  useQualities: () => ({
+    positive: [],
+    negative: [
+      {
+        id: "addiction",
+        name: "Addiction",
+        karmaBonus: 4,
+        summary: "Character is addicted to a substance",
+        effects: [
+          {
+            type: "dice-pool-modifier",
+            value: -2,
+            triggers: ["withdrawal"],
+            target: { attribute: "body" },
+          },
+        ],
+      },
+      {
+        id: "code-of-honor",
+        name: "Code of Honor",
+        karmaBonus: 5,
+        summary: "Character follows a code",
+        effects: [],
+      },
+    ],
+  }),
+}));
+
+// Mock effects module
+vi.mock("@/lib/rules/effects", () => ({
+  formatEffectBadge: vi.fn(() => {
+    // Return from the shared array so tests can control output
+    return mockEffectBadges.length > 0 ? mockEffectBadges.shift()! : null;
+  }),
+  isUnifiedEffect: (e: unknown) =>
+    typeof e === "object" &&
+    e !== null &&
+    "triggers" in e &&
+    Array.isArray((e as Record<string, unknown>).triggers),
+  resolveRatingBasedValue: vi.fn(() => null),
+  buildCharacterStateFlags: vi.fn(() => ({})),
+}));
+
+// Mock react-aria-components to render simple HTML
+vi.mock("react-aria-components", () => ({
+  ModalOverlay: ({ children, isOpen }: { children: React.ReactNode; isOpen: boolean }) =>
+    isOpen ? <div data-testid="modal-overlay">{children}</div> : null,
+  Modal: ({
+    children,
+  }: {
+    children:
+      | ((opts: { isEntering: boolean; isExiting: boolean }) => React.ReactNode)
+      | React.ReactNode;
+  }) =>
+    typeof children === "function" ? (
+      <div>{children({ isEntering: false, isExiting: false })}</div>
+    ) : (
+      <div>{children}</div>
+    ),
+  Dialog: ({
+    children,
+  }: {
+    children: ((opts: { close: () => void }) => React.ReactNode) | React.ReactNode;
+  }) =>
+    typeof children === "function" ? (
+      <div>{children({ close: vi.fn() })}</div>
+    ) : (
+      <div>{children}</div>
+    ),
+  Heading: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode;
+    slot?: string;
+    className?: string;
+  }) => <h2 {...props}>{children}</h2>,
+  Button: ({
+    children,
+    onPress,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+    className?: string;
+  }) => (
+    <button onClick={onPress} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+// Mock tracker components
+vi.mock("@/app/characters/[id]/components/trackers/AddictionTracker", () => ({
+  AddictionTracker: () => <div data-testid="addiction-tracker">Addiction Tracker</div>,
+}));
+vi.mock("@/app/characters/[id]/components/trackers/AllergyTracker", () => ({
+  AllergyTracker: () => <div data-testid="allergy-tracker">Allergy Tracker</div>,
+}));
+vi.mock("@/app/characters/[id]/components/trackers/DependentTracker", () => ({
+  DependentTracker: () => <div data-testid="dependent-tracker">Dependent Tracker</div>,
+}));
+vi.mock("@/app/characters/[id]/components/trackers/CodeOfHonorTracker", () => ({
+  CodeOfHonorTracker: () => <div data-testid="code-of-honor-tracker">Code of Honor Tracker</div>,
+}));
+
+function makeCharacter(overrides: Partial<Character> = {}): Character {
+  return {
+    id: "char-1",
+    userId: "user-1",
+    name: "Test Runner",
+    edition: "sr5",
+    creationMethod: "priority",
+    status: "active",
+    metatype: "human",
+    magicalPath: "mundane",
+    nuyen: 10000,
+    startingNuyen: 50000,
+    karmaCurrent: 10,
+    karmaTotal: 25,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    attributes: {} as Character["attributes"],
+    skills: [],
+    positiveQualities: [],
+    negativeQualities: [],
+    gear: [],
+    contacts: [],
+    weapons: [],
+    armor: [],
+    lifestyles: [],
+    identities: [],
+    ...overrides,
+  } as Character;
+}
+
+function makeAddictionSelection(overrides: Partial<QualitySelection> = {}): QualitySelection {
+  return {
+    qualityId: "addiction",
+    source: "creation",
+    dynamicState: {
+      type: "addiction" as const,
+      state: {
+        substance: "Psyche",
+        substanceType: "psychological",
+        severity: "mild",
+        originalSeverity: "mild",
+        withdrawalActive: false,
+        lastDose: "2024-01-01T00:00:00Z",
+        nextCravingCheck: "2024-01-02T00:00:00Z",
+        cravingActive: false,
+        withdrawalPenalty: 0,
+        daysClean: 0,
+        recoveryAttempts: 0,
+      },
+    },
+    ...overrides,
+  } as QualitySelection;
+}
+
+describe("DynamicStateModal effect badges (#492)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEffectBadges = [];
+  });
+
+  test("renders effect badges when quality has unified effects", () => {
+    mockEffectBadges = [
+      {
+        label: "-2 Body",
+        colorClass: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300",
+        trigger: "withdrawal",
+        triggerActive: false,
+      },
+    ];
+
+    const selection = makeAddictionSelection();
+
+    render(
+      <DynamicStateModal
+        character={makeCharacter({ negativeQualities: [selection] })}
+        selection={selection}
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId("active-effects-section")).toBeTruthy();
+    expect(screen.getByText("Active Effects")).toBeTruthy();
+    expect(screen.getByText("-2 Body")).toBeTruthy();
+    expect(screen.getByText("· withdrawal")).toBeTruthy();
+  });
+
+  test("shows trigger as active when character state matches", async () => {
+    const { buildCharacterStateFlags } = await import("@/lib/rules/effects");
+    vi.mocked(buildCharacterStateFlags).mockReturnValue({ withdrawalActive: true });
+
+    mockEffectBadges = [
+      {
+        label: "-2 Body",
+        colorClass: "bg-emerald-100 text-emerald-700",
+        trigger: "withdrawal",
+        triggerActive: true,
+      },
+    ];
+
+    const selection = makeAddictionSelection({
+      dynamicState: {
+        type: "addiction" as const,
+        state: {
+          substance: "Psyche",
+          substanceType: "psychological",
+          severity: "mild",
+          originalSeverity: "mild",
+          withdrawalActive: true,
+          lastDose: "2024-01-01T00:00:00Z",
+          nextCravingCheck: "2024-01-02T00:00:00Z",
+          cravingActive: false,
+          withdrawalPenalty: 2,
+          daysClean: 0,
+          recoveryAttempts: 0,
+        },
+      },
+    });
+
+    render(
+      <DynamicStateModal
+        character={makeCharacter({ negativeQualities: [selection] })}
+        selection={selection}
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    const triggerSpan = screen.getByText("· withdrawal");
+    expect(triggerSpan.className).toContain("font-semibold");
+    expect(triggerSpan.className).toContain("text-red-400");
+  });
+
+  test("no effect badges section when quality has no effects", () => {
+    mockEffectBadges = [];
+
+    const selection: QualitySelection = {
+      qualityId: "code-of-honor",
+      source: "creation",
+      dynamicState: {
+        type: "code-of-honor",
+        state: {
+          codeName: "Warrior's Code",
+          description: "Follow the warrior's path",
+          violations: [],
+          totalKarmaLost: 0,
+        },
+      },
+    } as QualitySelection;
+
+    render(
+      <DynamicStateModal
+        character={makeCharacter({ negativeQualities: [selection] })}
+        selection={selection}
+        isOpen={true}
+        onOpenChange={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId("active-effects-section")).toBeNull();
+    expect(screen.queryByText("Active Effects")).toBeNull();
+  });
+
+  test("does not render effect section when modal is closed", () => {
+    mockEffectBadges = [
+      {
+        label: "-2 Body",
+        colorClass: "bg-emerald-100 text-emerald-700",
+        trigger: "withdrawal",
+        triggerActive: false,
+      },
+    ];
+
+    const selection = makeAddictionSelection();
+
+    render(
+      <DynamicStateModal
+        character={makeCharacter({ negativeQualities: [selection] })}
+        selection={selection}
+        isOpen={false}
+        onOpenChange={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId("active-effects-section")).toBeNull();
+  });
+});

--- a/__tests__/components/QualitiesDisplay-feedback.test.tsx
+++ b/__tests__/components/QualitiesDisplay-feedback.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Tests for QualitiesDisplay visual feedback (#493)
+ *
+ * Covers: error surfacing, success flash, error banner auto-dismiss
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import type { Character, QualitySelection } from "@/lib/types";
+import {
+  setupDisplayCardMock,
+  LUCIDE_MOCK,
+  createSheetCharacter,
+} from "@/components/character/sheet/__tests__/test-helpers";
+
+// Setup mocks BEFORE imports
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+// Mock with withdrawal-trigger effect so toggle pills render
+vi.mock("@/lib/rules", () => ({
+  useQualities: () => ({
+    positive: [],
+    negative: [
+      {
+        id: "addiction",
+        name: "Addiction",
+        karmaBonus: 9,
+        summary: "Character is addicted to a substance.",
+        dynamicState: "addiction",
+        effects: [
+          {
+            type: "dice-pool-modifier",
+            value: -2,
+            triggers: ["withdrawal"],
+            target: { attribute: "body" },
+          },
+        ],
+      },
+    ],
+  }),
+}));
+vi.mock("@/app/characters/[id]/components/DynamicStateModal", () => ({
+  DynamicStateModal: () => null,
+}));
+vi.mock("@/lib/rules/effects", () => ({
+  formatEffectBadge: vi.fn(() => null),
+  isUnifiedEffect: (e: unknown) =>
+    typeof e === "object" &&
+    e !== null &&
+    "triggers" in e &&
+    Array.isArray((e as Record<string, unknown>).triggers),
+  resolveRatingBasedValue: vi.fn(() => null),
+  buildCharacterStateFlags: vi.fn(() => ({})),
+}));
+
+import { QualitiesDisplay } from "@/components/character/sheet/QualitiesDisplay";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function makeAddictionSelection(): QualitySelection {
+  return {
+    qualityId: "addiction",
+    source: "creation",
+    dynamicState: {
+      type: "addiction" as const,
+      state: {
+        substance: "Psyche",
+        substanceType: "psychological",
+        severity: "mild",
+        originalSeverity: "mild",
+        withdrawalActive: false,
+        lastDose: "2024-01-01T00:00:00Z",
+        nextCravingCheck: "2024-01-02T00:00:00Z",
+        cravingActive: false,
+        withdrawalPenalty: 0,
+        daysClean: 0,
+        recoveryAttempts: 0,
+      },
+    },
+  } as QualitySelection;
+}
+
+function renderWithAddiction(onUpdate: (c: Character) => void) {
+  const character = createSheetCharacter({
+    negativeQualities: [makeAddictionSelection()],
+  });
+  return render(<QualitiesDisplay character={character} onUpdate={onUpdate} />);
+}
+
+describe("QualitiesDisplay feedback (#493)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("surfaces error when API returns non-ok response", async () => {
+    const onUpdate = vi.fn();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: "Server error occurred" }),
+    });
+
+    renderWithAddiction(onUpdate);
+
+    // Click the withdrawal toggle pill (rendered because effect has withdrawal trigger)
+    const pill = screen.getByTestId("state-toggle-pill");
+    fireEvent.click(pill);
+
+    // Wait for async fetch to resolve
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(screen.getByTestId("toggle-error-banner")).toBeInTheDocument();
+    expect(screen.getByText("Server error occurred")).toBeInTheDocument();
+  });
+
+  test("surfaces error when fetch throws", async () => {
+    const onUpdate = vi.fn();
+    mockFetch.mockRejectedValue(new Error("Network failure"));
+
+    renderWithAddiction(onUpdate);
+
+    const pill = screen.getByTestId("state-toggle-pill");
+    fireEvent.click(pill);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(screen.getByTestId("toggle-error-banner")).toBeInTheDocument();
+    expect(screen.getByText("Network failure")).toBeInTheDocument();
+  });
+
+  test("clears error on successful toggle", async () => {
+    const onUpdate = vi.fn();
+    const character = createSheetCharacter({
+      negativeQualities: [makeAddictionSelection()],
+    });
+
+    // First call fails
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: "Temporary error" }),
+    });
+
+    render(<QualitiesDisplay character={character} onUpdate={onUpdate} />);
+
+    const pill = screen.getByTestId("state-toggle-pill");
+    fireEvent.click(pill);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(screen.getByTestId("toggle-error-banner")).toBeInTheDocument();
+
+    // Second call succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ character }),
+    });
+
+    fireEvent.click(pill);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(screen.queryByTestId("toggle-error-banner")).not.toBeInTheDocument();
+  });
+
+  test("error banner auto-dismisses after 4 seconds", async () => {
+    const onUpdate = vi.fn();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: "Temporary error" }),
+    });
+
+    renderWithAddiction(onUpdate);
+
+    const pill = screen.getByTestId("state-toggle-pill");
+    fireEvent.click(pill);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(screen.getByTestId("toggle-error-banner")).toBeInTheDocument();
+
+    // Advance past the auto-dismiss timeout
+    act(() => {
+      vi.advanceTimersByTime(4100);
+    });
+
+    expect(screen.queryByTestId("toggle-error-banner")).not.toBeInTheDocument();
+  });
+
+  test("success flash is applied on successful toggle", async () => {
+    const onUpdate = vi.fn();
+    const character = createSheetCharacter({
+      negativeQualities: [makeAddictionSelection()],
+    });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ character }),
+    });
+
+    render(<QualitiesDisplay character={character} onUpdate={onUpdate} />);
+
+    const pill = screen.getByTestId("state-toggle-pill");
+    fireEvent.click(pill);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    // The pill should have the ring-emerald class for the flash
+    expect(pill.className).toContain("ring-emerald");
+
+    // Flash clears after 600ms
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+
+    expect(pill.className).not.toContain("ring-emerald");
+  });
+
+  test("fallback error message when response body has no error field", async () => {
+    const onUpdate = vi.fn();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({}),
+    });
+
+    renderWithAddiction(onUpdate);
+
+    const pill = screen.getByTestId("state-toggle-pill");
+    fireEvent.click(pill);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(screen.getByText("Failed to update state (400)")).toBeInTheDocument();
+  });
+});

--- a/app/characters/[id]/components/DynamicStateModal.tsx
+++ b/app/characters/[id]/components/DynamicStateModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Button, Dialog, Heading, Modal, ModalOverlay } from "react-aria-components";
 import { X, Settings2 } from "lucide-react";
 import type {
@@ -11,6 +11,14 @@ import type {
   DependentState,
   CodeOfHonorState,
 } from "@/lib/types";
+import { useQualities } from "@/lib/rules";
+import {
+  formatEffectBadge,
+  isUnifiedEffect,
+  resolveRatingBasedValue,
+  buildCharacterStateFlags,
+} from "@/lib/rules/effects";
+import type { EffectBadgeContext } from "@/lib/rules/effects";
 import { AddictionTracker } from "./trackers/AddictionTracker";
 import { AllergyTracker } from "./trackers/AllergyTracker";
 import { DependentTracker } from "./trackers/DependentTracker";
@@ -33,6 +41,15 @@ export function DynamicStateModal({
 }: DynamicStateModalProps) {
   const [error, setError] = useState<string | null>(null);
   const [isInitializing, setIsInitializing] = useState(false);
+  const [successFlash, setSuccessFlash] = useState(false);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up timer on unmount
+  useEffect(() => {
+    return () => {
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    };
+  }, []);
 
   const handleUpdate = async (
     updates: Partial<AddictionState | AllergyState | DependentState | CodeOfHonorState>
@@ -55,6 +72,9 @@ export function DynamicStateModal({
 
       if (result.character) {
         onUpdate(result.character);
+        setSuccessFlash(true);
+        if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+        flashTimerRef.current = setTimeout(() => setSuccessFlash(false), 600);
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "An unknown error occurred";
@@ -70,6 +90,36 @@ export function DynamicStateModal({
       handleUpdate({}).finally(() => setIsInitializing(false));
     }
   }, [isOpen, selection.dynamicState]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Compute effect badges for this quality
+  const { positive: positiveData, negative: negativeData } = useQualities();
+  const allCatalog = [...positiveData, ...negativeData];
+  const qualityData = allCatalog.find((q) => q.id === selection.qualityId);
+  const rawEffects = ((qualityData?.effects || []) as unknown[]).filter(isUnifiedEffect);
+
+  const characterStateFlags = buildCharacterStateFlags(character);
+  const charRating = selection.rating;
+  const addictionState =
+    selection.dynamicState?.type === "addiction" ? selection.dynamicState.state : undefined;
+  const ratingEntry =
+    qualityData?.ratings && charRating !== undefined
+      ? (qualityData.ratings as Record<string, Record<string, unknown>>)[String(charRating)]
+      : undefined;
+
+  const effectBadges = rawEffects
+    .map((effect) => {
+      const ctx: EffectBadgeContext = {
+        rating: charRating,
+        dependencyType: addictionState?.substanceType,
+        activeCharacterStates: characterStateFlags,
+      };
+      if (typeof effect.value === "string" && ratingEntry) {
+        const resolved = resolveRatingBasedValue(effect, ratingEntry);
+        if (resolved !== null) ctx.resolvedValue = resolved;
+      }
+      return formatEffectBadge(effect, ctx);
+    })
+    .filter((b): b is NonNullable<typeof b> => b !== null);
 
   const renderTracker = () => {
     const type = selection.dynamicState?.type;
@@ -141,10 +191,44 @@ export function DynamicStateModal({
               </div>
 
               {/* Content */}
-              <div className="flex-1 overflow-y-auto p-6">
+              <div
+                data-testid="modal-content"
+                className={`flex-1 overflow-y-auto p-6 transition-colors duration-300${successFlash ? " border-l-2 border-emerald-500/40" : ""}`}
+              >
                 {error && (
                   <div className="mb-6 p-3 bg-red-500/10 border border-red-500/20 rounded text-red-500 text-xs font-medium">
                     {error}
+                  </div>
+                )}
+
+                {effectBadges.length > 0 && (
+                  <div
+                    data-testid="active-effects-section"
+                    className="mb-4 p-3 bg-muted/20 rounded border border-border/30 space-y-2"
+                  >
+                    <div className="text-[9px] font-bold uppercase tracking-widest text-muted-foreground">
+                      Active Effects
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      {effectBadges.map((badge, idx) => (
+                        <span
+                          key={idx}
+                          data-testid="effect-badge"
+                          className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium ${badge.colorClass}`}
+                        >
+                          {badge.label}
+                          {badge.trigger && (
+                            <span
+                              className={
+                                badge.triggerActive ? "font-semibold text-red-400" : "opacity-50"
+                              }
+                            >
+                              · {badge.trigger}
+                            </span>
+                          )}
+                        </span>
+                      ))}
+                    </div>
                   </div>
                 )}
 

--- a/components/character/sheet/QualitiesDisplay.tsx
+++ b/components/character/sheet/QualitiesDisplay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { Character, QualitySelection } from "@/lib/types";
 import type { QualityData } from "@/lib/rules/loader-types";
 import type { CharacterStateFlags } from "@/lib/types/effects";
@@ -64,11 +64,13 @@ function StateTogglePill({
   active,
   activeColor,
   onToggle,
+  flash,
 }: {
   label: string;
   active: boolean;
   activeColor: "red" | "amber";
   onToggle: () => void;
+  flash?: boolean;
 }) {
   const colors = {
     red: {
@@ -90,9 +92,9 @@ function StateTogglePill({
         e.stopPropagation();
         onToggle();
       }}
-      className={`shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-bold uppercase transition-colors ${
+      className={`shrink-0 rounded border px-1.5 py-0.5 text-[9px] font-bold uppercase transition-all ${
         active ? colors[activeColor].active : colors[activeColor].inactive
-      }`}
+      }${flash ? " ring-2 ring-emerald-500/60" : ""}`}
       title={`${active ? "Deactivate" : "Activate"} ${label}`}
     >
       {label}
@@ -134,6 +136,7 @@ function QualityRow({
   onSettingsClick,
   onStateToggle,
   onFirstMeetingToggle,
+  successFlash,
 }: {
   selection: QualitySelection;
   data: QualityData | undefined;
@@ -144,6 +147,7 @@ function QualityRow({
   onSettingsClick: (sel: QualitySelection) => void;
   onStateToggle?: (qualityId: string, field: string, value: boolean) => void;
   onFirstMeetingToggle?: () => void;
+  successFlash?: string | null;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -293,6 +297,7 @@ function QualityRow({
                   active={withdrawalActive}
                   activeColor="red"
                   onToggle={() => onStateToggle(id, "withdrawalActive", !withdrawalActive)}
+                  flash={successFlash === `${id}:withdrawalActive`}
                 />
               )}
               {hasExposureTrigger && onStateToggle && (
@@ -301,6 +306,7 @@ function QualityRow({
                   active={exposedActive}
                   activeColor="amber"
                   onToggle={() => onStateToggle(id, "currentlyExposed", !exposedActive)}
+                  flash={successFlash === `${id}:currentlyExposed`}
                 />
               )}
             </>
@@ -403,6 +409,18 @@ export function QualitiesDisplay({
   const [activeSelection, setActiveSelection] = useState<QualitySelection | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [localFirstMeeting, setLocalFirstMeeting] = useState(false);
+  const [toggleError, setToggleError] = useState<string | null>(null);
+  const [successFlash, setSuccessFlash] = useState<string | null>(null);
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up timers on unmount
+  useEffect(() => {
+    return () => {
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    };
+  }, []);
 
   // Use controlled state if provided, otherwise fall back to local state
   const firstMeeting = controlledFirstMeeting ?? localFirstMeeting;
@@ -423,11 +441,28 @@ export function QualitiesDisplay({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ [field]: value }),
         });
-        if (!res.ok) return;
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          const message = body?.error || `Failed to update state (${res.status})`;
+          setToggleError(message);
+          if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+          errorTimerRef.current = setTimeout(() => setToggleError(null), 4000);
+          return;
+        }
         const data = await res.json();
+        setToggleError(null);
         onUpdate(data.character);
-      } catch {
-        // Toggle failed — UI stays unchanged
+
+        // Brief success flash
+        const flashKey = `${qualityId}:${field}`;
+        setSuccessFlash(flashKey);
+        if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+        flashTimerRef.current = setTimeout(() => setSuccessFlash(null), 600);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "An unknown error occurred";
+        setToggleError(message);
+        if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+        errorTimerRef.current = setTimeout(() => setToggleError(null), 4000);
       }
     },
     [character.id, onUpdate]
@@ -459,6 +494,14 @@ export function QualitiesDisplay({
         icon={<ShieldCheck className="h-4 w-4 text-zinc-400" />}
         collapsible
       >
+        {toggleError && (
+          <div
+            data-testid="toggle-error-banner"
+            className="mb-3 p-3 bg-red-500/10 border border-red-500/20 rounded text-red-500 text-xs font-medium"
+          >
+            {toggleError}
+          </div>
+        )}
         {!hasQualities ? (
           <p className="px-1 text-sm italic text-zinc-500">No qualities selected</p>
         ) : (
@@ -492,6 +535,7 @@ export function QualitiesDisplay({
                             characterStateFlags={characterStateFlags}
                             onSettingsClick={handleSettingsClick}
                             onStateToggle={onUpdate ? handleStateToggle : undefined}
+                            successFlash={successFlash}
                             onFirstMeetingToggle={() => {
                               const newValue = !firstMeeting;
                               if (onFirstMeetingChange) {


### PR DESCRIPTION
## Summary
- **#493**: Surface errors from `handleStateToggle` with auto-dismissing error banner (4s), add emerald ring success flash on StateTogglePill (600ms) after successful API toggle
- **#493**: Add emerald border flash on DynamicStateModal content area after successful tracker updates
- **#492**: Compute and render "Active Effects" badge section inside DynamicStateModal above tracker controls, showing effect consequences (with trigger state) reactively

## Changes
- `QualitiesDisplay.tsx`: Error surfacing (was silently swallowed), success flash prop threaded through QualityRow → StateTogglePill
- `DynamicStateModal.tsx`: Success flash on content div, effect badge computation using `useQualities` + `formatEffectBadge`, "Active Effects" section with reactive trigger state

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` — all 8513 tests pass (398 files)
- [x] `pnpm lint` — 0 errors
- [x] New test: `QualitiesDisplay-feedback.test.tsx` (6 tests) — error surfacing, auto-dismiss, success flash
- [x] New test: `DynamicStateModal-effects.test.tsx` (4 tests) — effect badges render, trigger active styling, no-effects case, closed modal

Closes #493
Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)