### PR TITLE
feat: add live dice pool display during character creation (#444)

### DIFF
--- a/__tests__/components/creation/DerivedStatsCard-pools.test.tsx
+++ b/__tests__/components/creation/DerivedStatsCard-pools.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DerivedStatsCard } from "@/components/creation/DerivedStatsCard";
+import type { CreationState } from "@/lib/types";
+
+// Mock lucide-react icons
+vi.mock("lucide-react", () => {
+  const createIcon = (name: string) => {
+    const Icon = (props: Record<string, unknown>) => (
+      <span data-testid={`icon-${name}`} {...props} />
+    );
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    Activity: createIcon("Activity"),
+    Shield: createIcon("Shield"),
+    Heart: createIcon("Heart"),
+    Brain: createIcon("Brain"),
+    Footprints: createIcon("Footprints"),
+    Sparkles: createIcon("Sparkles"),
+    ChevronDown: createIcon("ChevronDown"),
+    ChevronUp: createIcon("ChevronUp"),
+    Dice5: createIcon("Dice5"),
+  };
+});
+
+// Mock CreationCard to render children directly
+vi.mock("@/components/creation/shared", () => ({
+  CreationCard: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div data-testid={`creation-card-${title.toLowerCase().replace(/\s+/g, "-")}`}>
+      <h2>{title}</h2>
+      {children}
+    </div>
+  ),
+}));
+
+// Mock the augmented attributes hook
+const mockAugmentedAttributes: Record<string, number> = {
+  body: 3,
+  agility: 5,
+  reaction: 4,
+  strength: 3,
+  willpower: 3,
+  logic: 4,
+  intuition: 4,
+  charisma: 2,
+};
+
+vi.mock("@/components/creation/hooks/useAugmentedAttributes", () => ({
+  useAugmentedAttributes: vi.fn(() => ({
+    attributes: { ...mockAugmentedAttributes },
+    augmentationEffects: {
+      essenceLoss: 0,
+      remainingEssence: 6,
+      initiativeDiceBonus: 0,
+      attributeBonuses: {},
+    },
+    unifiedAttributeBonuses: {},
+    effectSources: [],
+    passiveEffects: null,
+    unifiedInitiativeBonus: 0,
+  })),
+}));
+
+// Mock useSkills
+vi.mock("@/lib/rules", () => ({
+  useSkills: vi.fn(() => ({
+    activeSkills: [
+      { id: "firearms", name: "Firearms", linkedAttribute: "agility", group: "firearms-group" },
+      {
+        id: "perception",
+        name: "Perception",
+        linkedAttribute: "intuition",
+        group: "outdoors-group",
+      },
+      {
+        id: "spellcasting",
+        name: "Spellcasting",
+        linkedAttribute: "magic",
+        group: "sorcery-group",
+      },
+      { id: "sneaking", name: "Sneaking", linkedAttribute: "agility", group: "stealth-group" },
+    ],
+    skillGroups: [
+      { id: "firearms-group", name: "Firearms Group", skills: ["firearms"] },
+      {
+        id: "stealth-group",
+        name: "Stealth Group",
+        skills: ["sneaking", "palming", "disguise"],
+      },
+    ],
+  })),
+}));
+
+// Mock Tooltip to render children directly
+vi.mock("@/components/ui", () => ({
+  Tooltip: ({ children, content }: { children: React.ReactNode; content: React.ReactNode }) => (
+    <span title={typeof content === "string" ? content : "tooltip"}>{children}</span>
+  ),
+}));
+
+// Mock skill utils
+vi.mock("@/lib/rules/skills/group-utils", () => ({
+  getGroupRating: vi.fn((value: unknown) => {
+    if (typeof value === "number") return value;
+    if (typeof value === "object" && value !== null && "rating" in value)
+      return (value as { rating: number }).rating;
+    return 0;
+  }),
+  isGroupBroken: vi.fn((value: unknown) => {
+    if (typeof value === "object" && value !== null && "isBroken" in value)
+      return (value as { isBroken: boolean }).isBroken;
+    return false;
+  }),
+}));
+
+// Helper to create a minimal state
+function makeState(
+  overrides: Partial<CreationState["selections"]> = {},
+  priorities: Record<string, string> = {}
+): CreationState {
+  return {
+    editionCode: "sr5",
+    method: "priority",
+    priorities,
+    selections: {
+      metatype: "human",
+      attributes: {
+        body: 3,
+        agility: 5,
+        reaction: 4,
+        strength: 3,
+        willpower: 3,
+        logic: 4,
+        intuition: 4,
+        charisma: 2,
+      },
+      ...overrides,
+    },
+  } as unknown as CreationState;
+}
+
+describe("DerivedStatsCard - Dice Pools", () => {
+  const mockUpdateState = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows Dice Pools section with defense pool when attributes are set", () => {
+    const state = makeState();
+    render(<DerivedStatsCard state={state} updateState={mockUpdateState} />);
+
+    // Defense pool should be visible in the collapsed button text
+    expect(screen.getByText("Dice Pools")).toBeInTheDocument();
+    expect(screen.getByText("Def 8")).toBeInTheDocument(); // REA(4) + INT(4) = 8
+  });
+
+  it("shows skill pools when expanded", () => {
+    const state = makeState({
+      skills: { firearms: 4, perception: 3 },
+    });
+
+    render(<DerivedStatsCard state={state} updateState={mockUpdateState} />);
+
+    // Click to expand dice pools
+    const poolsButton = screen.getByText("Dice Pools").closest("button");
+    expect(poolsButton).toBeTruthy();
+    fireEvent.click(poolsButton!);
+
+    // Defense pool should show
+    expect(screen.getByText("Defense")).toBeInTheDocument();
+
+    // Skill pools should show
+    expect(screen.getByText("Firearms")).toBeInTheDocument();
+    expect(screen.getByText("Perception")).toBeInTheDocument();
+  });
+
+  it("shows correct pool values for skills", () => {
+    const state = makeState({
+      skills: { firearms: 4 },
+    });
+
+    render(<DerivedStatsCard state={state} updateState={mockUpdateState} />);
+
+    // Expand pools
+    const poolsButton = screen.getByText("Dice Pools").closest("button");
+    fireEvent.click(poolsButton!);
+
+    // Firearms pool: AGI(5) + Firearms(4) = 9
+    expect(screen.getByText("9d")).toBeInTheDocument();
+  });
+
+  it("shows defense pool formula as title", () => {
+    const state = makeState();
+    render(<DerivedStatsCard state={state} updateState={mockUpdateState} />);
+
+    // Expand pools
+    const poolsButton = screen.getByText("Dice Pools").closest("button");
+    fireEvent.click(poolsButton!);
+
+    const defenseRow = screen.getByText("Defense").closest("div");
+    expect(defenseRow?.getAttribute("title")).toBe("Reaction (4) + Intuition (4)");
+  });
+
+  it("shows prompt to add skills when no skills selected", () => {
+    const state = makeState();
+    render(<DerivedStatsCard state={state} updateState={mockUpdateState} />);
+
+    // Expand pools
+    const poolsButton = screen.getByText("Dice Pools").closest("button");
+    fireEvent.click(poolsButton!);
+
+    expect(screen.getByText("Add skills to see skill pools")).toBeInTheDocument();
+  });
+
+  it("sorts pools by value descending", () => {
+    const state = makeState({
+      skills: { firearms: 4, perception: 3, sneaking: 1 },
+    });
+
+    render(<DerivedStatsCard state={state} updateState={mockUpdateState} />);
+
+    // Expand pools
+    const poolsButton = screen.getByText("Dice Pools").closest("button");
+    fireEvent.click(poolsButton!);
+
+    const poolTexts = screen.getAllByText(/^\d+d$/);
+    const poolValues = poolTexts.map((el) => parseInt(el.textContent!));
+    // First value is defense pool (8), then sorted skill pools: 9, 7, 6
+    expect(poolValues).toEqual([8, 9, 7, 6]);
+  });
+
+  it("includes group skill pools from non-broken groups", () => {
+    const state = makeState({
+      skillGroups: { "stealth-group": 3 },
+    });
+
+    render(<DerivedStatsCard state={state} updateState={mockUpdateState} />);
+
+    // Expand pools
+    const poolsButton = screen.getByText("Dice Pools").closest("button");
+    fireEvent.click(poolsButton!);
+
+    // Sneaking (from stealth group): AGI(5) + rating(3) = 8
+    expect(screen.getByText("Sneaking")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/creation/hooks/useAugmentedAttributes.test.tsx
+++ b/__tests__/components/creation/hooks/useAugmentedAttributes.test.tsx
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAugmentedAttributes } from "@/components/creation/hooks/useAugmentedAttributes";
+import type { CreationState } from "@/lib/types";
+
+// Mock the rules module
+vi.mock("@/lib/rules", () => ({
+  useMetatypes: vi.fn(() => [
+    {
+      id: "human",
+      name: "Human",
+      attributes: {
+        body: { min: 1, max: 6 },
+        agility: { min: 1, max: 6 },
+        reaction: { min: 1, max: 6 },
+        strength: { min: 1, max: 6 },
+        willpower: { min: 1, max: 6 },
+        logic: { min: 1, max: 6 },
+        intuition: { min: 1, max: 6 },
+        charisma: { min: 1, max: 6 },
+        edge: { min: 2, max: 7 },
+      },
+    },
+  ]),
+  useRuleset: vi.fn(() => ({ ruleset: null })),
+  usePriorityTable: vi.fn(() => null),
+  useMagicPaths: vi.fn(() => []),
+}));
+
+// Mock the effects module
+vi.mock("@/lib/rules/effects", () => ({
+  buildCreationCharacter: vi.fn(() => ({
+    positiveQualities: [],
+    negativeQualities: [],
+    cyberware: [],
+    bioware: [],
+    adeptPowers: [],
+    gear: [],
+    weapons: [],
+    armor: [],
+    wirelessBonusesEnabled: true,
+  })),
+  gatherEffectSources: vi.fn(() => []),
+  resolveFromSources: vi.fn(() => ({
+    dicePoolModifiers: [],
+    limitModifiers: [],
+    thresholdModifiers: [],
+    accuracyModifiers: [],
+    initiativeModifiers: [],
+    totalDicePoolModifier: 0,
+    totalLimitModifier: 0,
+    totalThresholdModifier: 0,
+    totalAccuracyModifier: 0,
+    totalInitiativeModifier: 0,
+    excludedByStacking: [],
+  })),
+  EffectContextBuilder: {
+    forInitiative: vi.fn(() => ({
+      build: vi.fn(() => ({ action: { type: "initiative" } })),
+    })),
+  },
+}));
+
+// Helper to create a minimal state
+function makeState(
+  overrides: Record<string, unknown> = {},
+  priorities: Record<string, string> = {}
+): CreationState {
+  return {
+    editionCode: "sr5",
+    method: "priority",
+    priorities,
+    selections: {
+      metatype: "human",
+      ...overrides,
+    },
+  } as unknown as CreationState;
+}
+
+describe("useAugmentedAttributes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns base attribute values with no augmentations", () => {
+    const state = makeState({
+      attributes: {
+        body: 3,
+        agility: 5,
+        reaction: 4,
+        strength: 2,
+        willpower: 3,
+        logic: 4,
+        intuition: 3,
+        charisma: 2,
+      },
+    });
+
+    const { result } = renderHook(() => useAugmentedAttributes(state));
+
+    expect(result.current.attributes.body).toBe(3);
+    expect(result.current.attributes.agility).toBe(5);
+    expect(result.current.attributes.reaction).toBe(4);
+    expect(result.current.attributes.strength).toBe(2);
+    expect(result.current.attributes.willpower).toBe(3);
+    expect(result.current.attributes.logic).toBe(4);
+    expect(result.current.attributes.intuition).toBe(3);
+    expect(result.current.attributes.charisma).toBe(2);
+  });
+
+  it("falls back to metatype minimums when no attributes set", () => {
+    const state = makeState({ attributes: {} });
+
+    const { result } = renderHook(() => useAugmentedAttributes(state));
+
+    // Human metatype minimums are all 1
+    expect(result.current.attributes.body).toBe(1);
+    expect(result.current.attributes.agility).toBe(1);
+    expect(result.current.attributes.reaction).toBe(1);
+  });
+
+  it("includes cyberware attribute bonuses", () => {
+    const state = makeState({
+      attributes: { agility: 4 },
+      cyberware: [
+        {
+          id: "muscle-toner",
+          name: "Muscle Toner",
+          essenceCost: 0.5,
+          attributeBonuses: { agility: 2 },
+          catalogId: "muscle-toner",
+          category: "bodyware",
+          grade: "standard",
+          baseEssenceCost: 0.5,
+          rating: 2,
+          availability: 12,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useAugmentedAttributes(state));
+
+    expect(result.current.attributes.agility).toBe(6); // 4 + 2
+    expect(result.current.augmentationEffects.essenceLoss).toBe(0.5);
+    expect(result.current.augmentationEffects.remainingEssence).toBe(5.5);
+  });
+
+  it("includes bioware attribute bonuses", () => {
+    const state = makeState({
+      attributes: { agility: 3 },
+      bioware: [
+        {
+          id: "muscle-augmentation",
+          name: "Muscle Augmentation",
+          essenceCost: 0.2,
+          attributeBonuses: { agility: 1, strength: 1 },
+          catalogId: "muscle-augmentation",
+          category: "bioware",
+          grade: "standard",
+          baseEssenceCost: 0.2,
+          rating: 1,
+          availability: 8,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useAugmentedAttributes(state));
+
+    expect(result.current.attributes.agility).toBe(4); // 3 + 1
+    // strength falls back to metatype min (1) + bonus (1) = 2
+    expect(result.current.attributes.strength).toBe(2);
+  });
+
+  it("includes special attributes when allocated", () => {
+    const state = makeState({
+      specialAttributes: { edge: 3 },
+    });
+
+    const { result } = renderHook(() => useAugmentedAttributes(state));
+
+    // edge: metatype base (2) + allocated (3) = 5
+    expect(result.current.attributes.edge).toBe(5);
+  });
+
+  it("includes magic attribute from priority table", async () => {
+    // Mock priority table with magic rating
+    const { usePriorityTable } = await import("@/lib/rules");
+    (usePriorityTable as ReturnType<typeof vi.fn>).mockReturnValue({
+      table: {
+        A: {
+          magic: {
+            options: [{ path: "magician", magicRating: 6 }],
+          },
+        },
+      },
+    });
+
+    const state = makeState(
+      {
+        "magical-path": "magician",
+        specialAttributes: { magic: 1 },
+      },
+      { magic: "A" }
+    );
+
+    const { result } = renderHook(() => useAugmentedAttributes(state));
+
+    // magic: base (6) + allocated (1) = 7
+    expect(result.current.attributes.magic).toBe(7);
+  });
+
+  it("tracks initiative dice bonuses from cyberware", () => {
+    const state = makeState({
+      cyberware: [
+        {
+          id: "wired-reflexes-1",
+          name: "Wired Reflexes 1",
+          essenceCost: 2.0,
+          initiativeDiceBonus: 1,
+          catalogId: "wired-reflexes-1",
+          category: "bodyware",
+          grade: "standard",
+          baseEssenceCost: 2.0,
+          rating: 1,
+          availability: 8,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useAugmentedAttributes(state));
+
+    expect(result.current.augmentationEffects.initiativeDiceBonus).toBe(1);
+  });
+
+  it("returns effect sources from creation effects", () => {
+    const state = makeState();
+
+    const { result } = renderHook(() => useAugmentedAttributes(state));
+
+    expect(result.current.effectSources).toEqual([]);
+    expect(result.current.passiveEffects).toBeNull();
+  });
+
+  it("does not include magic attribute when value is zero", () => {
+    const state = makeState({
+      specialAttributes: {},
+    });
+
+    const { result } = renderHook(() => useAugmentedAttributes(state));
+
+    // magic should not be in the result since base + allocated = 0
+    expect(result.current.attributes.magic).toBeUndefined();
+  });
+});

--- a/components/creation/DerivedStatsCard.tsx
+++ b/components/creation/DerivedStatsCard.tsx
@@ -12,12 +12,13 @@
  * - Condition Monitors: Physical CM, Stun CM, Overflow
  * - Secondary Stats: Composure, Judge Intentions, Memory, Lift/Carry
  * - Movement: Walk, Run speeds
+ * - Dice Pools: Defense pool + top selected skill pools
  */
 
 import { useMemo, useState } from "react";
-import { useMetatypes, useRuleset } from "@/lib/rules";
-import type { CreationState, CyberwareItem, BiowareItem } from "@/lib/types";
-import type { CreationSelections } from "@/lib/types/creation-selections";
+import { useSkills } from "@/lib/rules";
+import type { CreationState } from "@/lib/types";
+import type { SkillGroupValue } from "@/lib/types/creation-selections";
 import { CreationCard } from "./shared";
 import {
   Activity,
@@ -28,8 +29,11 @@ import {
   Sparkles,
   ChevronDown,
   ChevronUp,
+  Dice5,
 } from "lucide-react";
-import { useCreationEffects } from "./hooks/useCreationEffects";
+import { useAugmentedAttributes } from "./hooks/useAugmentedAttributes";
+import { getCoreAttributeName } from "@/lib/constants/attributes";
+import { getGroupRating, isGroupBroken } from "@/lib/rules/skills/group-utils";
 
 // =============================================================================
 // TYPES
@@ -62,6 +66,34 @@ interface DerivedStats {
   runSpeed: number;
   // Essence
   essence: number;
+}
+
+interface PoolEntry {
+  name: string;
+  pool: number;
+  formula: string;
+}
+
+// =============================================================================
+// ATTRIBUTE DISPLAY NAME HELPER
+// =============================================================================
+
+const ATTRIBUTE_DISPLAY_NAMES: Record<string, string> = {
+  body: "Body",
+  agility: "Agility",
+  reaction: "Reaction",
+  strength: "Strength",
+  willpower: "Willpower",
+  logic: "Logic",
+  intuition: "Intuition",
+  charisma: "Charisma",
+  magic: "Magic",
+  resonance: "Resonance",
+  edge: "Edge",
+};
+
+function getAttributeDisplayName(key: string): string {
+  return ATTRIBUTE_DISPLAY_NAMES[key] || getCoreAttributeName(key);
 }
 
 // =============================================================================
@@ -99,135 +131,31 @@ function StatBlock({
 // =============================================================================
 
 export function DerivedStatsCard({ state }: DerivedStatsCardProps) {
-  const metatypes = useMetatypes();
-  const { ruleset } = useRuleset();
   const selectedMetatype = state.selections.metatype as string;
   const [showEffects, setShowEffects] = useState(false);
+  const [showPools, setShowPools] = useState(false);
+  const { activeSkills, skillGroups } = useSkills();
 
-  // Unified effects from creation selections
-  const { passiveEffects, sources } = useCreationEffects(
-    state.selections as CreationSelections,
-    ruleset
-  );
+  // Use shared augmented attributes hook
+  const {
+    attributes: augmentedAttributes,
+    augmentationEffects,
+    effectSources: sources,
+    unifiedInitiativeBonus,
+  } = useAugmentedAttributes(state);
 
-  // Get metatype data for attribute minimums
-  const metatypeData = useMemo(() => {
-    return metatypes.find((m) => m.id === selectedMetatype);
-  }, [metatypes, selectedMetatype]);
-
-  // Get current attributes from state
-  const attributes = useMemo(() => {
-    return (state.selections.attributes || {}) as Record<string, number>;
-  }, [state.selections.attributes]);
-
-  // Calculate augmentation effects (essence loss, attribute bonuses, initiative dice)
-  const augmentationEffects = useMemo(() => {
-    const cyberware = (state.selections.cyberware || []) as CyberwareItem[];
-    const bioware = (state.selections.bioware || []) as BiowareItem[];
-
-    let essenceLoss = 0;
-    let initiativeDiceBonus = 0;
-    const attributeBonuses: Record<string, number> = {};
-
-    // Process cyberware
-    cyberware.forEach((item) => {
-      essenceLoss += item.essenceCost || 0;
-
-      // Check for initiative dice bonuses
-      if (item.initiativeDiceBonus) {
-        initiativeDiceBonus += item.initiativeDiceBonus;
-      }
-
-      // Check for attribute bonuses
-      if (item.attributeBonuses) {
-        Object.entries(item.attributeBonuses).forEach(([attr, value]) => {
-          attributeBonuses[attr] = (attributeBonuses[attr] || 0) + value;
-        });
-      }
-    });
-
-    // Process bioware
-    bioware.forEach((item) => {
-      essenceLoss += item.essenceCost || 0;
-
-      // Check for attribute bonuses
-      if (item.attributeBonuses) {
-        Object.entries(item.attributeBonuses).forEach(([attr, value]) => {
-          attributeBonuses[attr] = (attributeBonuses[attr] || 0) + value;
-        });
-      }
-    });
-
-    return {
-      essenceLoss,
-      remainingEssence: Math.max(0, 6 - essenceLoss),
-      initiativeDiceBonus,
-      attributeBonuses,
-    };
-  }, [state.selections.cyberware, state.selections.bioware]);
-
-  // Extract per-attribute modifiers from unified effects
-  const unifiedAttributeBonuses = useMemo(() => {
-    const bonuses: Record<string, number> = {};
-    if (!passiveEffects) return bonuses;
-
-    // Attribute modifiers from unified effects (e.g., quality "attribute-modifier" effects)
-    // These are already resolved and stacked
-    for (const resolved of [
-      ...passiveEffects.dicePoolModifiers,
-      ...passiveEffects.limitModifiers,
-      ...passiveEffects.initiativeModifiers,
-    ]) {
-      // Only extract attribute-modifier type effects for stat calculation
-      if (resolved.effect.type === "attribute-modifier" && resolved.effect.target?.attribute) {
-        const attr = resolved.effect.target.attribute;
-        bonuses[attr] = (bonuses[attr] || 0) + resolved.resolvedValue;
-      }
-    }
-
-    return bonuses;
-  }, [passiveEffects]);
-
-  // Unified initiative modifier from effects system
-  const unifiedInitiativeBonus = passiveEffects?.totalInitiativeModifier ?? 0;
-
-  // Calculate derived stats
+  // Calculate derived stats from augmented attributes
   const derivedStats = useMemo((): DerivedStats => {
-    // Helper to get attribute value with metatype minimum fallback
-    const getAttr = (attrId: string): number => {
-      if (attributes[attrId] !== undefined) {
-        return attributes[attrId];
-      }
-      // Fall back to metatype minimum
-      if (metatypeData?.attributes?.[attrId]) {
-        const attrData = metatypeData.attributes[attrId];
-        if (typeof attrData === "object" && "min" in attrData) {
-          return attrData.min;
-        }
-      }
-      return 1; // Default minimum
-    };
-
-    // Merge manual augmentation bonuses with unified effect attribute bonuses
-    // Manual path covers items not yet migrated to unified effects
-    const augBonuses = augmentationEffects.attributeBonuses;
-    const mergedBonuses: Record<string, number> = { ...augBonuses };
-    for (const [attr, val] of Object.entries(unifiedAttributeBonuses)) {
-      mergedBonuses[attr] = (mergedBonuses[attr] || 0) + val;
-    }
-
-    // Base attributes with combined bonuses
-    const body = getAttr("body") + (mergedBonuses.body || 0);
-    const agility = getAttr("agility") + (mergedBonuses.agility || 0);
-    const reaction = getAttr("reaction") + (mergedBonuses.reaction || 0);
-    const strength = getAttr("strength") + (mergedBonuses.strength || 0);
-    const willpower = getAttr("willpower") + (mergedBonuses.willpower || 0);
-    const logic = getAttr("logic") + (mergedBonuses.logic || 0);
-    const intuition = getAttr("intuition") + (mergedBonuses.intuition || 0);
-    const charisma = getAttr("charisma") + (mergedBonuses.charisma || 0);
+    const body = augmentedAttributes.body || 1;
+    const agility = augmentedAttributes.agility || 1;
+    const reaction = augmentedAttributes.reaction || 1;
+    const strength = augmentedAttributes.strength || 1;
+    const willpower = augmentedAttributes.willpower || 1;
+    const logic = augmentedAttributes.logic || 1;
+    const intuition = augmentedAttributes.intuition || 1;
+    const charisma = augmentedAttributes.charisma || 1;
 
     const essence = augmentationEffects.remainingEssence;
-    // Combine manual initiative dice bonus with unified initiative modifier
     const initiativeDice = 1 + augmentationEffects.initiativeDiceBonus + unifiedInitiativeBonus;
 
     return {
@@ -253,16 +181,80 @@ export function DerivedStatsCard({ state }: DerivedStatsCardProps) {
       // Essence
       essence,
     };
+  }, [augmentedAttributes, augmentationEffects, unifiedInitiativeBonus]);
+
+  // Compute dice pools for selected skills
+  const poolEntries = useMemo((): PoolEntry[] => {
+    const skills = (state.selections.skills || {}) as Record<string, number>;
+    const groups = (state.selections.skillGroups || {}) as Record<string, SkillGroupValue>;
+    const entries: PoolEntry[] = [];
+
+    // Individual skills
+    for (const [skillId, rating] of Object.entries(skills)) {
+      const skillData = activeSkills.find((s) => s.id === skillId);
+      if (!skillData || rating <= 0) continue;
+
+      const attrValue = augmentedAttributes[skillData.linkedAttribute] || 0;
+      const pool = attrValue + rating;
+      const attrName = getAttributeDisplayName(skillData.linkedAttribute);
+      entries.push({
+        name: skillData.name,
+        pool,
+        formula: `${attrName} (${attrValue}) + ${skillData.name} (${rating})`,
+      });
+    }
+
+    // Group skills
+    for (const [groupId, groupValue] of Object.entries(groups)) {
+      if (isGroupBroken(groupValue)) continue;
+      const groupData = skillGroups.find((g) => g.id === groupId);
+      if (!groupData) continue;
+      const rating = getGroupRating(groupValue);
+      if (rating <= 0) continue;
+
+      for (const skillId of groupData.skills) {
+        const skillData = activeSkills.find((s) => s.id === skillId);
+        if (!skillData) continue;
+
+        const attrValue = augmentedAttributes[skillData.linkedAttribute] || 0;
+        const pool = attrValue + rating;
+        const attrName = getAttributeDisplayName(skillData.linkedAttribute);
+        entries.push({
+          name: skillData.name,
+          pool,
+          formula: `${attrName} (${attrValue}) + ${skillData.name} (${rating})`,
+        });
+      }
+    }
+
+    // Sort by pool descending, take top 8
+    entries.sort((a, b) => b.pool - a.pool);
+    return entries.slice(0, 8);
   }, [
-    attributes,
-    metatypeData,
-    augmentationEffects,
-    unifiedAttributeBonuses,
-    unifiedInitiativeBonus,
+    state.selections.skills,
+    state.selections.skillGroups,
+    activeSkills,
+    skillGroups,
+    augmentedAttributes,
   ]);
 
+  // Defense pool (always available if attributes exist)
+  const defensePool = useMemo(() => {
+    const reaction = augmentedAttributes.reaction || 0;
+    const intuition = augmentedAttributes.intuition || 0;
+    if (reaction === 0 && intuition === 0) return null;
+    return {
+      pool: reaction + intuition,
+      formula: `Reaction (${reaction}) + Intuition (${intuition})`,
+    };
+  }, [augmentedAttributes]);
+
+  const hasSkillPools = poolEntries.length > 0;
+  const hasPools = defensePool !== null || hasSkillPools;
+
   // Check if we have any attributes selected
-  const hasAttributes = Object.keys(attributes).length > 0 || !!selectedMetatype;
+  const coreAttributes = (state.selections.attributes || {}) as Record<string, number>;
+  const hasAttributes = Object.keys(coreAttributes).length > 0 || !!selectedMetatype;
 
   return (
     <CreationCard
@@ -410,6 +402,69 @@ export function DerivedStatsCard({ state }: DerivedStatsCardProps) {
             />
           </div>
         </div>
+
+        {/* Dice Pools */}
+        {hasPools && (
+          <div className="rounded border border-cyan-200 dark:border-cyan-800">
+            <button
+              onClick={() => setShowPools(!showPools)}
+              className="flex w-full items-center justify-between px-3 py-2 text-xs font-medium text-cyan-700 hover:bg-cyan-50 dark:text-cyan-300 dark:hover:bg-cyan-900/30"
+            >
+              <span className="flex items-center gap-1">
+                <Dice5 className="h-3 w-3" />
+                Dice Pools
+                {defensePool && (
+                  <span className="ml-1 rounded bg-cyan-100 px-1 py-0.5 font-mono text-[10px] dark:bg-cyan-900/40">
+                    Def {defensePool.pool}
+                  </span>
+                )}
+              </span>
+              {showPools ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            </button>
+            {showPools && (
+              <div className="border-t border-cyan-200 px-3 py-2 dark:border-cyan-800">
+                <div className="space-y-1.5">
+                  {/* Defense Pool */}
+                  {defensePool && (
+                    <div className="flex items-center justify-between" title={defensePool.formula}>
+                      <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
+                        Defense
+                      </span>
+                      <span className="flex items-center gap-1.5">
+                        <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+                          REA + INT
+                        </span>
+                        <span className="rounded bg-cyan-100 px-1.5 py-0.5 font-mono text-xs font-bold text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
+                          {defensePool.pool}d
+                        </span>
+                      </span>
+                    </div>
+                  )}
+                  {/* Top Skill Pools */}
+                  {poolEntries.map((entry) => (
+                    <div
+                      key={entry.name}
+                      className="flex items-center justify-between"
+                      title={entry.formula}
+                    >
+                      <span className="truncate text-xs text-zinc-600 dark:text-zinc-400">
+                        {entry.name}
+                      </span>
+                      <span className="ml-2 shrink-0 rounded bg-cyan-100 px-1.5 py-0.5 font-mono text-xs font-bold text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
+                        {entry.pool}d
+                      </span>
+                    </div>
+                  ))}
+                  {!hasSkillPools && (
+                    <div className="text-[10px] text-zinc-400 dark:text-zinc-500">
+                      Add skills to see skill pools
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Essence (if there's essence loss) */}
         {augmentationEffects.essenceLoss > 0 && (

--- a/components/creation/SkillsCard.tsx
+++ b/components/creation/SkillsCard.tsx
@@ -32,6 +32,7 @@ import { AlertTriangle, Star, RefreshCw } from "lucide-react";
 import { useSkillsCardHandlers, type SkillListEntry } from "./skills/useSkillsCardHandlers";
 import { SkillsListSection } from "./skills/SkillsListSection";
 import { SkillsModalsSection } from "./skills/SkillsModalsSection";
+import { useAugmentedAttributes } from "./hooks/useAugmentedAttributes";
 
 // =============================================================================
 // CONSTANTS
@@ -218,6 +219,9 @@ export function SkillsCard({ state, updateState }: SkillsCardProps) {
   );
 
   const { getSkillData } = handlers;
+
+  // Get augmented attributes for dice pool display
+  const { attributes: augmentedAttributes } = useAugmentedAttributes(state);
 
   // Calculate total specializations (for display purposes)
   const totalSpecializations = useMemo(() => {
@@ -490,6 +494,7 @@ export function SkillsCard({ state, updateState }: SkillsCardProps) {
             karmaRemaining={karmaRemaining}
             onOpenGroupModal={() => setIsGroupModalOpen(true)}
             onOpenSkillModal={() => setIsSkillModalOpen(true)}
+            augmentedAttributes={augmentedAttributes}
           />
 
           {/* Footer Summary */}

--- a/components/creation/__tests__/SkillsCard.test.tsx
+++ b/components/creation/__tests__/SkillsCard.test.tsx
@@ -14,10 +14,47 @@ import { SkillsCard } from "../SkillsCard";
 vi.mock("@/lib/rules", () => ({
   useSkills: vi.fn(),
   usePriorityTable: vi.fn(),
+  useMetatypes: vi.fn(() => []),
+  useRuleset: vi.fn(() => ({ ruleset: null })),
+  useMagicPaths: vi.fn(() => []),
 }));
 
 vi.mock("@/lib/contexts", () => ({
   useCreationBudgets: vi.fn(),
+}));
+
+// Mock effects module (needed by useAugmentedAttributes → useCreationEffects)
+vi.mock("@/lib/rules/effects", () => ({
+  buildCreationCharacter: vi.fn(() => ({
+    positiveQualities: [],
+    negativeQualities: [],
+    cyberware: [],
+    bioware: [],
+    adeptPowers: [],
+    gear: [],
+    weapons: [],
+    armor: [],
+    wirelessBonusesEnabled: true,
+  })),
+  gatherEffectSources: vi.fn(() => []),
+  resolveFromSources: vi.fn(() => ({
+    dicePoolModifiers: [],
+    limitModifiers: [],
+    thresholdModifiers: [],
+    accuracyModifiers: [],
+    initiativeModifiers: [],
+    totalDicePoolModifier: 0,
+    totalLimitModifier: 0,
+    totalThresholdModifier: 0,
+    totalAccuracyModifier: 0,
+    totalInitiativeModifier: 0,
+    excludedByStacking: [],
+  })),
+  EffectContextBuilder: {
+    forInitiative: vi.fn(() => ({
+      build: vi.fn(() => ({ action: { type: "initiative" } })),
+    })),
+  },
 }));
 
 // Mock extracted sub-components imported from direct paths by SkillsCard

--- a/components/creation/hooks/useAugmentedAttributes.ts
+++ b/components/creation/hooks/useAugmentedAttributes.ts
@@ -1,0 +1,253 @@
+"use client";
+
+/**
+ * useAugmentedAttributes Hook
+ *
+ * Extracts augmented attribute computation from DerivedStatsCard into a shared
+ * hook. Returns all attribute values with cyberware/bioware bonuses and unified
+ * effect bonuses applied. Used by both DerivedStatsCard and SkillsCard to show
+ * dice pools during character creation.
+ *
+ * @see Issue #444
+ */
+
+import { useMemo } from "react";
+import { useMetatypes, useRuleset, usePriorityTable } from "@/lib/rules";
+import type { CreationState, CyberwareItem, BiowareItem } from "@/lib/types";
+import type { CreationSelections } from "@/lib/types/creation-selections";
+import type { SourcedEffect } from "@/lib/rules/effects";
+import type { EffectResolutionResult } from "@/lib/types/effects";
+import { useCreationEffects } from "./useCreationEffects";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface AugmentationEffects {
+  essenceLoss: number;
+  remainingEssence: number;
+  initiativeDiceBonus: number;
+  attributeBonuses: Record<string, number>;
+}
+
+export interface AugmentedAttributeResult {
+  /** All attribute values with augmentation bonuses applied (core + special) */
+  attributes: Record<string, number>;
+  /** Raw augmentation effects (essence, initiative dice, attribute bonuses) */
+  augmentationEffects: AugmentationEffects;
+  /** Unified effect attribute bonuses (for display) */
+  unifiedAttributeBonuses: Record<string, number>;
+  /** Effect sources for Active Effects display */
+  effectSources: SourcedEffect[];
+  /** Passive effects result */
+  passiveEffects: EffectResolutionResult | null;
+  /** Unified initiative bonus */
+  unifiedInitiativeBonus: number;
+}
+
+// =============================================================================
+// HOOK
+// =============================================================================
+
+export function useAugmentedAttributes(state: CreationState): AugmentedAttributeResult {
+  const metatypes = useMetatypes();
+  const { ruleset } = useRuleset();
+  const priorityTable = usePriorityTable();
+  const selectedMetatype = state.selections.metatype as string;
+
+  // Unified effects from creation selections
+  const { passiveEffects, sources } = useCreationEffects(
+    state.selections as CreationSelections,
+    ruleset
+  );
+
+  // Get metatype data for attribute minimums
+  const metatypeData = useMemo(() => {
+    return metatypes.find((m) => m.id === selectedMetatype);
+  }, [metatypes, selectedMetatype]);
+
+  // Get current core attributes from state
+  const coreAttributes = useMemo(() => {
+    return (state.selections.attributes || {}) as Record<string, number>;
+  }, [state.selections.attributes]);
+
+  // Get special attribute allocated points
+  const specialAttributes = useMemo(() => {
+    return (state.selections.specialAttributes || {}) as Record<string, number>;
+  }, [state.selections.specialAttributes]);
+
+  // Compute special attribute base values from priority table
+  const specialAttributeBases = useMemo(() => {
+    const bases: Record<string, number> = {};
+
+    // Edge base from metatype
+    const edgeData = metatypeData?.attributes?.edge;
+    if (edgeData && typeof edgeData === "object" && "min" in edgeData) {
+      bases.edge = edgeData.min;
+    } else {
+      bases.edge = 1;
+    }
+
+    // Magic/Resonance base from magic priority
+    const magicPriority = state.priorities?.magic;
+    const selectedMagicPath = state.selections["magical-path"] as string | undefined;
+
+    if (magicPriority && selectedMagicPath && selectedMagicPath !== "mundane") {
+      const magicData = priorityTable?.table[magicPriority]?.magic as
+        | {
+            options: Array<{
+              path: string;
+              magicRating?: number;
+              resonanceRating?: number;
+            }>;
+          }
+        | undefined;
+
+      const option = magicData?.options?.find((o) => o.path === selectedMagicPath);
+      if (option?.magicRating) {
+        bases.magic = option.magicRating;
+      }
+      if (option?.resonanceRating) {
+        bases.resonance = option.resonanceRating;
+      }
+    }
+
+    return bases;
+  }, [metatypeData, priorityTable, state.priorities?.magic, state.selections]);
+
+  // Calculate augmentation effects (essence loss, attribute bonuses, initiative dice)
+  const augmentationEffects = useMemo((): AugmentationEffects => {
+    const cyberware = (state.selections.cyberware || []) as CyberwareItem[];
+    const bioware = (state.selections.bioware || []) as BiowareItem[];
+
+    let essenceLoss = 0;
+    let initiativeDiceBonus = 0;
+    const attributeBonuses: Record<string, number> = {};
+
+    // Process cyberware
+    cyberware.forEach((item) => {
+      essenceLoss += item.essenceCost || 0;
+
+      if (item.initiativeDiceBonus) {
+        initiativeDiceBonus += item.initiativeDiceBonus;
+      }
+
+      if (item.attributeBonuses) {
+        Object.entries(item.attributeBonuses).forEach(([attr, value]) => {
+          attributeBonuses[attr] = (attributeBonuses[attr] || 0) + value;
+        });
+      }
+    });
+
+    // Process bioware
+    bioware.forEach((item) => {
+      essenceLoss += item.essenceCost || 0;
+
+      if (item.attributeBonuses) {
+        Object.entries(item.attributeBonuses).forEach(([attr, value]) => {
+          attributeBonuses[attr] = (attributeBonuses[attr] || 0) + value;
+        });
+      }
+    });
+
+    return {
+      essenceLoss,
+      remainingEssence: Math.max(0, 6 - essenceLoss),
+      initiativeDiceBonus,
+      attributeBonuses,
+    };
+  }, [state.selections.cyberware, state.selections.bioware]);
+
+  // Extract per-attribute modifiers from unified effects
+  const unifiedAttributeBonuses = useMemo(() => {
+    const bonuses: Record<string, number> = {};
+    if (!passiveEffects) return bonuses;
+
+    for (const resolved of [
+      ...passiveEffects.dicePoolModifiers,
+      ...passiveEffects.limitModifiers,
+      ...passiveEffects.initiativeModifiers,
+    ]) {
+      if (resolved.effect.type === "attribute-modifier" && resolved.effect.target?.attribute) {
+        const attr = resolved.effect.target.attribute;
+        bonuses[attr] = (bonuses[attr] || 0) + resolved.resolvedValue;
+      }
+    }
+
+    return bonuses;
+  }, [passiveEffects]);
+
+  // Unified initiative modifier from effects system
+  const unifiedInitiativeBonus = passiveEffects?.totalInitiativeModifier ?? 0;
+
+  // Build final augmented attribute map (core + special, with all bonuses)
+  const attributes = useMemo(() => {
+    const getAttr = (attrId: string): number => {
+      if (coreAttributes[attrId] !== undefined) {
+        return coreAttributes[attrId];
+      }
+      // Fall back to metatype minimum
+      if (metatypeData?.attributes?.[attrId]) {
+        const attrData = metatypeData.attributes[attrId];
+        if (typeof attrData === "object" && "min" in attrData) {
+          return attrData.min;
+        }
+      }
+      return 1; // Default minimum
+    };
+
+    // Merge manual augmentation bonuses with unified effect attribute bonuses
+    const augBonuses = augmentationEffects.attributeBonuses;
+    const mergedBonuses: Record<string, number> = { ...augBonuses };
+    for (const [attr, val] of Object.entries(unifiedAttributeBonuses)) {
+      mergedBonuses[attr] = (mergedBonuses[attr] || 0) + val;
+    }
+
+    const result: Record<string, number> = {};
+
+    // Core attributes with bonuses
+    const coreAttrIds = [
+      "body",
+      "agility",
+      "reaction",
+      "strength",
+      "willpower",
+      "logic",
+      "intuition",
+      "charisma",
+    ];
+    for (const attr of coreAttrIds) {
+      result[attr] = getAttr(attr) + (mergedBonuses[attr] || 0);
+    }
+
+    // Special attributes: base + allocated + bonuses
+    for (const attr of ["edge", "magic", "resonance"]) {
+      const base = specialAttributeBases[attr] || 0;
+      const allocated = specialAttributes[attr] || 0;
+      const bonus = mergedBonuses[attr] || 0;
+      const total = base + allocated + bonus;
+      // Only include if there's a non-zero value (character has this attribute)
+      if (total > 0) {
+        result[attr] = total;
+      }
+    }
+
+    return result;
+  }, [
+    coreAttributes,
+    metatypeData,
+    augmentationEffects,
+    unifiedAttributeBonuses,
+    specialAttributeBases,
+    specialAttributes,
+  ]);
+
+  return {
+    attributes,
+    augmentationEffects,
+    unifiedAttributeBonuses,
+    effectSources: sources,
+    passiveEffects,
+    unifiedInitiativeBonus,
+  };
+}

--- a/components/creation/skills/SkillListItem.tsx
+++ b/components/creation/skills/SkillListItem.tsx
@@ -58,6 +58,12 @@ interface SkillListItemProps {
   onDesignate?: () => void;
   /** Callback when user wants to undesignate this skill */
   onUndesignate?: () => void;
+  /** Dice pool value (attribute + skill rating) */
+  dicePool?: number;
+  /** Augmented attribute value used for this skill's pool */
+  augmentedAttributeValue?: number;
+  /** Tooltip text for the dice pool formula */
+  dicePoolTooltip?: string;
 }
 
 // =============================================================================
@@ -90,6 +96,9 @@ export function SkillListItem({
   canDesignate = false,
   onDesignate,
   onUndesignate,
+  dicePool,
+  augmentedAttributeValue,
+  dicePoolTooltip,
 }: SkillListItemProps) {
   const isAtMax = rating >= maxRating;
   const hasSpecs = specializations.length > 0;
@@ -290,10 +299,37 @@ export function SkillListItem({
         </div>
       </div>
 
-      {/* Line 2: Linked attribute and group name */}
-      <div className="ml-5 mt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
-        {linkedAttribute.toUpperCase().slice(0, 3)}
-        {groupName && <span className="text-purple-500 dark:text-purple-400"> • {groupName}</span>}
+      {/* Line 2: Linked attribute, group name, and dice pool */}
+      <div className="ml-5 mt-0.5 flex items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400">
+        <span>
+          {linkedAttribute.toUpperCase().slice(0, 3)}
+          {groupName && (
+            <span className="text-purple-500 dark:text-purple-400"> • {groupName}</span>
+          )}
+        </span>
+        {dicePool !== undefined && dicePool > 0 && (
+          <Tooltip
+            content={
+              <div className="text-xs">
+                <div>
+                  {dicePoolTooltip ||
+                    `${linkedAttribute} (${augmentedAttributeValue ?? "?"}) + ${skillName} (${rating}) = ${dicePool} dice`}
+                </div>
+                {specializations.length > 0 && (
+                  <div className="mt-0.5 text-amber-300 dark:text-amber-400">
+                    +2 for: {specializations.join(", ")}
+                  </div>
+                )}
+              </div>
+            }
+            placement="top"
+            delay={300}
+          >
+            <span className="inline-flex cursor-help items-center rounded bg-cyan-100 px-1 py-0.5 font-mono text-[10px] font-bold text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
+              {dicePool}d
+            </span>
+          </Tooltip>
+        )}
       </div>
 
       {/* Line 3: Specializations (if any) */}

--- a/components/creation/skills/SkillsListSection.tsx
+++ b/components/creation/skills/SkillsListSection.tsx
@@ -17,6 +17,7 @@ import { MAX_GROUP_RATING } from "./useSkillsCardHandlers";
 import type { UseGroupBreakingResult } from "./useGroupBreaking";
 import type { UseKarmaPurchaseResult } from "./useKarmaPurchase";
 import type { UseSkillDesignationsResult } from "./useSkillDesignations";
+import { getCoreAttributeName } from "@/lib/constants/attributes";
 
 // =============================================================================
 // TYPES
@@ -45,6 +46,8 @@ export interface SkillsListSectionProps {
   onOpenGroupModal: () => void;
   /** Open skill modal callback */
   onOpenSkillModal: () => void;
+  /** Augmented attribute values for dice pool display */
+  augmentedAttributes?: Record<string, number>;
 }
 
 // =============================================================================
@@ -63,6 +66,7 @@ export function SkillsListSection({
   karmaRemaining,
   onOpenGroupModal,
   onOpenSkillModal,
+  augmentedAttributes,
 }: SkillsListSectionProps) {
   const {
     getGroupData,
@@ -197,6 +201,32 @@ export function SkillsListSection({
               const canDesignate =
                 !isGroupSkill && hasFreeSkillConfigs && canSkillBeDesignated(entry.skillId);
 
+              // Compute dice pool if augmented attributes are available
+              const attrValue = augmentedAttributes?.[skillData.linkedAttribute];
+              const dicePool = attrValue !== undefined ? attrValue + entry.rating : undefined;
+
+              // Build tooltip for dice pool
+              const ATTR_DISPLAY_NAMES: Record<string, string> = {
+                body: "Body",
+                agility: "Agility",
+                reaction: "Reaction",
+                strength: "Strength",
+                willpower: "Willpower",
+                logic: "Logic",
+                intuition: "Intuition",
+                charisma: "Charisma",
+                magic: "Magic",
+                resonance: "Resonance",
+                edge: "Edge",
+              };
+              const attrDisplayName =
+                ATTR_DISPLAY_NAMES[skillData.linkedAttribute] ||
+                getCoreAttributeName(skillData.linkedAttribute);
+              const dicePoolTooltip =
+                attrValue !== undefined
+                  ? `${attrDisplayName} (${attrValue}) + ${skillData.name} (${entry.rating}) = ${attrValue + entry.rating} dice`
+                  : undefined;
+
               return (
                 <SkillListItem
                   key={entry.skillId}
@@ -205,6 +235,9 @@ export function SkillsListSection({
                   rating={entry.rating}
                   maxRating={skillMaxRating}
                   specializations={entry.specializations}
+                  dicePool={dicePool}
+                  augmentedAttributeValue={attrValue}
+                  dicePoolTooltip={dicePoolTooltip}
                   isGroupSkill={isGroupSkill}
                   groupName={entry.source.type === "group" ? entry.source.groupName : undefined}
                   canIncrease={!isGroupSkill && purchaseInfo.mode === "skill-points"}


### PR DESCRIPTION
## Summary
- Extract augmented attribute computation into shared `useAugmentedAttributes` hook (used by both DerivedStatsCard and SkillsCard)
- Add collapsible **Dice Pools** section to DerivedStatsCard showing defense pool (REA + INT) and top 8 skill pools sorted by value
- Add inline cyan **dice pool badge** (`7d`) on each skill row with tooltip showing the formula (e.g., "Agility (4) + Firearms (3) = 7 dice")
- Pools update live as attributes, skills, and cyberware/bioware are allocated
- Specialization annotations (+2 bonus) shown in tooltip but not added to displayed pool

Closes #444

## Test plan
- [x] `pnpm type-check` passes (0 errors)
- [x] `pnpm test` passes (8529 tests, 400 files)
- [x] `pnpm lint` passes (0 errors, no new warnings)
- [ ] Manual: Set priorities and add attributes → Derived Stats "Dice Pools" section shows Defense pool
- [ ] Manual: Add a skill (e.g., Firearms at 3 with AGI 4) → skill row shows `7d` badge
- [ ] Manual: Hover badge → tooltip shows formula
- [ ] Manual: Add cyberware with AGI bonus → pool badge updates
- [ ] Manual: Add specialization → tooltip shows `+2 for: <spec>`
- [ ] Manual: Select Spellcasting (linked to Magic) → pool uses Magic attribute value

🤖 Generated with [Claude Code](https://claude.com/claude-code)