### PR TITLE
feat: add GM authorization model for cross-user character editing (#392)

### DIFF
--- a/__tests__/lib/auth/gm-character-access.test.ts
+++ b/__tests__/lib/auth/gm-character-access.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for GM Character Access module
+ *
+ * Tests the cross-user character resolution that allows GMs to
+ * perform gameplay edits on player characters in their campaigns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies
+vi.mock("@/lib/storage/characters", () => ({
+  getCharacter: vi.fn(),
+  getCharacterById: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/character-authorization", () => ({
+  determineRole: vi.fn(),
+  getPermissionsForRole: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+vi.mock("@/lib/storage/notifications", () => ({
+  createNotification: vi.fn(),
+}));
+
+import { getCharacter, getCharacterById } from "@/lib/storage/characters";
+import {
+  determineRole,
+  getPermissionsForRole,
+  hasPermission,
+} from "@/lib/auth/character-authorization";
+import { createNotification } from "@/lib/storage/notifications";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
+import type { Character } from "@/lib/types";
+import type { Campaign } from "@/lib/types/campaign";
+
+// =============================================================================
+// TEST DATA
+// =============================================================================
+
+const OWNER_ID = "owner-user-1";
+const GM_ID = "gm-user-2";
+const OTHER_USER_ID = "other-user-3";
+const CHARACTER_ID = "char-1";
+const CAMPAIGN_ID = "campaign-1";
+
+function createMockCharacter(overrides: Partial<Character> = {}): Character {
+  return {
+    id: CHARACTER_ID,
+    ownerId: OWNER_ID,
+    name: "Test Runner",
+    status: "active",
+    editionCode: "sr5",
+    editionId: "sr5-edition-id",
+    creationMethodId: "priority",
+    attachedBookIds: ["core-rulebook"],
+    metatype: "Human",
+    attributes: {
+      body: 4,
+      agility: 3,
+      reaction: 3,
+      strength: 3,
+      willpower: 4,
+      logic: 3,
+      intuition: 3,
+      charisma: 3,
+    },
+    skills: {},
+    positiveQualities: [],
+    negativeQualities: [],
+    magicalPath: "mundane",
+    nuyen: 5000,
+    startingNuyen: 5000,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    specialAttributes: { edge: 3, essence: 6 },
+    ...overrides,
+  } as Character;
+}
+
+const mockCampaign: Campaign = {
+  id: CAMPAIGN_ID,
+  title: "Test Campaign",
+  gmId: GM_ID,
+  editionId: "sr5-edition-id",
+  editionCode: "sr5",
+  enabledBookIds: ["core-rulebook"],
+  enabledCreationMethodIds: ["priority"],
+  gameplayLevel: "street",
+  status: "active",
+  playerIds: [OWNER_ID],
+  visibility: "private",
+  advancementSettings: {
+    trainingTimeMultiplier: 1.0,
+    attributeKarmaMultiplier: 5,
+    skillKarmaMultiplier: 2,
+    skillGroupKarmaMultiplier: 5,
+    knowledgeSkillKarmaMultiplier: 1,
+    specializationKarmaCost: 7,
+    spellKarmaCost: 5,
+    complexFormKarmaCost: 4,
+    attributeRatingCap: 10,
+    skillRatingCap: 13,
+    allowInstantAdvancement: false,
+    requireApproval: true,
+  },
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+// =============================================================================
+// resolveCharacterForGameplay
+// =============================================================================
+
+describe("resolveCharacterForGameplay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Owner fast path
+  // ---------------------------------------------------------------------------
+
+  it("should resolve via owner fast path when actor owns the character", async () => {
+    const character = createMockCharacter();
+    vi.mocked(getCharacter).mockResolvedValue(character);
+    vi.mocked(determineRole).mockResolvedValue({ role: "owner", campaign: null });
+    vi.mocked(getPermissionsForRole).mockReturnValue(["view", "gameplay_edit"]);
+    vi.mocked(hasPermission).mockReturnValue(true);
+
+    const result = await resolveCharacterForGameplay(OWNER_ID, CHARACTER_ID);
+
+    expect(result.authorized).toBe(true);
+    if (result.authorized) {
+      expect(result.character.id).toBe(CHARACTER_ID);
+      expect(result.ownerId).toBe(OWNER_ID);
+      expect(result.actorRole).toBe("owner");
+      expect(result.isGMAccess).toBe(false);
+    }
+
+    // Should NOT call getCharacterById (fast path)
+    expect(getCharacterById).not.toHaveBeenCalled();
+  });
+
+  it("should deny owner access when permission not granted", async () => {
+    const character = createMockCharacter({ status: "draft" });
+    vi.mocked(getCharacter).mockResolvedValue(character);
+    vi.mocked(determineRole).mockResolvedValue({ role: "owner", campaign: null });
+    vi.mocked(getPermissionsForRole).mockReturnValue(["view", "edit", "finalize"]);
+    vi.mocked(hasPermission).mockReturnValue(false);
+
+    const result = await resolveCharacterForGameplay(OWNER_ID, CHARACTER_ID, "gameplay_edit");
+
+    expect(result.authorized).toBe(false);
+    if (!result.authorized) {
+      expect(result.status).toBe(403);
+      expect(result.error).toContain("gameplay_edit");
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // GM path
+  // ---------------------------------------------------------------------------
+
+  it("should resolve via GM path when actor is campaign GM", async () => {
+    const character = createMockCharacter({ campaignId: CAMPAIGN_ID });
+    vi.mocked(getCharacter).mockResolvedValue(null); // Not owned by GM
+    vi.mocked(getCharacterById).mockResolvedValue(character);
+    vi.mocked(determineRole).mockResolvedValue({ role: "gm", campaign: mockCampaign });
+    vi.mocked(getPermissionsForRole).mockReturnValue(["view", "gameplay_edit", "retire"]);
+    vi.mocked(hasPermission).mockReturnValue(true);
+
+    const result = await resolveCharacterForGameplay(GM_ID, CHARACTER_ID);
+
+    expect(result.authorized).toBe(true);
+    if (result.authorized) {
+      expect(result.character.id).toBe(CHARACTER_ID);
+      expect(result.ownerId).toBe(OWNER_ID);
+      expect(result.actorRole).toBe("gm");
+      expect(result.campaign).toBe(mockCampaign);
+      expect(result.isGMAccess).toBe(true);
+    }
+  });
+
+  it("should deny when non-GM/non-owner tries to access", async () => {
+    const character = createMockCharacter({ campaignId: CAMPAIGN_ID });
+    vi.mocked(getCharacter).mockResolvedValue(null);
+    vi.mocked(getCharacterById).mockResolvedValue(character);
+    vi.mocked(determineRole).mockResolvedValue({ role: "owner", campaign: null });
+
+    const result = await resolveCharacterForGameplay(OTHER_USER_ID, CHARACTER_ID);
+
+    expect(result.authorized).toBe(false);
+    if (!result.authorized) {
+      expect(result.status).toBe(403);
+    }
+  });
+
+  it("should deny when character is not in a campaign (GM path)", async () => {
+    const character = createMockCharacter(); // No campaignId
+    vi.mocked(getCharacter).mockResolvedValue(null);
+    vi.mocked(getCharacterById).mockResolvedValue(character);
+
+    const result = await resolveCharacterForGameplay(GM_ID, CHARACTER_ID);
+
+    expect(result.authorized).toBe(false);
+    if (!result.authorized) {
+      expect(result.status).toBe(404);
+    }
+  });
+
+  it("should return 404 when character doesn't exist at all", async () => {
+    vi.mocked(getCharacter).mockResolvedValue(null);
+    vi.mocked(getCharacterById).mockResolvedValue(null);
+
+    const result = await resolveCharacterForGameplay(OTHER_USER_ID, CHARACTER_ID);
+
+    expect(result.authorized).toBe(false);
+    if (!result.authorized) {
+      expect(result.status).toBe(404);
+      expect(result.error).toBe("Character not found");
+    }
+  });
+
+  it("should deny GM when required permission not in matrix", async () => {
+    const character = createMockCharacter({ campaignId: CAMPAIGN_ID, status: "draft" });
+    vi.mocked(getCharacter).mockResolvedValue(null);
+    vi.mocked(getCharacterById).mockResolvedValue(character);
+    vi.mocked(determineRole).mockResolvedValue({ role: "gm", campaign: mockCampaign });
+    vi.mocked(getPermissionsForRole).mockReturnValue(["view"]); // GM can only view drafts
+    vi.mocked(hasPermission).mockReturnValue(false);
+
+    const result = await resolveCharacterForGameplay(GM_ID, CHARACTER_ID, "gameplay_edit");
+
+    expect(result.authorized).toBe(false);
+    if (!result.authorized) {
+      expect(result.status).toBe(403);
+      expect(result.error).toContain("gameplay_edit");
+    }
+  });
+
+  it("should allow view permission for GM on any character status", async () => {
+    const character = createMockCharacter({ campaignId: CAMPAIGN_ID, status: "draft" });
+    vi.mocked(getCharacter).mockResolvedValue(null);
+    vi.mocked(getCharacterById).mockResolvedValue(character);
+    vi.mocked(determineRole).mockResolvedValue({ role: "gm", campaign: mockCampaign });
+    vi.mocked(getPermissionsForRole).mockReturnValue(["view"]);
+    vi.mocked(hasPermission).mockReturnValue(true);
+
+    const result = await resolveCharacterForGameplay(GM_ID, CHARACTER_ID, "view");
+
+    expect(result.authorized).toBe(true);
+    if (result.authorized) {
+      expect(result.actorRole).toBe("gm");
+      expect(result.isGMAccess).toBe(true);
+    }
+  });
+});
+
+// =============================================================================
+// notifyOwnerOfGMEdit
+// =============================================================================
+
+describe("notifyOwnerOfGMEdit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should create notification for character owner", async () => {
+    const character = createMockCharacter({ campaignId: CAMPAIGN_ID });
+
+    await notifyOwnerOfGMEdit(
+      character,
+      mockCampaign,
+      GM_ID,
+      "3 physical damage applied",
+      "Combat"
+    );
+
+    expect(createNotification).toHaveBeenCalledWith({
+      userId: OWNER_ID,
+      campaignId: CAMPAIGN_ID,
+      type: "character_gm_edited",
+      title: "Character Updated by GM",
+      message: expect.stringContaining("3 physical damage applied"),
+      actionUrl: `/characters/${CHARACTER_ID}`,
+    });
+  });
+
+  it("should include details in notification message when provided", async () => {
+    const character = createMockCharacter({ campaignId: CAMPAIGN_ID });
+
+    await notifyOwnerOfGMEdit(character, mockCampaign, GM_ID, "damage applied", "Ares Predator");
+
+    expect(createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Ares Predator"),
+      })
+    );
+  });
+
+  it("should NOT notify when GM owns the character (NPC case)", async () => {
+    const npcCharacter = createMockCharacter({ ownerId: GM_ID, campaignId: CAMPAIGN_ID });
+
+    await notifyOwnerOfGMEdit(npcCharacter, mockCampaign, GM_ID, "damage applied");
+
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  it("should send notification without details when not provided", async () => {
+    const character = createMockCharacter({ campaignId: CAMPAIGN_ID });
+
+    await notifyOwnerOfGMEdit(character, mockCampaign, GM_ID, "modifier applied");
+
+    expect(createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("modifier applied"),
+      })
+    );
+  });
+});

--- a/app/api/characters/[characterId]/__tests__/route.test.ts
+++ b/app/api/characters/[characterId]/__tests__/route.test.ts
@@ -19,6 +19,10 @@ vi.mock("@/lib/auth/character-authorization", () => ({
   authorizeOwnerAccess: vi.fn(),
 }));
 
+vi.mock("@/lib/auth/gm-character-access", () => ({
+  resolveCharacterForGameplay: vi.fn(),
+}));
+
 vi.mock("@/lib/storage/characters", () => ({
   getCharacter: vi.fn(),
   updateCharacter: vi.fn(),
@@ -32,6 +36,7 @@ vi.mock("@/lib/rules/character/state-machine", () => ({
 
 import { getSession } from "@/lib/auth/session";
 import { authorizeOwnerAccess } from "@/lib/auth/character-authorization";
+import { resolveCharacterForGameplay } from "@/lib/auth/gm-character-access";
 import { updateCharacter, deleteCharacter } from "@/lib/storage/characters";
 import { createAuditEntry, appendAuditEntry } from "@/lib/rules/character/state-machine";
 import { GET, PATCH, DELETE } from "../route";
@@ -149,14 +154,11 @@ describe("GET /api/characters/[characterId]", () => {
 
   it("should return 403 when not authorized", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(authorizeOwnerAccess).mockResolvedValue(
-      createAuthResult({
-        authorized: false,
-        character: null,
-        error: "Permission denied: view",
-        status: 403,
-      })
-    );
+    vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+      authorized: false,
+      error: "Permission denied: view",
+      status: 403,
+    });
 
     const request = createMockRequest();
     const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -171,14 +173,11 @@ describe("GET /api/characters/[characterId]", () => {
 
   it("should return 404 when character not found", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(authorizeOwnerAccess).mockResolvedValue(
-      createAuthResult({
-        authorized: false,
-        character: null,
-        error: "Character not found",
-        status: 404,
-      })
-    );
+    vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+      authorized: false,
+      error: "Character not found",
+      status: 404,
+    });
 
     const request = createMockRequest();
     const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -194,9 +193,14 @@ describe("GET /api/characters/[characterId]", () => {
   it("should return 200 with character data on success", async () => {
     const mockCharacter = createMockCharacter();
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(authorizeOwnerAccess).mockResolvedValue(
-      createAuthResult({ character: mockCharacter })
-    );
+    vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+      authorized: true,
+      character: mockCharacter,
+      ownerId: TEST_USER_ID,
+      actorRole: "owner",
+      campaign: null,
+      isGMAccess: false,
+    });
 
     const request = createMockRequest();
     const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -212,7 +216,7 @@ describe("GET /api/characters/[characterId]", () => {
 
   it("should return 500 on storage error", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(authorizeOwnerAccess).mockRejectedValue(new Error("Storage error"));
+    vi.mocked(resolveCharacterForGameplay).mockRejectedValue(new Error("Storage error"));
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/app/api/characters/[characterId]/damage/__tests__/route.test.ts
+++ b/app/api/characters/[characterId]/damage/__tests__/route.test.ts
@@ -13,23 +13,18 @@ vi.mock("@/lib/auth/session", () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock("@/lib/storage/users", () => ({
-  getUserById: vi.fn(),
+vi.mock("@/lib/auth/gm-character-access", () => ({
+  resolveCharacterForGameplay: vi.fn(),
+  notifyOwnerOfGMEdit: vi.fn(),
 }));
 
 vi.mock("@/lib/storage/characters", () => ({
-  getCharacter: vi.fn(),
   updateCharacterWithAudit: vi.fn(),
 }));
 
-vi.mock("@/lib/storage/campaigns", () => ({
-  getCampaignById: vi.fn(),
-}));
-
 import { getSession } from "@/lib/auth/session";
-import { getUserById } from "@/lib/storage/users";
-import { getCharacter, updateCharacterWithAudit } from "@/lib/storage/characters";
-import { getCampaignById } from "@/lib/storage/campaigns";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
+import { updateCharacterWithAudit } from "@/lib/storage/characters";
 import { POST } from "../route";
 import type { Character } from "@/lib/types";
 import type { Campaign } from "@/lib/types/campaign";
@@ -42,53 +37,6 @@ const TEST_USER_ID = "test-user-123";
 const TEST_GM_ID = "test-gm-456";
 const TEST_CHARACTER_ID = "test-char-789";
 const TEST_CAMPAIGN_ID = "test-campaign-111";
-
-import type { User } from "@/lib/types";
-
-function createMockUser(overrides: Partial<User> = {}): User {
-  return {
-    id: TEST_USER_ID,
-    username: "testrunner",
-    email: "test@example.com",
-    passwordHash: "hashed_password",
-    role: ["user"],
-    preferences: { theme: "dark", navigationCollapsed: false },
-    createdAt: new Date().toISOString(),
-    lastLogin: new Date().toISOString(),
-    characters: [TEST_CHARACTER_ID],
-    failedLoginAttempts: 0,
-    lockoutUntil: null,
-    sessionVersion: 1,
-    sessionSecretHash: null,
-    accountStatus: "active",
-    statusChangedAt: null,
-    statusChangedBy: null,
-    statusReason: null,
-    lastRoleChangeAt: null,
-    lastRoleChangeBy: null,
-    emailVerified: true,
-    emailVerifiedAt: null,
-    emailVerificationTokenHash: null,
-    emailVerificationTokenExpiresAt: null,
-    emailVerificationTokenPrefix: null,
-    passwordResetTokenHash: null,
-    passwordResetTokenExpiresAt: null,
-    passwordResetTokenPrefix: null,
-    magicLinkTokenHash: null,
-    magicLinkTokenExpiresAt: null,
-    magicLinkTokenPrefix: null,
-    ...overrides,
-  };
-}
-
-const mockUser = createMockUser();
-
-const mockGm = createMockUser({
-  id: TEST_GM_ID,
-  username: "testgm",
-  email: "gm@example.com",
-  role: ["gamemaster"],
-});
 
 const mockCampaign: Campaign = {
   id: TEST_CAMPAIGN_ID,
@@ -170,6 +118,34 @@ function createMockRequest(body: Record<string, unknown>): NextRequest {
   });
 }
 
+/**
+ * Helper to mock resolveCharacterForGameplay for authorized owner access
+ */
+function mockOwnerAccess(character: Character) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: true,
+    character,
+    ownerId: TEST_USER_ID,
+    actorRole: "owner",
+    campaign: null,
+    isGMAccess: false,
+  });
+}
+
+/**
+ * Helper to mock resolveCharacterForGameplay for authorized GM access
+ */
+function mockGMAccess(character: Character) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: true,
+    character,
+    ownerId: "other-owner",
+    actorRole: "gm",
+    campaign: mockCampaign,
+    isGMAccess: true,
+  });
+}
+
 // =============================================================================
 // AUTHENTICATION TESTS
 // =============================================================================
@@ -194,9 +170,13 @@ describe("POST /api/characters/[characterId]/damage", () => {
       expect(data.error).toBe("Unauthorized");
     });
 
-    it("should return 404 when user not found", async () => {
+    it("should return 404 when character not found", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(null);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+        authorized: false,
+        error: "Character not found",
+        status: 404,
+      });
 
       const request = createMockRequest({ type: "physical", amount: 3 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -206,7 +186,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
 
       expect(response.status).toBe(404);
       expect(data.success).toBe(false);
-      expect(data.error).toBe("User not found");
+      expect(data.error).toBe("Character not found");
     });
   });
 
@@ -217,8 +197,11 @@ describe("POST /api/characters/[characterId]/damage", () => {
   describe("Authorization", () => {
     it("should return 404 when character not found", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(null);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+        authorized: false,
+        error: "Character not found",
+        status: 404,
+      });
 
       const request = createMockRequest({ type: "physical", amount: 3 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -233,31 +216,10 @@ describe("POST /api/characters/[characterId]/damage", () => {
 
     it("should return 403 when user is not owner and not GM", async () => {
       vi.mocked(getSession).mockResolvedValue("other-user-id");
-      vi.mocked(getUserById).mockResolvedValue({ ...mockUser, id: "other-user-id" });
-      vi.mocked(getCharacter).mockResolvedValue(null); // Not found for other user
-
-      const request = createMockRequest({ type: "physical", amount: 3 });
-      const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
-
-      const response = await POST(request, { params });
-      const data = await response.json();
-
-      expect(response.status).toBe(404);
-      expect(data.success).toBe(false);
-    });
-
-    it("should return 403 when not owner and campaign GM doesn't match", async () => {
-      vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(
-        createMockCharacter({
-          ownerId: "other-owner",
-          campaignId: TEST_CAMPAIGN_ID,
-        })
-      );
-      vi.mocked(getCampaignById).mockResolvedValue({
-        ...mockCampaign,
-        gmId: "different-gm",
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+        authorized: false,
+        error: "Not authorized to access this character",
+        status: 403,
       });
 
       const request = createMockRequest({ type: "physical", amount: 3 });
@@ -268,14 +230,32 @@ describe("POST /api/characters/[characterId]/damage", () => {
 
       expect(response.status).toBe(403);
       expect(data.success).toBe(false);
-      expect(data.error).toBe("Not authorized to modify this character");
+      expect(data.error).toBe("Not authorized to access this character");
+    });
+
+    it("should return 403 when not owner and campaign GM doesn't match", async () => {
+      vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+        authorized: false,
+        error: "Not authorized to access this character",
+        status: 403,
+      });
+
+      const request = createMockRequest({ type: "physical", amount: 3 });
+      const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
+
+      const response = await POST(request, { params });
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.success).toBe(false);
+      expect(data.error).toBe("Not authorized to access this character");
     });
 
     it("should allow owner to apply damage", async () => {
       const mockChar = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockResolvedValue(mockChar);
 
       const request = createMockRequest({ type: "physical", amount: 3 });
@@ -294,9 +274,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         campaignId: TEST_CAMPAIGN_ID,
       });
       vi.mocked(getSession).mockResolvedValue(TEST_GM_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockGm);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
-      vi.mocked(getCampaignById).mockResolvedValue(mockCampaign);
+      mockGMAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockResolvedValue(mockChar);
 
       const request = createMockRequest({ type: "physical", amount: 3 });
@@ -318,8 +296,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
     it("should return 400 when damage type is missing", async () => {
       const mockChar = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
 
       const request = createMockRequest({ amount: 3 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -335,8 +312,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
     it("should return 400 when damage type is invalid", async () => {
       const mockChar = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
 
       const request = createMockRequest({ type: "invalid", amount: 3 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -352,8 +328,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
     it("should return 400 when amount is not a number", async () => {
       const mockChar = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
 
       const request = createMockRequest({ type: "physical", amount: "three" });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -375,8 +350,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
     it("should apply physical damage correctly", async () => {
       const mockChar = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -398,8 +372,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 5, stunDamage: 0, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -421,8 +394,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 2, stunDamage: 0, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -445,8 +417,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 8, stunDamage: 0, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -474,8 +445,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
     it("should apply stun damage correctly", async () => {
       const mockChar = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -497,8 +467,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 0, stunDamage: 6, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -520,8 +489,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 0, stunDamage: 2, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -544,8 +512,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 0, stunDamage: 8, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -575,8 +542,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 10, stunDamage: 0, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -599,8 +565,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 10, stunDamage: 0, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -622,8 +587,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 10, stunDamage: 0, overflowDamage: 3 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -652,8 +616,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 3, stunDamage: 0, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -676,8 +639,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 2, stunDamage: 0, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -701,8 +663,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 0, stunDamage: 3, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -729,8 +690,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
     it("should create audit entry for damage", async () => {
       const mockChar = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -762,8 +722,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 5, stunDamage: 0, overflowDamage: 0 },
       });
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
+      mockOwnerAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -795,9 +754,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         campaignId: TEST_CAMPAIGN_ID,
       });
       vi.mocked(getSession).mockResolvedValue(TEST_GM_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockGm);
-      vi.mocked(getCharacter).mockResolvedValue(mockChar);
-      vi.mocked(getCampaignById).mockResolvedValue(mockCampaign);
+      mockGMAccess(mockChar);
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_, __, updates) => ({
         ...mockChar,
         ...updates,
@@ -816,6 +773,14 @@ describe("POST /api/characters/[characterId]/damage", () => {
           actor: { userId: TEST_GM_ID, role: "gm" },
         })
       );
+
+      expect(notifyOwnerOfGMEdit).toHaveBeenCalledWith(
+        mockChar,
+        mockCampaign,
+        TEST_GM_ID,
+        "3 physical damage applied",
+        undefined
+      );
     });
   });
 
@@ -826,8 +791,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
   describe("Error handling", () => {
     it("should return 500 on unexpected error", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockRejectedValue(new Error("Database error"));
+      vi.mocked(resolveCharacterForGameplay).mockRejectedValue(new Error("Database error"));
 
       const request = createMockRequest({ type: "physical", amount: 3 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });

--- a/app/api/characters/[characterId]/damage/route.ts
+++ b/app/api/characters/[characterId]/damage/route.ts
@@ -11,9 +11,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
-import { getUserById } from "@/lib/storage/users";
-import { getCharacter, updateCharacterWithAudit } from "@/lib/storage/characters";
-import { getCampaignById } from "@/lib/storage/campaigns";
+import { updateCharacterWithAudit } from "@/lib/storage/characters";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
 import type { Character } from "@/lib/types";
 
 // =============================================================================
@@ -182,75 +181,23 @@ export async function POST(
       );
     }
 
-    const user = await getUserById(userId);
-    if (!user) {
+    // Resolve character with GM cross-user support
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "gameplay_edit");
+    if (!resolution.authorized) {
       return NextResponse.json(
         {
           success: false,
-          error: "User not found",
+          error: resolution.error,
           character: {
             condition: { physicalDamage: 0, stunDamage: 0, overflowDamage: 0 },
             woundModifier: 0,
           },
         },
-        { status: 404 }
+        { status: resolution.status }
       );
     }
 
-    // Get the character - first try with current user as owner
-    const character = await getCharacter(userId, characterId);
-    let isOwner = true;
-
-    // If not found, check if user is GM for the character's campaign
-    if (!character) {
-      // Character might belong to another user in a campaign the current user GMs
-      // For now, we only allow owners or GMs to modify damage
-      // TODO: Implement cross-user character lookup for GM access
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Character not found",
-          character: {
-            condition: { physicalDamage: 0, stunDamage: 0, overflowDamage: 0 },
-            woundModifier: 0,
-          },
-        },
-        { status: 404 }
-      );
-    }
-
-    // Validate permission: Owner can always modify, GM can modify campaign characters
-    if (character.ownerId !== userId) {
-      if (character.campaignId) {
-        const campaign = await getCampaignById(character.campaignId);
-        if (!campaign || campaign.gmId !== userId) {
-          return NextResponse.json(
-            {
-              success: false,
-              error: "Not authorized to modify this character",
-              character: {
-                condition: { physicalDamage: 0, stunDamage: 0, overflowDamage: 0 },
-                woundModifier: 0,
-              },
-            },
-            { status: 403 }
-          );
-        }
-        isOwner = false;
-      } else {
-        return NextResponse.json(
-          {
-            success: false,
-            error: "Not authorized to modify this character",
-            character: {
-              condition: { physicalDamage: 0, stunDamage: 0, overflowDamage: 0 },
-              woundModifier: 0,
-            },
-          },
-          { status: 403 }
-        );
-      }
-    }
+    const { character, ownerId, actorRole, campaign, isGMAccess } = resolution;
 
     // Parse request body
     const body: DamageRequest = await request.json();
@@ -290,14 +237,14 @@ export async function POST(
 
     // Update character with audit trail
     const updatedCharacter = await updateCharacterWithAudit(
-      character.ownerId,
+      ownerId,
       characterId,
       { condition },
       {
         action: amount > 0 ? "damage_applied" : "damage_healed",
         actor: {
           userId,
-          role: isOwner ? "owner" : "gm",
+          role: actorRole,
         },
         details: {
           damageType: type,
@@ -305,11 +252,17 @@ export async function POST(
           source: source || "manual",
           previousCondition: character.condition,
           newCondition: condition,
-          actorName: user.username,
         },
         note: source ? `${amount > 0 ? "Damage" : "Healing"}: ${source}` : undefined,
       }
     );
+
+    // Notify owner if GM made the edit
+    if (isGMAccess && campaign) {
+      const actionDesc =
+        amount > 0 ? `${amount} ${type} damage applied` : `${Math.abs(amount)} ${type} healed`;
+      await notifyOwnerOfGMEdit(character, campaign, userId, actionDesc, source);
+    }
 
     // Calculate wound modifier
     const woundModifier = calculateTotalWoundModifier(updatedCharacter);
@@ -325,6 +278,7 @@ export async function POST(
         woundModifier,
       },
       overflow: overflow.physical > 0 || overflow.stun > 0 ? overflow : undefined,
+      actorRole,
     });
   } catch (error) {
     console.error("Failed to apply damage:", error);

--- a/app/api/characters/[characterId]/edge/__tests__/route.test.ts
+++ b/app/api/characters/[characterId]/edge/__tests__/route.test.ts
@@ -14,12 +14,12 @@ vi.mock("@/lib/auth/session", () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock("@/lib/storage/users", () => ({
-  getUserById: vi.fn(),
+vi.mock("@/lib/auth/gm-character-access", () => ({
+  resolveCharacterForGameplay: vi.fn(),
+  notifyOwnerOfGMEdit: vi.fn(),
 }));
 
 vi.mock("@/lib/storage/characters", () => ({
-  getCharacter: vi.fn(),
   spendEdge: vi.fn(),
   restoreEdge: vi.fn(),
   restoreFullEdge: vi.fn(),
@@ -28,9 +28,8 @@ vi.mock("@/lib/storage/characters", () => ({
 }));
 
 import { getSession } from "@/lib/auth/session";
-import { getUserById } from "@/lib/storage/users";
+import { resolveCharacterForGameplay } from "@/lib/auth/gm-character-access";
 import {
-  getCharacter,
   spendEdge,
   restoreEdge,
   restoreFullEdge,
@@ -38,7 +37,7 @@ import {
   getMaxEdge,
 } from "@/lib/storage/characters";
 import { GET, POST } from "../route";
-import type { User, Character } from "@/lib/types";
+import type { Character } from "@/lib/types";
 
 // =============================================================================
 // TEST DATA
@@ -46,42 +45,6 @@ import type { User, Character } from "@/lib/types";
 
 const TEST_USER_ID = "test-user-123";
 const TEST_CHARACTER_ID = "test-char-789";
-
-function createMockUser(overrides: Partial<User> = {}): User {
-  return {
-    id: TEST_USER_ID,
-    username: "testrunner",
-    email: "test@example.com",
-    passwordHash: "hashed_password",
-    role: ["user"],
-    preferences: { theme: "dark", navigationCollapsed: false },
-    createdAt: new Date().toISOString(),
-    lastLogin: new Date().toISOString(),
-    characters: [TEST_CHARACTER_ID],
-    failedLoginAttempts: 0,
-    lockoutUntil: null,
-    sessionVersion: 1,
-    sessionSecretHash: null,
-    accountStatus: "active",
-    statusChangedAt: null,
-    statusChangedBy: null,
-    statusReason: null,
-    lastRoleChangeAt: null,
-    lastRoleChangeBy: null,
-    emailVerified: true,
-    emailVerifiedAt: null,
-    emailVerificationTokenHash: null,
-    emailVerificationTokenExpiresAt: null,
-    emailVerificationTokenPrefix: null,
-    passwordResetTokenHash: null,
-    passwordResetTokenExpiresAt: null,
-    passwordResetTokenPrefix: null,
-    magicLinkTokenHash: null,
-    magicLinkTokenExpiresAt: null,
-    magicLinkTokenPrefix: null,
-    ...overrides,
-  };
-}
 
 function createMockCharacter(overrides: Partial<Character> = {}): Character {
   return {
@@ -140,8 +103,22 @@ function createMockPostRequest(body: Record<string, unknown>): NextRequest {
   });
 }
 
-const mockUser = createMockUser();
 const mockCharacter = createMockCharacter();
+
+const mockResolveSuccess = {
+  authorized: true as const,
+  character: mockCharacter,
+  ownerId: TEST_USER_ID,
+  actorRole: "owner" as const,
+  campaign: null,
+  isGMAccess: false,
+};
+
+const mockResolveNotFound = {
+  authorized: false as const,
+  error: "Character not found",
+  status: 404,
+};
 
 // =============================================================================
 // GET TESTS
@@ -167,9 +144,9 @@ describe("GET /api/characters/[characterId]/edge", () => {
       expect(data.error).toBe("Unauthorized");
     });
 
-    it("should return 404 when user not found", async () => {
+    it("should return 404 when character access is not authorized", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(null);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveNotFound);
 
       const request = createMockGetRequest();
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -179,15 +156,14 @@ describe("GET /api/characters/[characterId]/edge", () => {
 
       expect(response.status).toBe(404);
       expect(data.success).toBe(false);
-      expect(data.error).toBe("User not found");
+      expect(data.error).toBe("Character not found");
     });
   });
 
   describe("Authorization", () => {
     it("should return 404 when character not found", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(null);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveNotFound);
 
       const request = createMockGetRequest();
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -204,8 +180,7 @@ describe("GET /api/characters/[characterId]/edge", () => {
   describe("Success", () => {
     it("should return Edge status when character exists", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(3);
       vi.mocked(getMaxEdge).mockReturnValue(4);
 
@@ -225,8 +200,7 @@ describe("GET /api/characters/[characterId]/edge", () => {
 
     it("should show canSpend as false when Edge is 0", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(0);
       vi.mocked(getMaxEdge).mockReturnValue(4);
 
@@ -243,8 +217,7 @@ describe("GET /api/characters/[characterId]/edge", () => {
 
     it("should show canRestore as false when Edge is at max", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(4);
       vi.mocked(getMaxEdge).mockReturnValue(4);
 
@@ -263,8 +236,7 @@ describe("GET /api/characters/[characterId]/edge", () => {
   describe("Error handling", () => {
     it("should return 500 on unexpected error", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockRejectedValue(new Error("Database error"));
+      vi.mocked(resolveCharacterForGameplay).mockRejectedValue(new Error("Database error"));
 
       const request = createMockGetRequest();
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -303,9 +275,9 @@ describe("POST /api/characters/[characterId]/edge", () => {
       expect(data.error).toBe("Unauthorized");
     });
 
-    it("should return 404 when user not found", async () => {
+    it("should return 404 when character access is not authorized", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(null);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveNotFound);
 
       const request = createMockPostRequest({ action: "spend", amount: 1 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -315,15 +287,14 @@ describe("POST /api/characters/[characterId]/edge", () => {
 
       expect(response.status).toBe(404);
       expect(data.success).toBe(false);
-      expect(data.error).toBe("User not found");
+      expect(data.error).toBe("Character not found");
     });
   });
 
   describe("Authorization", () => {
     it("should return 404 when character not found", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(null);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveNotFound);
 
       const request = createMockPostRequest({ action: "spend", amount: 1 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -340,8 +311,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
   describe("Validation", () => {
     it("should return 400 when action is missing", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
 
       const request = createMockPostRequest({ amount: 1 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -356,8 +326,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
 
     it("should return 400 when amount is less than 1", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
 
       // Use negative number since 0 defaults to 1 via `body.amount || 1`
       const request = createMockPostRequest({ action: "spend", amount: -1 });
@@ -373,8 +342,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
 
     it("should return 400 for invalid action", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
 
       const request = createMockPostRequest({ action: "invalid", amount: 1 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -391,8 +359,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
   describe("Spend Edge", () => {
     it("should return 400 when insufficient Edge", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(1);
 
       const request = createMockPostRequest({ action: "spend", amount: 2 });
@@ -409,8 +376,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
     it("should spend Edge successfully", async () => {
       const updatedCharacter = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(4).mockReturnValueOnce(4);
       vi.mocked(getMaxEdge).mockReturnValue(4);
       vi.mocked(spendEdge).mockResolvedValue(updatedCharacter);
@@ -434,8 +400,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
     it("should default amount to 1 when not specified", async () => {
       const updatedCharacter = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(4);
       vi.mocked(getMaxEdge).mockReturnValue(4);
       vi.mocked(spendEdge).mockResolvedValue(updatedCharacter);
@@ -457,8 +422,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
     it("should restore Edge successfully", async () => {
       const updatedCharacter = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(2);
       vi.mocked(getMaxEdge).mockReturnValue(4);
       vi.mocked(restoreEdge).mockResolvedValue(updatedCharacter);
@@ -484,8 +448,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
     it("should call restoreFullEdge when amount equals max", async () => {
       const updatedCharacter = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(0);
       vi.mocked(getMaxEdge).mockReturnValue(4);
       vi.mocked(restoreFullEdge).mockResolvedValue(updatedCharacter);
@@ -505,8 +468,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
     it("should call restoreFullEdge when amount is undefined", async () => {
       const updatedCharacter = createMockCharacter();
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(0);
       vi.mocked(getMaxEdge).mockReturnValue(4);
       vi.mocked(restoreFullEdge).mockResolvedValue(updatedCharacter);
@@ -526,8 +488,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
   describe("Error handling", () => {
     it("should return 500 on unexpected error during spend", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(4);
       vi.mocked(spendEdge).mockRejectedValue(new Error("Storage error"));
 
@@ -544,8 +505,7 @@ describe("POST /api/characters/[characterId]/edge", () => {
 
     it("should return 500 on unexpected error during restore", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getUserById).mockResolvedValue(mockUser);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue(mockResolveSuccess);
       vi.mocked(getCurrentEdge).mockReturnValue(2);
       vi.mocked(getMaxEdge).mockReturnValue(4);
       vi.mocked(restoreEdge).mockRejectedValue(new Error("Storage error"));

--- a/app/api/characters/[characterId]/edge/route.ts
+++ b/app/api/characters/[characterId]/edge/route.ts
@@ -9,15 +9,14 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
-import { getUserById } from "@/lib/storage/users";
 import {
-  getCharacter,
   spendEdge,
   restoreEdge,
   restoreFullEdge,
   getCurrentEdge,
   getMaxEdge,
 } from "@/lib/storage/characters";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
 import type { EdgeRequest } from "@/lib/types";
 import { apiLogger } from "@/lib/logging";
 
@@ -37,19 +36,18 @@ export async function GET(
       return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    const user = await getUserById(userId);
-    if (!user) {
-      return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
-    }
-
     const { characterId } = await params;
 
-    // Verify character ownership
-    const character = await getCharacter(userId, characterId);
-    if (!character) {
-      return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
+    // Resolve character with GM cross-user support (view permission for GET)
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "view");
+    if (!resolution.authorized) {
+      return NextResponse.json(
+        { success: false, error: resolution.error },
+        { status: resolution.status }
+      );
     }
 
+    const { character } = resolution;
     const current = getCurrentEdge(character);
     const maximum = getMaxEdge(character);
 
@@ -88,18 +86,19 @@ export async function POST(
       return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    const user = await getUserById(userId);
-    if (!user) {
-      return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
-    }
-
     const { characterId } = await params;
 
-    // Verify character ownership
-    let character = await getCharacter(userId, characterId);
-    if (!character) {
-      return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
+    // Resolve character with GM cross-user support
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "gameplay_edit");
+    if (!resolution.authorized) {
+      return NextResponse.json(
+        { success: false, error: resolution.error },
+        { status: resolution.status }
+      );
     }
+
+    let { character } = resolution;
+    const { ownerId, actorRole, campaign, isGMAccess } = resolution;
 
     // Parse request body
     const body: EdgeRequest = await request.json();
@@ -132,7 +131,17 @@ export async function POST(
         );
       }
 
-      character = await spendEdge(userId, characterId, amount);
+      character = await spendEdge(ownerId, characterId, amount);
+
+      if (isGMAccess && campaign) {
+        await notifyOwnerOfGMEdit(
+          resolution.character,
+          campaign,
+          userId,
+          `${amount} Edge spent`,
+          body.reason
+        );
+      }
 
       return NextResponse.json({
         success: true,
@@ -141,13 +150,24 @@ export async function POST(
         edgeCurrent: getCurrentEdge(character),
         edgeMaximum: getMaxEdge(character),
         reason: body.reason,
+        actorRole,
       });
     } else if (body.action === "restore") {
       // Check if "full" restore requested
       if (body.amount === undefined || body.amount === getMaxEdge(character)) {
-        character = await restoreFullEdge(userId, characterId);
+        character = await restoreFullEdge(ownerId, characterId);
       } else {
-        character = await restoreEdge(userId, characterId, amount);
+        character = await restoreEdge(ownerId, characterId, amount);
+      }
+
+      if (isGMAccess && campaign) {
+        await notifyOwnerOfGMEdit(
+          resolution.character,
+          campaign,
+          userId,
+          `${amount} Edge restored`,
+          body.reason
+        );
       }
 
       return NextResponse.json({
@@ -157,6 +177,7 @@ export async function POST(
         edgeCurrent: getCurrentEdge(character),
         edgeMaximum: getMaxEdge(character),
         reason: body.reason,
+        actorRole,
       });
     }
 

--- a/app/api/characters/[characterId]/gameplay/__tests__/route.test.ts
+++ b/app/api/characters/[characterId]/gameplay/__tests__/route.test.ts
@@ -23,9 +23,13 @@ vi.mock("@/lib/storage/characters", () => ({
   killCharacter: vi.fn(),
 }));
 
+vi.mock("@/lib/auth/gm-character-access", () => ({
+  resolveCharacterForGameplay: vi.fn(),
+  notifyOwnerOfGMEdit: vi.fn(),
+}));
+
 import { getSession } from "@/lib/auth/session";
 import {
-  getCharacter,
   applyDamage,
   healCharacter,
   spendKarma,
@@ -33,6 +37,7 @@ import {
   retireCharacter,
   killCharacter,
 } from "@/lib/storage/characters";
+import { resolveCharacterForGameplay } from "@/lib/auth/gm-character-access";
 import { POST } from "../route";
 import type { Character } from "@/lib/types";
 
@@ -95,6 +100,27 @@ function createMockRequest(body: Record<string, unknown>): NextRequest {
   });
 }
 
+/** Helper to mock resolveCharacterForGameplay as authorized (owner) */
+function mockResolutionSuccess(character: Character) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: true,
+    character,
+    ownerId: character.ownerId,
+    actorRole: "owner",
+    campaign: null,
+    isGMAccess: false,
+  });
+}
+
+/** Helper to mock resolveCharacterForGameplay as denied */
+function mockResolutionDenied(status: number, error: string) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: false,
+    error,
+    status,
+  });
+}
+
 // =============================================================================
 // AUTHENTICATION TESTS
 // =============================================================================
@@ -123,7 +149,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
   describe("Authorization", () => {
     it("should return 404 when character not found", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(null);
+      mockResolutionDenied(404, "Character not found");
 
       const request = createMockRequest({ action: "damage", physical: 3, stun: 0 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -136,10 +162,10 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       expect(data.error).toBe("Character not found");
     });
 
-    it("should return 400 when character is not active", async () => {
-      const draftCharacter = createMockCharacter({ status: "draft" });
+    it("should return 403 when character is not active (draft)", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(draftCharacter);
+      // gameplay_edit permission denied for non-active characters
+      mockResolutionDenied(403, "Permission denied: gameplay_edit");
 
       const request = createMockRequest({ action: "damage", physical: 3, stun: 0 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -147,15 +173,14 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const response = await POST(request, { params });
       const data = await response.json();
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(403);
       expect(data.success).toBe(false);
-      expect(data.error).toBe("Character must be active for gameplay actions");
     });
 
-    it("should return 400 when character is retired", async () => {
-      const retiredCharacter = createMockCharacter({ status: "retired" });
+    it("should return 403 when character is retired", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(retiredCharacter);
+      // gameplay_edit permission denied for retired characters
+      mockResolutionDenied(403, "Permission denied: gameplay_edit");
 
       const request = createMockRequest({ action: "damage", physical: 3, stun: 0 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -163,9 +188,8 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const response = await POST(request, { params });
       const data = await response.json();
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(403);
       expect(data.success).toBe(false);
-      expect(data.error).toBe("Character must be active for gameplay actions");
     });
   });
 
@@ -181,7 +205,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       });
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(applyDamage).mockResolvedValue(damagedCharacter);
 
       const request = createMockRequest({ action: "damage", physical: 3, stun: 2 });
@@ -204,7 +228,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       });
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(applyDamage).mockResolvedValue(damagedCharacter);
 
       const request = createMockRequest({ action: "damage", physical: 3 });
@@ -231,7 +255,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       });
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(healCharacter).mockResolvedValue(healedCharacter);
 
       const request = createMockRequest({ action: "heal", physical: 3, stun: 3 });
@@ -254,7 +278,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       });
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(healCharacter).mockResolvedValue(healedCharacter);
 
       const request = createMockRequest({ action: "heal", stun: 3 });
@@ -277,7 +301,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const updatedCharacter = createMockCharacter({ karmaTotal: 60, karmaCurrent: 5 });
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(spendKarma).mockResolvedValue(updatedCharacter);
 
       const request = createMockRequest({ action: "spendKarma", amount: 5 });
@@ -295,7 +319,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const mockCharacter = createMockCharacter();
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
 
       const request = createMockRequest({ action: "spendKarma" });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -312,7 +336,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const mockCharacter = createMockCharacter();
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
 
       const request = createMockRequest({ action: "spendKarma", amount: 0 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -329,7 +353,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const mockCharacter = createMockCharacter();
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
 
       const request = createMockRequest({ action: "spendKarma", amount: -5 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -349,7 +373,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const updatedCharacter = createMockCharacter({ karmaTotal: 60, karmaCurrent: 15 });
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(awardKarma).mockResolvedValue(updatedCharacter);
 
       const request = createMockRequest({ action: "awardKarma", amount: 10 });
@@ -367,7 +391,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const mockCharacter = createMockCharacter();
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
 
       const request = createMockRequest({ action: "awardKarma" });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -384,7 +408,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const mockCharacter = createMockCharacter();
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
 
       const request = createMockRequest({ action: "awardKarma", amount: 0 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -408,7 +432,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const retiredCharacter = createMockCharacter({ status: "retired" });
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(retireCharacter).mockResolvedValue(retiredCharacter);
 
       const request = createMockRequest({ action: "retire" });
@@ -430,7 +454,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const deceasedCharacter = createMockCharacter({ status: "deceased" });
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(killCharacter).mockResolvedValue(deceasedCharacter);
 
       const request = createMockRequest({ action: "kill" });
@@ -455,7 +479,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const mockCharacter = createMockCharacter();
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
 
       const request = createMockRequest({ action: "invalid" });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -476,7 +500,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
   describe("Error handling", () => {
     it("should return 500 on unexpected error", async () => {
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockRejectedValue(new Error("Storage error"));
+      vi.mocked(resolveCharacterForGameplay).mockRejectedValue(new Error("Storage error"));
 
       const request = createMockRequest({ action: "damage", physical: 3, stun: 0 });
       const params = Promise.resolve({ characterId: TEST_CHARACTER_ID });
@@ -493,7 +517,7 @@ describe("POST /api/characters/[characterId]/gameplay", () => {
       const mockCharacter = createMockCharacter();
 
       vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(applyDamage).mockRejectedValue(new Error("Failed to apply damage"));
 
       const request = createMockRequest({ action: "damage", physical: 3, stun: 0 });

--- a/app/api/characters/[characterId]/gameplay/route.ts
+++ b/app/api/characters/[characterId]/gameplay/route.ts
@@ -7,7 +7,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import {
-  getCharacter,
   applyDamage,
   healCharacter,
   spendKarma,
@@ -17,6 +16,7 @@ import {
   retireCharacter,
   killCharacter,
 } from "@/lib/storage/characters";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
 import { apiLogger } from "@/lib/logging";
 
 type GameplayAction =
@@ -42,11 +42,17 @@ export async function POST(
 
     const { characterId } = await params;
 
-    // Check character exists and belongs to user
-    const existing = await getCharacter(userId, characterId);
-    if (!existing) {
-      return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
+    // Resolve character with GM cross-user support
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "gameplay_edit");
+    if (!resolution.authorized) {
+      return NextResponse.json(
+        { success: false, error: resolution.error },
+        { status: resolution.status }
+      );
     }
+
+    const { ownerId, actorRole, campaign, isGMAccess } = resolution;
+    const existing = resolution.character;
 
     // Check character is active
     if (existing.status !== "active") {
@@ -60,14 +66,17 @@ export async function POST(
     const body: GameplayAction = await request.json();
 
     let character;
+    let actionDesc = "";
 
     switch (body.action) {
       case "damage":
-        character = await applyDamage(userId, characterId, body.physical || 0, body.stun || 0);
+        character = await applyDamage(ownerId, characterId, body.physical || 0, body.stun || 0);
+        actionDesc = `${body.physical || 0}P/${body.stun || 0}S damage applied`;
         break;
 
       case "heal":
-        character = await healCharacter(userId, characterId, body.physical || 0, body.stun || 0);
+        character = await healCharacter(ownerId, characterId, body.physical || 0, body.stun || 0);
+        actionDesc = `${body.physical || 0}P/${body.stun || 0}S healed`;
         break;
 
       case "spendKarma":
@@ -77,7 +86,8 @@ export async function POST(
             { status: 400 }
           );
         }
-        character = await spendKarma(userId, characterId, body.amount);
+        character = await spendKarma(ownerId, characterId, body.amount);
+        actionDesc = `${body.amount} karma spent`;
         break;
 
       case "awardKarma":
@@ -87,7 +97,8 @@ export async function POST(
             { status: 400 }
           );
         }
-        character = await awardKarma(userId, characterId, body.amount);
+        character = await awardKarma(ownerId, characterId, body.amount);
+        actionDesc = `${body.amount} karma awarded`;
         break;
 
       case "spendNuyen":
@@ -97,7 +108,8 @@ export async function POST(
             { status: 400 }
           );
         }
-        character = await spendNuyen(userId, characterId, body.amount, body.reason);
+        character = await spendNuyen(ownerId, characterId, body.amount, body.reason);
+        actionDesc = `${body.amount}¥ spent`;
         break;
 
       case "awardNuyen":
@@ -107,24 +119,33 @@ export async function POST(
             { status: 400 }
           );
         }
-        character = await awardNuyen(userId, characterId, body.amount);
+        character = await awardNuyen(ownerId, characterId, body.amount);
+        actionDesc = `${body.amount}¥ awarded`;
         break;
 
       case "retire":
-        character = await retireCharacter(userId, characterId);
+        character = await retireCharacter(ownerId, characterId);
+        actionDesc = "character retired";
         break;
 
       case "kill":
-        character = await killCharacter(userId, characterId);
+        character = await killCharacter(ownerId, characterId);
+        actionDesc = "character killed";
         break;
 
       default:
         return NextResponse.json({ success: false, error: "Unknown action" }, { status: 400 });
     }
 
+    // Notify owner if GM made the edit
+    if (isGMAccess && campaign) {
+      await notifyOwnerOfGMEdit(existing, campaign, userId, actionDesc);
+    }
+
     return NextResponse.json({
       success: true,
       character,
+      actorRole,
     });
   } catch (error) {
     const { characterId } = await params;

--- a/app/api/characters/[characterId]/inventory/__tests__/route.test.ts
+++ b/app/api/characters/[characterId]/inventory/__tests__/route.test.ts
@@ -9,14 +9,18 @@ import { GET, PATCH } from "../route";
 import { NextRequest } from "next/server";
 import * as sessionModule from "@/lib/auth/session";
 import * as characterStorageModule from "@/lib/storage/characters";
-import * as authorizationModule from "@/lib/auth/character-authorization";
 
 import type { Character, Weapon, ArmorItem } from "@/lib/types";
 
 // Mock dependencies
 vi.mock("@/lib/auth/session");
 vi.mock("@/lib/storage/characters");
-vi.mock("@/lib/auth/character-authorization");
+vi.mock("@/lib/auth/gm-character-access", () => ({
+  resolveCharacterForGameplay: vi.fn(),
+  notifyOwnerOfGMEdit: vi.fn(),
+}));
+
+import { resolveCharacterForGameplay } from "@/lib/auth/gm-character-access";
 
 // Helper to create a NextRequest
 function createMockRequest(url: string, body?: unknown, method = "GET"): NextRequest {
@@ -56,6 +60,27 @@ function createMockCharacter(overrides: Partial<Character> = {}): Character {
     startingNuyen: 5000,
     ...overrides,
   } as Character;
+}
+
+/** Helper to mock resolveCharacterForGameplay as authorized (owner) */
+function mockResolutionSuccess(character: Character) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: true,
+    character,
+    ownerId: character.ownerId,
+    actorRole: "owner",
+    campaign: null,
+    isGMAccess: false,
+  });
+}
+
+/** Helper to mock resolveCharacterForGameplay as denied */
+function mockResolutionDenied(status: number, error: string) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: false,
+    error,
+    status,
+  });
 }
 
 describe("GET /api/characters/[characterId]/inventory", () => {
@@ -98,14 +123,7 @@ describe("GET /api/characters/[characterId]/inventory", () => {
     });
 
     vi.mocked(sessionModule.getSession).mockResolvedValue(userId);
-    vi.mocked(authorizationModule.authorizeOwnerAccess).mockResolvedValue({
-      authorized: true,
-      character: mockCharacter,
-      campaign: null,
-      role: "owner",
-      permissions: ["view", "edit"],
-      status: 200,
-    });
+    mockResolutionSuccess(mockCharacter);
   });
 
   it("should return inventory state with encumbrance", async () => {
@@ -141,15 +159,7 @@ describe("GET /api/characters/[characterId]/inventory", () => {
   });
 
   it("should return 404 when character not found", async () => {
-    vi.mocked(authorizationModule.authorizeOwnerAccess).mockResolvedValue({
-      authorized: false,
-      character: null,
-      campaign: null,
-      role: "owner",
-      permissions: [],
-      error: "Character not found",
-      status: 404,
-    });
+    mockResolutionDenied(404, "Character not found");
 
     const request = createMockRequest(
       `http://localhost:3000/api/characters/${characterId}/inventory`
@@ -190,14 +200,7 @@ describe("PATCH /api/characters/[characterId]/inventory", () => {
     });
 
     vi.mocked(sessionModule.getSession).mockResolvedValue(userId);
-    vi.mocked(authorizationModule.authorizeOwnerAccess).mockResolvedValue({
-      authorized: true,
-      character: mockCharacter,
-      campaign: null,
-      role: "owner",
-      permissions: ["view", "edit"],
-      status: 200,
-    });
+    mockResolutionSuccess(mockCharacter);
     vi.mocked(characterStorageModule.updateCharacter).mockResolvedValue(mockCharacter);
   });
 
@@ -241,14 +244,7 @@ describe("PATCH /api/characters/[characterId]/inventory", () => {
       ],
     });
 
-    vi.mocked(authorizationModule.authorizeOwnerAccess).mockResolvedValue({
-      authorized: true,
-      character: mockCharacter,
-      campaign: null,
-      role: "owner",
-      permissions: ["view", "edit"],
-      status: 200,
-    });
+    mockResolutionSuccess(mockCharacter);
 
     const requestBody = {
       itemId: "armor-1",

--- a/app/api/characters/[characterId]/inventory/route.ts
+++ b/app/api/characters/[characterId]/inventory/route.ts
@@ -11,7 +11,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { updateCharacter } from "@/lib/storage/characters";
-import { authorizeOwnerAccess } from "@/lib/auth/character-authorization";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
 import {
   setEquipmentReadiness,
   getEquipmentStateSummary,
@@ -74,17 +74,16 @@ export async function GET(
 
     const { characterId } = await params;
 
-    // Authorize view access
-    const authResult = await authorizeOwnerAccess(userId, userId, characterId, "view");
-
-    if (!authResult.authorized) {
+    // Resolve character with GM cross-user support (view permission for GET)
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "view");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, error: authResult.error },
-        { status: authResult.status }
+        { success: false, error: resolution.error },
+        { status: resolution.status }
       );
     }
 
-    const character = authResult.character!;
+    const character = resolution.character;
 
     // Calculate encumbrance
     const encumbranceState = calculateEncumbrance(character);
@@ -132,17 +131,16 @@ export async function PATCH(
 
     const { characterId } = await params;
 
-    // Authorize edit access
-    const authResult = await authorizeOwnerAccess(userId, userId, characterId, "edit");
-
-    if (!authResult.authorized) {
+    // Resolve character with GM cross-user support
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "gameplay_edit");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, error: authResult.error },
-        { status: authResult.status }
+        { success: false, error: resolution.error },
+        { status: resolution.status }
       );
     }
 
-    const character = authResult.character!;
+    const { character, ownerId, campaign, isGMAccess } = resolution;
 
     // Parse request body
     const body: UpdateStateRequest = await request.json();
@@ -178,7 +176,7 @@ export async function PATCH(
         if (result.success) {
           const updatedWeapons = [...character.weapons!];
           updatedWeapons[weaponIndex] = result.item as Weapon;
-          await updateCharacter(userId, characterId, { weapons: updatedWeapons });
+          await updateCharacter(ownerId, characterId, { weapons: updatedWeapons });
         }
         break;
       }
@@ -200,7 +198,7 @@ export async function PATCH(
           updatedArmor[armorIndex] = result.item as ArmorItem;
           // Also update legacy equipped field
           (updatedArmor[armorIndex] as ArmorItem).equipped = newState === "worn";
-          await updateCharacter(userId, characterId, { armor: updatedArmor });
+          await updateCharacter(ownerId, characterId, { armor: updatedArmor });
         }
         break;
       }
@@ -224,7 +222,7 @@ export async function PATCH(
         if (result.success) {
           const updatedGear = [...character.gear!];
           updatedGear[gearIndex] = result.item as GearItem;
-          await updateCharacter(userId, characterId, { gear: updatedGear });
+          await updateCharacter(ownerId, characterId, { gear: updatedGear });
         }
         break;
       }
@@ -245,6 +243,16 @@ export async function PATCH(
 
     if (!result.success) {
       return NextResponse.json({ success: false, error: result.error, result }, { status: 400 });
+    }
+
+    // Notify owner if GM made the edit
+    if (isGMAccess && campaign) {
+      await notifyOwnerOfGMEdit(
+        character,
+        campaign,
+        userId,
+        `${itemType} readiness changed to ${newState}`
+      );
     }
 
     return NextResponse.json({

--- a/app/api/characters/[characterId]/matrix/__tests__/route.test.ts
+++ b/app/api/characters/[characterId]/matrix/__tests__/route.test.ts
@@ -9,11 +9,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GET, PATCH } from "../route";
 import { NextRequest } from "next/server";
 import * as sessionModule from "@/lib/auth/session";
-import * as usersModule from "@/lib/storage/users";
 import * as charactersModule from "@/lib/storage/characters";
 import * as cyberdeckValidator from "@/lib/rules/matrix/cyberdeck-validator";
 import type { Character } from "@/lib/types";
-import type { User } from "@/lib/types/user";
 import type { CharacterProgram } from "@/lib/types/programs";
 import type {
   CyberdeckAttributeConfig,
@@ -23,9 +21,14 @@ import type {
 
 // Mock dependencies
 vi.mock("@/lib/auth/session");
-vi.mock("@/lib/storage/users");
 vi.mock("@/lib/storage/characters");
 vi.mock("@/lib/rules/matrix/cyberdeck-validator");
+vi.mock("@/lib/auth/gm-character-access", () => ({
+  resolveCharacterForGameplay: vi.fn(),
+  notifyOwnerOfGMEdit: vi.fn(),
+}));
+
+import { resolveCharacterForGameplay } from "@/lib/auth/gm-character-access";
 
 // Helper to create a NextRequest for PATCH
 function createPatchRequest(characterId: string, body?: unknown): NextRequest {
@@ -133,49 +136,29 @@ function createMockProgram(overrides?: Partial<CharacterProgram>): CharacterProg
   };
 }
 
-// Helper to create full User mock
-function createMockUser(overrides?: Partial<User>): User {
-  return {
-    id: "test-user-id",
-    email: "test@example.com",
-    username: "testuser",
-    passwordHash: "hashed-password",
-    role: ["user"],
-    createdAt: new Date().toISOString(),
-    lastLogin: new Date().toISOString(),
-    characters: [],
-    failedLoginAttempts: 0,
-    lockoutUntil: null,
-    sessionVersion: 1,
-    sessionSecretHash: null,
-    preferences: {
-      theme: "system",
-      navigationCollapsed: false,
-    },
-    accountStatus: "active",
-    statusChangedAt: null,
-    statusChangedBy: null,
-    statusReason: null,
-    lastRoleChangeAt: null,
-    lastRoleChangeBy: null,
-    emailVerified: true,
-    emailVerifiedAt: null,
-    emailVerificationTokenHash: null,
-    emailVerificationTokenExpiresAt: null,
-    emailVerificationTokenPrefix: null,
-    passwordResetTokenHash: null,
-    passwordResetTokenExpiresAt: null,
-    passwordResetTokenPrefix: null,
-    magicLinkTokenHash: null,
-    magicLinkTokenExpiresAt: null,
-    magicLinkTokenPrefix: null,
-    ...overrides,
-  };
+/** Helper to mock resolveCharacterForGameplay as authorized (owner) */
+function mockResolutionSuccess(character: Character) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: true,
+    character,
+    ownerId: character.ownerId,
+    actorRole: "owner",
+    campaign: null,
+    isGMAccess: false,
+  });
+}
+
+/** Helper to mock resolveCharacterForGameplay as denied */
+function mockResolutionDenied(status: number, error: string) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: false,
+    error,
+    status,
+  });
 }
 
 describe("/api/characters/[characterId]/matrix", () => {
   const mockUserId = "test-user-id";
-  const mockUser = createMockUser({ id: mockUserId });
   const mockDeck = createMockCyberdeck();
   const mockCommlink = createMockCommlink();
   const mockCharacter = createMockCharacter({
@@ -227,9 +210,9 @@ describe("/api/characters/[characterId]/matrix", () => {
       expect(data.error).toBe("Unauthorized");
     });
 
-    it("should return 404 when user not found", async () => {
+    it("should return 404 when character not found", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(null);
+      mockResolutionDenied(404, "Character not found");
 
       const request = createGetRequest("test-char-id");
       const response = await GET(request, {
@@ -238,31 +221,12 @@ describe("/api/characters/[characterId]/matrix", () => {
       const data = await response.json();
 
       expect(response.status).toBe(404);
-      expect(data.error).toBe("User not found");
-    });
-
-    it("should return 404 when character not found", async () => {
-      vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(null);
-
-      const request = createGetRequest("non-existent-id");
-      const response = await GET(request, {
-        params: Promise.resolve({ characterId: "non-existent-id" }),
-      });
-      const data = await response.json();
-
-      expect(response.status).toBe(404);
       expect(data.error).toBe("Character not found");
     });
 
-    it("should return 403 when user doesn't own character", async () => {
+    it("should return 403 when not authorized", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue({
-        ...mockCharacter,
-        ownerId: "different-user-id",
-      });
+      mockResolutionDenied(403, "Permission denied: view");
 
       const request = createGetRequest("test-char-id");
       const response = await GET(request, {
@@ -271,7 +235,7 @@ describe("/api/characters/[characterId]/matrix", () => {
       const data = await response.json();
 
       expect(response.status).toBe(403);
-      expect(data.error).toBe("Not authorized to view this character");
+      expect(data.error).toBe("Permission denied: view");
     });
 
     it("should return empty arrays when no matrix equipment", async () => {
@@ -282,8 +246,7 @@ describe("/api/characters/[characterId]/matrix", () => {
       });
 
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(emptyCharacter);
+      mockResolutionSuccess(emptyCharacter);
       vi.mocked(cyberdeckValidator.getCharacterCyberdecks).mockReturnValue([]);
       vi.mocked(cyberdeckValidator.getCharacterCommlinks).mockReturnValue([]);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue(null);
@@ -302,8 +265,7 @@ describe("/api/characters/[characterId]/matrix", () => {
 
     it("should return cyberdecks with current config", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
 
       const request = createGetRequest("test-char-id");
       const response = await GET(request, {
@@ -324,8 +286,7 @@ describe("/api/characters/[characterId]/matrix", () => {
 
     it("should return commlinks with derived stats", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
 
       const request = createGetRequest("test-char-id");
       const response = await GET(request, {
@@ -353,8 +314,7 @@ describe("/api/characters/[characterId]/matrix", () => {
       });
 
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(charWithLoadedPrograms);
+      mockResolutionSuccess(charWithLoadedPrograms);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue(deckWithLoaded);
 
       const request = createGetRequest("test-char-id");
@@ -380,8 +340,7 @@ describe("/api/characters/[characterId]/matrix", () => {
       });
 
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(charWithoutActiveDevice);
+      mockResolutionSuccess(charWithoutActiveDevice);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue(mockDeck);
 
       const request = createGetRequest("test-char-id");
@@ -413,9 +372,9 @@ describe("/api/characters/[characterId]/matrix", () => {
       expect(data.error).toBe("Unauthorized");
     });
 
-    it("should return 404 when user not found", async () => {
+    it("should return 404 when character not found", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(null);
+      mockResolutionDenied(404, "Character not found");
 
       const request = createPatchRequest("test-char-id", { deckConfig: validConfig });
       const response = await PATCH(request, {
@@ -424,31 +383,12 @@ describe("/api/characters/[characterId]/matrix", () => {
       const data = await response.json();
 
       expect(response.status).toBe(404);
-      expect(data.error).toBe("User not found");
-    });
-
-    it("should return 404 when character not found", async () => {
-      vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(null);
-
-      const request = createPatchRequest("non-existent-id", { deckConfig: validConfig });
-      const response = await PATCH(request, {
-        params: Promise.resolve({ characterId: "non-existent-id" }),
-      });
-      const data = await response.json();
-
-      expect(response.status).toBe(404);
       expect(data.error).toBe("Character not found");
     });
 
-    it("should return 403 when user doesn't own character", async () => {
+    it("should return 403 when not authorized", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue({
-        ...mockCharacter,
-        ownerId: "different-user-id",
-      });
+      mockResolutionDenied(403, "Permission denied: gameplay_edit");
 
       const request = createPatchRequest("test-char-id", { deckConfig: validConfig });
       const response = await PATCH(request, {
@@ -457,15 +397,12 @@ describe("/api/characters/[characterId]/matrix", () => {
       const data = await response.json();
 
       expect(response.status).toBe(403);
-      expect(data.error).toBe("Not authorized to modify this character");
+      expect(data.error).toBe("Permission denied: gameplay_edit");
     });
 
     it("should return 400 when no active cyberdeck for deckConfig update", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(
-        createMockCharacter({ cyberdecks: [] })
-      );
+      mockResolutionSuccess(createMockCharacter({ cyberdecks: [] }));
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue(null);
 
       const request = createPatchRequest("test-char-id", { deckConfig: validConfig });
@@ -480,8 +417,7 @@ describe("/api/characters/[characterId]/matrix", () => {
 
     it("should return 400 for invalid deck config", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue(mockDeck);
       vi.mocked(cyberdeckValidator.validateCyberdeckConfig).mockReturnValue({
         valid: false,
@@ -509,8 +445,7 @@ describe("/api/characters/[characterId]/matrix", () => {
 
     it("should update deck config successfully", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue(mockDeck);
       vi.mocked(cyberdeckValidator.validateCyberdeckConfig).mockReturnValue({
         valid: true,
@@ -522,12 +457,10 @@ describe("/api/characters/[characterId]/matrix", () => {
         ...mockCharacter,
         cyberdecks: [{ ...mockDeck, currentConfig: validConfig }],
       });
-      vi.mocked(charactersModule.getCharacter)
-        .mockResolvedValueOnce(mockCharacter) // First call
-        .mockResolvedValueOnce({
-          ...mockCharacter,
-          cyberdecks: [{ ...mockDeck, currentConfig: validConfig }],
-        }); // Second call after update
+      vi.mocked(charactersModule.getCharacter).mockResolvedValue({
+        ...mockCharacter,
+        cyberdecks: [{ ...mockDeck, currentConfig: validConfig }],
+      });
 
       const request = createPatchRequest("test-char-id", { deckConfig: validConfig });
       const response = await PATCH(request, {
@@ -542,8 +475,7 @@ describe("/api/characters/[characterId]/matrix", () => {
 
     it("should return 400 when program slots exceeded", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue({
         ...mockDeck,
         programSlots: 2,
@@ -565,8 +497,7 @@ describe("/api/characters/[characterId]/matrix", () => {
 
     it("should load programs successfully", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue({
         ...mockDeck,
         programSlots: 4,
@@ -576,12 +507,10 @@ describe("/api/characters/[characterId]/matrix", () => {
         ...mockCharacter,
         cyberdecks: [{ ...mockDeck, loadedPrograms: ["browse", "edit"] }],
       });
-      vi.mocked(charactersModule.getCharacter)
-        .mockResolvedValueOnce(mockCharacter)
-        .mockResolvedValueOnce({
-          ...mockCharacter,
-          cyberdecks: [{ ...mockDeck, loadedPrograms: ["browse", "edit"] }],
-        });
+      vi.mocked(charactersModule.getCharacter).mockResolvedValue({
+        ...mockCharacter,
+        cyberdecks: [{ ...mockDeck, loadedPrograms: ["browse", "edit"] }],
+      });
 
       const request = createPatchRequest("test-char-id", {
         loadPrograms: ["browse", "edit"],
@@ -607,19 +536,16 @@ describe("/api/characters/[characterId]/matrix", () => {
       };
 
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(charWithLoadedPrograms);
+      mockResolutionSuccess(charWithLoadedPrograms as Character);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue(deckWithLoadedPrograms);
       vi.mocked(charactersModule.updateCharacterWithAudit).mockResolvedValue({
         ...mockCharacter,
         cyberdecks: [{ ...mockDeck, loadedPrograms: ["browse"] }],
       });
-      vi.mocked(charactersModule.getCharacter)
-        .mockResolvedValueOnce(charWithLoadedPrograms)
-        .mockResolvedValueOnce({
-          ...mockCharacter,
-          cyberdecks: [{ ...mockDeck, loadedPrograms: ["browse"] }],
-        });
+      vi.mocked(charactersModule.getCharacter).mockResolvedValue({
+        ...mockCharacter,
+        cyberdecks: [{ ...mockDeck, loadedPrograms: ["browse"] }],
+      });
 
       const request = createPatchRequest("test-char-id", {
         unloadPrograms: ["edit"],
@@ -646,19 +572,16 @@ describe("/api/characters/[characterId]/matrix", () => {
       };
 
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(charWithSomeLoaded);
+      mockResolutionSuccess(charWithSomeLoaded as Character);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue(deckWithSomeLoaded);
       vi.mocked(charactersModule.updateCharacterWithAudit).mockResolvedValue({
         ...mockCharacter,
         cyberdecks: [{ ...mockDeck, loadedPrograms: ["browse", "edit"] }],
       });
-      vi.mocked(charactersModule.getCharacter)
-        .mockResolvedValueOnce(charWithSomeLoaded)
-        .mockResolvedValueOnce({
-          ...mockCharacter,
-          cyberdecks: [{ ...mockDeck, loadedPrograms: ["browse", "edit"] }],
-        });
+      vi.mocked(charactersModule.getCharacter).mockResolvedValue({
+        ...mockCharacter,
+        cyberdecks: [{ ...mockDeck, loadedPrograms: ["browse", "edit"] }],
+      });
 
       const request = createPatchRequest("test-char-id", {
         loadPrograms: ["browse", "edit"], // browse is already loaded
@@ -674,8 +597,7 @@ describe("/api/characters/[characterId]/matrix", () => {
 
     it("should create audit trail for changes", async () => {
       vi.mocked(sessionModule.getSession).mockResolvedValue(mockUserId);
-      vi.mocked(usersModule.getUserById).mockResolvedValue(mockUser);
-      vi.mocked(charactersModule.getCharacter).mockResolvedValue(mockCharacter);
+      mockResolutionSuccess(mockCharacter);
       vi.mocked(cyberdeckValidator.getActiveCyberdeck).mockReturnValue(mockDeck);
       vi.mocked(cyberdeckValidator.validateCyberdeckConfig).mockReturnValue({
         valid: true,
@@ -684,6 +606,7 @@ describe("/api/characters/[characterId]/matrix", () => {
         effectiveAttributes: validConfig,
       });
       vi.mocked(charactersModule.updateCharacterWithAudit).mockResolvedValue(mockCharacter);
+      vi.mocked(charactersModule.getCharacter).mockResolvedValue(mockCharacter);
 
       const request = createPatchRequest("test-char-id", { deckConfig: validConfig });
       await PATCH(request, { params: Promise.resolve({ characterId: "test-char-id" }) });

--- a/app/api/characters/[characterId]/matrix/route.ts
+++ b/app/api/characters/[characterId]/matrix/route.ts
@@ -11,8 +11,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
-import { getUserById } from "@/lib/storage/users";
 import { getCharacter, updateCharacterWithAudit } from "@/lib/storage/characters";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
 import type {
   MatrixEquipmentResponse,
   UpdateMatrixStateRequest,
@@ -43,21 +43,13 @@ export async function GET(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const user = await getUserById(userId);
-    if (!user) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    // Resolve character with GM cross-user support (view permission for GET)
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "view");
+    if (!resolution.authorized) {
+      return NextResponse.json({ error: resolution.error }, { status: resolution.status });
     }
 
-    // Get the character
-    const character = await getCharacter(userId, characterId);
-    if (!character) {
-      return NextResponse.json({ error: "Character not found" }, { status: 404 });
-    }
-
-    // Check ownership
-    if (character.ownerId !== userId) {
-      return NextResponse.json({ error: "Not authorized to view this character" }, { status: 403 });
-    }
+    const character = resolution.character;
 
     // Get matrix equipment
     const cyberdecks = getCharacterCyberdecks(character);
@@ -125,24 +117,16 @@ export async function PATCH(
       return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    const user = await getUserById(userId);
-    if (!user) {
-      return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
-    }
-
-    // Get the character
-    const character = await getCharacter(userId, characterId);
-    if (!character) {
-      return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
-    }
-
-    // Check ownership
-    if (character.ownerId !== userId) {
+    // Resolve character with GM cross-user support
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "gameplay_edit");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, error: "Not authorized to modify this character" },
-        { status: 403 }
+        { success: false, error: resolution.error },
+        { status: resolution.status }
       );
     }
+
+    const { character, ownerId, actorRole, campaign, isGMAccess } = resolution;
 
     // Parse request
     const body: UpdateMatrixStateRequest = await request.json();
@@ -307,19 +291,29 @@ export async function PATCH(
 
     // Apply updates if any
     if (Object.keys(updates).length > 0) {
-      await updateCharacterWithAudit(character.ownerId, characterId, updates, {
+      await updateCharacterWithAudit(ownerId, characterId, updates, {
         action: "updated",
         actor: {
           userId,
-          role: "owner",
+          role: actorRole,
         },
         details: auditDetails,
         note: "Matrix equipment configuration updated",
       });
+
+      // Notify owner if GM made the edit
+      if (isGMAccess && campaign) {
+        await notifyOwnerOfGMEdit(
+          character,
+          campaign,
+          userId,
+          "matrix equipment configuration updated"
+        );
+      }
     }
 
     // Return updated cyberdecks
-    const updatedCharacter = await getCharacter(userId, characterId);
+    const updatedCharacter = await getCharacter(ownerId, characterId);
     return NextResponse.json({
       success: true,
       cyberdecks: updatedCharacter?.cyberdecks,

--- a/app/api/characters/[characterId]/modifiers/[modifierId]/route.ts
+++ b/app/api/characters/[characterId]/modifiers/[modifierId]/route.ts
@@ -8,7 +8,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
-import { getCharacter, updateCharacterWithAudit } from "@/lib/storage/characters";
+import { updateCharacterWithAudit } from "@/lib/storage/characters";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
 
 // =============================================================================
 // TYPES
@@ -38,17 +39,16 @@ export async function DELETE(
       return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    const character = await getCharacter(userId, characterId);
-    if (!character) {
-      return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
-    }
-
-    if (character.ownerId !== userId) {
+    // Resolve character with GM cross-user support
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "gameplay_edit");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, error: "Not authorized to modify this character" },
-        { status: 403 }
+        { success: false, error: resolution.error },
+        { status: resolution.status }
       );
     }
+
+    const { character, ownerId, actorRole, campaign, isGMAccess } = resolution;
 
     const existing = character.activeModifiers ?? [];
     const modifier = existing.find((m) => m.id === modifierId);
@@ -59,12 +59,12 @@ export async function DELETE(
     const updated = existing.filter((m) => m.id !== modifierId);
 
     await updateCharacterWithAudit(
-      userId,
+      ownerId,
       characterId,
       { activeModifiers: updated },
       {
         action: "modifier_removed",
-        actor: { userId, role: "owner" },
+        actor: { userId, role: actorRole },
         details: {
           modifierId: modifier.id,
           modifierName: modifier.name,
@@ -74,6 +74,11 @@ export async function DELETE(
         note: `Removed modifier: ${modifier.name}`,
       }
     );
+
+    // Notify owner if GM made the edit
+    if (isGMAccess && campaign) {
+      await notifyOwnerOfGMEdit(character, campaign, userId, `modifier removed: ${modifier.name}`);
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/api/characters/[characterId]/modifiers/__tests__/route.test.ts
+++ b/app/api/characters/[characterId]/modifiers/__tests__/route.test.ts
@@ -22,8 +22,14 @@ vi.mock("@/lib/storage/characters", () => ({
   updateCharacterWithAudit: vi.fn(),
 }));
 
+vi.mock("@/lib/auth/gm-character-access", () => ({
+  resolveCharacterForGameplay: vi.fn(),
+  notifyOwnerOfGMEdit: vi.fn(),
+}));
+
 import { getSession } from "@/lib/auth/session";
-import { getCharacter, updateCharacterWithAudit } from "@/lib/storage/characters";
+import { updateCharacterWithAudit } from "@/lib/storage/characters";
+import { resolveCharacterForGameplay } from "@/lib/auth/gm-character-access";
 import { GET, POST } from "../route";
 import { DELETE } from "../[modifierId]/route";
 import type { Character } from "@/lib/types";
@@ -103,6 +109,27 @@ const mockParamsWithModifier = Promise.resolve({
   modifierId: TEST_MODIFIER_ID,
 });
 
+/** Helper to mock resolveCharacterForGameplay as authorized (owner) */
+function mockResolutionSuccess(character: Character) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: true,
+    character,
+    ownerId: character.ownerId,
+    actorRole: "owner",
+    campaign: null,
+    isGMAccess: false,
+  });
+}
+
+/** Helper to mock resolveCharacterForGameplay as denied */
+function mockResolutionDenied(status: number, error: string) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: false,
+    error,
+    status,
+  });
+}
+
 // =============================================================================
 // TESTS
 // =============================================================================
@@ -120,21 +147,21 @@ describe("GET /api/characters/[characterId]/modifiers", () => {
 
   it("returns 404 when character not found", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(null);
+    mockResolutionDenied(404, "Character not found");
     const res = await GET(makeRequest("GET"), { params: mockParams });
     expect(res.status).toBe(404);
   });
 
   it("returns 403 when not the owner", async () => {
     vi.mocked(getSession).mockResolvedValue("different-user");
-    vi.mocked(getCharacter).mockResolvedValue(createTestCharacter());
+    mockResolutionDenied(403, "Permission denied: view");
     const res = await GET(makeRequest("GET"), { params: mockParams });
     expect(res.status).toBe(403);
   });
 
   it("returns empty array when no modifiers", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(createTestCharacter());
+    mockResolutionSuccess(createTestCharacter());
     const res = await GET(makeRequest("GET"), { params: mockParams });
     const data = await res.json();
     expect(res.status).toBe(200);
@@ -144,9 +171,7 @@ describe("GET /api/characters/[characterId]/modifiers", () => {
 
   it("returns existing modifiers", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(
-      createTestCharacter({ activeModifiers: [mockModifier] })
-    );
+    mockResolutionSuccess(createTestCharacter({ activeModifiers: [mockModifier] }));
     const res = await GET(makeRequest("GET"), { params: mockParams });
     const data = await res.json();
     expect(data.success).toBe(true);
@@ -169,21 +194,21 @@ describe("POST /api/characters/[characterId]/modifiers", () => {
 
   it("returns 404 when character not found", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(null);
+    mockResolutionDenied(404, "Character not found");
     const res = await POST(makeRequest("POST", {}), { params: mockParams });
     expect(res.status).toBe(404);
   });
 
   it("returns 403 when not the owner", async () => {
     vi.mocked(getSession).mockResolvedValue("different-user");
-    vi.mocked(getCharacter).mockResolvedValue(createTestCharacter());
+    mockResolutionDenied(403, "Permission denied: gameplay_edit");
     const res = await POST(makeRequest("POST", {}), { params: mockParams });
     expect(res.status).toBe(403);
   });
 
   it("returns 400 on validation failure", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(createTestCharacter());
+    mockResolutionSuccess(createTestCharacter());
     const res = await POST(makeRequest("POST", { source: "invalid", duration: "bad" }), {
       params: mockParams,
     });
@@ -194,7 +219,7 @@ describe("POST /api/characters/[characterId]/modifiers", () => {
 
   it("adds template modifier successfully", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(createTestCharacter());
+    mockResolutionSuccess(createTestCharacter());
     const res = await POST(
       makeRequest("POST", {
         templateId: "partial-cover",
@@ -212,7 +237,7 @@ describe("POST /api/characters/[characterId]/modifiers", () => {
 
   it("adds custom modifier successfully", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(createTestCharacter());
+    mockResolutionSuccess(createTestCharacter());
     const res = await POST(
       makeRequest("POST", {
         name: "Wind Penalty",
@@ -232,7 +257,7 @@ describe("POST /api/characters/[characterId]/modifiers", () => {
 
   it("calls updateCharacterWithAudit with modifier_applied", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(createTestCharacter());
+    mockResolutionSuccess(createTestCharacter());
     await POST(
       makeRequest("POST", {
         templateId: "partial-cover",
@@ -264,21 +289,21 @@ describe("DELETE /api/characters/[characterId]/modifiers/[modifierId]", () => {
 
   it("returns 404 when character not found", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(null);
+    mockResolutionDenied(404, "Character not found");
     const res = await DELETE(makeRequest("DELETE"), { params: mockParamsWithModifier });
     expect(res.status).toBe(404);
   });
 
   it("returns 403 when not the owner", async () => {
     vi.mocked(getSession).mockResolvedValue("different-user");
-    vi.mocked(getCharacter).mockResolvedValue(createTestCharacter());
+    mockResolutionDenied(403, "Permission denied: gameplay_edit");
     const res = await DELETE(makeRequest("DELETE"), { params: mockParamsWithModifier });
     expect(res.status).toBe(403);
   });
 
   it("returns 404 when modifier not found", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(createTestCharacter({ activeModifiers: [] }));
+    mockResolutionSuccess(createTestCharacter({ activeModifiers: [] }));
     const res = await DELETE(makeRequest("DELETE"), { params: mockParamsWithModifier });
     expect(res.status).toBe(404);
     const data = await res.json();
@@ -287,9 +312,7 @@ describe("DELETE /api/characters/[characterId]/modifiers/[modifierId]", () => {
 
   it("removes modifier successfully", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(
-      createTestCharacter({ activeModifiers: [mockModifier] })
-    );
+    mockResolutionSuccess(createTestCharacter({ activeModifiers: [mockModifier] }));
     const res = await DELETE(makeRequest("DELETE"), { params: mockParamsWithModifier });
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -298,9 +321,7 @@ describe("DELETE /api/characters/[characterId]/modifiers/[modifierId]", () => {
 
   it("calls updateCharacterWithAudit with modifier_removed", async () => {
     vi.mocked(getSession).mockResolvedValue(TEST_USER_ID);
-    vi.mocked(getCharacter).mockResolvedValue(
-      createTestCharacter({ activeModifiers: [mockModifier] })
-    );
+    mockResolutionSuccess(createTestCharacter({ activeModifiers: [mockModifier] }));
     await DELETE(makeRequest("DELETE"), { params: mockParamsWithModifier });
     expect(updateCharacterWithAudit).toHaveBeenCalledWith(
       TEST_USER_ID,

--- a/app/api/characters/[characterId]/modifiers/route.ts
+++ b/app/api/characters/[characterId]/modifiers/route.ts
@@ -9,7 +9,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
-import { getCharacter, updateCharacterWithAudit } from "@/lib/storage/characters";
+import { updateCharacterWithAudit } from "@/lib/storage/characters";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
 import { validateAddModifier, getModifierTemplate, computeExpiresAt } from "@/lib/rules/modifiers";
 import type { AddModifierRequest } from "@/lib/rules/modifiers";
 import type { ActiveModifier, Effect } from "@/lib/types/effects";
@@ -54,24 +55,18 @@ export async function GET(
       );
     }
 
-    const character = await getCharacter(userId, characterId);
-    if (!character) {
+    // Resolve character with GM cross-user support (view permission for GET)
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "view");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, modifiers: [], error: "Character not found" },
-        { status: 404 }
-      );
-    }
-
-    if (character.ownerId !== userId) {
-      return NextResponse.json(
-        { success: false, modifiers: [], error: "Not authorized to view this character" },
-        { status: 403 }
+        { success: false, modifiers: [], error: resolution.error },
+        { status: resolution.status }
       );
     }
 
     return NextResponse.json({
       success: true,
-      modifiers: character.activeModifiers ?? [],
+      modifiers: resolution.character.activeModifiers ?? [],
     });
   } catch (error) {
     console.error("Failed to get modifiers:", error);
@@ -97,17 +92,16 @@ export async function POST(
       return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
     }
 
-    const character = await getCharacter(userId, characterId);
-    if (!character) {
-      return NextResponse.json({ success: false, error: "Character not found" }, { status: 404 });
-    }
-
-    if (character.ownerId !== userId) {
+    // Resolve character with GM cross-user support
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "gameplay_edit");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, error: "Not authorized to modify this character" },
-        { status: 403 }
+        { success: false, error: resolution.error },
+        { status: resolution.status }
       );
     }
+
+    const { character, ownerId, actorRole, campaign, isGMAccess } = resolution;
 
     const body: AddModifierRequest = await request.json();
 
@@ -162,12 +156,12 @@ export async function POST(
     // Append and save
     const existingModifiers = character.activeModifiers ?? [];
     await updateCharacterWithAudit(
-      userId,
+      ownerId,
       characterId,
       { activeModifiers: [...existingModifiers, modifier] },
       {
         action: "modifier_applied",
-        actor: { userId, role: "owner" },
+        actor: { userId, role: actorRole },
         details: {
           modifierId: modifier.id,
           modifierName: name,
@@ -180,6 +174,11 @@ export async function POST(
         note: `Applied modifier: ${name}`,
       }
     );
+
+    // Notify owner if GM made the edit
+    if (isGMAccess && campaign) {
+      await notifyOwnerOfGMEdit(character, campaign, userId, `modifier applied: ${name}`);
+    }
 
     return NextResponse.json({ success: true, modifier }, { status: 201 });
   } catch (error) {

--- a/app/api/characters/[characterId]/route.ts
+++ b/app/api/characters/[characterId]/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { getCharacter, updateCharacter, deleteCharacter } from "@/lib/storage/characters";
 import { authorizeOwnerAccess, type CharacterPermission } from "@/lib/auth/character-authorization";
+import { resolveCharacterForGameplay } from "@/lib/auth/gm-character-access";
 import { createAuditEntry, appendAuditEntry } from "@/lib/rules/character/state-machine";
 
 export async function GET(
@@ -28,19 +29,18 @@ export async function GET(
 
     const { characterId } = await params;
 
-    // Authorize view access
-    const authResult = await authorizeOwnerAccess(userId, userId, characterId, "view");
-
-    if (!authResult.authorized) {
+    // Resolve character with GM cross-user support (view permission for GET)
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "view");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, error: authResult.error },
-        { status: authResult.status }
+        { success: false, error: resolution.error },
+        { status: resolution.status }
       );
     }
 
     return NextResponse.json({
       success: true,
-      character: authResult.character,
+      character: resolution.character,
     });
   } catch (error) {
     console.error("Failed to get character:", error);

--- a/app/api/characters/[characterId]/wireless/__tests__/route.test.ts
+++ b/app/api/characters/[characterId]/wireless/__tests__/route.test.ts
@@ -9,14 +9,14 @@ import { GET, PATCH, POST } from "../route";
 import { NextRequest } from "next/server";
 import * as sessionModule from "@/lib/auth/session";
 import * as characterStorageModule from "@/lib/storage/characters";
-import * as authorizationModule from "@/lib/auth/character-authorization";
+import * as gmAccessModule from "@/lib/auth/gm-character-access";
 
 import type { Character, Weapon, CyberwareItem } from "@/lib/types";
 
 // Mock dependencies
 vi.mock("@/lib/auth/session");
 vi.mock("@/lib/storage/characters");
-vi.mock("@/lib/auth/character-authorization");
+vi.mock("@/lib/auth/gm-character-access");
 
 // Helper to create a NextRequest
 function createMockRequest(url: string, body?: unknown, method = "GET"): NextRequest {
@@ -102,13 +102,13 @@ describe("GET /api/characters/[characterId]/wireless", () => {
     });
 
     vi.mocked(sessionModule.getSession).mockResolvedValue(userId);
-    vi.mocked(authorizationModule.authorizeOwnerAccess).mockResolvedValue({
+    vi.mocked(gmAccessModule.resolveCharacterForGameplay).mockResolvedValue({
       authorized: true,
       character: mockCharacter,
+      ownerId: "test-user-id",
+      actorRole: "owner",
       campaign: null,
-      role: "owner",
-      permissions: ["view", "edit"],
-      status: 200,
+      isGMAccess: false,
     });
   });
 
@@ -182,13 +182,13 @@ describe("PATCH /api/characters/[characterId]/wireless", () => {
     });
 
     vi.mocked(sessionModule.getSession).mockResolvedValue(userId);
-    vi.mocked(authorizationModule.authorizeOwnerAccess).mockResolvedValue({
+    vi.mocked(gmAccessModule.resolveCharacterForGameplay).mockResolvedValue({
       authorized: true,
       character: mockCharacter,
+      ownerId: "test-user-id",
+      actorRole: "owner",
       campaign: null,
-      role: "owner",
-      permissions: ["view", "edit"],
-      status: 200,
+      isGMAccess: false,
     });
     vi.mocked(characterStorageModule.updateCharacter).mockResolvedValue(mockCharacter);
   });
@@ -308,13 +308,13 @@ describe("POST /api/characters/[characterId]/wireless", () => {
     });
 
     vi.mocked(sessionModule.getSession).mockResolvedValue(userId);
-    vi.mocked(authorizationModule.authorizeOwnerAccess).mockResolvedValue({
+    vi.mocked(gmAccessModule.resolveCharacterForGameplay).mockResolvedValue({
       authorized: true,
       character: mockCharacter,
+      ownerId: "test-user-id",
+      actorRole: "owner",
       campaign: null,
-      role: "owner",
-      permissions: ["view", "edit"],
-      status: 200,
+      isGMAccess: false,
     });
     vi.mocked(characterStorageModule.updateCharacter).mockResolvedValue(mockCharacter);
   });
@@ -342,13 +342,13 @@ describe("POST /api/characters/[characterId]/wireless", () => {
       wirelessBonusesEnabled: false,
     });
 
-    vi.mocked(authorizationModule.authorizeOwnerAccess).mockResolvedValue({
+    vi.mocked(gmAccessModule.resolveCharacterForGameplay).mockResolvedValue({
       authorized: true,
       character: mockCharacter,
+      ownerId: "test-user-id",
+      actorRole: "owner",
       campaign: null,
-      role: "owner",
-      permissions: ["view", "edit"],
-      status: 200,
+      isGMAccess: false,
     });
 
     const requestBody = {

--- a/app/api/characters/[characterId]/wireless/route.ts
+++ b/app/api/characters/[characterId]/wireless/route.ts
@@ -12,7 +12,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { updateCharacter } from "@/lib/storage/characters";
-import { authorizeOwnerAccess } from "@/lib/auth/character-authorization";
+import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
 import {
   toggleWireless,
   toggleAugmentationWireless,
@@ -86,17 +86,16 @@ export async function GET(
 
     const { characterId } = await params;
 
-    // Authorize view access
-    const authResult = await authorizeOwnerAccess(userId, userId, characterId, "view");
-
-    if (!authResult.authorized) {
+    // Resolve character with GM cross-user support (view permission for GET)
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "view");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, error: authResult.error },
-        { status: authResult.status }
+        { success: false, error: resolution.error },
+        { status: resolution.status }
       );
     }
 
-    const character = authResult.character!;
+    const character = resolution.character;
 
     // Get global wireless state
     const globalEnabled = isGlobalWirelessEnabled(character);
@@ -183,17 +182,16 @@ export async function PATCH(
 
     const { characterId } = await params;
 
-    // Authorize edit access
-    const authResult = await authorizeOwnerAccess(userId, userId, characterId, "edit");
-
-    if (!authResult.authorized) {
+    // Resolve character with GM cross-user support
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "gameplay_edit");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, error: authResult.error },
-        { status: authResult.status }
+        { success: false, error: resolution.error },
+        { status: resolution.status }
       );
     }
 
-    const character = authResult.character!;
+    const { character, ownerId, campaign, isGMAccess } = resolution;
 
     // Parse request body
     const body: ToggleWirelessRequest = await request.json();
@@ -212,7 +210,16 @@ export async function PATCH(
       if (updatedCharacter.cyberware) updates.cyberware = updatedCharacter.cyberware;
       if (updatedCharacter.bioware) updates.bioware = updatedCharacter.bioware;
       if (updatedCharacter.drones) updates.drones = updatedCharacter.drones;
-      await updateCharacter(userId, characterId, updates);
+      await updateCharacter(ownerId, characterId, updates);
+
+      if (isGMAccess && campaign) {
+        await notifyOwnerOfGMEdit(
+          character,
+          campaign,
+          userId,
+          `global wireless ${enabled ? "enabled" : "disabled"}`
+        );
+      }
 
       return NextResponse.json({
         success: true,
@@ -252,7 +259,7 @@ export async function PATCH(
 
         const updatedWeapons = [...character.weapons!];
         updatedWeapons[weaponIndex] = item as Weapon;
-        await updateCharacter(userId, characterId, { weapons: updatedWeapons });
+        await updateCharacter(ownerId, characterId, { weapons: updatedWeapons });
         break;
       }
 
@@ -272,7 +279,7 @@ export async function PATCH(
 
         const updatedArmor = [...character.armor!];
         updatedArmor[armorIndex] = item as ArmorItem;
-        await updateCharacter(userId, characterId, { armor: updatedArmor });
+        await updateCharacter(ownerId, characterId, { armor: updatedArmor });
         break;
       }
 
@@ -296,7 +303,7 @@ export async function PATCH(
 
         const updatedGear = [...character.gear!];
         updatedGear[gearIndex] = item as GearItem;
-        await updateCharacter(userId, characterId, { gear: updatedGear });
+        await updateCharacter(ownerId, characterId, { gear: updatedGear });
         break;
       }
 
@@ -316,7 +323,7 @@ export async function PATCH(
 
         const updatedCyberware = [...character.cyberware!];
         updatedCyberware[cyberIndex] = item as CyberwareItem;
-        await updateCharacter(userId, characterId, { cyberware: updatedCyberware });
+        await updateCharacter(ownerId, characterId, { cyberware: updatedCyberware });
         break;
       }
 
@@ -339,7 +346,7 @@ export async function PATCH(
 
         const updatedBioware = [...character.bioware!];
         updatedBioware[bioIndex] = item as typeof bioItem;
-        await updateCharacter(userId, characterId, { bioware: updatedBioware });
+        await updateCharacter(ownerId, characterId, { bioware: updatedBioware });
         break;
       }
 
@@ -348,6 +355,16 @@ export async function PATCH(
           { success: false, error: `Invalid item type: ${itemType}` },
           { status: 400 }
         );
+    }
+
+    // Notify owner if GM made the edit
+    if (isGMAccess && campaign) {
+      await notifyOwnerOfGMEdit(
+        character,
+        campaign,
+        userId,
+        `wireless ${enabled ? "enabled" : "disabled"} on ${itemType}`
+      );
     }
 
     return NextResponse.json({
@@ -381,17 +398,16 @@ export async function POST(
 
     const { characterId } = await params;
 
-    // Authorize edit access
-    const authResult = await authorizeOwnerAccess(userId, userId, characterId, "edit");
-
-    if (!authResult.authorized) {
+    // Resolve character with GM cross-user support
+    const resolution = await resolveCharacterForGameplay(userId, characterId, "gameplay_edit");
+    if (!resolution.authorized) {
       return NextResponse.json(
-        { success: false, error: authResult.error },
-        { status: authResult.status }
+        { success: false, error: resolution.error },
+        { status: resolution.status }
       );
     }
 
-    const character = authResult.character!;
+    const { character, ownerId, campaign, isGMAccess } = resolution;
 
     // Parse request body
     const body: ToggleAllWirelessRequest = await request.json();
@@ -415,7 +431,16 @@ export async function POST(
     if (updatedCharacter.cyberware) updates.cyberware = updatedCharacter.cyberware;
     if (updatedCharacter.bioware) updates.bioware = updatedCharacter.bioware;
     if (updatedCharacter.drones) updates.drones = updatedCharacter.drones;
-    await updateCharacter(userId, characterId, updates);
+    await updateCharacter(ownerId, characterId, updates);
+
+    if (isGMAccess && campaign) {
+      await notifyOwnerOfGMEdit(
+        character,
+        campaign,
+        userId,
+        `all wireless ${enabled ? "enabled" : "disabled"}`
+      );
+    }
 
     return NextResponse.json({
       success: true,

--- a/app/api/characters/__tests__/damage.test.ts
+++ b/app/api/characters/__tests__/damage.test.ts
@@ -14,23 +14,19 @@ vi.mock("@/lib/auth/session", () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock("@/lib/storage/users", () => ({
-  getUserById: vi.fn(),
+vi.mock("@/lib/auth/gm-character-access", () => ({
+  resolveCharacterForGameplay: vi.fn(),
+  notifyOwnerOfGMEdit: vi.fn(),
 }));
 
 vi.mock("@/lib/storage/characters", () => ({
-  getCharacter: vi.fn(),
   updateCharacterWithAudit: vi.fn(),
 }));
 
-vi.mock("@/lib/storage/campaigns", () => ({
-  getCampaignById: vi.fn(),
-}));
-
 import { getSession } from "@/lib/auth/session";
-import { getUserById } from "@/lib/storage/users";
-import { getCharacter, updateCharacterWithAudit } from "@/lib/storage/characters";
-import type { Character, User } from "@/lib/types";
+import { resolveCharacterForGameplay } from "@/lib/auth/gm-character-access";
+import { updateCharacterWithAudit } from "@/lib/storage/characters";
+import type { Character } from "@/lib/types";
 
 // Helper to create mock request
 function createMockRequest(body: unknown): NextRequest {
@@ -42,12 +38,6 @@ function createMockRequest(body: unknown): NextRequest {
 }
 
 // Sample test data
-const mockUser: Partial<User> = {
-  id: "user-1",
-  username: "testuser",
-  email: "test@example.com",
-};
-
 const mockCharacter: Partial<Character> = {
   id: "char-1",
   ownerId: "user-1",
@@ -63,6 +53,18 @@ const mockCharacter: Partial<Character> = {
     overflowDamage: 0,
   },
 };
+
+/** Helper to mock resolveCharacterForGameplay as authorized */
+function mockResolveAuthorized(character: Partial<Character> = mockCharacter) {
+  vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+    authorized: true,
+    character: character as Character,
+    ownerId: "user-1",
+    actorRole: "owner",
+    campaign: null,
+    isGMAccess: false,
+  });
+}
 
 describe("POST /api/characters/[characterId]/damage", () => {
   beforeEach(() => {
@@ -86,9 +88,13 @@ describe("POST /api/characters/[characterId]/damage", () => {
       expect(data.error).toBe("Unauthorized");
     });
 
-    it("returns 404 if user not found", async () => {
+    it("returns 404 if character resolution fails", async () => {
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(null);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+        authorized: false,
+        error: "Character not found",
+        status: 404,
+      });
 
       const request = createMockRequest({ type: "physical", amount: 3 });
       const response = await POST(request, { params: Promise.resolve({ characterId: "char-1" }) });
@@ -96,15 +102,18 @@ describe("POST /api/characters/[characterId]/damage", () => {
 
       expect(response.status).toBe(404);
       expect(data.success).toBe(false);
-      expect(data.error).toBe("User not found");
+      expect(data.error).toBe("Character not found");
     });
   });
 
   describe("Authorization", () => {
     it("returns 404 if character not found", async () => {
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(null);
+      vi.mocked(resolveCharacterForGameplay).mockResolvedValue({
+        authorized: false,
+        error: "Character not found",
+        status: 404,
+      });
 
       const request = createMockRequest({ type: "physical", amount: 3 });
       const response = await POST(request, { params: Promise.resolve({ characterId: "char-1" }) });
@@ -119,8 +128,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
   describe("Validation", () => {
     it("returns 400 for invalid damage type", async () => {
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter as Character);
+      mockResolveAuthorized();
 
       const request = createMockRequest({ type: "invalid", amount: 3 });
       const response = await POST(request, { params: Promise.resolve({ characterId: "char-1" }) });
@@ -133,8 +141,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
 
     it("returns 400 if amount is not a number", async () => {
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter as Character);
+      mockResolveAuthorized();
 
       const request = createMockRequest({ type: "physical", amount: "three" });
       const response = await POST(request, { params: Promise.resolve({ characterId: "char-1" }) });
@@ -149,8 +156,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
   describe("Damage Application", () => {
     it("applies physical damage correctly", async () => {
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter as Character);
+      mockResolveAuthorized();
       vi.mocked(updateCharacterWithAudit).mockResolvedValue({
         ...mockCharacter,
         condition: { physicalDamage: 3, stunDamage: 0, overflowDamage: 0 },
@@ -168,8 +174,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
 
     it("applies stun damage correctly", async () => {
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter as Character);
+      mockResolveAuthorized();
       vi.mocked(updateCharacterWithAudit).mockResolvedValue({
         ...mockCharacter,
         condition: { physicalDamage: 0, stunDamage: 6, overflowDamage: 0 },
@@ -191,8 +196,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 3, stunDamage: 0, overflowDamage: 0 },
       };
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(charWithDamage as Character);
+      mockResolveAuthorized(charWithDamage);
       vi.mocked(updateCharacterWithAudit).mockResolvedValue({
         ...charWithDamage,
         condition: { physicalDamage: 3, stunDamage: 3, overflowDamage: 0 },
@@ -215,8 +219,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 5, stunDamage: 0, overflowDamage: 0 },
       };
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(wounded as Character);
+      mockResolveAuthorized(wounded);
       vi.mocked(updateCharacterWithAudit).mockResolvedValue({
         ...wounded,
         condition: { physicalDamage: 2, stunDamage: 0, overflowDamage: 0 },
@@ -237,8 +240,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 2, stunDamage: 0, overflowDamage: 0 },
       };
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(wounded as Character);
+      mockResolveAuthorized(wounded);
       vi.mocked(updateCharacterWithAudit).mockResolvedValue({
         ...wounded,
         condition: { physicalDamage: 0, stunDamage: 0, overflowDamage: 0 },
@@ -259,8 +261,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
       // Physical monitor = 10 boxes
       // Applying 12 damage should fill physical and add 2 to overflow
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter as Character);
+      mockResolveAuthorized();
 
       // The actual overflow logic is in applyDamageWithOverflow
       // We capture the condition passed to updateCharacterWithAudit
@@ -292,8 +293,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
       // Stun monitor = 10 boxes
       // Applying 12 stun should fill stun and add 2 physical
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter as Character);
+      mockResolveAuthorized();
 
       let capturedCondition: unknown;
       vi.mocked(updateCharacterWithAudit).mockImplementation(async (_userId, _charId, updates) => {
@@ -323,8 +323,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
   describe("Audit Logging", () => {
     it("creates audit entry with correct action for damage", async () => {
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(mockCharacter as Character);
+      mockResolveAuthorized();
       vi.mocked(updateCharacterWithAudit).mockResolvedValue({
         ...mockCharacter,
         condition: { physicalDamage: 3, stunDamage: 0, overflowDamage: 0 },
@@ -359,8 +358,7 @@ describe("POST /api/characters/[characterId]/damage", () => {
         condition: { physicalDamage: 5, stunDamage: 0, overflowDamage: 0 },
       };
       vi.mocked(getSession).mockResolvedValue("user-1");
-      vi.mocked(getUserById).mockResolvedValue(mockUser as User);
-      vi.mocked(getCharacter).mockResolvedValue(wounded as Character);
+      mockResolveAuthorized(wounded);
       vi.mocked(updateCharacterWithAudit).mockResolvedValue({
         ...wounded,
         condition: { physicalDamage: 2, stunDamage: 0, overflowDamage: 0 },

--- a/lib/auth/character-authorization.ts
+++ b/lib/auth/character-authorization.ts
@@ -37,7 +37,8 @@ export type CharacterPermission =
   | "approve_advancement" // Approve pending advancements (GM)
   | "reject_advancement" // Reject pending advancements (GM)
   | "transfer" // Transfer ownership (admin)
-  | "manage_campaign"; // Join/leave campaign
+  | "manage_campaign" // Join/leave campaign
+  | "gameplay_edit"; // Gameplay actions (damage, healing, karma, inventory, etc.)
 
 // =============================================================================
 // AUTHORIZATION RESULT
@@ -97,13 +98,14 @@ export function getPermissionsForRole(
         "reject_advancement",
         "transfer",
         "manage_campaign",
+        "gameplay_edit",
       ];
 
     case "gm":
       // GM can view campaign characters and manage approvals
       permissions.push("view");
       if (characterStatus === "active") {
-        permissions.push("retire", "approve_advancement", "reject_advancement");
+        permissions.push("retire", "approve_advancement", "reject_advancement", "gameplay_edit");
       }
       if (characterStatus === "deceased") {
         permissions.push("resurrect");
@@ -117,7 +119,7 @@ export function getPermissionsForRole(
         permissions.push("edit", "finalize");
       }
       if (characterStatus === "active") {
-        permissions.push("retire", "advance");
+        permissions.push("retire", "advance", "gameplay_edit");
       }
       if (characterStatus === "retired") {
         // Can reactivate retired characters
@@ -139,6 +141,7 @@ export function getPermissionsForRole(
         "reject_advancement",
         "transfer",
         "manage_campaign",
+        "gameplay_edit",
       ];
   }
 

--- a/lib/auth/gm-character-access.ts
+++ b/lib/auth/gm-character-access.ts
@@ -1,0 +1,164 @@
+/**
+ * GM Character Access
+ *
+ * Provides cross-user character resolution for GM gameplay edits.
+ * When a GM needs to modify a player's character (damage, healing, karma, etc.),
+ * this module resolves the character across user boundaries and validates
+ * GM permissions via the campaign relationship.
+ */
+
+import type { Character } from "@/lib/types/character";
+import type { Campaign } from "@/lib/types/campaign";
+import type { ID } from "@/lib/types/core";
+import type { ActorRole } from "@/lib/types/audit";
+import type { CharacterPermission } from "./character-authorization";
+import { getCharacter, getCharacterById } from "@/lib/storage/characters";
+import { determineRole, getPermissionsForRole, hasPermission } from "./character-authorization";
+import { createNotification } from "@/lib/storage/notifications";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Result of resolving a character for gameplay access
+ */
+export interface GameplayAccessResult {
+  authorized: true;
+  character: Character;
+  ownerId: ID;
+  actorRole: ActorRole;
+  campaign: Campaign | null;
+  isGMAccess: boolean;
+}
+
+export interface GameplayAccessDenied {
+  authorized: false;
+  error: string;
+  status: number;
+}
+
+export type GameplayResolution = GameplayAccessResult | GameplayAccessDenied;
+
+// =============================================================================
+// CORE RESOLUTION
+// =============================================================================
+
+/**
+ * Resolve a character for gameplay access, supporting cross-user GM lookup.
+ *
+ * 1. Fast path: check if actorUserId owns the character
+ * 2. GM path: find character across all users, verify actor is GM of character's campaign
+ * 3. Check required permission against the permission matrix
+ */
+export async function resolveCharacterForGameplay(
+  actorUserId: ID,
+  characterId: ID,
+  requiredPermission: CharacterPermission = "gameplay_edit"
+): Promise<GameplayResolution> {
+  // Fast path: actor owns the character
+  const ownedCharacter = await getCharacter(actorUserId, characterId);
+  if (ownedCharacter) {
+    const { role, campaign } = await determineRole(actorUserId, ownedCharacter);
+    const permissions = getPermissionsForRole(role, ownedCharacter.status);
+
+    if (!hasPermission(permissions, requiredPermission)) {
+      return {
+        authorized: false,
+        error: `Permission denied: ${requiredPermission}`,
+        status: 403,
+      };
+    }
+
+    return {
+      authorized: true,
+      character: ownedCharacter,
+      ownerId: actorUserId,
+      actorRole: role,
+      campaign,
+      isGMAccess: false,
+    };
+  }
+
+  // GM path: character belongs to another user
+  const character = await getCharacterById(characterId);
+  if (!character) {
+    return {
+      authorized: false,
+      error: "Character not found",
+      status: 404,
+    };
+  }
+
+  // Character must be in a campaign for GM access
+  if (!character.campaignId) {
+    return {
+      authorized: false,
+      error: "Character not found",
+      status: 404,
+    };
+  }
+
+  // Determine actor's role for this character
+  const { role, campaign } = await determineRole(actorUserId, character);
+
+  if (role !== "gm" && role !== "admin") {
+    return {
+      authorized: false,
+      error: "Not authorized to access this character",
+      status: 403,
+    };
+  }
+
+  // Check permission
+  const permissions = getPermissionsForRole(role, character.status);
+  if (!hasPermission(permissions, requiredPermission)) {
+    return {
+      authorized: false,
+      error: `Permission denied: ${requiredPermission}`,
+      status: 403,
+    };
+  }
+
+  return {
+    authorized: true,
+    character,
+    ownerId: character.ownerId,
+    actorRole: role,
+    campaign,
+    isGMAccess: true,
+  };
+}
+
+// =============================================================================
+// NOTIFICATION HELPER
+// =============================================================================
+
+/**
+ * Notify the character owner that a GM has edited their character.
+ */
+export async function notifyOwnerOfGMEdit(
+  character: Character,
+  campaign: Campaign,
+  gmUserId: ID,
+  action: string,
+  details?: string
+): Promise<void> {
+  // Don't notify if the GM owns the character (e.g., GM's own NPC)
+  if (character.ownerId === gmUserId) {
+    return;
+  }
+
+  const message = details
+    ? `GM made a gameplay edit to ${character.name}: ${action} — ${details}`
+    : `GM made a gameplay edit to ${character.name}: ${action}`;
+
+  await createNotification({
+    userId: character.ownerId,
+    campaignId: campaign.id,
+    type: "character_gm_edited",
+    title: `Character Updated by GM`,
+    message,
+    actionUrl: `/characters/${character.id}`,
+  });
+}

--- a/lib/types/campaign.ts
+++ b/lib/types/campaign.ts
@@ -405,7 +405,8 @@ export type NotificationType =
   | "karma_awarded"
   | "post_created"
   | "mentioned"
-  | "edge_refreshed";
+  | "edge_refreshed"
+  | "character_gm_edited";
 
 /**
  * User notification


### PR DESCRIPTION
## Summary
- Adds `gameplay_edit` permission and `resolveCharacterForGameplay()` helper enabling campaign GMs to perform gameplay edits (damage, healing, karma, inventory readiness, wireless, modifiers, matrix) on player characters
- Creates `notifyOwnerOfGMEdit()` to notify character owners when a GM modifies their character (skips NPC case where GM owns the character)
- Updates 9 API routes to use the new resolution helper with proper `ownerId` for storage calls, `actorRole` in audit entries, and GM notification on mutations

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` — 407 files, 8660 tests all pass
- [x] `pnpm knip` — no new dead exports
- [x] Unit tests for `resolveCharacterForGameplay`: owner fast path, GM cross-user path, permission denied, no campaign, character not found
- [x] Unit tests for `notifyOwnerOfGMEdit`: creates notification, includes details, skips NPC case
- [x] All 9 route test files updated to mock new authorization flow

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)