### PR TITLE
fix: filter creation methods by campaign enabledCreationMethodIds

### DIFF
--- a/__tests__/lib/rules/creation-method-filter.test.ts
+++ b/__tests__/lib/rules/creation-method-filter.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for creation method filtering by campaign settings
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  getAvailableCreationMethods,
+  validateCreationMethodForCampaign,
+} from "@/lib/rules/creation-method-filter";
+import type { CreationMethod, ID } from "@/lib/types";
+import type { Campaign } from "@/lib/types/campaign";
+
+// =============================================================================
+// TEST FIXTURES
+// =============================================================================
+
+function makeMethod(id: string, name: string): CreationMethod {
+  return {
+    id,
+    editionId: "sr5",
+    editionCode: "sr5",
+    name,
+    type: "priority",
+    steps: [],
+    budgets: [],
+    constraints: [],
+    version: "1.0.0",
+    createdAt: "2026-01-01T00:00:00Z",
+  } as CreationMethod;
+}
+
+const priorityMethod = makeMethod("sr5-priority", "Priority");
+const sumToTenMethod = makeMethod("sr5-sum-to-ten", "Sum to Ten");
+const pointBuyMethod = makeMethod("sr5-point-buy", "Point Buy");
+const allMethods = [priorityMethod, sumToTenMethod, pointBuyMethod];
+
+function makeCampaign(enabledCreationMethodIds: ID[]): Campaign {
+  return {
+    id: "campaign-1",
+    gmId: "gm-1",
+    title: "Test Campaign",
+    status: "active",
+    editionId: "sr5",
+    editionCode: "sr5",
+    enabledBookIds: ["core-rulebook"],
+    enabledCreationMethodIds,
+    gameplayLevel: "street",
+    advancementSettings: {
+      trainingTimeMultiplier: 1,
+      attributeKarmaMultiplier: 5,
+      skillKarmaMultiplier: 2,
+      skillGroupKarmaMultiplier: 5,
+      knowledgeSkillKarmaMultiplier: 1,
+      specializationKarmaCost: 7,
+      spellKarmaCost: 5,
+      complexFormKarmaCost: 4,
+      attributeRatingCap: 10,
+      skillRatingCap: 13,
+      allowInstantAdvancement: false,
+      requireApproval: true,
+    },
+    playerIds: [],
+    visibility: "private",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  } as Campaign;
+}
+
+// =============================================================================
+// getAvailableCreationMethods
+// =============================================================================
+
+describe("getAvailableCreationMethods", () => {
+  describe("standalone creation (no campaign)", () => {
+    it("returns all methods when no campaign is provided", () => {
+      const result = getAvailableCreationMethods(allMethods, null, "sr5-priority");
+      expect(result.availableMethods).toEqual(allMethods);
+      expect(result.isCurrentMethodValid).toBe(true);
+      expect(result.hasNoMethods).toBe(false);
+    });
+
+    it("returns all methods when campaign is undefined", () => {
+      const result = getAvailableCreationMethods(allMethods, undefined, "sr5-priority");
+      expect(result.availableMethods).toEqual(allMethods);
+    });
+
+    it("marks invalid current method and suggests first", () => {
+      const result = getAvailableCreationMethods(allMethods, null, "nonexistent");
+      expect(result.isCurrentMethodValid).toBe(false);
+      expect(result.suggestedMethodId).toBe("sr5-priority");
+    });
+
+    it("handles empty methods list", () => {
+      const result = getAvailableCreationMethods([], null, "sr5-priority");
+      expect(result.availableMethods).toEqual([]);
+      expect(result.hasNoMethods).toBe(true);
+      expect(result.suggestedMethodId).toBeNull();
+    });
+  });
+
+  describe("campaign with restrictions", () => {
+    it("filters to only enabled methods", () => {
+      const campaign = makeCampaign(["sr5-priority"]);
+      const result = getAvailableCreationMethods(allMethods, campaign, "sr5-priority");
+      expect(result.availableMethods).toEqual([priorityMethod]);
+      expect(result.isCurrentMethodValid).toBe(true);
+      expect(result.hasNoMethods).toBe(false);
+    });
+
+    it("filters to multiple enabled methods", () => {
+      const campaign = makeCampaign(["sr5-priority", "sr5-sum-to-ten"]);
+      const result = getAvailableCreationMethods(allMethods, campaign, "sr5-priority");
+      expect(result.availableMethods).toEqual([priorityMethod, sumToTenMethod]);
+    });
+
+    it("marks current method invalid if not in enabled list", () => {
+      const campaign = makeCampaign(["sr5-sum-to-ten"]);
+      const result = getAvailableCreationMethods(allMethods, campaign, "sr5-priority");
+      expect(result.isCurrentMethodValid).toBe(false);
+      expect(result.suggestedMethodId).toBe("sr5-sum-to-ten");
+    });
+
+    it("returns empty when enabled IDs match no methods", () => {
+      const campaign = makeCampaign(["nonexistent-method"]);
+      const result = getAvailableCreationMethods(allMethods, campaign, "sr5-priority");
+      expect(result.availableMethods).toEqual([]);
+      expect(result.hasNoMethods).toBe(true);
+      expect(result.suggestedMethodId).toBeNull();
+    });
+  });
+
+  describe("campaign with no restrictions", () => {
+    it("returns all methods when enabledCreationMethodIds is empty", () => {
+      const campaign = makeCampaign([]);
+      const result = getAvailableCreationMethods(allMethods, campaign, "sr5-priority");
+      expect(result.availableMethods).toEqual(allMethods);
+    });
+  });
+
+  describe("null/undefined currentMethodId", () => {
+    it("handles null currentMethodId", () => {
+      const result = getAvailableCreationMethods(allMethods, null, null);
+      expect(result.isCurrentMethodValid).toBe(false);
+      expect(result.suggestedMethodId).toBe("sr5-priority");
+    });
+
+    it("handles undefined currentMethodId", () => {
+      const result = getAvailableCreationMethods(allMethods, null, undefined);
+      expect(result.isCurrentMethodValid).toBe(false);
+      expect(result.suggestedMethodId).toBe("sr5-priority");
+    });
+  });
+});
+
+// =============================================================================
+// validateCreationMethodForCampaign
+// =============================================================================
+
+describe("validateCreationMethodForCampaign", () => {
+  it("returns null for standalone creation (no campaign)", () => {
+    expect(validateCreationMethodForCampaign("sr5-priority", null)).toBeNull();
+  });
+
+  it("returns null for campaign with no restrictions", () => {
+    const campaign = makeCampaign([]);
+    expect(validateCreationMethodForCampaign("sr5-priority", campaign)).toBeNull();
+  });
+
+  it("returns null for allowed method", () => {
+    const campaign = makeCampaign(["sr5-priority", "sr5-sum-to-ten"]);
+    expect(validateCreationMethodForCampaign("sr5-priority", campaign)).toBeNull();
+  });
+
+  it("returns error for disallowed method", () => {
+    const campaign = makeCampaign(["sr5-sum-to-ten"]);
+    const result = validateCreationMethodForCampaign("sr5-priority", campaign);
+    expect(result).not.toBeNull();
+    expect(result).toContain("sr5-priority");
+    expect(result).toContain("not allowed");
+  });
+
+  it("returns null for undefined campaign", () => {
+    expect(validateCreationMethodForCampaign("sr5-priority", undefined)).toBeNull();
+  });
+});

--- a/app/api/characters/route.ts
+++ b/app/api/characters/route.ts
@@ -251,6 +251,22 @@ export async function POST(request: NextRequest) {
           { status: 400 }
         );
       }
+
+      // Validate creation method is allowed by campaign
+      const enabledMethodIds = campaignForNotification.enabledCreationMethodIds;
+      if (
+        enabledMethodIds &&
+        enabledMethodIds.length > 0 &&
+        !enabledMethodIds.includes(creationMethodId)
+      ) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: `Creation method "${creationMethodId}" is not allowed in this campaign. Allowed methods: ${enabledMethodIds.join(", ")}`,
+          },
+          { status: 400 }
+        );
+      }
     }
 
     // Create draft

--- a/app/characters/create/sheet/components/SheetCreationLayout.tsx
+++ b/app/characters/create/sheet/components/SheetCreationLayout.tsx
@@ -30,7 +30,12 @@ import {
   BookOpen,
 } from "lucide-react";
 import { InfoTooltip } from "@/components/ui";
-import { useQualities, useSkills, useGameplayLevelModifiers } from "@/lib/rules/RulesetContext";
+import {
+  useQualities,
+  useSkills,
+  useGameplayLevelModifiers,
+  useCreationMethod,
+} from "@/lib/rules/RulesetContext";
 
 // Phase 2, 3, 4, 5 & 6 Components - Static imports for always-visible cards
 import {
@@ -819,6 +824,8 @@ export function SheetCreationLayout({
   campaign,
   serverValidation,
 }: SheetCreationLayoutProps) {
+  const currentCreationMethod = useCreationMethod();
+
   // Determine what sections are available based on selections
   const magicPath = creationState.selections["magical-path"] as string | undefined;
   const isMagical = ["magician", "mystic-adept", "aspected-mage"].includes(magicPath || "");
@@ -863,7 +870,7 @@ export function SheetCreationLayout({
         </div>
       </div>
 
-      {/* Active Books Banner */}
+      {/* Active Campaign Banner */}
       {campaign && (
         <div className="rounded-md bg-blue-50 px-4 py-3 dark:bg-blue-900/20">
           <div className="flex items-center gap-2 text-sm">
@@ -872,6 +879,7 @@ export function SheetCreationLayout({
             <span className="text-blue-600 dark:text-blue-400">
               — {campaign.enabledBookIds.length} book
               {campaign.enabledBookIds.length !== 1 ? "s" : ""} active
+              {currentCreationMethod && <> · {currentCreationMethod.name}</>}
             </span>
           </div>
         </div>

--- a/app/characters/create/sheet/page.tsx
+++ b/app/characters/create/sheet/page.tsx
@@ -18,7 +18,9 @@ import {
   useRuleset,
   usePriorityTable,
   useMetatypes,
+  useCreationMethods,
 } from "@/lib/rules";
+import { getAvailableCreationMethods } from "@/lib/rules/creation-method-filter";
 import { CreationBudgetProvider } from "@/lib/contexts";
 import { SheetCreationLayout } from "./components/SheetCreationLayout";
 import { EditionSelector } from "@/components/creation/EditionSelector";
@@ -70,9 +72,10 @@ function SheetCreationContent({
     (existingCharacter?.editionCode as EditionCode) || campaign?.editionCode || null
   );
   const { loading, error, ready } = useRulesetStatus();
-  const { loadRuleset, editionCode, ruleset } = useRuleset();
+  const { loadRuleset, editionCode, ruleset, selectCreationMethod } = useRuleset();
   const priorityTable = usePriorityTable();
   const metatypes = useMetatypes();
+  const allCreationMethods = useCreationMethods();
 
   // localStorage key for backup (development safety net)
   const localStorageKey = existingCharacter?.id
@@ -131,6 +134,30 @@ function SheetCreationContent({
   } | null>(null);
   const serverValidationRef = useRef(serverValidation);
   serverValidationRef.current = serverValidation;
+
+  // Filter creation methods by campaign settings
+  const creationMethodFilter = getAvailableCreationMethods(
+    allCreationMethods,
+    campaign,
+    creationState.creationMethodId
+  );
+
+  // Auto-correct creation method if current is invalid for this campaign
+  useEffect(() => {
+    if (!ready) return;
+    if (creationMethodFilter.isCurrentMethodValid) return;
+    if (creationMethodFilter.hasNoMethods) return;
+    if (!creationMethodFilter.suggestedMethodId) return;
+
+    // Switch to the first available method
+    const suggestedId = creationMethodFilter.suggestedMethodId;
+    selectCreationMethod(suggestedId);
+    setCreationState((prev) => ({
+      ...prev,
+      creationMethodId: suggestedId,
+      updatedAt: new Date().toISOString(),
+    }));
+  }, [ready, creationMethodFilter, selectCreationMethod]);
 
   // Refs for managing auto-save race conditions
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -524,6 +551,45 @@ function SheetCreationContent({
   // Show gameplay level setup for standalone characters
   if (ready && needsSetup) {
     return <CreationSetup onComplete={handleGameplayLevelSelect} />;
+  }
+
+  // Show error if no creation methods are available for this campaign
+  if (ready && creationMethodFilter.hasNoMethods) {
+    return (
+      <div className="flex min-h-[400px] items-center justify-center">
+        <div className="max-w-md rounded-lg border border-amber-200 bg-amber-50 p-6 text-center dark:border-amber-900 dark:bg-amber-950">
+          <div className="mx-auto h-12 w-12 rounded-full bg-amber-100 p-3 dark:bg-amber-900">
+            <svg
+              className="h-6 w-6 text-amber-600 dark:text-amber-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          </div>
+          <h3 className="mt-4 text-sm font-medium text-amber-800 dark:text-amber-200">
+            No Creation Methods Available
+          </h3>
+          <p className="mt-1 text-sm text-amber-600 dark:text-amber-400">
+            {campaign
+              ? `The campaign "${campaign.title}" has no valid creation methods enabled. Ask the GM to enable at least one creation method in campaign settings.`
+              : "No creation methods are available for this edition."}
+          </p>
+          <button
+            onClick={() => router.back()}
+            className="mt-4 rounded-lg bg-amber-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-700"
+          >
+            Go Back
+          </button>
+        </div>
+      </div>
+    );
   }
 
   // Show sheet creation when ready

--- a/lib/rules/creation-method-filter.ts
+++ b/lib/rules/creation-method-filter.ts
@@ -1,0 +1,97 @@
+/**
+ * Creation Method Filter
+ *
+ * Filters available creation methods based on campaign settings.
+ * When a campaign is active, only methods in `enabledCreationMethodIds` are shown.
+ * Standalone creation (no campaign) shows all methods from loaded books.
+ */
+
+import type { CreationMethod, ID } from "../types";
+import type { Campaign } from "../types/campaign";
+
+/**
+ * Result of filtering creation methods with diagnostic information
+ */
+export interface CreationMethodFilterResult {
+  /** Methods available for selection */
+  readonly availableMethods: readonly CreationMethod[];
+  /** Whether the current method is valid (included in available methods) */
+  readonly isCurrentMethodValid: boolean;
+  /** Suggested default method ID if current is invalid */
+  readonly suggestedMethodId: ID | null;
+  /** Whether no methods are available (error state) */
+  readonly hasNoMethods: boolean;
+}
+
+/**
+ * Filters creation methods by campaign settings.
+ *
+ * - If no campaign, returns all methods unchanged.
+ * - If campaign with enabledCreationMethodIds, filters to only those.
+ * - If campaign with empty enabledCreationMethodIds, returns all (no restriction).
+ */
+export function getAvailableCreationMethods(
+  allMethods: readonly CreationMethod[],
+  campaign: Campaign | null | undefined,
+  currentMethodId: ID | null | undefined
+): CreationMethodFilterResult {
+  // No campaign = standalone creation, show all methods
+  if (!campaign) {
+    const isCurrentMethodValid = currentMethodId
+      ? allMethods.some((m) => m.id === currentMethodId)
+      : false;
+    return {
+      availableMethods: allMethods,
+      isCurrentMethodValid,
+      suggestedMethodId: isCurrentMethodValid ? null : (allMethods[0]?.id ?? null),
+      hasNoMethods: allMethods.length === 0,
+    };
+  }
+
+  // Campaign with no restrictions (empty array) = show all
+  const enabledIds = campaign.enabledCreationMethodIds;
+  if (!enabledIds || enabledIds.length === 0) {
+    const isCurrentMethodValid = currentMethodId
+      ? allMethods.some((m) => m.id === currentMethodId)
+      : false;
+    return {
+      availableMethods: allMethods,
+      isCurrentMethodValid,
+      suggestedMethodId: isCurrentMethodValid ? null : (allMethods[0]?.id ?? null),
+      hasNoMethods: allMethods.length === 0,
+    };
+  }
+
+  // Campaign with restrictions: filter methods
+  const availableMethods = allMethods.filter((m) => enabledIds.includes(m.id));
+  const isCurrentMethodValid = currentMethodId
+    ? availableMethods.some((m) => m.id === currentMethodId)
+    : false;
+
+  return {
+    availableMethods,
+    isCurrentMethodValid,
+    suggestedMethodId: isCurrentMethodValid ? null : (availableMethods[0]?.id ?? null),
+    hasNoMethods: availableMethods.length === 0,
+  };
+}
+
+/**
+ * Validates that a creation method ID is allowed for a campaign.
+ * Returns null if valid, or an error message if not.
+ */
+export function validateCreationMethodForCampaign(
+  creationMethodId: ID,
+  campaign: Campaign | null | undefined
+): string | null {
+  if (!campaign) return null;
+
+  const enabledIds = campaign.enabledCreationMethodIds;
+  if (!enabledIds || enabledIds.length === 0) return null;
+
+  if (!enabledIds.includes(creationMethodId)) {
+    return `Creation method "${creationMethodId}" is not allowed in campaign "${campaign.title}". Allowed methods: ${enabledIds.join(", ")}`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Closes #548

- **Client-side filtering**: Creation methods are filtered by `campaign.enabledCreationMethodIds` when creating a character within a campaign. Standalone creation (no campaign) continues to show all methods.
- **Auto-correction**: If the current method (default: `sr5-priority`) is not allowed by the campaign, automatically switches to the first available method.
- **Server-side validation**: POST `/api/characters` now rejects creation requests with a method not in the campaign's enabled list (400 error).
- **No-methods error state**: Shows a clear warning when no creation methods are available, directing the player to contact the GM.
- **Campaign banner**: Displays the active creation method name alongside book count.

## New files
- `lib/rules/creation-method-filter.ts` — Pure utility functions `getAvailableCreationMethods()` and `validateCreationMethodForCampaign()`
- `__tests__/lib/rules/creation-method-filter.test.ts` — 16 unit tests covering all filter scenarios

## Test plan
- [x] 16 unit tests pass for `getAvailableCreationMethods` and `validateCreationMethodForCampaign`
- [x] TypeScript type-check passes
- [x] All 8749 existing tests pass (1 pre-existing flaky timeout in users.test.ts)
- [ ] Manual: Create campaign with only Priority enabled → verify Sum to Ten is hidden
- [ ] Manual: Create standalone character → verify all methods shown
- [ ] Manual: Campaign with no methods enabled → verify error state shown