### PR TITLE
feat: enforce action economy for equipment readiness changes (#393)

### DIFF
--- a/app/api/combat/[sessionId]/spend-action/__tests__/route.test.ts
+++ b/app/api/combat/[sessionId]/spend-action/__tests__/route.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for /api/combat/[sessionId]/spend-action endpoint
+ *
+ * Tests action economy spending for readiness changes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+import * as sessionModule from "@/lib/auth/session";
+import * as usersModule from "@/lib/storage/users";
+import * as combatModule from "@/lib/storage/combat";
+import type { User, CombatSession, CombatParticipant } from "@/lib/types";
+
+vi.mock("@/lib/auth/session");
+vi.mock("@/lib/storage/users");
+vi.mock("@/lib/storage/combat");
+
+function createMockRequest(body: unknown): NextRequest {
+  const request = new NextRequest("http://localhost:3000/api/combat/session-1/spend-action", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+  (request as { json: () => Promise<unknown> }).json = async () => body;
+  return request;
+}
+
+function createMockUser(overrides?: Partial<User>): User {
+  return {
+    id: "test-user-id",
+    email: "test@example.com",
+    username: "testuser",
+    passwordHash: "mock-hash",
+    role: ["user"],
+    createdAt: new Date().toISOString(),
+    lastLogin: null,
+    characters: [],
+    failedLoginAttempts: 0,
+    lockoutUntil: null,
+    sessionVersion: 1,
+    sessionSecretHash: null,
+    preferences: { theme: "system", navigationCollapsed: false },
+    accountStatus: "active",
+    statusChangedAt: null,
+    statusChangedBy: null,
+    statusReason: null,
+    lastRoleChangeAt: null,
+    lastRoleChangeBy: null,
+    emailVerified: true,
+    emailVerifiedAt: null,
+    emailVerificationTokenHash: null,
+    emailVerificationTokenExpiresAt: null,
+    emailVerificationTokenPrefix: null,
+    passwordResetTokenHash: null,
+    passwordResetTokenExpiresAt: null,
+    passwordResetTokenPrefix: null,
+    magicLinkTokenHash: null,
+    magicLinkTokenExpiresAt: null,
+    magicLinkTokenPrefix: null,
+    ...overrides,
+  };
+}
+
+function createMockParticipant(overrides?: Partial<CombatParticipant>): CombatParticipant {
+  return {
+    id: "p1",
+    type: "character",
+    entityId: "char-1",
+    name: "Test Character",
+    initiativeScore: 10,
+    initiativeDice: [4],
+    actionsRemaining: { free: 999, simple: 2, complex: 1, interrupt: true },
+    interruptsPending: [],
+    status: "active",
+    controlledBy: "test-user-id",
+    isGMControlled: false,
+    woundModifier: 0,
+    conditions: [],
+    ...overrides,
+  };
+}
+
+function createMockSession(overrides?: Partial<CombatSession>): CombatSession {
+  return {
+    id: "session-1",
+    ownerId: "test-user-id",
+    editionCode: "sr5",
+    participants: [createMockParticipant()],
+    initiativeOrder: ["p1"],
+    currentTurn: 0,
+    currentPhase: "action",
+    round: 1,
+    status: "active",
+    environment: {
+      visibility: "normal",
+      weather: "clear",
+      terrain: "urban",
+      backgroundCount: 0,
+      noise: 0,
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createRouteParams(sessionId = "session-1") {
+  return { params: Promise.resolve({ sessionId }) };
+}
+
+describe("POST /api/combat/[sessionId]/spend-action", () => {
+  const mockUser = createMockUser();
+  const mockSession = createMockSession();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sessionModule.getSession).mockResolvedValue(mockUser.id);
+    vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
+    vi.mocked(combatModule.getCombatSession).mockResolvedValue(mockSession);
+    vi.mocked(combatModule.updateParticipantActions).mockResolvedValue(null);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue(null);
+    const request = createMockRequest({ participantId: "p1", actionType: "simple" });
+    const response = await POST(request, createRouteParams());
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when user not found", async () => {
+    vi.mocked(usersModule.getUserById).mockResolvedValue(null);
+    const request = createMockRequest({ participantId: "p1", actionType: "simple" });
+    const response = await POST(request, createRouteParams());
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when session not found", async () => {
+    vi.mocked(combatModule.getCombatSession).mockResolvedValue(null);
+    const request = createMockRequest({ participantId: "p1", actionType: "simple" });
+    const response = await POST(request, createRouteParams());
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 403 when user does not own session", async () => {
+    vi.mocked(combatModule.getCombatSession).mockResolvedValue(
+      createMockSession({ ownerId: "other-user" })
+    );
+    const request = createMockRequest({ participantId: "p1", actionType: "simple" });
+    const response = await POST(request, createRouteParams());
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 when session is not active", async () => {
+    vi.mocked(combatModule.getCombatSession).mockResolvedValue(
+      createMockSession({ status: "completed" })
+    );
+    const request = createMockRequest({ participantId: "p1", actionType: "simple" });
+    const response = await POST(request, createRouteParams());
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const request = createMockRequest({ participantId: "p1" });
+    const response = await POST(request, createRouteParams());
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for invalid actionType", async () => {
+    const request = createMockRequest({ participantId: "p1", actionType: "interrupt" });
+    const response = await POST(request, createRouteParams());
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 404 when participant not found", async () => {
+    const request = createMockRequest({ participantId: "nonexistent", actionType: "simple" });
+    const response = await POST(request, createRouteParams());
+    expect(response.status).toBe(404);
+  });
+
+  it("successfully spends a simple action", async () => {
+    const request = createMockRequest({ participantId: "p1", actionType: "simple" });
+    const response = await POST(request, createRouteParams());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.actionsRemaining.simple).toBe(1);
+    expect(vi.mocked(combatModule.updateParticipantActions)).toHaveBeenCalledTimes(1);
+  });
+
+  it("successfully spends a free action", async () => {
+    const request = createMockRequest({ participantId: "p1", actionType: "free" });
+    const response = await POST(request, createRouteParams());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.actionsRemaining.free).toBe(998);
+  });
+
+  it("successfully spends a complex action", async () => {
+    const request = createMockRequest({ participantId: "p1", actionType: "complex" });
+    const response = await POST(request, createRouteParams());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.actionsRemaining.complex).toBe(0);
+    expect(data.actionsRemaining.simple).toBe(0);
+  });
+
+  it("returns 400 when no simple actions remaining", async () => {
+    const noSimple = createMockParticipant({
+      actionsRemaining: { free: 999, simple: 0, complex: 0, interrupt: true },
+    });
+    vi.mocked(combatModule.getCombatSession).mockResolvedValue(
+      createMockSession({ participants: [noSimple] })
+    );
+    const request = createMockRequest({ participantId: "p1", actionType: "simple" });
+    const response = await POST(request, createRouteParams());
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("No simple actions remaining");
+  });
+
+  it("returns 400 when no complex actions remaining", async () => {
+    const noComplex = createMockParticipant({
+      actionsRemaining: { free: 999, simple: 0, complex: 0, interrupt: true },
+    });
+    vi.mocked(combatModule.getCombatSession).mockResolvedValue(
+      createMockSession({ participants: [noComplex] })
+    );
+    const request = createMockRequest({ participantId: "p1", actionType: "complex" });
+    const response = await POST(request, createRouteParams());
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toContain("No complex actions remaining");
+  });
+
+  it("spends complex via two simple actions when no complex slot", async () => {
+    const noComplexSlot = createMockParticipant({
+      actionsRemaining: { free: 999, simple: 2, complex: 0, interrupt: true },
+    });
+    vi.mocked(combatModule.getCombatSession).mockResolvedValue(
+      createMockSession({ participants: [noComplexSlot] })
+    );
+    const request = createMockRequest({ participantId: "p1", actionType: "complex" });
+    const response = await POST(request, createRouteParams());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.actionsRemaining.simple).toBe(0);
+  });
+});

--- a/app/api/combat/[sessionId]/spend-action/route.ts
+++ b/app/api/combat/[sessionId]/spend-action/route.ts
@@ -1,0 +1,129 @@
+/**
+ * API Route: /api/combat/[sessionId]/spend-action
+ *
+ * POST - Spend an action from a participant's action economy.
+ * Used for readiness changes and other non-combat-roll actions
+ * that still cost an action during combat.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { getUserById } from "@/lib/storage/users";
+import { getCombatSession, updateParticipantActions } from "@/lib/storage/combat";
+import { consumeAction } from "@/lib/rules/action-resolution/action-executor";
+import type { ActionAllocation } from "@/lib/types";
+
+interface RouteParams {
+  params: Promise<{ sessionId: string }>;
+}
+
+/**
+ * POST /api/combat/[sessionId]/spend-action
+ *
+ * Spend an action from a participant's action economy.
+ *
+ * Body:
+ * - participantId: ID of the participant spending the action
+ * - actionType: "free" | "simple" | "complex"
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    // Check authentication
+    const userId = await getSession();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await getUserById(userId);
+    if (!user) {
+      return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
+    }
+
+    const { sessionId } = await params;
+    const session = await getCombatSession(sessionId);
+
+    if (!session) {
+      return NextResponse.json(
+        { success: false, error: "Combat session not found" },
+        { status: 404 }
+      );
+    }
+
+    // Check ownership
+    if (session.ownerId !== user.id) {
+      return NextResponse.json({ success: false, error: "Access denied" }, { status: 403 });
+    }
+
+    // Check session is active
+    if (session.status !== "active") {
+      return NextResponse.json(
+        { success: false, error: "Combat session is not active" },
+        { status: 400 }
+      );
+    }
+
+    // Parse body
+    const body = await request.json();
+    const { participantId, actionType } = body;
+
+    if (!participantId || !actionType) {
+      return NextResponse.json(
+        { success: false, error: "Missing required fields: participantId, actionType" },
+        { status: 400 }
+      );
+    }
+
+    if (!["free", "simple", "complex"].includes(actionType)) {
+      return NextResponse.json(
+        { success: false, error: "Invalid actionType. Must be free, simple, or complex" },
+        { status: 400 }
+      );
+    }
+
+    // Find participant
+    const participant = session.participants.find((p) => p.id === participantId);
+    if (!participant) {
+      return NextResponse.json({ success: false, error: "Participant not found" }, { status: 404 });
+    }
+
+    // Consume the action
+    const before = participant.actionsRemaining;
+    const after = consumeAction(before, actionType);
+
+    // Validate something was actually consumed
+    if (!wasActionConsumed(before, after, actionType)) {
+      return NextResponse.json(
+        { success: false, error: `No ${actionType} actions remaining` },
+        { status: 400 }
+      );
+    }
+
+    // Persist
+    await updateParticipantActions(sessionId, participantId, after);
+
+    return NextResponse.json({
+      success: true,
+      actionsRemaining: after,
+    });
+  } catch (error) {
+    console.error("Failed to spend action:", error);
+    return NextResponse.json({ success: false, error: "Failed to spend action" }, { status: 500 });
+  }
+}
+
+function wasActionConsumed(
+  before: ActionAllocation,
+  after: ActionAllocation,
+  actionType: string
+): boolean {
+  switch (actionType) {
+    case "free":
+      return after.free < before.free || before.free === 0;
+    case "simple":
+      return after.simple < before.simple;
+    case "complex":
+      return after.complex < before.complex || after.simple < before.simple;
+    default:
+      return false;
+  }
+}

--- a/components/character/sheet/ArmorDisplay.tsx
+++ b/components/character/sheet/ArmorDisplay.tsx
@@ -6,6 +6,7 @@ import type { Character, ArmorItem } from "@/lib/types";
 import type { ArmorData, GearCatalogData } from "@/lib/rules/RulesetContext";
 import type { EquipmentReadiness } from "@/lib/types/gear-state";
 import { useGear } from "@/lib/rules";
+import { useCombatReadiness } from "@/lib/combat";
 import { calculateArmorTotal } from "@/lib/rules/gameplay";
 import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
 import { Tooltip } from "@/components/ui";
@@ -181,6 +182,8 @@ function ArmorRow({
   isExpanded: boolean;
   onToggleExpand: () => void;
 }) {
+  const { canChangeReadiness, performReadinessChange } = useCombatReadiness();
+
   // Readiness state
   const readiness: EquipmentReadiness =
     item.state?.readiness ?? (item.equipped ? "worn" : "stored");
@@ -303,20 +306,33 @@ function ArmorRow({
                 {READINESS_BY_EQUIPMENT.armor.map((state) => {
                   const cost =
                     state !== readiness ? getTransitionActionCost(readiness, state) : undefined;
+                  const combatCheck =
+                    state !== readiness ? canChangeReadiness(readiness, state) : undefined;
+                  const isBlocked = combatCheck ? !combatCheck.allowed : false;
                   return (
                     <button
                       key={state}
                       data-testid={`readiness-${state}`}
-                      disabled={state === readiness}
-                      onClick={(e) => {
+                      disabled={state === readiness || isBlocked}
+                      onClick={async (e) => {
                         e.stopPropagation();
-                        changeArmorReadiness(character, itemIndex, state, onCharacterUpdate);
+                        await performReadinessChange(readiness, state, () =>
+                          changeArmorReadiness(character, itemIndex, state, onCharacterUpdate)
+                        );
                       }}
-                      title={cost && cost !== "none" ? getActionCostLabel(cost) : undefined}
+                      title={
+                        isBlocked && combatCheck?.reason
+                          ? combatCheck.reason
+                          : cost && cost !== "none"
+                            ? getActionCostLabel(cost)
+                            : undefined
+                      }
                       className={`rounded border px-2 py-0.5 text-[10px] font-medium transition-colors ${
                         state === readiness
                           ? getReadinessColor(state)
-                          : "border-zinc-300 text-zinc-400 hover:border-zinc-400 hover:text-zinc-300 dark:border-zinc-700 dark:text-zinc-500 dark:hover:border-zinc-600"
+                          : isBlocked
+                            ? "border-zinc-300 text-zinc-400 opacity-50 cursor-not-allowed dark:border-zinc-700 dark:text-zinc-500"
+                            : "border-zinc-300 text-zinc-400 hover:border-zinc-400 hover:text-zinc-300 dark:border-zinc-700 dark:text-zinc-500 dark:hover:border-zinc-600"
                       }`}
                     >
                       {getReadinessLabel(state)}

--- a/components/character/sheet/GearDisplay.tsx
+++ b/components/character/sheet/GearDisplay.tsx
@@ -5,6 +5,7 @@ import type { Character, GearItem } from "@/lib/types";
 import type { GearItemData, GearCatalogData } from "@/lib/rules/RulesetContext";
 import type { EquipmentReadiness, ContainerProperties } from "@/lib/types/gear-state";
 import { useGear } from "@/lib/rules";
+import { useCombatReadiness } from "@/lib/combat";
 import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
 import { DisplayCard } from "./DisplayCard";
 import { MoveToContainerControl } from "./MoveToContainerControl";
@@ -145,6 +146,7 @@ function GearRow({
   editable?: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const { canChangeReadiness, performReadinessChange } = useCombatReadiness();
 
   const extras = catalogItem as (GearItemData & CatalogExtras) | undefined;
 
@@ -365,20 +367,33 @@ function GearRow({
                 {READINESS_BY_EQUIPMENT.gear.map((state) => {
                   const cost =
                     state !== readiness ? getTransitionActionCost(readiness, state) : undefined;
+                  const combatCheck =
+                    state !== readiness ? canChangeReadiness(readiness, state) : undefined;
+                  const isBlocked = combatCheck ? !combatCheck.allowed : false;
                   return (
                     <button
                       key={state}
                       data-testid={`readiness-${state}`}
-                      disabled={state === readiness}
-                      onClick={(e) => {
+                      disabled={state === readiness || isBlocked}
+                      onClick={async (e) => {
                         e.stopPropagation();
-                        changeGearReadiness(character, itemIndex, state, onCharacterUpdate);
+                        await performReadinessChange(readiness, state, () =>
+                          changeGearReadiness(character, itemIndex, state, onCharacterUpdate)
+                        );
                       }}
-                      title={cost && cost !== "none" ? getActionCostLabel(cost) : undefined}
+                      title={
+                        isBlocked && combatCheck?.reason
+                          ? combatCheck.reason
+                          : cost && cost !== "none"
+                            ? getActionCostLabel(cost)
+                            : undefined
+                      }
                       className={`rounded border px-2 py-0.5 text-[10px] font-medium transition-colors ${
                         state === readiness
                           ? getReadinessColor(state)
-                          : "border-zinc-300 text-zinc-400 hover:border-zinc-400 hover:text-zinc-300 dark:border-zinc-700 dark:text-zinc-500 dark:hover:border-zinc-600"
+                          : isBlocked
+                            ? "border-zinc-300 text-zinc-400 opacity-50 cursor-not-allowed dark:border-zinc-700 dark:text-zinc-500"
+                            : "border-zinc-300 text-zinc-400 hover:border-zinc-400 hover:text-zinc-300 dark:border-zinc-700 dark:text-zinc-500 dark:hover:border-zinc-600"
                       }`}
                     >
                       {getReadinessLabel(state)}

--- a/components/character/sheet/WeaponsDisplay.tsx
+++ b/components/character/sheet/WeaponsDisplay.tsx
@@ -6,6 +6,7 @@ import type { WeaponData, GearCatalogData } from "@/lib/rules/RulesetContext";
 import type { EquipmentReadiness } from "@/lib/types/gear-state";
 import type { AmmunitionItem } from "@/lib/types/gear-state";
 import { useGear } from "@/lib/rules";
+import { useCombatReadiness } from "@/lib/combat";
 import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
 import { DisplayCard } from "./DisplayCard";
 import { isMeleeWeapon } from "./constants";
@@ -184,6 +185,7 @@ function WeaponRow({
   const { pool, label } = calculateWeaponPool(weapon, character);
   const isMelee = isMeleeWeapon(weapon);
   const modeStr = weapon.mode?.join("/") || "";
+  const { canChangeReadiness, performReadinessChange } = useCombatReadiness();
 
   // Resolve stats: character weapon takes priority, catalog fills gaps
   const avail = weapon.availability ?? catalogWeapon?.availability;
@@ -474,20 +476,33 @@ function WeaponRow({
                 {READINESS_BY_EQUIPMENT.weapon.map((state) => {
                   const cost =
                     state !== readiness ? getTransitionActionCost(readiness, state) : undefined;
+                  const combatCheck =
+                    state !== readiness ? canChangeReadiness(readiness, state) : undefined;
+                  const isBlocked = combatCheck ? !combatCheck.allowed : false;
                   return (
                     <button
                       key={state}
                       data-testid={`readiness-${state}`}
-                      disabled={state === readiness}
-                      onClick={(e) => {
+                      disabled={state === readiness || isBlocked}
+                      onClick={async (e) => {
                         e.stopPropagation();
-                        changeWeaponReadiness(character, weaponId, state, onCharacterUpdate);
+                        await performReadinessChange(readiness, state, () =>
+                          changeWeaponReadiness(character, weaponId, state, onCharacterUpdate)
+                        );
                       }}
-                      title={cost && cost !== "none" ? getActionCostLabel(cost) : undefined}
+                      title={
+                        isBlocked && combatCheck?.reason
+                          ? combatCheck.reason
+                          : cost && cost !== "none"
+                            ? getActionCostLabel(cost)
+                            : undefined
+                      }
                       className={`rounded border px-2 py-0.5 text-[10px] font-medium transition-colors ${
                         state === readiness
                           ? getReadinessColor(state)
-                          : "border-zinc-300 text-zinc-400 hover:border-zinc-400 hover:text-zinc-300 dark:border-zinc-700 dark:text-zinc-500 dark:hover:border-zinc-600"
+                          : isBlocked
+                            ? "border-zinc-300 text-zinc-400 opacity-50 cursor-not-allowed dark:border-zinc-700 dark:text-zinc-500"
+                            : "border-zinc-300 text-zinc-400 hover:border-zinc-400 hover:text-zinc-300 dark:border-zinc-700 dark:text-zinc-500 dark:hover:border-zinc-600"
                       }`}
                     >
                       {getReadinessLabel(state)}

--- a/components/character/sheet/__tests__/ArmorDisplay.test.tsx
+++ b/components/character/sheet/__tests__/ArmorDisplay.test.tsx
@@ -60,6 +60,29 @@ vi.mock("@/lib/rules/wireless", () => ({
   isGlobalWirelessEnabled: vi.fn(() => true),
 }));
 
+// Default mock: not in combat, all transitions allowed
+const mockCanChangeReadiness = vi.fn(
+  (): { allowed: boolean; reason?: string; actionCost: string } => ({
+    allowed: true,
+    actionCost: "simple",
+  })
+);
+const mockPerformReadinessChange = vi.fn(
+  async (_from: unknown, _to: unknown, applyChange: () => void) => {
+    applyChange();
+    return true;
+  }
+);
+
+vi.mock("@/lib/combat", () => ({
+  useCombatReadiness: () => ({
+    isInCombat: false,
+    isMyTurn: false,
+    canChangeReadiness: mockCanChangeReadiness,
+    performReadinessChange: mockPerformReadinessChange,
+  }),
+}));
+
 vi.mock("react-aria-components", () => ({
   Button: ({
     children,
@@ -152,6 +175,13 @@ import { calculateArmorTotal } from "@/lib/rules/gameplay";
 beforeEach(() => {
   vi.clearAllMocks();
   (isGlobalWirelessEnabled as ReturnType<typeof vi.fn>).mockReturnValue(true);
+  mockCanChangeReadiness.mockReturnValue({ allowed: true, actionCost: "simple" });
+  mockPerformReadinessChange.mockImplementation(
+    async (_from: unknown, _to: unknown, applyChange: () => void) => {
+      applyChange();
+      return true;
+    }
+  );
 });
 
 describe("ArmorDisplay", () => {
@@ -504,6 +534,44 @@ describe("ArmorDisplay", () => {
 
       // Row should still be expanded after moving from Worn to Carried section
       expect(screen.getByTestId("expanded-content")).toBeInTheDocument();
+    });
+  });
+
+  // --- Combat readiness gating ---
+
+  describe("combat readiness gating", () => {
+    it("disables readiness button when combat check blocks it", () => {
+      mockCanChangeReadiness.mockReturnValue({
+        allowed: false,
+        reason: "No complex actions remaining",
+        actionCost: "complex",
+      });
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={vi.fn()} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("readiness-carried")).toBeDisabled();
+    });
+
+    it("shows combat block reason in title when blocked", () => {
+      mockCanChangeReadiness.mockReturnValue({
+        allowed: false,
+        reason: "Not your turn",
+        actionCost: "complex",
+      });
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={vi.fn()} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("readiness-carried")).toHaveAttribute("title", "Not your turn");
+    });
+
+    it("calls performReadinessChange on click", () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ armor: [MOCK_ARMOR_EQUIPPED] });
+      render(<ArmorDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("readiness-carried"));
+      expect(mockPerformReadinessChange).toHaveBeenCalledTimes(1);
+      expect(onUpdate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/components/character/sheet/__tests__/GearDisplay.test.tsx
+++ b/components/character/sheet/__tests__/GearDisplay.test.tsx
@@ -133,6 +133,29 @@ vi.mock("@/lib/rules/wireless", () => ({
   isGlobalWirelessEnabled: (character: unknown) => mockIsGlobalWirelessEnabled(character),
 }));
 
+// Default mock: not in combat, all transitions allowed
+const mockCanChangeReadiness = vi.fn(
+  (): { allowed: boolean; reason?: string; actionCost: string } => ({
+    allowed: true,
+    actionCost: "simple",
+  })
+);
+const mockPerformReadinessChange = vi.fn(
+  async (_from: unknown, _to: unknown, applyChange: () => void) => {
+    applyChange();
+    return true;
+  }
+);
+
+vi.mock("@/lib/combat", () => ({
+  useCombatReadiness: () => ({
+    isInCombat: false,
+    isMyTurn: false,
+    canChangeReadiness: mockCanChangeReadiness,
+    performReadinessChange: mockPerformReadinessChange,
+  }),
+}));
+
 import { GearDisplay } from "../GearDisplay";
 
 // ---------------------------------------------------------------------------
@@ -178,7 +201,15 @@ function expandRow(index = 0) {
 
 describe("GearDisplay", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockIsGlobalWirelessEnabled.mockReturnValue(true);
+    mockCanChangeReadiness.mockReturnValue({ allowed: true, actionCost: "simple" });
+    mockPerformReadinessChange.mockImplementation(
+      async (_from: unknown, _to: unknown, applyChange: () => void) => {
+        applyChange();
+        return true;
+      }
+    );
   });
 
   // --- Empty state ---
@@ -585,6 +616,64 @@ describe("GearDisplay", () => {
     const updated = onUpdate.mock.calls[0][0] as Character;
     const updatedItem = updated.gear?.find((g) => g.name === "Headjammer");
     expect(updatedItem?.state?.wirelessEnabled).toBe(false);
+  });
+
+  // --- Combat readiness gating ---
+
+  it("disables readiness button when combat check blocks it", () => {
+    mockCanChangeReadiness.mockReturnValue({
+      allowed: false,
+      reason: "No simple actions remaining",
+      actionCost: "simple",
+    });
+    renderGear(
+      [
+        makeGear({
+          name: "Headjammer",
+          category: "electronics",
+          state: { readiness: "carried", wirelessEnabled: true },
+        }),
+      ],
+      { editable: true, onCharacterUpdate: vi.fn() }
+    );
+    expandRow();
+    expect(screen.getByTestId("readiness-holstered")).toBeDisabled();
+  });
+
+  it("shows combat block reason in title when blocked", () => {
+    mockCanChangeReadiness.mockReturnValue({
+      allowed: false,
+      reason: "Not your turn",
+      actionCost: "simple",
+    });
+    renderGear(
+      [
+        makeGear({
+          name: "Headjammer",
+          category: "electronics",
+          state: { readiness: "carried", wirelessEnabled: true },
+        }),
+      ],
+      { editable: true, onCharacterUpdate: vi.fn() }
+    );
+    expandRow();
+    expect(screen.getByTestId("readiness-holstered")).toHaveAttribute("title", "Not your turn");
+  });
+
+  it("calls performReadinessChange on readiness click", () => {
+    const onUpdate = vi.fn();
+    const gear = [
+      makeGear({
+        name: "Headjammer",
+        category: "electronics",
+        state: { readiness: "carried", wirelessEnabled: true },
+      }),
+    ];
+    renderGear(gear, { editable: true, onCharacterUpdate: onUpdate });
+    expandRow();
+    fireEvent.click(screen.getByTestId("readiness-holstered"));
+    expect(mockPerformReadinessChange).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
   });
 
   // --- Wireless toggle (expanded, editable) ---

--- a/components/character/sheet/__tests__/WeaponsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/WeaponsDisplay.test.tsx
@@ -71,6 +71,29 @@ vi.mock("@/lib/rules/inventory", () => ({
   getTransitionActionCost: vi.fn(() => "simple"),
 }));
 
+// Default mock: not in combat, all transitions allowed
+const mockCanChangeReadiness = vi.fn(
+  (): { allowed: boolean; reason?: string; actionCost: string } => ({
+    allowed: true,
+    actionCost: "simple",
+  })
+);
+const mockPerformReadinessChange = vi.fn(
+  async (_from: unknown, _to: unknown, applyChange: () => void) => {
+    applyChange();
+    return true;
+  }
+);
+
+vi.mock("@/lib/combat", () => ({
+  useCombatReadiness: () => ({
+    isInCombat: false,
+    isMyTurn: false,
+    canChangeReadiness: mockCanChangeReadiness,
+    performReadinessChange: mockPerformReadinessChange,
+  }),
+}));
+
 // ---------------------------------------------------------------------------
 // Catalog mock
 // ---------------------------------------------------------------------------
@@ -156,6 +179,13 @@ import { isGlobalWirelessEnabled } from "@/lib/rules/wireless";
 beforeEach(() => {
   vi.clearAllMocks();
   (isGlobalWirelessEnabled as ReturnType<typeof vi.fn>).mockReturnValue(true);
+  mockCanChangeReadiness.mockReturnValue({ allowed: true, actionCost: "simple" });
+  mockPerformReadinessChange.mockImplementation(
+    async (_from: unknown, _to: unknown, applyChange: () => void) => {
+      applyChange();
+      return true;
+    }
+  );
 });
 
 describe("WeaponsDisplay", () => {
@@ -887,6 +917,60 @@ describe("WeaponsDisplay", () => {
       render(<WeaponsDisplay character={character} editable={true} />);
       fireEvent.click(screen.getByTestId("expand-button"));
       expect(screen.queryByTestId("move-to-container-control")).not.toBeInTheDocument();
+    });
+  });
+
+  // =========================================================================
+  // Combat readiness gating
+  // =========================================================================
+
+  describe("combat readiness gating", () => {
+    it("disables readiness button when combat check blocks it", () => {
+      mockCanChangeReadiness.mockReturnValue({
+        allowed: false,
+        reason: "No simple actions remaining",
+        actionCost: "simple",
+      });
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      // Non-current readiness buttons should be disabled
+      expect(screen.getByTestId("readiness-readied")).toBeDisabled();
+    });
+
+    it("shows combat block reason in title when blocked", () => {
+      mockCanChangeReadiness.mockReturnValue({
+        allowed: false,
+        reason: "Not your turn",
+        actionCost: "simple",
+      });
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      expect(screen.getByTestId("readiness-readied")).toHaveAttribute("title", "Not your turn");
+    });
+
+    it("calls performReadinessChange on click instead of direct change", async () => {
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("readiness-readied"));
+      expect(mockPerformReadinessChange).toHaveBeenCalledTimes(1);
+      expect(onUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onCharacterUpdate when performReadinessChange fails", async () => {
+      mockPerformReadinessChange.mockResolvedValue(false);
+      const onUpdate = vi.fn();
+      const character = createSheetCharacter({ weapons: [MOCK_RANGED_WEAPON] });
+      render(<WeaponsDisplay character={character} editable={true} onCharacterUpdate={onUpdate} />);
+      fireEvent.click(screen.getByTestId("expand-button"));
+      fireEvent.click(screen.getByTestId("readiness-readied"));
+      expect(mockPerformReadinessChange).toHaveBeenCalledTimes(1);
+      expect(onUpdate).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/combat/CombatSessionContext.tsx
+++ b/lib/combat/CombatSessionContext.tsx
@@ -51,6 +51,8 @@ export interface CombatSessionActions {
     targetId?: string,
     options?: { weaponId?: string; firingMode?: string; magazineId?: string; ammoItemId?: string }
   ) => Promise<boolean>;
+  /** Spend an action from the current participant's action economy */
+  spendAction: (actionType: "free" | "simple" | "complex") => Promise<boolean>;
   /** Delay turn */
   delayTurn: () => Promise<boolean>;
   /** End turn */
@@ -272,6 +274,54 @@ export function CombatSessionProvider({
     [session, participant]
   );
 
+  // Spend an action from action economy (for readiness changes, etc.)
+  const spendAction = useCallback(
+    async (actionType: "free" | "simple" | "complex"): Promise<boolean> => {
+      if (!session || !participant) {
+        setError("Not in combat");
+        return false;
+      }
+
+      try {
+        const response = await fetch(`/api/combat/${session.id}/spend-action`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            participantId: participant.id,
+            actionType,
+          }),
+        });
+
+        const data = await response.json();
+
+        if (!data.success) {
+          setError(data.error || `No ${actionType} actions remaining`);
+          return false;
+        }
+
+        // Update session with new action allocation
+        if (data.actionsRemaining) {
+          setSession((prev) => {
+            if (!prev) return prev;
+            return {
+              ...prev,
+              participants: prev.participants.map((p) =>
+                p.id === participant.id ? { ...p, actionsRemaining: data.actionsRemaining } : p
+              ),
+            };
+          });
+        }
+
+        return true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to spend action";
+        setError(message);
+        return false;
+      }
+    },
+    [session, participant]
+  );
+
   // Delay turn
   const delayTurn = useCallback(async (): Promise<boolean> => {
     if (!session || !participant) {
@@ -453,6 +503,7 @@ export function CombatSessionProvider({
       leaveSession,
       refreshSession,
       executeAction,
+      spendAction,
       delayTurn,
       endTurn,
       useInterrupt,
@@ -469,6 +520,7 @@ export function CombatSessionProvider({
       leaveSession,
       refreshSession,
       executeAction,
+      spendAction,
       delayTurn,
       endTurn,
       useInterrupt,
@@ -502,6 +554,7 @@ export function useCombatSession(): CombatSessionContextValue {
       leaveSession: async () => false,
       refreshSession: async () => {},
       executeAction: async () => false,
+      spendAction: async () => false,
       delayTurn: async () => false,
       endTurn: async () => false,
       useInterrupt: async () => false,

--- a/lib/combat/__tests__/useCombatReadiness.test.ts
+++ b/lib/combat/__tests__/useCombatReadiness.test.ts
@@ -1,0 +1,283 @@
+/**
+ * useCombatReadiness Hook Tests
+ *
+ * Tests combat-aware readiness change gating: outside combat all allowed,
+ * in combat checks turn, action costs, and available actions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { EquipmentReadiness } from "@/lib/types/gear-state";
+
+// Mock the combat session context
+const mockUseCombatSession = vi.fn();
+const mockUseCanPerformAction = vi.fn();
+
+vi.mock("../CombatSessionContext", () => ({
+  useCombatSession: () => mockUseCombatSession(),
+  useCanPerformAction: (type: string) => mockUseCanPerformAction(type),
+}));
+
+// Mock the inventory state-manager
+vi.mock("@/lib/rules/inventory/state-manager", () => ({
+  getTransitionActionCost: vi.fn((from: string, to: string) => {
+    const costs: Record<string, string> = {
+      "holstered->readied": "simple",
+      "readied->holstered": "free",
+      "carried->readied": "complex",
+      "readied->carried": "complex",
+      "readied->stashed": "narrative",
+      "holstered->stashed": "narrative",
+      "readied->readied": "none",
+      "holstered->holstered": "none",
+    };
+    return costs[`${from}->${to}`] ?? "complex";
+  }),
+}));
+
+import { useCombatReadiness } from "../useCombatReadiness";
+
+// Defaults: not in combat
+function setNotInCombat() {
+  mockUseCombatSession.mockReturnValue({
+    isInCombat: false,
+    isMyTurn: false,
+    spendAction: vi.fn().mockResolvedValue(false),
+  });
+  mockUseCanPerformAction.mockReturnValue(true);
+}
+
+function setInCombatMyTurn(actions: { free?: boolean; simple?: boolean; complex?: boolean } = {}) {
+  const spendAction = vi.fn().mockResolvedValue(true);
+  mockUseCombatSession.mockReturnValue({
+    isInCombat: true,
+    isMyTurn: true,
+    spendAction,
+  });
+  mockUseCanPerformAction.mockImplementation((type: string) => {
+    if (type === "free") return actions.free ?? true;
+    if (type === "simple") return actions.simple ?? true;
+    if (type === "complex") return actions.complex ?? true;
+    return false;
+  });
+  return spendAction;
+}
+
+function setInCombatNotMyTurn() {
+  mockUseCombatSession.mockReturnValue({
+    isInCombat: true,
+    isMyTurn: false,
+    spendAction: vi.fn().mockResolvedValue(false),
+  });
+  mockUseCanPerformAction.mockReturnValue(true);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setNotInCombat();
+});
+
+describe("useCombatReadiness", () => {
+  describe("canChangeReadiness", () => {
+    it("allows all transitions outside combat", () => {
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "holstered" as EquipmentReadiness,
+        "readied" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(true);
+      expect(check.actionCost).toBe("simple");
+      expect(check.reason).toBeUndefined();
+    });
+
+    it("blocks all transitions when not your turn", () => {
+      setInCombatNotMyTurn();
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "holstered" as EquipmentReadiness,
+        "readied" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(false);
+      expect(check.reason).toBe("Not your turn");
+    });
+
+    it("blocks narrative-cost transitions during combat", () => {
+      setInCombatMyTurn();
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "readied" as EquipmentReadiness,
+        "stashed" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(false);
+      expect(check.reason).toBe("Not available during combat");
+      expect(check.actionCost).toBe("narrative");
+    });
+
+    it("allows simple action when simple actions available", () => {
+      setInCombatMyTurn({ simple: true });
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "holstered" as EquipmentReadiness,
+        "readied" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(true);
+      expect(check.actionCost).toBe("simple");
+    });
+
+    it("blocks simple action when no simple actions remain", () => {
+      setInCombatMyTurn({ simple: false });
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "holstered" as EquipmentReadiness,
+        "readied" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(false);
+      expect(check.reason).toBe("No simple actions remaining");
+    });
+
+    it("allows free action when free actions available", () => {
+      setInCombatMyTurn({ free: true });
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "readied" as EquipmentReadiness,
+        "holstered" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(true);
+      expect(check.actionCost).toBe("free");
+    });
+
+    it("blocks free action when no free actions remain", () => {
+      setInCombatMyTurn({ free: false });
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "readied" as EquipmentReadiness,
+        "holstered" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(false);
+      expect(check.reason).toBe("No free actions remaining");
+    });
+
+    it("allows complex action when complex actions available", () => {
+      setInCombatMyTurn({ complex: true });
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "carried" as EquipmentReadiness,
+        "readied" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(true);
+      expect(check.actionCost).toBe("complex");
+    });
+
+    it("blocks complex action when no complex actions remain", () => {
+      setInCombatMyTurn({ complex: false });
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "carried" as EquipmentReadiness,
+        "readied" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(false);
+      expect(check.reason).toBe("No complex actions remaining");
+    });
+
+    it("allows same-state transition (no-op)", () => {
+      setInCombatMyTurn();
+      const { result } = renderHook(() => useCombatReadiness());
+
+      const check = result.current.canChangeReadiness(
+        "readied" as EquipmentReadiness,
+        "readied" as EquipmentReadiness
+      );
+      expect(check.allowed).toBe(true);
+      expect(check.actionCost).toBe("none");
+    });
+  });
+
+  describe("performReadinessChange", () => {
+    it("calls applyChange directly outside combat", async () => {
+      const { result } = renderHook(() => useCombatReadiness());
+      const applyChange = vi.fn();
+
+      const success = await result.current.performReadinessChange(
+        "holstered" as EquipmentReadiness,
+        "readied" as EquipmentReadiness,
+        applyChange
+      );
+
+      expect(success).toBe(true);
+      expect(applyChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls spendAction then applyChange in combat", async () => {
+      const spendAction = setInCombatMyTurn();
+      const { result } = renderHook(() => useCombatReadiness());
+      const applyChange = vi.fn();
+
+      const success = await result.current.performReadinessChange(
+        "holstered" as EquipmentReadiness,
+        "readied" as EquipmentReadiness,
+        applyChange
+      );
+
+      expect(success).toBe(true);
+      expect(spendAction).toHaveBeenCalledWith("simple");
+      expect(applyChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call applyChange when spendAction fails", async () => {
+      const spendAction = setInCombatMyTurn();
+      spendAction.mockResolvedValue(false);
+      const { result } = renderHook(() => useCombatReadiness());
+      const applyChange = vi.fn();
+
+      const success = await result.current.performReadinessChange(
+        "holstered" as EquipmentReadiness,
+        "readied" as EquipmentReadiness,
+        applyChange
+      );
+
+      expect(success).toBe(false);
+      expect(spendAction).toHaveBeenCalledWith("simple");
+      expect(applyChange).not.toHaveBeenCalled();
+    });
+
+    it("returns false when change is not allowed", async () => {
+      setInCombatNotMyTurn();
+      const { result } = renderHook(() => useCombatReadiness());
+      const applyChange = vi.fn();
+
+      const success = await result.current.performReadinessChange(
+        "holstered" as EquipmentReadiness,
+        "readied" as EquipmentReadiness,
+        applyChange
+      );
+
+      expect(success).toBe(false);
+      expect(applyChange).not.toHaveBeenCalled();
+    });
+
+    it("applies no-cost transitions without spending action in combat", async () => {
+      const spendAction = setInCombatMyTurn();
+      const { result } = renderHook(() => useCombatReadiness());
+      const applyChange = vi.fn();
+
+      const success = await result.current.performReadinessChange(
+        "readied" as EquipmentReadiness,
+        "readied" as EquipmentReadiness,
+        applyChange
+      );
+
+      expect(success).toBe(true);
+      expect(spendAction).not.toHaveBeenCalled();
+      expect(applyChange).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/lib/combat/index.ts
+++ b/lib/combat/index.ts
@@ -14,3 +14,9 @@ export {
   type CombatSessionActions,
   type CombatSessionContextValue,
 } from "./CombatSessionContext";
+
+export {
+  useCombatReadiness,
+  type ReadinessChangeCheck,
+  type CombatReadinessHook,
+} from "./useCombatReadiness";

--- a/lib/combat/useCombatReadiness.ts
+++ b/lib/combat/useCombatReadiness.ts
@@ -1,0 +1,129 @@
+"use client";
+
+/**
+ * useCombatReadiness Hook
+ *
+ * Bridges combat session state with equipment readiness transitions.
+ * When in combat, gates readiness changes behind action economy checks.
+ * When outside combat, all valid transitions are freely allowed.
+ */
+
+import { useCallback } from "react";
+import type { EquipmentReadiness } from "@/lib/types/gear-state";
+import type { ActionType } from "@/lib/rules/inventory/state-manager";
+import { getTransitionActionCost } from "@/lib/rules/inventory/state-manager";
+import { useCombatSession, useCanPerformAction } from "./CombatSessionContext";
+
+export interface ReadinessChangeCheck {
+  /** Whether the readiness change is allowed */
+  allowed: boolean;
+  /** Human-readable reason when blocked (for tooltip) */
+  reason?: string;
+  /** The action type this transition costs */
+  actionCost: ActionType;
+}
+
+export interface CombatReadinessHook {
+  /** Whether the character is currently in combat */
+  isInCombat: boolean;
+  /** Whether it's the character's turn */
+  isMyTurn: boolean;
+  /** Check if a readiness change is allowed */
+  canChangeReadiness: (from: EquipmentReadiness, to: EquipmentReadiness) => ReadinessChangeCheck;
+  /** Attempt a readiness change, spending action if in combat. Returns true on success. */
+  performReadinessChange: (
+    from: EquipmentReadiness,
+    to: EquipmentReadiness,
+    applyChange: () => void
+  ) => Promise<boolean>;
+}
+
+export function useCombatReadiness(): CombatReadinessHook {
+  const { isInCombat, isMyTurn, spendAction } = useCombatSession();
+
+  const canPerformFree = useCanPerformAction("free");
+  const canPerformSimple = useCanPerformAction("simple");
+  const canPerformComplex = useCanPerformAction("complex");
+
+  const canChangeReadiness = useCallback(
+    (from: EquipmentReadiness, to: EquipmentReadiness): ReadinessChangeCheck => {
+      const actionCost = getTransitionActionCost(from, to);
+
+      // Same state = no-op
+      if (actionCost === "none") {
+        return { allowed: true, actionCost };
+      }
+
+      // Not in combat — always allowed
+      if (!isInCombat) {
+        return { allowed: true, actionCost };
+      }
+
+      // In combat but not my turn
+      if (!isMyTurn) {
+        return { allowed: false, reason: "Not your turn", actionCost };
+      }
+
+      // Narrative cost — not available during combat
+      if (actionCost === "narrative") {
+        return { allowed: false, reason: "Not available during combat", actionCost };
+      }
+
+      // Check action availability
+      switch (actionCost) {
+        case "free":
+          return canPerformFree
+            ? { allowed: true, actionCost }
+            : { allowed: false, reason: "No free actions remaining", actionCost };
+        case "simple":
+          return canPerformSimple
+            ? { allowed: true, actionCost }
+            : { allowed: false, reason: "No simple actions remaining", actionCost };
+        case "complex":
+          return canPerformComplex
+            ? { allowed: true, actionCost }
+            : { allowed: false, reason: "No complex actions remaining", actionCost };
+        default:
+          return { allowed: false, reason: "Unknown action cost", actionCost };
+      }
+    },
+    [isInCombat, isMyTurn, canPerformFree, canPerformSimple, canPerformComplex]
+  );
+
+  const performReadinessChange = useCallback(
+    async (
+      from: EquipmentReadiness,
+      to: EquipmentReadiness,
+      applyChange: () => void
+    ): Promise<boolean> => {
+      const check = canChangeReadiness(from, to);
+
+      if (!check.allowed) {
+        return false;
+      }
+
+      // Not in combat or no-cost transition — just apply
+      if (!isInCombat || check.actionCost === "none") {
+        applyChange();
+        return true;
+      }
+
+      // In combat — spend the action first
+      const spent = await spendAction(check.actionCost as "free" | "simple" | "complex");
+      if (!spent) {
+        return false;
+      }
+
+      applyChange();
+      return true;
+    },
+    [isInCombat, canChangeReadiness, spendAction]
+  );
+
+  return {
+    isInCombat,
+    isMyTurn,
+    canChangeReadiness,
+    performReadinessChange,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `spendAction` method to `CombatSessionContext` and `POST /api/combat/[sessionId]/spend-action` endpoint for spending combat actions
- Create `useCombatReadiness` hook that bridges combat session state with equipment readiness transition costs
- Update WeaponsDisplay, ArmorDisplay, and GearDisplay to disable readiness buttons when combat action economy blocks the transition

Closes #393

## Test plan
- [x] `pnpm type-check` passes
- [x] All 8601 tests pass (405 test files)
- [x] New `useCombatReadiness` hook tests verify: outside-combat allows all, not-your-turn blocks, narrative-cost blocks, action availability checks, `performReadinessChange` spend-then-apply flow
- [x] New spend-action API tests verify: auth, validation, successful deduction for each action type, rejection when exhausted
- [x] Display component tests verify: disabled buttons when blocked, reason shown in title, `performReadinessChange` called on click
- [ ] Manual: Outside combat, readiness buttons work as before (no regression)
- [ ] Manual: In combat, buttons disable when actions exhausted

🤖 Generated with [Claude Code](https://claude.com/claude-code)