### PR TITLE
feat: add Run Faster sourcebook skeleton with empty module stubs

### DIFF
--- a/data/editions/sr5/edition.json
+++ b/data/editions/sr5/edition.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "description": "The fifth edition of Shadowrun, published by Catalyst Game Labs in 2013. Features the Priority character creation system, Limits, and an updated Matrix.",
   "releaseYear": 2013,
-  "bookIds": ["core-rulebook", "core-errata-2014-02-09"],
+  "bookIds": ["core-rulebook", "core-errata-2014-02-09", "run-faster"],
   "creationMethodIds": ["priority"],
   "defaultCreationMethodId": "priority",
   "philosophy": "Fifth Edition brings a streamlined approach to the classic Shadowrun experience, balancing narrative freedom with structured mechanical resolution. The Priority system provides clear trade-offs during character creation, while Limits ensure no single attribute dominates dice rolls.",

--- a/data/editions/sr5/run-faster.json
+++ b/data/editions/sr5/run-faster.json
@@ -1,0 +1,28 @@
+{
+  "meta": {
+    "bookId": "run-faster",
+    "title": "Run Faster",
+    "edition": "sr5",
+    "version": "1.0.0",
+    "category": "sourcebook",
+    "publisher": "Catalyst Game Labs",
+    "releaseYear": 2014,
+    "abbreviation": "RF",
+    "description": "Advanced character options for Shadowrun 5th Edition, including new metatypes, qualities, creation methods, lifestyles, contacts, and more.",
+    "isbn": "978-1-936876-88-2"
+  },
+  "modules": {
+    "metatypes": { "mergeStrategy": "append", "payload": { "metatypes": [] } },
+    "qualities": { "mergeStrategy": "append", "payload": { "positive": [], "negative": [] } },
+    "creationMethods": { "mergeStrategy": "append", "payload": { "creationMethods": [] } },
+    "lifestyle": { "mergeStrategy": "merge", "payload": {} },
+    "contactArchetypes": { "mergeStrategy": "append", "payload": { "archetypes": [] } },
+    "contactTemplates": { "mergeStrategy": "append", "payload": { "templates": [] } },
+    "equipmentPacks": { "mergeStrategy": "replace", "payload": {} },
+    "metagenics": { "mergeStrategy": "replace", "payload": {} },
+    "infected": { "mergeStrategy": "replace", "payload": {} },
+    "lifeModules": { "mergeStrategy": "replace", "payload": {} },
+    "shapeshifters": { "mergeStrategy": "replace", "payload": {} },
+    "johnsonProfiles": { "mergeStrategy": "replace", "payload": {} }
+  }
+}

--- a/lib/types/edition.ts
+++ b/lib/types/edition.ts
@@ -161,7 +161,13 @@ export type RuleModuleType =
   | "socialModifiers" // Social test modifiers
   | "actions" // Action definitions for combat and other activities
   | "categoryModificationDefaults" // Default modification capabilities per gear category
-  | "gameplayLevels"; // Gameplay level modifiers (street, experienced, prime-runner)
+  | "gameplayLevels" // Gameplay level modifiers (street, experienced, prime-runner)
+  | "equipmentPacks" // Pre-built equipment packages (Run Faster)
+  | "metagenics" // Metagenic qualities / SURGE system (Run Faster)
+  | "infected" // HMHVV infected character types (Run Faster)
+  | "lifeModules" // Life module character creation (Run Faster)
+  | "shapeshifters" // Shapeshifter character types (Run Faster)
+  | "johnsonProfiles"; // Mr. Johnson NPC profiles (Run Faster)
 
 /**
  * Rules governing character advancement post-creation.


### PR DESCRIPTION
## Summary

Closes #538

- Create `data/editions/sr5/run-faster.json` with metadata and 12 empty module stubs (metatypes, qualities, creationMethods, lifestyle, contactArchetypes, contactTemplates, equipmentPacks, metagenics, infected, lifeModules, shapeshifters, johnsonProfiles)
- Add 6 new `RuleModuleType` values for Run Faster-specific content
- Register `run-faster` in `edition.json` bookIds

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm verify-data` — no new findings
- [x] `pnpm verify-naming` — all IDs use kebab-case
- [x] Loader, merge, and editions tests pass (105/105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)