### PR TITLE
refactor: extract shared E2E helpers and fixtures

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,26 +1,10 @@
 import { test, expect, type Page } from "@playwright/test";
+import { generateTestUser, setupRateLimitBypass, TEST_PASSWORD } from "./helpers/auth";
 
 // Add E2E bypass header to all API requests to skip rate limiting
 test.beforeEach(async ({ page }) => {
-  await page.route("**/api/**", async (route) => {
-    const headers = {
-      ...route.request().headers(),
-      "x-e2e-bypass": "true",
-    };
-    await route.continue({ headers });
-  });
+  await setupRateLimitBypass(page);
 });
-
-// Helper to generate unique test users
-function generateTestUser() {
-  const timestamp = Date.now();
-  const random = Math.random().toString(36).substring(7);
-  return {
-    email: `test-${timestamp}-${random}@example.com`,
-    username: `testuser${timestamp}${random}`.substring(0, 20), // Keep username reasonable length
-    password: "TestPass123!",
-  };
-}
 
 // Helper to wait for client-side navigation to home page
 // Uses toHaveURL instead of waitForURL since router.push does client-side navigation
@@ -96,7 +80,7 @@ test.describe("Sign Up", () => {
   test("should show error for password mismatch", async ({ page }) => {
     await page.locator("#email").fill("test@example.com");
     await page.locator("#username").fill("testuser");
-    await page.locator("#password").fill("TestPass123!");
+    await page.locator("#password").fill(TEST_PASSWORD);
     await page.locator("#confirmPassword").fill("DifferentPass123!");
     await page.getByRole("button", { name: "Sign Up" }).click();
 
@@ -107,8 +91,8 @@ test.describe("Sign Up", () => {
   test("should show error for short username", async ({ page }) => {
     await page.locator("#email").fill("test@example.com");
     await page.locator("#username").fill("ab");
-    await page.locator("#password").fill("TestPass123!");
-    await page.locator("#confirmPassword").fill("TestPass123!");
+    await page.locator("#password").fill(TEST_PASSWORD);
+    await page.locator("#confirmPassword").fill(TEST_PASSWORD);
     await page.getByRole("button", { name: "Sign Up" }).click();
 
     await expect(page.locator("#username-error")).toBeVisible();

--- a/e2e/character-approval.spec.ts
+++ b/e2e/character-approval.spec.ts
@@ -2,28 +2,29 @@
  * E2E: GM Character Approval Workflow (#445 / PR #507)
  *
  * Verifies the full character approval lifecycle:
- * 1. Campaign character → finalize → pending-review (requiresApproval: true)
+ * 1. Campaign character -> finalize -> pending-review (requiresApproval: true)
  * 2. GM sees character in Approvals tab with badge count
- * 3. GM approves → character becomes active
- * 4. GM rejects with feedback → draft + "Revision Requested" banner
- * 5. Player re-submits after rejection → pending-review again
- * 6. Non-campaign character → finalize directly to active
+ * 3. GM approves -> character becomes active
+ * 4. GM rejects with feedback -> draft + "Revision Requested" banner
+ * 5. Player re-submits after rejection -> pending-review again
+ * 6. Non-campaign character -> finalize directly to active
  *
  * Strategy: Two browser contexts (GM + Player) with API-driven setup.
  * File injection provides minimal valid character fields to pass validation.
  */
 
 import { test, expect, type Page, type BrowserContext } from "@playwright/test";
-import * as fs from "fs";
-import * as path from "path";
+import { signUpTestUser, setupRateLimitBypass } from "./helpers/auth";
+import {
+  readCharacterFromUser,
+  writeCharacterForUser,
+  cleanupUserCharacters,
+  cleanupCampaign,
+} from "./helpers/fixtures";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-const DATA_DIR = path.resolve("data");
-const CAMPAIGNS_DIR = path.join(DATA_DIR, "campaigns");
-const CHARACTERS_DIR = path.join(DATA_DIR, "characters");
 
 const EDITION_CODE = "sr5";
 const EDITION_ID = "sr5";
@@ -70,67 +71,6 @@ const MINIMAL_VALID_FIELDS = {
   karmaCurrent: 0,
   karmaSpentAtCreation: 0,
 };
-
-// ---------------------------------------------------------------------------
-// File-system helpers
-// ---------------------------------------------------------------------------
-
-function readCharacterFile(characterId: string, userId: string): Record<string, unknown> {
-  const filePath = path.join(CHARACTERS_DIR, userId, `${characterId}.json`);
-  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
-}
-
-function writeCharacterFile(
-  characterId: string,
-  userId: string,
-  data: Record<string, unknown>
-): void {
-  const filePath = path.join(CHARACTERS_DIR, userId, `${characterId}.json`);
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
-}
-
-function cleanupUserCharacters(userId: string): void {
-  const dir = path.join(CHARACTERS_DIR, userId);
-  if (!fs.existsSync(dir)) return;
-  for (const file of fs.readdirSync(dir)) {
-    fs.unlinkSync(path.join(dir, file));
-  }
-  fs.rmdirSync(dir);
-}
-
-function cleanupCampaign(campaignId: string): void {
-  // Remove campaign JSON file
-  const campaignFile = path.join(CAMPAIGNS_DIR, `${campaignId}.json`);
-  if (fs.existsSync(campaignFile)) fs.unlinkSync(campaignFile);
-  // Remove campaign directory if it exists (for subdirectories like activity, etc.)
-  const campaignDir = path.join(CAMPAIGNS_DIR, campaignId);
-  if (fs.existsSync(campaignDir)) {
-    fs.rmSync(campaignDir, { recursive: true, force: true });
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Auth helpers
-// ---------------------------------------------------------------------------
-
-async function signUpTestUser(page: Page, prefix: string): Promise<string> {
-  const ts = Date.now();
-  const rnd = Math.random().toString(36).substring(7);
-
-  await page.goto("/signup");
-  await page.locator("#email").fill(`e2e-${prefix}-${ts}-${rnd}@test.com`);
-  await page.locator("#username").fill(`${prefix}${ts}`.substring(0, 20));
-  await page.locator("#password").fill("TestPass123!");
-  await page.locator("#confirmPassword").fill("TestPass123!");
-  await page.getByRole("button", { name: "Sign Up" }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
-
-  const resp = await page.evaluate(() => fetch("/api/auth/me").then((r) => r.json()));
-  if (!resp.success || !resp.user?.id) {
-    throw new Error(`Failed to get user ID after signup: ${JSON.stringify(resp)}`);
-  }
-  return resp.user.id as string;
-}
 
 // ---------------------------------------------------------------------------
 // API helpers (called via page.evaluate to inherit auth cookies)
@@ -229,9 +169,9 @@ async function finalizeCharacterViaAPI(
  * This bypasses creation UI and makes the character pass validateCharacterComplete.
  */
 function injectValidCharacterFields(characterId: string, userId: string): void {
-  const charData = readCharacterFile(characterId, userId);
+  const charData = readCharacterFromUser(characterId, userId);
   const updated = { ...charData, ...MINIMAL_VALID_FIELDS };
-  writeCharacterFile(characterId, userId, updated);
+  writeCharacterForUser(characterId, userId, updated);
 }
 
 // ---------------------------------------------------------------------------
@@ -249,14 +189,6 @@ test.describe("GM Character Approval Workflow (#445)", () => {
   let playerUserId: string;
   let campaignId: string;
 
-  // Bypass rate limiting on all API calls
-  async function setupRateLimitBypass(page: Page): Promise<void> {
-    await page.route("**/api/**", async (route) => {
-      const headers = { ...route.request().headers(), "x-e2e-bypass": "true" };
-      await route.continue({ headers });
-    });
-  }
-
   test.beforeAll(async ({ browser }) => {
     // Create two separate browser contexts for GM and Player
     gmContext = await browser.newContext();
@@ -269,10 +201,10 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     await setupRateLimitBypass(playerPage);
 
     // Sign up GM user
-    gmUserId = await signUpTestUser(gmPage, "gm");
+    gmUserId = await signUpTestUser(gmPage, "e2e-approval-gm");
 
     // Sign up Player user
-    playerUserId = await signUpTestUser(playerPage, "plyr");
+    playerUserId = await signUpTestUser(playerPage, "e2e-approval-plyr");
 
     // GM creates a campaign
     const campaign = await createCampaignViaAPI(gmPage);
@@ -295,7 +227,7 @@ test.describe("GM Character Approval Workflow (#445)", () => {
   // Track character IDs created by each test for cross-test cleanup
   let test1CharId: string;
 
-  test("1. Campaign character finalize → pending-review with requiresApproval", async () => {
+  test("1. Campaign character finalize -> pending-review with requiresApproval", async () => {
     // Player creates a character linked to the campaign
     const char = await createCharacterViaAPI(playerPage, campaignId);
     test1CharId = char.id;
@@ -311,7 +243,7 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     expect((result.character as Record<string, unknown>).status).toBe("pending-review");
 
     // Verify on disk
-    const charData = readCharacterFile(char.id, playerUserId);
+    const charData = readCharacterFromUser(char.id, playerUserId);
     expect(charData.status).toBe("pending-review");
   });
 
@@ -341,7 +273,7 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     await expect(gmPage.getByRole("button", { name: "Reject" })).toBeVisible();
   });
 
-  test("3. GM approves → character becomes active", async () => {
+  test("3. GM approves -> character becomes active", async () => {
     // Create and finalize a new character for the approve test
     const char = await createCharacterViaAPI(playerPage, campaignId);
     injectValidCharacterFields(char.id, playerUserId);
@@ -365,7 +297,7 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     expect(approveResult.success).toBe(true);
 
     // Verify on disk: character should now be active
-    const charData = readCharacterFile(char.id, playerUserId);
+    const charData = readCharacterFromUser(char.id, playerUserId);
     expect(charData.status).toBe("active");
 
     // Player navigates to character page and sees active status (no pending-review banner)
@@ -390,7 +322,7 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     }
   });
 
-  test("4. GM rejects with feedback → draft + feedback banner", async () => {
+  test("4. GM rejects with feedback -> draft + feedback banner", async () => {
     const feedbackText = "Please adjust your attributes to match the priority table.";
 
     // Create and finalize a new character for the reject test
@@ -429,7 +361,7 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     });
 
     // Verify on disk: character should be back to draft
-    const charData = readCharacterFile(char.id, playerUserId);
+    const charData = readCharacterFromUser(char.id, playerUserId);
     expect(charData.status).toBe("draft");
     expect(charData.approvalStatus).toBe("rejected");
     expect(charData.approvalFeedback).toBe(feedbackText);
@@ -440,7 +372,7 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     await expect(playerPage.getByText(feedbackText)).toBeVisible();
   });
 
-  test("5. Player re-submits after rejection → pending-review again", async () => {
+  test("5. Player re-submits after rejection -> pending-review again", async () => {
     // Create, finalize, then reject a character
     const char = await createCharacterViaAPI(playerPage, campaignId);
     injectValidCharacterFields(char.id, playerUserId);
@@ -466,7 +398,7 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     );
 
     // Verify character is now draft
-    let charData = readCharacterFile(char.id, playerUserId);
+    let charData = readCharacterFromUser(char.id, playerUserId);
     expect(charData.status).toBe("draft");
 
     // Player re-finalizes the character
@@ -475,11 +407,11 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     expect((result.character as Record<string, unknown>).status).toBe("pending-review");
 
     // Verify on disk
-    charData = readCharacterFile(char.id, playerUserId);
+    charData = readCharacterFromUser(char.id, playerUserId);
     expect(charData.status).toBe("pending-review");
   });
 
-  test("6. Non-campaign character → finalize directly to active", async () => {
+  test("6. Non-campaign character -> finalize directly to active", async () => {
     // Create a character WITHOUT a campaign
     const char = await createCharacterViaAPI(playerPage);
 
@@ -492,7 +424,7 @@ test.describe("GM Character Approval Workflow (#445)", () => {
     expect((result.character as Record<string, unknown>).status).toBe("active");
 
     // Verify on disk
-    const charData = readCharacterFile(char.id, playerUserId);
+    const charData = readCharacterFromUser(char.id, playerUserId);
     expect(charData.status).toBe("active");
   });
 });

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared E2E auth helpers.
+ *
+ * Extracted from the per-spec duplicates so every test file can
+ * set up a fresh user in one call.
+ */
+
+import { expect, type Page } from "@playwright/test";
+
+export const TEST_PASSWORD = "TestPass123!";
+
+/**
+ * Generate a unique test user object (email, username, password).
+ * @param prefix  Email prefix, e.g. `"e2e-rigging"`. Defaults to `"e2e"`.
+ */
+export function generateTestUser(prefix = "e2e") {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(7);
+  return {
+    email: `${prefix}-${timestamp}-${random}@test.com`,
+    username: `${prefix}${timestamp}${random}`.substring(0, 20),
+    password: TEST_PASSWORD,
+  };
+}
+
+/**
+ * Add `x-e2e-bypass: true` header to every API request so the
+ * server-side rate limiter is skipped during E2E runs.
+ */
+export async function setupRateLimitBypass(page: Page): Promise<void> {
+  await page.route("**/api/**", async (route) => {
+    const headers = {
+      ...route.request().headers(),
+      "x-e2e-bypass": "true",
+    };
+    await route.continue({ headers });
+  });
+}
+
+/**
+ * Sign up a brand-new test user through the UI and return the user ID.
+ *
+ * @param page    Playwright page (rate-limit bypass should already be set up)
+ * @param prefix  Email prefix for uniqueness, e.g. `"e2e-rigging"`.
+ */
+export async function signUpTestUser(page: Page, prefix = "e2e"): Promise<string> {
+  const user = generateTestUser(prefix);
+
+  await page.goto("/signup");
+  await page.locator("#email").fill(user.email);
+  await page.locator("#username").fill(user.username);
+  await page.locator("#password").fill(user.password);
+  await page.locator("#confirmPassword").fill(user.password);
+  await page.getByRole("button", { name: "Sign Up" }).click();
+  await expect(page).toHaveURL("/", { timeout: 15000 });
+
+  const resp = await page.evaluate(() => fetch("/api/auth/me").then((r) => r.json()));
+  if (!resp.success || !resp.user?.id) {
+    throw new Error(`Failed to get user ID after signup: ${JSON.stringify(resp)}`);
+  }
+  return resp.user.id as string;
+}

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared E2E file-system fixtures.
+ *
+ * Provides helpers for copying, reading, writing, and cleaning up
+ * character and campaign files used across multiple E2E specs.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+// ---------------------------------------------------------------------------
+// Path constants
+// ---------------------------------------------------------------------------
+
+export const DATA_DIR = path.resolve("data");
+export const CHARACTERS_DIR = path.join(DATA_DIR, "characters");
+export const CAMPAIGNS_DIR = path.join(DATA_DIR, "campaigns");
+
+/** The admin/seed user who owns the fixture characters on disk. */
+export const ORIGINAL_OWNER = "b7e99950-bbeb-40ee-9139-ae5b2e9a2a0c";
+
+// ---------------------------------------------------------------------------
+// Known fixture character IDs
+// ---------------------------------------------------------------------------
+
+/** Whisper — Adept, active, Magic 5/6 */
+export const WHISPER_ID = "0bd8f72f-b5d9-45b7-a530-0c7f462257a1";
+
+/** Glitch — Technomancer, Resonance with essence hole */
+export const GLITCH_ID = "b04cc67c-d31c-4f7e-9b89-54e38f163894";
+
+// ---------------------------------------------------------------------------
+// Character file helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Copy a fixture character from the original owner's directory into a
+ * test user's directory, rewriting `ownerId` so the app treats it as theirs.
+ */
+export function copyCharacterToUser(characterId: string, userId: string): void {
+  const srcFile = path.join(CHARACTERS_DIR, ORIGINAL_OWNER, `${characterId}.json`);
+  if (!fs.existsSync(srcFile)) return;
+
+  const destDir = path.join(CHARACTERS_DIR, userId);
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+
+  const charData = JSON.parse(fs.readFileSync(srcFile, "utf-8"));
+  charData.ownerId = userId;
+  fs.writeFileSync(path.join(destDir, `${characterId}.json`), JSON.stringify(charData, null, 2));
+}
+
+/** Read a character JSON file for a given user. */
+export function readCharacterFromUser(
+  characterId: string,
+  userId: string
+): Record<string, unknown> {
+  const filePath = path.join(CHARACTERS_DIR, userId, `${characterId}.json`);
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+/** Write (overwrite) a character JSON file for a given user. */
+export function writeCharacterForUser(
+  characterId: string,
+  userId: string,
+  data: Record<string, unknown>
+): void {
+  const filePath = path.join(CHARACTERS_DIR, userId, `${characterId}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+/**
+ * Delete all character files for a test user and remove the directory.
+ * Safe to call even if the directory doesn't exist.
+ */
+export function cleanupUserCharacters(userId: string): void {
+  const destDir = path.join(CHARACTERS_DIR, userId);
+  if (!fs.existsSync(destDir)) return;
+  for (const file of fs.readdirSync(destDir)) {
+    fs.unlinkSync(path.join(destDir, file));
+  }
+  fs.rmdirSync(destDir);
+}
+
+// ---------------------------------------------------------------------------
+// Campaign file helpers
+// ---------------------------------------------------------------------------
+
+/** Remove a campaign JSON file and its subdirectory (if any). */
+export function cleanupCampaign(campaignId: string): void {
+  const campaignFile = path.join(CAMPAIGNS_DIR, `${campaignId}.json`);
+  if (fs.existsSync(campaignFile)) fs.unlinkSync(campaignFile);
+
+  const campaignDir = path.join(CAMPAIGNS_DIR, campaignId);
+  if (fs.existsSync(campaignDir)) {
+    fs.rmSync(campaignDir, { recursive: true, force: true });
+  }
+}

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,0 +1,3 @@
+export * from "./auth";
+export * from "./fixtures";
+export { test, expect } from "./test-fixtures";

--- a/e2e/helpers/test-fixtures.ts
+++ b/e2e/helpers/test-fixtures.ts
@@ -1,0 +1,35 @@
+/**
+ * Extended Playwright `test` with custom E2E fixtures.
+ *
+ * Usage:
+ *   import { test, expect } from "./helpers/test-fixtures";
+ *
+ *   test("my test", async ({ authenticatedPage: { page, userId } }) => {
+ *     // page already has rate-limit bypass + a logged-in user
+ *   });
+ */
+
+/* eslint-disable react-hooks/rules-of-hooks -- Playwright fixture `use` is not a React hook */
+import { test as base, type Page } from "@playwright/test";
+import { signUpTestUser, setupRateLimitBypass } from "./auth";
+
+type E2EFixtures = {
+  /** Page with rate-limit bypass already configured. */
+  e2ePage: Page;
+  /** Authenticated page + userId (creates a fresh user and logs in). */
+  authenticatedPage: { page: Page; userId: string };
+};
+
+export const test = base.extend<E2EFixtures>({
+  e2ePage: async ({ page }, use) => {
+    await setupRateLimitBypass(page);
+    await use(page);
+  },
+  authenticatedPage: async ({ page }, use) => {
+    await setupRateLimitBypass(page);
+    const userId = await signUpTestUser(page);
+    await use({ page, userId });
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/lifestyles-display.spec.ts
+++ b/e2e/lifestyles-display.spec.ts
@@ -20,80 +20,14 @@
  */
 
 import { test, expect, type Page, type Locator } from "@playwright/test";
-import * as fs from "fs";
-import * as path from "path";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const WHISPER_ID = "0bd8f72f-b5d9-45b7-a530-0c7f462257a1";
-const ORIGINAL_OWNER = "b7e99950-bbeb-40ee-9139-ae5b2e9a2a0c";
-const DATA_DIR = path.resolve("data");
-
-// ---------------------------------------------------------------------------
-// File-system helpers (same pattern as magic-resonance-reduction.spec.ts)
-// ---------------------------------------------------------------------------
-
-function copyCharacterToUser(characterId: string, userId: string): void {
-  const srcFile = path.join(DATA_DIR, "characters", ORIGINAL_OWNER, `${characterId}.json`);
-  if (!fs.existsSync(srcFile)) return;
-
-  const destDir = path.join(DATA_DIR, "characters", userId);
-  if (!fs.existsSync(destDir)) {
-    fs.mkdirSync(destDir, { recursive: true });
-  }
-
-  const charData = JSON.parse(fs.readFileSync(srcFile, "utf-8"));
-  charData.ownerId = userId;
-  fs.writeFileSync(path.join(destDir, `${characterId}.json`), JSON.stringify(charData, null, 2));
-}
-
-function readCharacterFromUser(characterId: string, userId: string): Record<string, unknown> {
-  const filePath = path.join(DATA_DIR, "characters", userId, `${characterId}.json`);
-  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
-}
-
-function writeCharacterForUser(
-  characterId: string,
-  userId: string,
-  data: Record<string, unknown>
-): void {
-  const filePath = path.join(DATA_DIR, "characters", userId, `${characterId}.json`);
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
-}
-
-function cleanupUserCharacters(userId: string): void {
-  const destDir = path.join(DATA_DIR, "characters", userId);
-  if (!fs.existsSync(destDir)) return;
-  for (const file of fs.readdirSync(destDir)) {
-    fs.unlinkSync(path.join(destDir, file));
-  }
-  fs.rmdirSync(destDir);
-}
-
-// ---------------------------------------------------------------------------
-// Auth helpers
-// ---------------------------------------------------------------------------
-
-async function signUpTestUser(page: Page): Promise<string> {
-  const ts = Date.now();
-  const rnd = Math.random().toString(36).substring(7);
-
-  await page.goto("/signup");
-  await page.locator("#email").fill(`e2e-lifestyles-${ts}-${rnd}@test.com`);
-  await page.locator("#username").fill(`lstyle${ts}`.substring(0, 20));
-  await page.locator("#password").fill("TestPass123!");
-  await page.locator("#confirmPassword").fill("TestPass123!");
-  await page.getByRole("button", { name: "Sign Up" }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
-
-  const resp = await page.evaluate(() => fetch("/api/auth/me").then((r) => r.json()));
-  if (!resp.success || !resp.user?.id) {
-    throw new Error(`Failed to get user ID after signup: ${JSON.stringify(resp)}`);
-  }
-  return resp.user.id as string;
-}
+import { signUpTestUser, setupRateLimitBypass } from "./helpers/auth";
+import {
+  WHISPER_ID,
+  copyCharacterToUser,
+  readCharacterFromUser,
+  writeCharacterForUser,
+  cleanupUserCharacters,
+} from "./helpers/fixtures";
 
 // ---------------------------------------------------------------------------
 // Page helpers
@@ -132,15 +66,12 @@ test.describe("Lifestyles Display (#455)", () => {
 
   // Bypass rate limiting on all API calls
   test.beforeEach(async ({ page }) => {
-    await page.route("**/api/**", async (route) => {
-      const headers = { ...route.request().headers(), "x-e2e-bypass": "true" };
-      await route.continue({ headers });
-    });
+    await setupRateLimitBypass(page);
   });
 
   test.describe("Section layout", () => {
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-lifestyles");
       copyCharacterToUser(WHISPER_ID, testUserId);
     });
 
@@ -188,7 +119,7 @@ test.describe("Lifestyles Display (#455)", () => {
 
   test.describe("Expanded row and actions", () => {
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-lifestyles");
       copyCharacterToUser(WHISPER_ID, testUserId);
     });
 
@@ -217,7 +148,7 @@ test.describe("Lifestyles Display (#455)", () => {
 
   test.describe("Add lifestyle", () => {
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-lifestyles");
       copyCharacterToUser(WHISPER_ID, testUserId);
       const charData = readCharacterFromUser(WHISPER_ID, testUserId);
       writeCharacterForUser(WHISPER_ID, testUserId, {
@@ -292,7 +223,7 @@ test.describe("Lifestyles Display (#455)", () => {
 
   test.describe("Edit lifestyle", () => {
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-lifestyles");
       copyCharacterToUser(WHISPER_ID, testUserId);
       // Ensure enough nuyen so the modal's Save button is enabled (canAfford check)
       const charData = readCharacterFromUser(WHISPER_ID, testUserId);
@@ -332,7 +263,7 @@ test.describe("Lifestyles Display (#455)", () => {
 
   test.describe("Pay Month — prepaid > 0 (local decrement)", () => {
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-lifestyles");
       copyCharacterToUser(WHISPER_ID, testUserId);
     });
 
@@ -382,7 +313,7 @@ test.describe("Lifestyles Display (#455)", () => {
 
   test.describe("Pay Month — prepaid = 0 (deducts nuyen via API)", () => {
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-lifestyles");
       copyCharacterToUser(WHISPER_ID, testUserId);
       const charData = readCharacterFromUser(WHISPER_ID, testUserId);
       const lifestyles = charData.lifestyles as Array<Record<string, unknown>>;
@@ -444,7 +375,7 @@ test.describe("Lifestyles Display (#455)", () => {
 
   test.describe("Remove lifestyle", () => {
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-lifestyles");
       copyCharacterToUser(WHISPER_ID, testUserId);
     });
 
@@ -489,7 +420,7 @@ test.describe("Lifestyles Display (#455)", () => {
 
   test.describe("Nuyen warning banner", () => {
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-lifestyles");
       copyCharacterToUser(WHISPER_ID, testUserId);
     });
 

--- a/e2e/magic-resonance-reduction.spec.ts
+++ b/e2e/magic-resonance-reduction.spec.ts
@@ -13,57 +13,19 @@
 import { test, expect, type Page, type Locator } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
-
-const WHISPER_ID = "0bd8f72f-b5d9-45b7-a530-0c7f462257a1";
-const GLITCH_ID = "b04cc67c-d31c-4f7e-9b89-54e38f163894";
-const ORIGINAL_OWNER = "b7e99950-bbeb-40ee-9139-ae5b2e9a2a0c";
-const DATA_DIR = path.resolve("data");
+import { signUpTestUser, setupRateLimitBypass } from "./helpers/auth";
+import {
+  WHISPER_ID,
+  GLITCH_ID,
+  DATA_DIR,
+  ORIGINAL_OWNER,
+  copyCharacterToUser,
+  cleanupUserCharacters,
+} from "./helpers/fixtures";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function copyCharacterToUser(characterId: string, userId: string): void {
-  const srcFile = path.join(DATA_DIR, "characters", ORIGINAL_OWNER, `${characterId}.json`);
-  if (!fs.existsSync(srcFile)) return;
-
-  const destDir = path.join(DATA_DIR, "characters", userId);
-  if (!fs.existsSync(destDir)) {
-    fs.mkdirSync(destDir, { recursive: true });
-  }
-
-  const charData = JSON.parse(fs.readFileSync(srcFile, "utf-8"));
-  charData.ownerId = userId;
-  fs.writeFileSync(path.join(destDir, `${characterId}.json`), JSON.stringify(charData, null, 2));
-}
-
-function cleanupUserCharacters(userId: string): void {
-  const destDir = path.join(DATA_DIR, "characters", userId);
-  if (!fs.existsSync(destDir)) return;
-  for (const file of fs.readdirSync(destDir)) {
-    fs.unlinkSync(path.join(destDir, file));
-  }
-  fs.rmdirSync(destDir);
-}
-
-async function signUpTestUser(page: Page): Promise<string> {
-  const ts = Date.now();
-  const rnd = Math.random().toString(36).substring(7);
-
-  await page.goto("/signup");
-  await page.locator("#email").fill(`e2e-magic-${ts}-${rnd}@test.com`);
-  await page.locator("#username").fill(`mtest${ts}`.substring(0, 20));
-  await page.locator("#password").fill("TestPass123!");
-  await page.locator("#confirmPassword").fill("TestPass123!");
-  await page.getByRole("button", { name: "Sign Up" }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
-
-  const resp = await page.evaluate(() => fetch("/api/auth/me").then((r) => r.json()));
-  if (!resp.success || !resp.user?.id) {
-    throw new Error(`Failed to get user ID: ${JSON.stringify(resp)}`);
-  }
-  return resp.user.id;
-}
 
 /**
  * Find a display card by its heading text.
@@ -86,15 +48,12 @@ test.describe("Magic/Resonance Reduction Display (#454)", () => {
 
   // Bypass rate limiting for all API requests
   test.beforeEach(async ({ page }) => {
-    await page.route("**/api/**", async (route) => {
-      const headers = { ...route.request().headers(), "x-e2e-bypass": "true" };
-      await route.continue({ headers });
-    });
+    await setupRateLimitBypass(page);
   });
 
   test.describe("Whisper (Adept) — Magic Reduction", () => {
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-magic");
       copyCharacterToUser(WHISPER_ID, testUserId);
     });
 
@@ -192,7 +151,7 @@ test.describe("Magic/Resonance Reduction Display (#454)", () => {
         test.skip();
         return;
       }
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-magic");
       copyCharacterToUser(GLITCH_ID, testUserId);
     });
 

--- a/e2e/rigging-system.spec.ts
+++ b/e2e/rigging-system.spec.ts
@@ -20,80 +20,14 @@
  */
 
 import { test, expect, type Page } from "@playwright/test";
-import * as fs from "fs";
-import * as path from "path";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const WHISPER_ID = "0bd8f72f-b5d9-45b7-a530-0c7f462257a1";
-const ORIGINAL_OWNER = "b7e99950-bbeb-40ee-9139-ae5b2e9a2a0c";
-const DATA_DIR = path.resolve("data");
-
-// ---------------------------------------------------------------------------
-// File-system helpers
-// ---------------------------------------------------------------------------
-
-function copyCharacterToUser(characterId: string, userId: string): void {
-  const srcFile = path.join(DATA_DIR, "characters", ORIGINAL_OWNER, `${characterId}.json`);
-  if (!fs.existsSync(srcFile)) return;
-
-  const destDir = path.join(DATA_DIR, "characters", userId);
-  if (!fs.existsSync(destDir)) {
-    fs.mkdirSync(destDir, { recursive: true });
-  }
-
-  const charData = JSON.parse(fs.readFileSync(srcFile, "utf-8"));
-  charData.ownerId = userId;
-  fs.writeFileSync(path.join(destDir, `${characterId}.json`), JSON.stringify(charData, null, 2));
-}
-
-function readCharacterFromUser(characterId: string, userId: string): Record<string, unknown> {
-  const filePath = path.join(DATA_DIR, "characters", userId, `${characterId}.json`);
-  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
-}
-
-function writeCharacterForUser(
-  characterId: string,
-  userId: string,
-  data: Record<string, unknown>
-): void {
-  const filePath = path.join(DATA_DIR, "characters", userId, `${characterId}.json`);
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
-}
-
-function cleanupUserCharacters(userId: string): void {
-  const destDir = path.join(DATA_DIR, "characters", userId);
-  if (!fs.existsSync(destDir)) return;
-  for (const file of fs.readdirSync(destDir)) {
-    fs.unlinkSync(path.join(destDir, file));
-  }
-  fs.rmdirSync(destDir);
-}
-
-// ---------------------------------------------------------------------------
-// Auth helpers
-// ---------------------------------------------------------------------------
-
-async function signUpTestUser(page: Page): Promise<string> {
-  const ts = Date.now();
-  const rnd = Math.random().toString(36).substring(7);
-
-  await page.goto("/signup");
-  await page.locator("#email").fill(`e2e-rigging-${ts}-${rnd}@test.com`);
-  await page.locator("#username").fill(`rig${ts}`.substring(0, 20));
-  await page.locator("#password").fill("TestPass123!");
-  await page.locator("#confirmPassword").fill("TestPass123!");
-  await page.getByRole("button", { name: "Sign Up" }).click();
-  await expect(page).toHaveURL("/", { timeout: 15000 });
-
-  const resp = await page.evaluate(() => fetch("/api/auth/me").then((r) => r.json()));
-  if (!resp.success || !resp.user?.id) {
-    throw new Error(`Failed to get user ID after signup: ${JSON.stringify(resp)}`);
-  }
-  return resp.user.id as string;
-}
+import { signUpTestUser, setupRateLimitBypass } from "./helpers/auth";
+import {
+  WHISPER_ID,
+  copyCharacterToUser,
+  readCharacterFromUser,
+  writeCharacterForUser,
+  cleanupUserCharacters,
+} from "./helpers/fixtures";
 
 // ---------------------------------------------------------------------------
 // Rigging data injection
@@ -287,10 +221,7 @@ test.describe("Rigging System E2E (#407-410)", () => {
 
   // Bypass rate limiting on all API calls
   test.beforeEach(async ({ page }) => {
-    await page.route("**/api/**", async (route) => {
-      const headers = { ...route.request().headers(), "x-e2e-bypass": "true" };
-      await route.continue({ headers });
-    });
+    await setupRateLimitBypass(page);
   });
 
   // ---------------------------------------------------------------------------
@@ -301,7 +232,7 @@ test.describe("Rigging System E2E (#407-410)", () => {
     let testUserId: string;
 
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-rigging");
       copyCharacterToUser(WHISPER_ID, testUserId);
       injectRiggingFields(testUserId);
     });
@@ -342,7 +273,7 @@ test.describe("Rigging System E2E (#407-410)", () => {
     let testUserId: string;
 
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-rigging");
       copyCharacterToUser(WHISPER_ID, testUserId);
       injectRiggingFields(testUserId);
     });
@@ -398,7 +329,7 @@ test.describe("Rigging System E2E (#407-410)", () => {
     let testUserId: string;
 
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-rigging");
       copyCharacterToUser(WHISPER_ID, testUserId);
       injectRiggingFields(testUserId);
     });
@@ -499,7 +430,7 @@ test.describe("Rigging System E2E (#407-410)", () => {
     let testUserId: string;
 
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-rigging");
       copyCharacterToUser(WHISPER_ID, testUserId);
       injectRiggingFields(testUserId);
     });
@@ -588,7 +519,7 @@ test.describe("Rigging System E2E (#407-410)", () => {
     let testUserId: string;
 
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-rigging");
       copyCharacterToUser(WHISPER_ID, testUserId);
       injectRiggingFields(testUserId);
     });
@@ -678,7 +609,7 @@ test.describe("Rigging System E2E (#407-410)", () => {
     let testUserId: string;
 
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-rigging");
       copyCharacterToUser(WHISPER_ID, testUserId);
       injectRiggingFields(testUserId);
     });
@@ -733,7 +664,7 @@ test.describe("Rigging System E2E (#407-410)", () => {
     let testUserId: string;
 
     test.beforeEach(async ({ page }) => {
-      testUserId = await signUpTestUser(page);
+      testUserId = await signUpTestUser(page, "e2e-rigging");
       // Copy Whisper WITHOUT injecting rigging fields
       copyCharacterToUser(WHISPER_ID, testUserId);
     });


### PR DESCRIPTION
## Summary
- Extract duplicated auth helpers (`signUpTestUser`, `generateTestUser`, `setupRateLimitBypass`, `TEST_PASSWORD`) into `e2e/helpers/auth.ts`
- Extract duplicated file-system helpers (`copyCharacterToUser`, `readCharacterFromUser`, `writeCharacterForUser`, `cleanupUserCharacters`, `cleanupCampaign`) and constants (`WHISPER_ID`, `GLITCH_ID`, `ORIGINAL_OWNER`, path constants) into `e2e/helpers/fixtures.ts`
- Add Playwright custom fixtures (`e2ePage`, `authenticatedPage`) in `e2e/helpers/test-fixtures.ts` for one-line test setup
- Refactor all 5 E2E spec files to import from shared helpers, removing ~340 lines of duplication (net -64 lines)

## Test plan
- [x] `pnpm type-check` passes clean
- [x] `pnpm test` passes (1 pre-existing timeout in users.test.ts, unrelated)
- [x] `npx playwright test --list` confirms all 216 E2E tests parse correctly
- [x] No duplicated helper function definitions remain in spec files (verified via grep)
- [ ] `pnpm test:e2e` — all existing E2E tests still pass (requires dev server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)