### PR TITLE
feat: add quality-driven creation budget modifiers (#551)

### DIFF
--- a/components/creation/AugmentationsCard.tsx
+++ b/components/creation/AugmentationsCard.tsx
@@ -70,7 +70,7 @@ interface AugmentationsCardProps {
 
 export function AugmentationsCard({ state, updateState }: AugmentationsCardProps) {
   const augmentationRules = useAugmentationRules();
-  const { getBudget } = useCreationBudgets();
+  const { getBudget, qualityModifiers } = useCreationBudgets();
   const nuyenBudget = getBudget("nuyen");
   const karmaBudget = getBudget("karma");
 
@@ -160,6 +160,7 @@ export function AugmentationsCard({ state, updateState }: AugmentationsCardProps
     karmaRemaining,
     currentConversion: karmaConversion,
     onConvert: handleKarmaConvert,
+    maxKarmaConversion: qualityModifiers.karmaToNuyenCap,
   });
 
   // Calculate essence

--- a/components/creation/SkillsCard.tsx
+++ b/components/creation/SkillsCard.tsx
@@ -55,7 +55,7 @@ interface SkillsCardProps {
 
 export function SkillsCard({ state, updateState }: SkillsCardProps) {
   const { activeSkills, skillGroups } = useSkills();
-  const { getBudget } = useCreationBudgets();
+  const { getBudget, qualityModifiers } = useCreationBudgets();
   const skillBudget = getBudget("skill-points");
   const groupBudget = getBudget("skill-group-points");
   const karmaBudget = getBudget("karma");
@@ -201,7 +201,8 @@ export function SkillsCard({ state, updateState }: SkillsCardProps) {
     activeSkills,
     skillPointsRemaining,
     groupPointsRemaining,
-    karmaRemaining
+    karmaRemaining,
+    qualityModifiers.jackOfAllTrades
   );
 
   // Use extracted handlers hook

--- a/components/creation/VehiclesCard.tsx
+++ b/components/creation/VehiclesCard.tsx
@@ -86,7 +86,7 @@ interface VehiclesCardProps {
 // =============================================================================
 
 export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
-  const { getBudget } = useCreationBudgets();
+  const { getBudget, qualityModifiers } = useCreationBudgets();
   const nuyenBudget = getBudget("nuyen");
   const karmaBudget = getBudget("karma");
 
@@ -153,6 +153,7 @@ export function VehiclesCard({ state, updateState }: VehiclesCardProps) {
     karmaRemaining,
     currentConversion: karmaConversion,
     onConvert: handleKarmaConvert,
+    maxKarmaConversion: qualityModifiers.karmaToNuyenCap,
   });
 
   // Add vehicle from modal

--- a/components/creation/WeaponsPanel.tsx
+++ b/components/creation/WeaponsPanel.tsx
@@ -130,7 +130,7 @@ export function WeaponsPanel({ state, updateState }: WeaponsPanelProps) {
   const { ruleset } = useRuleset();
   const gearCatalog = useGear();
   const weaponModsCatalog = useWeaponModifications();
-  const { getBudget } = useCreationBudgets();
+  const { getBudget, qualityModifiers } = useCreationBudgets();
   const nuyenBudget = getBudget("nuyen");
   const karmaBudget = getBudget("karma");
 
@@ -223,6 +223,7 @@ export function WeaponsPanel({ state, updateState }: WeaponsPanelProps) {
     karmaRemaining,
     currentConversion: karmaConversion,
     onConvert: handleKarmaConvert,
+    maxKarmaConversion: qualityModifiers.karmaToNuyenCap,
   });
 
   // Add weapon (actual implementation - called after affordability check)

--- a/components/creation/__tests__/AttributesCard.test.tsx
+++ b/components/creation/__tests__/AttributesCard.test.tsx
@@ -175,6 +175,12 @@ describe("AttributesCard", () => {
       errors: [],
       warnings: [],
       isComplete: false,
+      qualityModifiers: {
+        karmaToNuyenCap: 10,
+        knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+        languageCostMultiplier: 1,
+        jackOfAllTrades: false,
+      },
     } as unknown as ReturnType<typeof useCreationBudgets>);
   });
 

--- a/components/creation/__tests__/AugmentationsCard.test.tsx
+++ b/components/creation/__tests__/AugmentationsCard.test.tsx
@@ -195,6 +195,12 @@ describe("AugmentationsCard", () => {
       errors: [],
       warnings: [],
       isComplete: false,
+      qualityModifiers: {
+        karmaToNuyenCap: 10,
+        knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+        languageCostMultiplier: 1,
+        jackOfAllTrades: false,
+      },
     } as unknown as ReturnType<typeof useCreationBudgets>);
   });
 

--- a/components/creation/__tests__/ComplexFormsCard.test.tsx
+++ b/components/creation/__tests__/ComplexFormsCard.test.tsx
@@ -165,6 +165,12 @@ describe("ComplexFormsCard", () => {
       errors: [],
       warnings: [],
       isComplete: false,
+      qualityModifiers: {
+        karmaToNuyenCap: 10,
+        knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+        languageCostMultiplier: 1,
+        jackOfAllTrades: false,
+      },
     } as unknown as ReturnType<typeof useCreationBudgets>);
   });
 

--- a/components/creation/__tests__/PrioritySelectionCard.test.tsx
+++ b/components/creation/__tests__/PrioritySelectionCard.test.tsx
@@ -159,6 +159,12 @@ describe("PrioritySelectionCard", () => {
       getBudget: vi.fn(),
       hasRemaining: vi.fn(),
       isOverspent: vi.fn(),
+      qualityModifiers: {
+        karmaToNuyenCap: 10,
+        knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+        languageCostMultiplier: 1,
+        jackOfAllTrades: false,
+      },
     } as unknown as ReturnType<typeof useCreationBudgets>);
   });
 
@@ -554,6 +560,12 @@ describe("PrioritySelectionCard", () => {
         getBudget: vi.fn(),
         hasRemaining: vi.fn(),
         isOverspent: vi.fn(),
+        qualityModifiers: {
+          karmaToNuyenCap: 10,
+          knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+          languageCostMultiplier: 1,
+          jackOfAllTrades: false,
+        },
       } as unknown as ReturnType<typeof useCreationBudgets>);
 
       const state = createBaseState();
@@ -577,6 +589,12 @@ describe("PrioritySelectionCard", () => {
         getBudget: vi.fn(),
         hasRemaining: vi.fn(),
         isOverspent: vi.fn(),
+        qualityModifiers: {
+          karmaToNuyenCap: 10,
+          knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+          languageCostMultiplier: 1,
+          jackOfAllTrades: false,
+        },
       } as unknown as ReturnType<typeof useCreationBudgets>);
 
       const state = createBaseState();
@@ -600,6 +618,12 @@ describe("PrioritySelectionCard", () => {
         getBudget: vi.fn(),
         hasRemaining: vi.fn(),
         isOverspent: vi.fn(),
+        qualityModifiers: {
+          karmaToNuyenCap: 10,
+          knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+          languageCostMultiplier: 1,
+          jackOfAllTrades: false,
+        },
       } as unknown as ReturnType<typeof useCreationBudgets>);
 
       const state = createBaseState();

--- a/components/creation/__tests__/SkillsCard.test.tsx
+++ b/components/creation/__tests__/SkillsCard.test.tsx
@@ -375,6 +375,12 @@ describe("SkillsCard", () => {
       errors: [],
       warnings: [],
       isComplete: false,
+      qualityModifiers: {
+        karmaToNuyenCap: 10,
+        knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+        languageCostMultiplier: 1,
+        jackOfAllTrades: false,
+      },
     } as unknown as ReturnType<typeof useCreationBudgets>);
   });
 

--- a/components/creation/__tests__/SpellsCard.test.tsx
+++ b/components/creation/__tests__/SpellsCard.test.tsx
@@ -245,6 +245,12 @@ describe("SpellsCard", () => {
       errors: [],
       warnings: [],
       isComplete: false,
+      qualityModifiers: {
+        karmaToNuyenCap: 10,
+        knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+        languageCostMultiplier: 1,
+        jackOfAllTrades: false,
+      },
     } as unknown as ReturnType<typeof useCreationBudgets>);
   });
 

--- a/components/creation/__tests__/VehiclesCard.test.tsx
+++ b/components/creation/__tests__/VehiclesCard.test.tsx
@@ -166,6 +166,12 @@ describe("VehiclesCard", () => {
       errors: [],
       warnings: [],
       isComplete: false,
+      qualityModifiers: {
+        karmaToNuyenCap: 10,
+        knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+        languageCostMultiplier: 1,
+        jackOfAllTrades: false,
+      },
     } as unknown as ReturnType<typeof useCreationBudgets>);
   });
 

--- a/components/creation/__tests__/WeaponsPanel.test.tsx
+++ b/components/creation/__tests__/WeaponsPanel.test.tsx
@@ -182,6 +182,12 @@ describe("WeaponsPanel", () => {
       errors: [],
       warnings: [],
       isComplete: false,
+      qualityModifiers: {
+        karmaToNuyenCap: 10,
+        knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+        languageCostMultiplier: 1,
+        jackOfAllTrades: false,
+      },
     } as unknown as ReturnType<typeof useCreationBudgets>);
   });
 

--- a/components/creation/armor/ArmorPanel.tsx
+++ b/components/creation/armor/ArmorPanel.tsx
@@ -126,7 +126,7 @@ interface ArmorPanelProps {
 
 export function ArmorPanel({ state, updateState }: ArmorPanelProps) {
   const gearCatalog = useGear();
-  const { getBudget } = useCreationBudgets();
+  const { getBudget, qualityModifiers } = useCreationBudgets();
   const nuyenBudget = getBudget("nuyen");
   const karmaBudget = getBudget("karma");
 
@@ -215,6 +215,7 @@ export function ArmorPanel({ state, updateState }: ArmorPanelProps) {
     karmaRemaining,
     currentConversion: karmaConversion,
     onConvert: handleKarmaConvert,
+    maxKarmaConversion: qualityModifiers.karmaToNuyenCap,
   });
 
   // Add armor (actual implementation)

--- a/components/creation/drugs-toxins/DrugsPanel.tsx
+++ b/components/creation/drugs-toxins/DrugsPanel.tsx
@@ -61,7 +61,7 @@ interface DrugsPanelProps {
 // =============================================================================
 
 export function DrugsPanel({ state, updateState }: DrugsPanelProps) {
-  const { getBudget } = useCreationBudgets();
+  const { getBudget, qualityModifiers } = useCreationBudgets();
   const nuyenBudget = getBudget("nuyen");
   const karmaBudget = getBudget("karma");
 
@@ -117,6 +117,7 @@ export function DrugsPanel({ state, updateState }: DrugsPanelProps) {
     karmaRemaining,
     currentConversion: karmaConversion,
     onConvert: handleKarmaConvert,
+    maxKarmaConversion: qualityModifiers.karmaToNuyenCap,
   });
 
   // Add drug (actual implementation)

--- a/components/creation/drugs-toxins/__tests__/DrugsPanel.test.tsx
+++ b/components/creation/drugs-toxins/__tests__/DrugsPanel.test.tsx
@@ -115,6 +115,12 @@ const mockBudgets = {
     nuyen: { total: 50000, spent: 10000, remaining: 40000 },
     karma: { total: 25, spent: 0, remaining: 25 },
   },
+  qualityModifiers: {
+    karmaToNuyenCap: 10,
+    knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+    languageCostMultiplier: 1,
+    jackOfAllTrades: false,
+  },
 };
 
 function makeState(overrides: Partial<CreationState> = {}): CreationState {

--- a/components/creation/gear/GearPanel.tsx
+++ b/components/creation/gear/GearPanel.tsx
@@ -101,7 +101,7 @@ interface GearPanelProps {
 
 export function GearPanel({ state, updateState }: GearPanelProps) {
   const gearCatalog = useGear();
-  const { getBudget } = useCreationBudgets();
+  const { getBudget, qualityModifiers } = useCreationBudgets();
   const nuyenBudget = getBudget("nuyen");
   const karmaBudget = getBudget("karma");
 
@@ -195,6 +195,7 @@ export function GearPanel({ state, updateState }: GearPanelProps) {
     karmaRemaining,
     currentConversion: karmaConversion,
     onConvert: handleKarmaConvert,
+    maxKarmaConversion: qualityModifiers.karmaToNuyenCap,
   });
 
   // Calculate gear cost based on rating

--- a/components/creation/matrix-gear/MatrixGearCard.tsx
+++ b/components/creation/matrix-gear/MatrixGearCard.tsx
@@ -223,7 +223,7 @@ function DataSoftwareRow({
 export function MatrixGearCard({ state, updateState }: MatrixGearCardProps) {
   const commlinksCatalog = useCommlinks();
   const cyberdecksCatalog = useCyberdecks();
-  const { getBudget } = useCreationBudgets();
+  const { getBudget, qualityModifiers } = useCreationBudgets();
   const nuyenBudget = getBudget("nuyen");
   const karmaBudget = getBudget("karma");
 
@@ -339,6 +339,7 @@ export function MatrixGearCard({ state, updateState }: MatrixGearCardProps) {
     karmaRemaining,
     currentConversion: karmaConversion,
     onConvert: handleKarmaConvert,
+    maxKarmaConversion: qualityModifiers.karmaToNuyenCap,
   });
 
   // Add commlink (actual implementation) - modal stays open for bulk-add

--- a/components/creation/shared/useKarmaConversionPrompt.ts
+++ b/components/creation/shared/useKarmaConversionPrompt.ts
@@ -43,6 +43,8 @@ export interface UseKarmaConversionPromptOptions {
   currentConversion: number;
   /** Callback to update karma conversion in state */
   onConvert: (newTotalConversion: number) => void;
+  /** Override maximum karma conversion (default 10, Born Rich → 40) */
+  maxKarmaConversion?: number;
 }
 
 export interface KarmaConversionModalState {
@@ -98,7 +100,9 @@ export function useKarmaConversionPrompt({
   karmaRemaining,
   currentConversion,
   onConvert,
+  maxKarmaConversion: maxKarmaConversionOverride,
 }: UseKarmaConversionPromptOptions): UseKarmaConversionPromptReturn {
+  const effectiveMaxConversion = maxKarmaConversionOverride ?? MAX_KARMA_CONVERSION;
   // Modal state
   const [modalState, setModalState] = useState<KarmaConversionModalState>({
     isOpen: false,
@@ -126,20 +130,20 @@ export function useKarmaConversionPrompt({
       const nuyenGained = karmaNeeded * KARMA_TO_NUYEN_RATE;
 
       // Check if already at max conversion
-      if (currentConversion >= MAX_KARMA_CONVERSION) {
+      if (currentConversion >= effectiveMaxConversion) {
         return {
           karmaNeeded,
           nuyenGained,
           canConvert: false,
-          reason: `Already at maximum conversion (${MAX_KARMA_CONVERSION} karma)`,
+          reason: `Already at maximum conversion (${effectiveMaxConversion} karma)`,
         };
       }
 
       // Check if would exceed max conversion
       const newTotal = currentConversion + karmaNeeded;
-      if (newTotal > MAX_KARMA_CONVERSION) {
+      if (newTotal > effectiveMaxConversion) {
         // Calculate max additional karma we can convert
-        const maxAdditional = MAX_KARMA_CONVERSION - currentConversion;
+        const maxAdditional = effectiveMaxConversion - currentConversion;
         const maxAdditionalNuyen = maxAdditional * KARMA_TO_NUYEN_RATE;
 
         // Check if max additional would be enough
@@ -161,7 +165,7 @@ export function useKarmaConversionPrompt({
           karmaNeeded,
           nuyenGained,
           canConvert: false,
-          reason: `Would exceed maximum conversion (${MAX_KARMA_CONVERSION} karma)`,
+          reason: `Would exceed maximum conversion (${effectiveMaxConversion} karma)`,
         };
       }
 
@@ -182,7 +186,7 @@ export function useKarmaConversionPrompt({
         canConvert: true,
       };
     },
-    [remaining, karmaRemaining, currentConversion]
+    [remaining, karmaRemaining, currentConversion, effectiveMaxConversion]
   );
 
   /**
@@ -251,6 +255,6 @@ export function useKarmaConversionPrompt({
     currentRemaining: remaining,
     karmaAvailable: karmaRemaining,
     currentKarmaConversion: currentConversion,
-    maxKarmaConversion: MAX_KARMA_CONVERSION,
+    maxKarmaConversion: effectiveMaxConversion,
   };
 }

--- a/components/creation/skills/useKarmaPurchase.ts
+++ b/components/creation/skills/useKarmaPurchase.ts
@@ -17,6 +17,7 @@ import {
   getGroupRating,
   isGroupBroken,
 } from "@/lib/rules/skills/group-utils";
+import { applyJackOfAllTradesModifier } from "@/lib/rules/qualities/budget-modifiers";
 import type { SkillGroupData, SkillData } from "@/lib/rules";
 import { getKarmaSpent } from "./utils";
 
@@ -74,7 +75,8 @@ export function useKarmaPurchase(
   activeSkills: SkillData[],
   skillPointsRemaining: number,
   groupPointsRemaining: number,
-  karmaRemaining: number
+  karmaRemaining: number,
+  hasJackOfAllTrades: boolean = false
 ): UseKarmaPurchaseResult {
   // Karma purchase confirmation states
   const [karmaSkillPurchase, setKarmaSkillPurchase] = useState<SkillKarmaPurchaseState | null>(
@@ -99,7 +101,10 @@ export function useKarmaPurchase(
         return { mode: "skill-points" };
       }
       // Skill points exhausted - check if karma purchase is possible
-      const karmaCost = calculateSkillRaiseKarmaCost(currentRating, currentRating + 1);
+      const baseCost = calculateSkillRaiseKarmaCost(currentRating, currentRating + 1);
+      const karmaCost = hasJackOfAllTrades
+        ? applyJackOfAllTradesModifier(baseCost, currentRating, currentRating + 1)
+        : baseCost;
       if (karmaRemaining >= karmaCost) {
         return { mode: "karma" };
       }
@@ -108,7 +113,7 @@ export function useKarmaPurchase(
         disabledReason: `No skill points. Need ${karmaCost} karma (have ${karmaRemaining})`,
       };
     },
-    [skillPointsRemaining, karmaRemaining]
+    [skillPointsRemaining, karmaRemaining, hasJackOfAllTrades]
   );
 
   /**
@@ -163,7 +168,10 @@ export function useKarmaPurchase(
 
     const { skillId, currentRating } = karmaSkillPurchase;
     const newRating = currentRating + 1;
-    const karmaCost = calculateSkillRaiseKarmaCost(currentRating, newRating);
+    const baseCost = calculateSkillRaiseKarmaCost(currentRating, newRating);
+    const karmaCost = hasJackOfAllTrades
+      ? applyJackOfAllTradesModifier(baseCost, currentRating, newRating)
+      : baseCost;
 
     // Update skill rating
     const newSkills = { ...skills, [skillId]: newRating };

--- a/lib/contexts/CreationBudgetContext.tsx
+++ b/lib/contexts/CreationBudgetContext.tsx
@@ -34,6 +34,10 @@ import {
 } from "../rules/skills/free-skills";
 import { FREE_SKILL_TYPE_LABELS } from "@/components/creation/magic-path/constants";
 import { calculateBrokenGroupSkillPointOffset } from "../rules/skills/group-utils";
+import {
+  getQualityBudgetModifiers,
+  type QualityBudgetModifiers,
+} from "../rules/qualities/budget-modifiers";
 
 // =============================================================================
 // SKILL CATEGORY HELPERS
@@ -116,6 +120,9 @@ export interface CreationBudgetContextValue {
 
   /** Check if a budget is overspent */
   isOverspent: (budgetId: string) => boolean;
+
+  /** Quality-derived budget modifiers (karma cap, knowledge cost multipliers, etc.) */
+  qualityModifiers: QualityBudgetModifiers;
 }
 
 /**
@@ -314,7 +321,13 @@ function extractSpentValues(
   priorityTable: PriorityTableData | null,
   priorities: Record<string, string> | undefined,
   skillCategories: Record<string, string | undefined>,
-  skillGroupDefs: { id: string; skills: string[] }[] = []
+  skillGroupDefs: { id: string; skills: string[] }[] = [],
+  qualityModifiers: QualityBudgetModifiers = {
+    karmaToNuyenCap: 10,
+    knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+    languageCostMultiplier: 1,
+    jackOfAllTrades: false,
+  }
 ): Record<string, number> {
   const spent: Record<string, number> = {};
 
@@ -452,13 +465,21 @@ function extractSpentValues(
 
   // Calculate knowledge points spent from selections (languages + knowledge skills)
   // Native languages are free and do not count toward the knowledge point budget (SR5 Core)
+  // Apply quality modifiers: Linguist halves language costs, education qualities halve category costs
   const languages = (selections.languages || []) as Array<{ rating: number; isNative?: boolean }>;
-  const knowledgeSkills = (selections.knowledgeSkills || []) as Array<{ rating: number }>;
+  const knowledgeSkills = (selections.knowledgeSkills || []) as Array<{
+    rating: number;
+    category?: string;
+  }>;
   const languagePointsSpent = languages
     .filter((lang) => !lang.isNative)
-    .reduce((sum, lang) => sum + (lang.rating || 0), 0);
-  const knowledgePointsSpent = knowledgeSkills.reduce((sum, skill) => sum + (skill.rating || 0), 0);
-  spent["knowledge-points"] = languagePointsSpent + knowledgePointsSpent;
+    .reduce((sum, lang) => sum + (lang.rating || 0) * qualityModifiers.languageCostMultiplier, 0);
+  const knowledgePointsSpent = knowledgeSkills.reduce((sum, skill) => {
+    const category = skill.category as keyof typeof qualityModifiers.knowledgeCostMultipliers;
+    const multiplier = qualityModifiers.knowledgeCostMultipliers[category] ?? 1;
+    return sum + (skill.rating || 0) * multiplier;
+  }, 0);
+  spent["knowledge-points"] = Math.ceil(languagePointsSpent + knowledgePointsSpent);
 
   // Nuyen is special - calculate from all spending categories in selections
   const gear = (selections.gear || []) as Array<{
@@ -689,7 +710,13 @@ function validateBudgets(
   budgets: Record<string, BudgetState>,
   state: CreationState,
   priorityTable: PriorityTableData | null,
-  skillCategories: Record<string, string | undefined>
+  skillCategories: Record<string, string | undefined>,
+  qualityModifiers: QualityBudgetModifiers = {
+    karmaToNuyenCap: 10,
+    knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+    languageCostMultiplier: 1,
+    jackOfAllTrades: false,
+  }
 ): { errors: ValidationError[]; warnings: ValidationError[] } {
   const errors: ValidationError[] = [];
   const warnings: ValidationError[] = [];
@@ -765,13 +792,13 @@ function validateBudgets(
     });
   }
 
-  // Check karma-to-nuyen conversion limit (max 10 karma)
-  const MAX_KARMA_CONVERSION = 10;
+  // Check karma-to-nuyen conversion limit (dynamic: default 10, Born Rich → 40)
+  const karmaToNuyenCap = qualityModifiers.karmaToNuyenCap;
   const karmaSpentGear = (state.budgets["karma-spent-gear"] as number) || 0;
-  if (karmaSpentGear > MAX_KARMA_CONVERSION) {
+  if (karmaSpentGear > karmaToNuyenCap) {
     errors.push({
       constraintId: "karma-conversion-limit",
-      message: `Karma-to-nuyen conversion cannot exceed ${MAX_KARMA_CONVERSION} karma (currently ${karmaSpentGear})`,
+      message: `Karma-to-nuyen conversion cannot exceed ${karmaToNuyenCap} karma (currently ${karmaSpentGear})`,
       severity: "error",
     });
   }
@@ -888,6 +915,15 @@ export function CreationBudgetProvider({
   // Get gameplay level modifiers for budget calculations
   const gameplayModifiers = useGameplayLevelModifiers(creationState.gameplayLevel);
 
+  // Compute quality-driven budget modifiers from selections
+  const qualityModifiers = useMemo(
+    () =>
+      getQualityBudgetModifiers(
+        creationState.selections as import("@/lib/types/creation-selections").CreationSelections
+      ),
+    [creationState.selections]
+  );
+
   // Calculate budget totals from priorities
   const budgetTotals = useMemo(
     () =>
@@ -917,7 +953,8 @@ export function CreationBudgetProvider({
         priorityTable,
         creationState.priorities,
         skillCategories,
-        skillGroupDefs
+        skillGroupDefs,
+        qualityModifiers
       ),
     [
       creationState.budgets,
@@ -927,6 +964,7 @@ export function CreationBudgetProvider({
       creationState.priorities,
       skillCategories,
       skillGroupDefs,
+      qualityModifiers,
     ]
   );
 
@@ -970,7 +1008,8 @@ export function CreationBudgetProvider({
         budgets,
         creationState,
         priorityTable,
-        skillCategories
+        skillCategories,
+        qualityModifiers
       );
 
       // Add custom validation if provided
@@ -995,6 +1034,7 @@ export function CreationBudgetProvider({
     validationDebounceMs,
     priorityTable,
     skillCategories,
+    qualityModifiers,
   ]);
 
   // Update spent callback - this notifies parent to update CreationState
@@ -1055,6 +1095,7 @@ export function CreationBudgetProvider({
       getBudget,
       hasRemaining,
       isOverspent,
+      qualityModifiers,
     }),
     [
       budgets,
@@ -1066,6 +1107,7 @@ export function CreationBudgetProvider({
       getBudget,
       hasRemaining,
       isOverspent,
+      qualityModifiers,
     ]
   );
 

--- a/lib/rules/qualities/__tests__/budget-modifiers.test.ts
+++ b/lib/rules/qualities/__tests__/budget-modifiers.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import type { CreationSelections } from "@/lib/types/creation-selections";
+import type { SelectedQuality } from "@/lib/types/creation-selections";
+import { getQualityBudgetModifiers, applyJackOfAllTradesModifier } from "../budget-modifiers";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function makeSelections(positiveQualities: (string | SelectedQuality)[] = []): CreationSelections {
+  return { positiveQualities } as CreationSelections;
+}
+
+// =============================================================================
+// getQualityBudgetModifiers
+// =============================================================================
+
+describe("getQualityBudgetModifiers", () => {
+  it("returns defaults when no qualities selected", () => {
+    const result = getQualityBudgetModifiers({} as CreationSelections);
+    expect(result).toEqual({
+      karmaToNuyenCap: 10,
+      knowledgeCostMultipliers: { academic: 1, street: 1, professional: 1, interests: 1 },
+      languageCostMultiplier: 1,
+      jackOfAllTrades: false,
+    });
+  });
+
+  it("returns defaults for empty quality array", () => {
+    const result = getQualityBudgetModifiers(makeSelections([]));
+    expect(result.karmaToNuyenCap).toBe(10);
+    expect(result.jackOfAllTrades).toBe(false);
+  });
+
+  it("returns defaults for unrelated qualities", () => {
+    const result = getQualityBudgetModifiers(
+      makeSelections(["ambidextrous", "exceptional-attribute"])
+    );
+    expect(result.karmaToNuyenCap).toBe(10);
+    expect(result.languageCostMultiplier).toBe(1);
+  });
+
+  // Born Rich
+  it("Born Rich raises karma-to-nuyen cap to 40", () => {
+    const result = getQualityBudgetModifiers(makeSelections(["born-rich"]));
+    expect(result.karmaToNuyenCap).toBe(40);
+  });
+
+  // College Education
+  it("College Education halves academic knowledge cost", () => {
+    const result = getQualityBudgetModifiers(makeSelections(["college-education"]));
+    expect(result.knowledgeCostMultipliers.academic).toBe(0.5);
+    expect(result.knowledgeCostMultipliers.street).toBe(1);
+    expect(result.knowledgeCostMultipliers.professional).toBe(1);
+    expect(result.knowledgeCostMultipliers.interests).toBe(1);
+  });
+
+  // School of Hard Knocks
+  it("School of Hard Knocks halves street knowledge cost", () => {
+    const result = getQualityBudgetModifiers(makeSelections(["school-of-hard-knocks"]));
+    expect(result.knowledgeCostMultipliers.street).toBe(0.5);
+    expect(result.knowledgeCostMultipliers.academic).toBe(1);
+  });
+
+  // Technical School Education
+  it("Technical School Education halves professional knowledge cost", () => {
+    const result = getQualityBudgetModifiers(makeSelections(["technical-school-education"]));
+    expect(result.knowledgeCostMultipliers.professional).toBe(0.5);
+    expect(result.knowledgeCostMultipliers.academic).toBe(1);
+  });
+
+  // Linguist
+  it("Linguist halves language cost", () => {
+    const result = getQualityBudgetModifiers(makeSelections(["linguist"]));
+    expect(result.languageCostMultiplier).toBe(0.5);
+  });
+
+  // Jack of All Trades
+  it("Jack of All Trades sets flag", () => {
+    const result = getQualityBudgetModifiers(makeSelections(["jack-of-all-trades"]));
+    expect(result.jackOfAllTrades).toBe(true);
+  });
+
+  // Combinations
+  it("handles multiple qualities together", () => {
+    const result = getQualityBudgetModifiers(
+      makeSelections([
+        "born-rich",
+        "college-education",
+        "school-of-hard-knocks",
+        "linguist",
+        "jack-of-all-trades",
+      ])
+    );
+    expect(result.karmaToNuyenCap).toBe(40);
+    expect(result.knowledgeCostMultipliers.academic).toBe(0.5);
+    expect(result.knowledgeCostMultipliers.street).toBe(0.5);
+    expect(result.knowledgeCostMultipliers.professional).toBe(1);
+    expect(result.languageCostMultiplier).toBe(0.5);
+    expect(result.jackOfAllTrades).toBe(true);
+  });
+
+  // SelectedQuality format
+  it("works with SelectedQuality objects", () => {
+    const result = getQualityBudgetModifiers(
+      makeSelections([
+        { id: "born-rich", karma: 5 },
+        { id: "linguist", karma: 4 },
+      ])
+    );
+    expect(result.karmaToNuyenCap).toBe(40);
+    expect(result.languageCostMultiplier).toBe(0.5);
+  });
+
+  // Mixed formats
+  it("works with mixed string and SelectedQuality formats", () => {
+    const result = getQualityBudgetModifiers(
+      makeSelections(["college-education", { id: "jack-of-all-trades", karma: 2 }])
+    );
+    expect(result.knowledgeCostMultipliers.academic).toBe(0.5);
+    expect(result.jackOfAllTrades).toBe(true);
+  });
+});
+
+// =============================================================================
+// applyJackOfAllTradesModifier
+// =============================================================================
+
+describe("applyJackOfAllTradesModifier", () => {
+  it("returns 0 for no change", () => {
+    expect(applyJackOfAllTradesModifier(0, 3, 3)).toBe(0);
+    expect(applyJackOfAllTradesModifier(0, 5, 4)).toBe(0);
+  });
+
+  // Ratings <= 5: -1 per level
+  it("reduces cost by 1 per level for ratings <= 5", () => {
+    // Raising from 0 to 1: base = 1*2 = 2, adjusted = max(1, 2-1) = 1
+    expect(applyJackOfAllTradesModifier(2, 0, 1)).toBe(1);
+
+    // Raising from 2 to 3: base = 3*2 = 6, adjusted = max(1, 6-1) = 5
+    expect(applyJackOfAllTradesModifier(6, 2, 3)).toBe(5);
+
+    // Raising from 4 to 5: base = 5*2 = 10, adjusted = max(1, 10-1) = 9
+    expect(applyJackOfAllTradesModifier(10, 4, 5)).toBe(9);
+  });
+
+  it("enforces minimum 1 karma per level for low ratings", () => {
+    // Raising from 0 to 1: base = 1*2 = 2, adjusted = max(1, 2-1) = 1
+    // This is already 1, but the minimum ensures it never drops below 1
+    expect(applyJackOfAllTradesModifier(2, 0, 1)).toBeGreaterThanOrEqual(1);
+  });
+
+  // Ratings > 5: +2 per level
+  it("increases cost by 2 per level for ratings > 5", () => {
+    // Raising from 5 to 6: base = 6*2 = 12, adjusted = 12+2 = 14
+    expect(applyJackOfAllTradesModifier(12, 5, 6)).toBe(14);
+
+    // Raising from 6 to 7: base = 7*2 = 14, adjusted = 14+2 = 16
+    expect(applyJackOfAllTradesModifier(14, 6, 7)).toBe(16);
+  });
+
+  // Cross-boundary
+  it("handles crossing the rating 5 boundary", () => {
+    // Raising from 4 to 6:
+    // Level 5: base = 5*2 = 10, adjusted = 10-1 = 9
+    // Level 6: base = 6*2 = 12, adjusted = 12+2 = 14
+    // Total = 9 + 14 = 23
+    expect(applyJackOfAllTradesModifier(22, 4, 6)).toBe(23);
+  });
+
+  // Multi-level within <= 5
+  it("handles multi-level raise within <= 5", () => {
+    // Raising from 1 to 4:
+    // Level 2: max(1, 4-1) = 3
+    // Level 3: max(1, 6-1) = 5
+    // Level 4: max(1, 8-1) = 7
+    // Total = 3 + 5 + 7 = 15
+    expect(applyJackOfAllTradesModifier(18, 1, 4)).toBe(15);
+  });
+
+  // Multi-level within > 5
+  it("handles multi-level raise within > 5", () => {
+    // Raising from 6 to 8:
+    // Level 7: 14+2 = 16
+    // Level 8: 16+2 = 18
+    // Total = 16 + 18 = 34
+    expect(applyJackOfAllTradesModifier(30, 6, 8)).toBe(34);
+  });
+});

--- a/lib/rules/qualities/budget-modifiers.ts
+++ b/lib/rules/qualities/budget-modifiers.ts
@@ -1,0 +1,141 @@
+/**
+ * Quality Budget Modifiers
+ *
+ * Pure-function module that calculates how certain Run Faster qualities
+ * modify character creation budget calculations (karma-to-nuyen cap,
+ * knowledge skill costs, language costs, skill karma costs).
+ *
+ * Importable from both client and server code (no React dependencies).
+ */
+
+import type { CreationSelections } from "@/lib/types/creation-selections";
+import { getPositiveQualityIds } from "@/lib/types/creation-selections";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Knowledge skill category multipliers.
+ * Default 1.0 means full cost; 0.5 means half cost.
+ */
+export interface KnowledgeCostMultipliers {
+  academic: number;
+  street: number;
+  professional: number;
+  interests: number;
+}
+
+/**
+ * Budget modifiers derived from selected qualities.
+ */
+export interface QualityBudgetModifiers {
+  /** Maximum karma that can be converted to nuyen (default 10, Born Rich -> 40) */
+  karmaToNuyenCap: number;
+  /** Per-category cost multipliers for knowledge skills */
+  knowledgeCostMultipliers: KnowledgeCostMultipliers;
+  /** Cost multiplier for language skills (default 1.0, Linguist -> 0.5) */
+  languageCostMultiplier: number;
+  /** Whether Jack of All Trades is active */
+  jackOfAllTrades: boolean;
+}
+
+// =============================================================================
+// QUALITY IDS
+// =============================================================================
+
+const BORN_RICH = "born-rich";
+const COLLEGE_EDUCATION = "college-education";
+const SCHOOL_OF_HARD_KNOCKS = "school-of-hard-knocks";
+const TECHNICAL_SCHOOL_EDUCATION = "technical-school-education";
+const LINGUIST = "linguist";
+const JACK_OF_ALL_TRADES = "jack-of-all-trades";
+
+// =============================================================================
+// DEFAULTS
+// =============================================================================
+
+const DEFAULT_KARMA_TO_NUYEN_CAP = 10;
+const BORN_RICH_KARMA_TO_NUYEN_CAP = 40;
+
+const DEFAULT_MODIFIERS: QualityBudgetModifiers = {
+  karmaToNuyenCap: DEFAULT_KARMA_TO_NUYEN_CAP,
+  knowledgeCostMultipliers: {
+    academic: 1.0,
+    street: 1.0,
+    professional: 1.0,
+    interests: 1.0,
+  },
+  languageCostMultiplier: 1.0,
+  jackOfAllTrades: false,
+};
+
+// =============================================================================
+// MAIN FUNCTIONS
+// =============================================================================
+
+/**
+ * Compute budget modifiers from selected qualities.
+ *
+ * Checks for the following Run Faster qualities:
+ * - Born Rich: karma-to-nuyen cap 10 -> 40
+ * - College Education: academic knowledge skills at half cost
+ * - School of Hard Knocks: street knowledge skills at half cost
+ * - Technical School Education: professional knowledge skills at half cost
+ * - Linguist: language skills at half cost
+ * - Jack of All Trades: modifies individual skill karma costs
+ */
+export function getQualityBudgetModifiers(selections: CreationSelections): QualityBudgetModifiers {
+  const qualityIds = getPositiveQualityIds(selections);
+
+  if (qualityIds.length === 0) {
+    return DEFAULT_MODIFIERS;
+  }
+
+  const qualitySet = new Set(qualityIds);
+
+  return {
+    karmaToNuyenCap: qualitySet.has(BORN_RICH)
+      ? BORN_RICH_KARMA_TO_NUYEN_CAP
+      : DEFAULT_KARMA_TO_NUYEN_CAP,
+    knowledgeCostMultipliers: {
+      academic: qualitySet.has(COLLEGE_EDUCATION) ? 0.5 : 1.0,
+      street: qualitySet.has(SCHOOL_OF_HARD_KNOCKS) ? 0.5 : 1.0,
+      professional: qualitySet.has(TECHNICAL_SCHOOL_EDUCATION) ? 0.5 : 1.0,
+      interests: 1.0,
+    },
+    languageCostMultiplier: qualitySet.has(LINGUIST) ? 0.5 : 1.0,
+    jackOfAllTrades: qualitySet.has(JACK_OF_ALL_TRADES),
+  };
+}
+
+/**
+ * Apply Jack of All Trades modifier to a skill karma cost.
+ *
+ * SR5 Run Faster rule:
+ * - For each level up to and including rating 5: -1 karma per level (minimum 1)
+ * - For each level above rating 5: +2 karma per level
+ *
+ * This applies per-level, so raising from 3 to 5 gets -1 per level = -2 total.
+ * Raising from 4 to 7 gets -1 for levels 5, +2 for levels 6-7.
+ *
+ * @param baseCost - The base karma cost (New Rating x 2 per level)
+ * @param fromRating - Starting rating
+ * @param toRating - Target rating
+ * @returns Adjusted karma cost (minimum 1 karma per level)
+ */
+export function applyJackOfAllTradesModifier(
+  baseCost: number,
+  fromRating: number,
+  toRating: number
+): number {
+  if (toRating <= fromRating) return 0;
+
+  let adjustedTotal = 0;
+  for (let r = fromRating + 1; r <= toRating; r++) {
+    const levelBaseCost = r * 2; // SR5: New Rating × 2
+    const adjustment = r <= 5 ? -1 : 2;
+    adjustedTotal += Math.max(1, levelBaseCost + adjustment);
+  }
+  return adjustedTotal;
+}

--- a/lib/rules/validation/budget-calculator.ts
+++ b/lib/rules/validation/budget-calculator.ts
@@ -11,6 +11,7 @@
  */
 
 import type { CreationSelections } from "@/lib/types/creation-selections";
+import { getQualityBudgetModifiers } from "@/lib/rules/qualities/budget-modifiers";
 
 // =============================================================================
 // NUYEN CALCULATION
@@ -231,8 +232,16 @@ export interface KarmaBreakdown {
   total: number;
 }
 
-/** Maximum karma that can be converted to nuyen during creation */
+/** Default maximum karma that can be converted to nuyen during creation */
 export const KARMA_TO_NUYEN_LIMIT = 10;
+
+/**
+ * Get the dynamic karma-to-nuyen limit based on selected qualities.
+ * Born Rich raises the cap from 10 to 40.
+ */
+export function getKarmaToNuyenLimit(selections: CreationSelections): number {
+  return getQualityBudgetModifiers(selections).karmaToNuyenCap;
+}
 
 /** Starting karma budget for SR5 character creation */
 export const SR5_KARMA_BUDGET = 25;

--- a/lib/rules/validation/character-validator.ts
+++ b/lib/rules/validation/character-validator.ts
@@ -59,7 +59,7 @@ import type { PriorityTableData } from "../loader-types";
 import {
   calculateNuyenSpent,
   calculateKarmaSpent,
-  KARMA_TO_NUYEN_LIMIT,
+  getKarmaToNuyenLimit,
   SR5_KARMA_BUDGET,
   getKarmaBudget,
   getContactMultiplier,
@@ -2365,11 +2365,12 @@ const karmaBudgetValidator: ValidatorDefinition = {
     // Get client-reported spending
     const clientSpent = (budgets["karma-spent"] as number) ?? serverSpent;
 
-    // Check karma-to-nuyen conversion limit (max 10 karma)
-    if (karmaBreakdown.karmaToNuyen > KARMA_TO_NUYEN_LIMIT) {
+    // Check karma-to-nuyen conversion limit (dynamic: default 10, Born Rich → 40)
+    const karmaToNuyenLimit = getKarmaToNuyenLimit(selections);
+    if (karmaBreakdown.karmaToNuyen > karmaToNuyenLimit) {
       issues.push({
         code: "KARMA_TO_NUYEN_LIMIT_EXCEEDED",
-        message: `Karma-to-nuyen conversion exceeds limit: ${karmaBreakdown.karmaToNuyen} karma spent, maximum ${KARMA_TO_NUYEN_LIMIT} allowed`,
+        message: `Karma-to-nuyen conversion exceeds limit: ${karmaBreakdown.karmaToNuyen} karma spent, maximum ${karmaToNuyenLimit} allowed`,
         field: "karma",
         severity: "error",
       });

--- a/lib/rules/validation/index.ts
+++ b/lib/rules/validation/index.ts
@@ -34,6 +34,7 @@ export {
   calculateNuyenSpent,
   calculateKarmaSpent,
   KARMA_TO_NUYEN_LIMIT,
+  getKarmaToNuyenLimit,
   SR5_KARMA_BUDGET,
   getKarmaBudget,
   getContactMultiplier,


### PR DESCRIPTION
## Summary

- Add `budget-modifiers.ts` module that maps Run Faster qualities to creation budget adjustments (karma-to-nuyen cap, knowledge skill cost multipliers, language cost multiplier, Jack of All Trades skill karma reduction)
- Thread `qualityModifiers` through `CreationBudgetContext` and all creation components that use karma conversion or skill purchases
- Update server-side validation to use dynamic karma-to-nuyen cap based on selected qualities

## Test plan

- [x] `pnpm type-check` passes
- [x] 19 budget-modifier tests pass
- [x] 215 creation component tests pass
- [x] `pnpm lint` passes (0 errors)

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)