### PR TITLE
fix: increase timeout for slow users.test.ts tests

### DIFF
--- a/lib/storage/__tests__/users.test.ts
+++ b/lib/storage/__tests__/users.test.ts
@@ -224,7 +224,7 @@ describe("User Storage", () => {
       expect(foundUsers.length).toBe(2);
       expect(users.map((u) => u.email)).toContain(user1.email);
       expect(users.map((u) => u.email)).toContain(user2.email);
-    });
+    }, 15000);
 
     it("should return users (may include existing data)", async () => {
       const users = await getAllUsers();
@@ -498,6 +498,6 @@ describe("User Storage", () => {
           );
         }
       }
-    });
+    }, 15000);
   });
 });


### PR DESCRIPTION
## Summary
- Two tests in `lib/storage/__tests__/users.test.ts` intermittently fail by exceeding the global 5s timeout by just 5-12ms
- Added per-test 15s timeout overrides to prevent flaky failures without masking real issues
- Affected tests: "should return all users including test users" and "should prevent suspending the last administrator"

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` — all 8660 tests pass (407 files)
- [x] The two previously flaky tests now have comfortable timeout headroom

🤖 Generated with [Claude Code](https://claude.com/claude-code)