### PR TITLE
feat: integrate CombatTrackerModal into character sheet (#90)

### DIFF
--- a/__tests__/app/characters/[id]/CombatTrackerIntegration.test.tsx
+++ b/__tests__/app/characters/[id]/CombatTrackerIntegration.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * Combat Tracker Integration Tests (#90)
+ *
+ * Verifies the CombatTrackerModal is properly wired into the character sheet:
+ * - QuickCombatControls shows "Open Combat Tracker" button when callback provided
+ * - QuickCombatControls hides tracker button when callback not provided
+ * - Clicking the button invokes the onOpenCombatTracker callback
+ */
+
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { Character } from "@/lib/types";
+import { createMockCharacter } from "@/__tests__/mocks/storage";
+
+// Mock DisplayCard as pass-through
+vi.mock("@/components/character/sheet/DisplayCard", () => ({
+  DisplayCard: ({
+    title,
+    children,
+    headerAction,
+  }: {
+    title: string;
+    children: React.ReactNode;
+    headerAction?: React.ReactNode;
+  }) => (
+    <div data-testid={`display-card-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`}>
+      <h2>{title}</h2>
+      {headerAction}
+      {children}
+    </div>
+  ),
+}));
+
+// Mock lucide-react icons
+vi.mock("lucide-react", () => {
+  const createIcon = (name: string) => {
+    const Icon = (props: Record<string, unknown>) => <span data-icon={name} {...props} />;
+    Icon.displayName = name;
+    return Icon;
+  };
+  return {
+    Swords: createIcon("Swords"),
+    Play: createIcon("Play"),
+    Square: createIcon("Square"),
+    SkipForward: createIcon("SkipForward"),
+    Clock: createIcon("Clock"),
+    AlertCircle: createIcon("AlertCircle"),
+    Loader2: createIcon("Loader2"),
+    Shield: createIcon("Shield"),
+    Zap: createIcon("Zap"),
+    Users: createIcon("Users"),
+    Maximize2: createIcon("Maximize2"),
+  };
+});
+
+// Mock react-aria-components Button to render as plain HTML button
+vi.mock("react-aria-components", () => ({
+  Button: ({
+    children,
+    onPress,
+    isDisabled,
+    className,
+    "aria-label": ariaLabel,
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+    isDisabled?: boolean;
+    className?: string;
+    "aria-label"?: string;
+  }) => (
+    <button
+      onClick={onPress}
+      disabled={isDisabled ?? false}
+      className={className}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+// Mock useCombatSession to simulate active combat
+const mockUseCombatSession = vi.fn();
+vi.mock("@/lib/combat", () => ({
+  useCombatSession: () => mockUseCombatSession(),
+  CombatSessionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { QuickCombatControls } from "@/app/characters/[id]/components/QuickCombatControls";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCharacter(overrides?: Partial<Character>): Character {
+  return createMockCharacter({
+    status: "active",
+    attributes: { reaction: 4, intuition: 3 },
+    ...overrides,
+  });
+}
+
+function activeCombatSession() {
+  return {
+    session: {
+      id: "session-1",
+      round: 2,
+      currentTurn: 0,
+      participants: [
+        {
+          id: "p1",
+          name: "Runner",
+          initiativeScore: 12,
+          actionsRemaining: { free: 1, simple: 2, complex: 1, interrupt: true },
+        },
+      ],
+    },
+    participant: {
+      id: "p1",
+      name: "Runner",
+      initiativeScore: 12,
+      actionsRemaining: { free: 1, simple: 2, complex: 1, interrupt: true },
+    },
+    isInCombat: true,
+    isMyTurn: true,
+    isLoading: false,
+    error: null,
+    endTurn: vi.fn(),
+    delayTurn: vi.fn(),
+    leaveSession: vi.fn(),
+    joinSession: vi.fn(),
+    refreshSession: vi.fn(),
+  };
+}
+
+function noCombatSession() {
+  return {
+    session: null,
+    participant: null,
+    isInCombat: false,
+    isMyTurn: false,
+    isLoading: false,
+    error: null,
+    endTurn: vi.fn(),
+    delayTurn: vi.fn(),
+    leaveSession: vi.fn(),
+    joinSession: vi.fn(),
+    refreshSession: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CombatTrackerIntegration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCombatSession.mockReturnValue(noCombatSession());
+  });
+
+  describe("QuickCombatControls - Open Combat Tracker button", () => {
+    test("shows Open Combat Tracker button when in combat with callback", () => {
+      mockUseCombatSession.mockReturnValue(activeCombatSession());
+      const onOpen = vi.fn();
+
+      render(
+        <QuickCombatControls
+          character={makeCharacter()}
+          editionCode="sr5"
+          onOpenCombatTracker={onOpen}
+        />
+      );
+
+      expect(screen.getByText("Open Combat Tracker")).toBeDefined();
+    });
+
+    test("clicking Open Combat Tracker invokes callback", () => {
+      mockUseCombatSession.mockReturnValue(activeCombatSession());
+      const onOpen = vi.fn();
+
+      render(
+        <QuickCombatControls
+          character={makeCharacter()}
+          editionCode="sr5"
+          onOpenCombatTracker={onOpen}
+        />
+      );
+
+      fireEvent.click(screen.getByText("Open Combat Tracker"));
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    });
+
+    test("hides Open Combat Tracker button when callback not provided", () => {
+      mockUseCombatSession.mockReturnValue(activeCombatSession());
+
+      render(<QuickCombatControls character={makeCharacter()} editionCode="sr5" />);
+
+      expect(screen.queryByText("Open Combat Tracker")).toBeNull();
+    });
+
+    test("does not show Open Combat Tracker when not in combat", () => {
+      mockUseCombatSession.mockReturnValue(noCombatSession());
+      const onOpen = vi.fn();
+
+      render(
+        <QuickCombatControls
+          character={makeCharacter()}
+          editionCode="sr5"
+          onOpenCombatTracker={onOpen}
+        />
+      );
+
+      // When not in combat, the "Start Quick Combat" view is shown instead
+      expect(screen.queryByText("Open Combat Tracker")).toBeNull();
+      expect(screen.getByText("Start Quick Combat")).toBeDefined();
+    });
+  });
+});

--- a/app/characters/[id]/components/QuickCombatControls.tsx
+++ b/app/characters/[id]/components/QuickCombatControls.tsx
@@ -23,6 +23,7 @@ import {
   Shield,
   Zap,
   Users,
+  Maximize2,
 } from "lucide-react";
 import { DisplayCard } from "@/components/character/sheet/DisplayCard";
 import { useCombatSession } from "@/lib/combat";
@@ -35,6 +36,8 @@ interface QuickCombatControlsProps {
   editionCode: string;
   /** Callback when combat state changes */
   onCombatStateChange?: (isInCombat: boolean) => void;
+  /** Callback to open the full combat tracker modal */
+  onOpenCombatTracker?: () => void;
 }
 
 /**
@@ -79,6 +82,7 @@ export function QuickCombatControls({
   character,
   editionCode,
   onCombatStateChange,
+  onOpenCombatTracker,
 }: QuickCombatControlsProps) {
   // Combat session context
   const {
@@ -440,6 +444,23 @@ export function QuickCombatControls({
                 </div>
               </div>
             </div>
+          )}
+
+          {/* Open Full Tracker */}
+          {onOpenCombatTracker && (
+            <Button
+              onPress={onOpenCombatTracker}
+              className={`
+                w-full flex items-center justify-center gap-2
+                px-3 py-2 rounded font-medium text-sm
+                bg-amber-500/20 text-amber-500 border border-amber-500/30
+                hover:bg-amber-500/30
+                transition-colors
+              `}
+            >
+              <Maximize2 className="w-4 h-4" />
+              Open Combat Tracker
+            </Button>
           )}
 
           {/* Participants Count */}

--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -9,16 +9,28 @@ import { useAuth } from "@/lib/auth/AuthProvider";
 import AdminActionsPanel from "../components/AdminActionsPanel";
 import { RulesetProvider, useRuleset, useMergedRuleset, useRulesetStatus } from "@/lib/rules";
 import { calculateLimit, calculateWoundModifier } from "@/lib/rules/qualities";
-import { ArrowLeft, Download, Pencil, Dice5, Printer, TrendingUp, Users, X } from "lucide-react";
+import {
+  ArrowLeft,
+  Download,
+  Pencil,
+  Dice5,
+  Printer,
+  TrendingUp,
+  Users,
+  X,
+  Swords,
+} from "lucide-react";
 import { downloadCharacterJson } from "@/lib/utils";
 import { ActionPanel } from "./components/ActionPanel";
 import { QuickCombatControls } from "./components/QuickCombatControls";
 import { QuickNPCPanel } from "./components/QuickNPCPanel";
 import { useCharacterSheetPreferences } from "./hooks/useCharacterSheetPreferences";
 import { useCharacterEffects } from "./hooks/useCharacterEffects";
-import { CombatSessionProvider } from "@/lib/combat";
+import { CombatSessionProvider, useCombatSession } from "@/lib/combat";
 import { MatrixSessionProvider, useMatrixSession } from "@/lib/matrix";
 import { RiggingSessionProvider, useRiggingSession } from "@/lib/rigging";
+import { CombatTrackerModal } from "./components/CombatTrackerModal";
+import { THEMES, DEFAULT_THEME } from "@/lib/themes";
 
 import {
   ActiveModifiersPanel,
@@ -99,6 +111,10 @@ function CharacterSheet({
 
   const { updatePreference: updateSheetPref } = useCharacterSheetPreferences(character.id);
   const matrixSession = useMatrixSession();
+  const { isInCombat } = useCombatSession();
+  const theme = THEMES[DEFAULT_THEME];
+  const [showCombatTracker, setShowCombatTracker] = useState(false);
+  const handleOpenCombatTracker = useCallback(() => setShowCombatTracker(true), []);
   const [firstMeeting, setFirstMeeting] = useState(false);
   const { sources: effectSources, resolve: resolveEffectsBase } = useCharacterEffects(
     character,
@@ -281,6 +297,16 @@ function CharacterSheet({
           >
             <Dice5 className={`w-6 h-6 ${showDiceRoller ? "text-emerald-400" : ""}`} />
           </Button>
+          {isInCombat && (
+            <Button
+              className="relative p-2 text-amber-500 hover:text-amber-400 transition-colors"
+              onPress={() => setShowCombatTracker(true)}
+              aria-label="Open Combat Tracker"
+            >
+              <Swords className="w-5 h-5" />
+              <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-amber-500 animate-pulse" />
+            </Button>
+          )}
           {character.status === "active" && (
             <>
               <Link
@@ -365,6 +391,15 @@ function CharacterSheet({
           </Modal>
         </ModalOverlay>
 
+        {/* Combat Tracker Modal */}
+        <CombatTrackerModal
+          isOpen={showCombatTracker}
+          onClose={() => setShowCombatTracker(false)}
+          theme={theme}
+          characterId={character.id}
+          character={character}
+        />
+
         {/* Main Content Grid */}
         <div className="character-sheet-grid grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {/* Left Column - Attributes & Condition */}
@@ -428,7 +463,11 @@ function CharacterSheet({
             />
 
             {/* Quick Combat Controls */}
-            <QuickCombatControls character={character} editionCode={character.editionCode} />
+            <QuickCombatControls
+              character={character}
+              editionCode={character.editionCode}
+              onOpenCombatTracker={handleOpenCombatTracker}
+            />
 
             <QuickNPCPanel />
           </div>

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -56,7 +56,6 @@ const config: KnipConfig = {
     "app/characters/[id]/components/ActionResultToast.tsx", // Combat action feedback
     "app/characters/[id]/components/AugmentationsPanel.tsx", // Augmentations display
     "app/characters/[id]/components/CombatModeIndicator.tsx", // Combat state indicator
-    "app/characters/[id]/components/CombatTrackerModal.tsx", // Initiative tracker
     "components/AugmentationCard.tsx", // Augmentation display card
     "components/EssenceDisplay.tsx", // Essence meter component
     "components/character/**", // Character sheet sub-components (Matrix, Rigging, Magic)


### PR DESCRIPTION
## Summary
- Wire existing `CombatTrackerModal` into the character sheet page so players can view the full initiative order during combat
- Add Swords icon button in Actions Bar (visible only when `isInCombat`), with amber color and pulsing indicator dot
- Add "Open Combat Tracker" button in `QuickCombatControls` for quick access from the combat card
- Remove `CombatTrackerModal.tsx` from knip ignore list since it's now imported

## Test plan
- [x] `pnpm type-check` passes with no errors
- [x] `pnpm test` — all tests pass (4 new integration tests, no regressions)
- [x] `pnpm knip` — CombatTrackerModal no longer flagged as unused
- [ ] Manual: Start combat via QuickCombatControls, verify Swords icon appears in Actions Bar
- [ ] Manual: Click Swords icon to open full tracker modal showing initiative order
- [ ] Manual: Click "Open Combat Tracker" button in QuickCombatControls card
- [ ] Manual: Verify modal closes via X button and backdrop click

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)