### PR TITLE
feat: improve username validation (#182)

### DIFF
--- a/app/api/auth/__tests__/signup.test.ts
+++ b/app/api/auth/__tests__/signup.test.ts
@@ -93,6 +93,7 @@ describe("POST /api/auth/signup", () => {
     };
 
     vi.mocked(validationModule.isValidEmail).mockReturnValue(true);
+    vi.mocked(validationModule.isValidUsername).mockReturnValue(true);
     vi.mocked(validationModule.isStrongPassword).mockReturnValue(true);
     vi.mocked(storageModule.getUserByEmail).mockResolvedValue(null);
     vi.mocked(passwordModule.hashPassword).mockResolvedValue("hashed-password");
@@ -112,6 +113,7 @@ describe("POST /api/auth/signup", () => {
     expect(data.user.role).toEqual(mockNewUser.role);
 
     expect(validationModule.isValidEmail).toHaveBeenCalledWith("newuser@example.com");
+    expect(validationModule.isValidUsername).toHaveBeenCalledWith("newuser");
     expect(validationModule.isStrongPassword).toHaveBeenCalledWith("ValidPass123!");
     expect(storageModule.getUserByEmail).toHaveBeenCalledWith("newuser@example.com");
     expect(passwordModule.hashPassword).toHaveBeenCalledWith("ValidPass123!");
@@ -201,6 +203,7 @@ describe("POST /api/auth/signup", () => {
     };
 
     vi.mocked(validationModule.isValidEmail).mockReturnValue(true);
+    vi.mocked(validationModule.isValidUsername).mockReturnValue(true);
     vi.mocked(validationModule.isStrongPassword).mockReturnValue(false);
     vi.mocked(validationModule.getPasswordStrengthError).mockReturnValue(
       "Password must be at least 8 characters long"
@@ -261,6 +264,7 @@ describe("POST /api/auth/signup", () => {
     };
 
     vi.mocked(validationModule.isValidEmail).mockReturnValue(true);
+    vi.mocked(validationModule.isValidUsername).mockReturnValue(true);
     vi.mocked(validationModule.isStrongPassword).mockReturnValue(true);
     vi.mocked(storageModule.getUserByEmail).mockResolvedValue(existingUser);
 
@@ -284,6 +288,7 @@ describe("POST /api/auth/signup", () => {
     };
 
     vi.mocked(validationModule.isValidEmail).mockReturnValue(true);
+    vi.mocked(validationModule.isValidUsername).mockReturnValue(true);
     vi.mocked(validationModule.isStrongPassword).mockReturnValue(true);
     vi.mocked(storageModule.getUserByEmail).mockResolvedValue(null);
     vi.mocked(passwordModule.hashPassword).mockResolvedValue("hashed-password");
@@ -312,6 +317,7 @@ describe("POST /api/auth/signup", () => {
     };
 
     vi.mocked(validationModule.isValidEmail).mockReturnValue(true);
+    vi.mocked(validationModule.isValidUsername).mockReturnValue(true);
     vi.mocked(validationModule.isStrongPassword).mockReturnValue(true);
     vi.mocked(storageModule.getUserByEmail).mockRejectedValue(new Error("Database error"));
 

--- a/app/api/auth/signup/__tests__/route.test.ts
+++ b/app/api/auth/signup/__tests__/route.test.ts
@@ -87,6 +87,8 @@ describe("POST /api/auth/signup", () => {
 
     // Default validation mocks (passing)
     vi.mocked(validationModule.isValidEmail).mockReturnValue(true);
+    vi.mocked(validationModule.isValidUsername).mockReturnValue(true);
+    vi.mocked(validationModule.getUsernameError).mockReturnValue(null);
     vi.mocked(validationModule.isStrongPassword).mockReturnValue(true);
     vi.mocked(validationModule.getPasswordStrengthError).mockReturnValue(null);
 
@@ -204,6 +206,31 @@ describe("POST /api/auth/signup", () => {
     expect(data.success).toBe(false);
     expect(data.error).toBe("Invalid email format");
     expect(validationModule.isValidEmail).toHaveBeenCalledWith("invalid-email");
+    expect(storageModule.getUserByEmail).not.toHaveBeenCalled();
+    expect(storageModule.createUser).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 when username format is invalid", async () => {
+    vi.mocked(validationModule.isValidUsername).mockReturnValue(false);
+    vi.mocked(validationModule.getUsernameError).mockReturnValue(
+      "Username can only contain letters, numbers, hyphens, and underscores"
+    );
+
+    const requestBody = {
+      email: "newuser@example.com",
+      username: "<script>alert</script>",
+      password: "ValidPass123!",
+    };
+
+    const request = createMockRequest("http://localhost:3000/api/auth/signup", requestBody, "POST");
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Username can only contain letters, numbers, hyphens, and underscores");
+    expect(validationModule.isValidUsername).toHaveBeenCalledWith("<script>alert</script>");
     expect(storageModule.getUserByEmail).not.toHaveBeenCalled();
     expect(storageModule.createUser).not.toHaveBeenCalled();
   });

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -3,7 +3,13 @@ import { createUser, getUserByEmail, type NewUserData } from "@/lib/storage/user
 import { hashPassword } from "@/lib/auth/password";
 import { createSession } from "@/lib/auth/session";
 import { toPublicUser } from "@/lib/auth/middleware";
-import { isValidEmail, isStrongPassword, getPasswordStrengthError } from "@/lib/auth/validation";
+import {
+  isValidEmail,
+  isStrongPassword,
+  getPasswordStrengthError,
+  isValidUsername,
+  getUsernameError,
+} from "@/lib/auth/validation";
 import { sendVerificationEmail } from "@/lib/auth/email-verification";
 import { sendAdminNewUserNotification } from "@/lib/email";
 import { RateLimiter } from "@/lib/security/rate-limit";
@@ -47,6 +53,15 @@ export async function POST(request: NextRequest): Promise<NextResponse<AuthRespo
     // Validate email format
     if (!isValidEmail(email)) {
       return NextResponse.json({ success: false, error: "Invalid email format" }, { status: 400 });
+    }
+
+    // Validate username format
+    if (!isValidUsername(username)) {
+      const errorMessage = getUsernameError(username);
+      return NextResponse.json(
+        { success: false, error: errorMessage || "Invalid username format" },
+        { status: 400 }
+      );
     }
 
     // Validate password strength

--- a/lib/auth/__tests__/validation.test.ts
+++ b/lib/auth/__tests__/validation.test.ts
@@ -177,19 +177,24 @@ describe("validation", () => {
   });
 
   describe("isValidUsername", () => {
-    it("returns true for usernames between 3 and 50 characters", () => {
-      expect(isValidUsername("abc")).toBe(true); // 3 chars (minimum)
+    it("returns true for valid usernames", () => {
+      expect(isValidUsername("abc")).toBe(true);
       expect(isValidUsername("username")).toBe(true);
-      expect(isValidUsername("a".repeat(50))).toBe(true); // 50 chars (maximum)
+      expect(isValidUsername("a".repeat(50))).toBe(true);
+      expect(isValidUsername("user_name")).toBe(true);
+      expect(isValidUsername("user-name")).toBe(true);
+      expect(isValidUsername("User123")).toBe(true);
+      expect(isValidUsername("a_b")).toBe(true);
+      expect(isValidUsername("a-b")).toBe(true);
     });
 
     it("returns false for usernames under 3 characters", () => {
-      expect(isValidUsername("ab")).toBe(false); // 2 chars
+      expect(isValidUsername("ab")).toBe(false);
       expect(isValidUsername("a")).toBe(false);
     });
 
     it("returns false for usernames over 50 characters", () => {
-      expect(isValidUsername("a".repeat(51))).toBe(false); // 51 chars
+      expect(isValidUsername("a".repeat(51))).toBe(false);
       expect(isValidUsername("a".repeat(100))).toBe(false);
     });
 
@@ -197,10 +202,39 @@ describe("validation", () => {
       expect(isValidUsername("")).toBe(false);
     });
 
-    it("accepts usernames with special characters if within length", () => {
-      expect(isValidUsername("user_name")).toBe(true);
-      expect(isValidUsername("user-name")).toBe(true);
-      expect(isValidUsername("user.name")).toBe(true);
+    it("returns false for usernames with dots", () => {
+      expect(isValidUsername("user.name")).toBe(false);
+    });
+
+    it("returns false for usernames with HTML tags", () => {
+      expect(isValidUsername("<script>alert</script>")).toBe(false);
+      expect(isValidUsername("<b>bold</b>")).toBe(false);
+    });
+
+    it("returns false for usernames with whitespace", () => {
+      expect(isValidUsername("user name")).toBe(false);
+      expect(isValidUsername("   ")).toBe(false);
+      expect(isValidUsername("user\tname")).toBe(false);
+      expect(isValidUsername("user\nname")).toBe(false);
+    });
+
+    it("returns false for usernames with unicode characters", () => {
+      expect(isValidUsername("usеrname")).toBe(false); // Cyrillic 'е'
+      expect(isValidUsername("user\u200Bname")).toBe(false); // zero-width space
+      expect(isValidUsername("héllo")).toBe(false);
+    });
+
+    it("returns false for usernames starting or ending with special chars", () => {
+      expect(isValidUsername("_username")).toBe(false);
+      expect(isValidUsername("-username")).toBe(false);
+      expect(isValidUsername("username_")).toBe(false);
+      expect(isValidUsername("username-")).toBe(false);
+    });
+
+    it("returns false for usernames with other special characters", () => {
+      expect(isValidUsername("user@name")).toBe(false);
+      expect(isValidUsername("user!name")).toBe(false);
+      expect(isValidUsername("user#name")).toBe(false);
     });
   });
 
@@ -209,6 +243,8 @@ describe("validation", () => {
       expect(getUsernameError("abc")).toBeNull();
       expect(getUsernameError("username")).toBeNull();
       expect(getUsernameError("a".repeat(50))).toBeNull();
+      expect(getUsernameError("user_name")).toBeNull();
+      expect(getUsernameError("user-name")).toBeNull();
     });
 
     it("returns too short error for usernames under 3 characters", () => {
@@ -224,6 +260,30 @@ describe("validation", () => {
 
     it("returns too short error for empty string", () => {
       expect(getUsernameError("")).toBe("Username must be at least 3 characters long");
+    });
+
+    it("returns invalid characters error for disallowed characters", () => {
+      expect(getUsernameError("user.name")).toBe(
+        "Username can only contain letters, numbers, hyphens, and underscores"
+      );
+      expect(getUsernameError("user@name")).toBe(
+        "Username can only contain letters, numbers, hyphens, and underscores"
+      );
+      expect(getUsernameError("<script>")).toBe(
+        "Username can only contain letters, numbers, hyphens, and underscores"
+      );
+    });
+
+    it("returns start/end error for leading or trailing special chars", () => {
+      expect(getUsernameError("_username")).toBe(
+        "Username must start and end with a letter or number"
+      );
+      expect(getUsernameError("username_")).toBe(
+        "Username must start and end with a letter or number"
+      );
+      expect(getUsernameError("-username")).toBe(
+        "Username must start and end with a letter or number"
+      );
     });
   });
 });

--- a/lib/auth/validation.ts
+++ b/lib/auth/validation.ts
@@ -68,11 +68,14 @@ export function getPasswordStrengthError(password: string): string | null {
 }
 
 /**
- * Validate username length
- * Username must be between 3 and 50 characters
+ * Validate username format
+ * - Between 3 and 50 characters
+ * - Only alphanumeric characters, hyphens, and underscores
+ * - Must start and end with an alphanumeric character
  */
 export function isValidUsername(username: string): boolean {
-  return username.length >= 3 && username.length <= 50;
+  if (username.length < 3 || username.length > 50) return false;
+  return /^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$/.test(username);
 }
 
 /**
@@ -84,6 +87,12 @@ export function getUsernameError(username: string): string | null {
   }
   if (username.length > 50) {
     return "Username must be no more than 50 characters long";
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
+    return "Username can only contain letters, numbers, hyphens, and underscores";
+  }
+  if (!/^[a-zA-Z0-9]/.test(username) || !/[a-zA-Z0-9]$/.test(username)) {
+    return "Username must start and end with a letter or number";
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Strengthen `isValidUsername()` to only allow `[a-zA-Z0-9_-]`, must start/end with alphanumeric character
- Add specific error messages in `getUsernameError()` for invalid characters and start/end rules
- Add missing `isValidUsername()` call to signup route (`/api/auth/signup`)
- Prevents HTML injection, unicode homoglyphs, whitespace-only usernames, and identity confusion

## Test plan
- [x] `pnpm vitest run lib/auth/__tests__/validation.test.ts` — 46 tests pass
- [x] `pnpm vitest run app/api/auth/signup/__tests__/route.test.ts` — 19 tests pass
- [x] `pnpm vitest run app/api/auth/__tests__/signup.test.ts` — 9 tests pass
- [x] `pnpm type-check` — no errors
- [x] Manual test: signup with `<script>`, unicode, whitespace usernames → rejected with clear error

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)