### PR TITLE
feat: implement Daredevil quality edge regain (#553)

### DIFF
--- a/app/api/characters/[characterId]/edge/route.ts
+++ b/app/api/characters/[characterId]/edge/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/storage/characters";
 import { resolveCharacterForGameplay, notifyOwnerOfGMEdit } from "@/lib/auth/gm-character-access";
 import type { EdgeRequest } from "@/lib/types";
+import { calculateEdgeRegainAmount } from "@/lib/rules/action-resolution/edge-actions";
 import { apiLogger } from "@/lib/logging";
 
 /**
@@ -110,7 +111,11 @@ export async function POST(
       );
     }
 
-    const amount = body.amount || 1;
+    // For restore actions, calculate amount based on Daredevil quality + context
+    const regainContext = body.context || "normal";
+    const defaultRestoreAmount =
+      body.action === "restore" ? calculateEdgeRegainAmount(character, regainContext) : 1;
+    const amount = body.amount || defaultRestoreAmount;
 
     if (amount < 1) {
       return NextResponse.json(

--- a/components/action-resolution/EdgeTracker.tsx
+++ b/components/action-resolution/EdgeTracker.tsx
@@ -4,6 +4,9 @@ import React from "react";
 import { Button } from "react-aria-components";
 import { Zap, Plus, Minus, RotateCcw } from "lucide-react";
 
+/** Context for edge restoration: normal or daring (Daredevil quality) */
+type EdgeRestoreContext = "normal" | "daring";
+
 interface EdgeTrackerProps {
   /** Current Edge points */
   current: number;
@@ -13,10 +16,12 @@ interface EdgeTrackerProps {
   isLoading?: boolean;
   /** Callback when Edge is spent */
   onSpend?: (amount: number) => void;
-  /** Callback when Edge is restored */
-  onRestore?: (amount: number) => void;
+  /** Callback when Edge is restored, with optional context */
+  onRestore?: (amount: number, context?: EdgeRestoreContext) => void;
   /** Callback when Edge is fully restored */
   onRestoreFull?: () => void;
+  /** Whether character has Daredevil quality (shows daring action option) */
+  hasDaredevil?: boolean;
   /** Whether to show controls */
   showControls?: boolean;
   /** Size variant */
@@ -32,6 +37,7 @@ export function EdgeTracker({
   onSpend,
   onRestore,
   onRestoreFull,
+  hasDaredevil = false,
   showControls = true,
   size = "md",
   compact = false,
@@ -169,7 +175,7 @@ export function EdgeTracker({
             Spend
           </Button>
           <Button
-            onPress={() => onRestore?.(1)}
+            onPress={() => onRestore?.(1, "normal")}
             isDisabled={!canRestore}
             className={`
               flex-1 flex items-center justify-center gap-1.5
@@ -181,8 +187,25 @@ export function EdgeTracker({
             `}
           >
             <Plus className="w-3 h-3" />
-            Restore
+            {hasDaredevil ? "Normal (1)" : "Restore"}
           </Button>
+          {hasDaredevil && (
+            <Button
+              onPress={() => onRestore?.(2, "daring")}
+              isDisabled={!canRestore}
+              className={`
+                flex-1 flex items-center justify-center gap-1.5
+                px-3 py-1.5 rounded
+                bg-amber-500/20 text-amber-500 dark:text-amber-400 border border-amber-500/30
+                hover:bg-amber-500/30
+                disabled:opacity-50 disabled:cursor-not-allowed
+                transition-colors ${s.text}
+              `}
+            >
+              <Zap className="w-3 h-3" />
+              Daring (2)
+            </Button>
+          )}
           {onRestoreFull && (
             <Button
               onPress={onRestoreFull}

--- a/lib/rules/action-resolution/__tests__/daredevil-edge-regain.test.ts
+++ b/lib/rules/action-resolution/__tests__/daredevil-edge-regain.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for Daredevil quality edge regain modifier
+ *
+ * SR5 Run Faster: Daredevil quality grants 2 Edge regain instead of 1
+ * when performing a "daring action" (GM judgment call).
+ *
+ * Eval-first: these tests are written before the implementation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Character } from "@/lib/types";
+
+// Mock dice-engine (same as edge-actions tests)
+vi.mock("../dice-engine", () => ({
+  DEFAULT_DICE_RULES: {
+    hitThreshold: 5,
+    glitchThreshold: 0.5,
+    criticalGlitchRequiresZeroHits: true,
+    allowExplodingSixes: false,
+    maxDicePool: 50,
+    minDicePool: 1,
+    edgeActions: {},
+    woundModifiers: { boxesPerPenalty: 3, maxPenalty: -4 },
+  },
+  executeRoll: vi.fn(),
+  executeReroll: vi.fn(),
+  rollDiceExploding: vi.fn(),
+  calculateHitsWithLimit: vi.fn(),
+  calculateGlitch: vi.fn(),
+  sortDiceForDisplay: vi.fn(),
+}));
+
+vi.mock("../pool-builder", () => ({
+  getAttributeValue: vi.fn(),
+  addModifiersToPool: vi.fn(),
+}));
+
+import {
+  calculateEdgeRegainAmount,
+  DAREDEVIL_QUALITY_ID,
+  DAREDEVIL_REGAIN_AMOUNT,
+  DEFAULT_REGAIN_AMOUNT,
+} from "../edge-actions";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function createMockCharacter(overrides: Partial<Character> = {}): Character {
+  return {
+    id: "char-1",
+    ownerId: "user-1",
+    editionCode: "sr5",
+    name: "Test Runner",
+    status: "active",
+    approvalStatus: "approved",
+    karma: 0,
+    totalKarma: 25,
+    nuyen: 5000,
+    totalNuyen: 10000,
+    streetCred: 0,
+    notoriety: 0,
+    publicAwareness: 0,
+    metatype: "human",
+    attributes: {
+      body: 4,
+      agility: 5,
+      reaction: 4,
+      strength: 3,
+      charisma: 3,
+      intuition: 4,
+      logic: 3,
+      willpower: 4,
+      edge: 3,
+      magic: 0,
+      resonance: 0,
+      essence: 6,
+    },
+    skills: [],
+    specializations: [],
+    knowledgeSkills: [],
+    languageSkills: [],
+    positiveQualities: [],
+    negativeQualities: [],
+    contacts: [],
+    lifestyles: [],
+    weapons: [],
+    armor: [],
+    gear: [],
+    vehicles: [],
+    cyberware: [],
+    bioware: [],
+    spells: [],
+    complexForms: [],
+    adeptPowers: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Character;
+}
+
+function createDaredevilCharacter(): Character {
+  return createMockCharacter({
+    positiveQualities: [
+      {
+        qualityId: DAREDEVIL_QUALITY_ID,
+        source: "creation",
+      },
+    ],
+  });
+}
+
+// =============================================================================
+// EVAL: Constants
+// =============================================================================
+
+describe("Daredevil constants", () => {
+  it("DAREDEVIL_QUALITY_ID is 'daredevil'", () => {
+    expect(DAREDEVIL_QUALITY_ID).toBe("daredevil");
+  });
+
+  it("DAREDEVIL_REGAIN_AMOUNT is 2", () => {
+    expect(DAREDEVIL_REGAIN_AMOUNT).toBe(2);
+  });
+
+  it("DEFAULT_REGAIN_AMOUNT is 1", () => {
+    expect(DEFAULT_REGAIN_AMOUNT).toBe(1);
+  });
+});
+
+// =============================================================================
+// EVAL: calculateEdgeRegainAmount
+// =============================================================================
+
+describe("calculateEdgeRegainAmount", () => {
+  it("returns 1 for character without Daredevil (no context)", () => {
+    const char = createMockCharacter();
+    expect(calculateEdgeRegainAmount(char)).toBe(1);
+  });
+
+  it("returns 1 for character with Daredevil but normal context", () => {
+    const char = createDaredevilCharacter();
+    expect(calculateEdgeRegainAmount(char, "normal")).toBe(1);
+  });
+
+  it("returns 2 for character with Daredevil and daring context", () => {
+    const char = createDaredevilCharacter();
+    expect(calculateEdgeRegainAmount(char, "daring")).toBe(2);
+  });
+
+  it("returns 1 for character without Daredevil even with daring context", () => {
+    const char = createMockCharacter();
+    expect(calculateEdgeRegainAmount(char, "daring")).toBe(1);
+  });
+
+  it("returns 1 for character with Daredevil and no context (default is normal)", () => {
+    const char = createDaredevilCharacter();
+    expect(calculateEdgeRegainAmount(char)).toBe(1);
+  });
+
+  it("caps regain at max edge remaining", () => {
+    // Character with Daredevil, current edge = max - 1 (only 1 restorable)
+    const char = createDaredevilCharacter();
+    char.condition = { physicalDamage: 0, stunDamage: 0, edgeCurrent: 2 };
+    // Max edge is 3, current is 2, so only 1 can be restored
+    const amount = calculateEdgeRegainAmount(char, "daring");
+    // Should return 2 (the quality amount), capping is done by restoreEdge storage layer
+    expect(amount).toBe(2);
+  });
+
+  it("detects Daredevil via qualityId field", () => {
+    const char = createMockCharacter({
+      positiveQualities: [
+        { qualityId: "some-other-quality", source: "creation" },
+        { qualityId: DAREDEVIL_QUALITY_ID, source: "creation" },
+      ],
+    });
+    expect(calculateEdgeRegainAmount(char, "daring")).toBe(2);
+  });
+
+  it("detects Daredevil via deprecated id field", () => {
+    const char = createMockCharacter({
+      positiveQualities: [
+        { id: DAREDEVIL_QUALITY_ID, qualityId: DAREDEVIL_QUALITY_ID, source: "creation" },
+      ],
+    });
+    expect(calculateEdgeRegainAmount(char, "daring")).toBe(2);
+  });
+});

--- a/lib/rules/action-resolution/edge-actions.ts
+++ b/lib/rules/action-resolution/edge-actions.ts
@@ -389,6 +389,41 @@ export function executeEdgeAction(
 // EDGE RESTORATION
 // =============================================================================
 
+/** Quality ID for the Daredevil quality (Run Faster) */
+export const DAREDEVIL_QUALITY_ID = "daredevil";
+
+/** Edge regain amount when Daredevil performs a daring action */
+export const DAREDEVIL_REGAIN_AMOUNT = 2;
+
+/** Default edge regain amount (normal action) */
+export const DEFAULT_REGAIN_AMOUNT = 1;
+
+/** Edge regain context: "normal" (default) or "daring" (GM-judged daring action) */
+export type EdgeRegainContext = "normal" | "daring";
+
+/**
+ * Calculate the edge regain amount for a character.
+ *
+ * SR5 Run Faster: Daredevil quality grants 2 Edge regain instead of 1
+ * when performing a "daring action" (GM judgment call).
+ *
+ * @param character - The character regaining edge
+ * @param context - Whether the action is "normal" or "daring" (default: "normal")
+ * @returns The amount of edge to regain (1 or 2)
+ */
+export function calculateEdgeRegainAmount(
+  character: Character,
+  context: EdgeRegainContext = "normal"
+): number {
+  if (context !== "daring") return DEFAULT_REGAIN_AMOUNT;
+
+  const hasDaredevil = character.positiveQualities.some(
+    (q) => q.qualityId === DAREDEVIL_QUALITY_ID || q.id === DAREDEVIL_QUALITY_ID
+  );
+
+  return hasDaredevil ? DAREDEVIL_REGAIN_AMOUNT : DEFAULT_REGAIN_AMOUNT;
+}
+
 /**
  * Calculate how much Edge can be restored
  */

--- a/lib/types/action-resolution.ts
+++ b/lib/types/action-resolution.ts
@@ -316,6 +316,8 @@ export interface EdgeRequest {
   amount: number;
   /** Reason for the change */
   reason?: string;
+  /** Context for edge regain: "daring" triggers Daredevil quality (2 Edge instead of 1) */
+  context?: "normal" | "daring";
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements the Daredevil quality edge regain modifier from Run Faster:

- **Pure function**: `calculateEdgeRegainAmount(character, context)` returns 2 Edge when a Daredevil character performs a "daring action" (GM judgment), 1 otherwise
- **API endpoint**: `POST /api/characters/:id/edge` accepts `context: "daring"` to auto-calculate the regain amount
- **UI**: EdgeTracker shows "Normal (1) | Daring (2)" restore buttons when `hasDaredevil` is true

Built with eval-first methodology: 11 capability tests written before implementation, all passing with 0 regressions on the existing 58 edge-actions tests.

## Test plan

- [x] `pnpm type-check` passes
- [x] 11 new Daredevil tests pass (constants, regain calculation, quality detection)
- [x] 58 existing edge-actions tests pass (0 regressions)
- [ ] Manual: Character with Daredevil shows "Normal (1) | Daring (2)" in EdgeTracker
- [ ] Manual: POST `{ action: "restore", context: "daring" }` restores 2 Edge for Daredevil char
- [ ] Manual: Non-Daredevil characters unaffected

Closes #553