### PR TITLE
feat: add Sum to Ten character creation method

### DIFF
--- a/__tests__/lib/rules/sum-to-ten-validation.test.ts
+++ b/__tests__/lib/rules/sum-to-ten-validation.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculatePriorityPointTotal,
+  validateSumToTenBudget,
+  SUM_TO_TEN_POINT_VALUES,
+  SUM_TO_TEN_TOTAL,
+} from "@/lib/rules/sum-to-ten-validation";
+import type { CreationConstraint } from "@/lib/types";
+import type { ValidationContext } from "@/lib/rules/constraint-validation";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function makeConstraint(overrides: Partial<CreationConstraint> = {}): CreationConstraint {
+  return {
+    id: "sum-to-ten-budget",
+    type: "sum-to-ten-budget",
+    description: "Priority points must total exactly 10.",
+    severity: "error",
+    params: {
+      totalBudget: 10,
+      pointValues: { A: 4, B: 3, C: 2, D: 1, E: 0 },
+      categories: ["metatype", "attributes", "magic", "skills", "resources"],
+    },
+    ...overrides,
+  };
+}
+
+function makeContext(
+  priorities: Record<string, string> | undefined,
+  overrides: Partial<ValidationContext> = {}
+): ValidationContext {
+  return {
+    character: { metatype: "human", name: "Test" } as ValidationContext["character"],
+    ruleset: {} as ValidationContext["ruleset"],
+    creationState: priorities
+      ? {
+          characterId: "test-char",
+          creationMethodId: "sum-to-ten",
+          currentStep: 0,
+          completedSteps: [],
+          budgets: {},
+          selections: {} as ValidationContext["creationState"] extends { selections: infer S }
+            ? S
+            : never,
+          priorities,
+          errors: [],
+          warnings: [],
+          updatedAt: "2025-01-01T00:00:00.000Z",
+        }
+      : undefined,
+    creationMethod: {
+      id: "sum-to-ten",
+      editionId: "sr5",
+      editionCode: "sr5" as const,
+      name: "Sum to Ten",
+      type: "sum-to-ten",
+      version: "1.0.0",
+      steps: [
+        {
+          id: "priorities",
+          title: "Assign Priorities",
+          type: "priority" as const,
+          payload: {
+            type: "priority" as const,
+            categories: ["metatype", "attributes", "magic", "skills", "resources"],
+            levels: ["A", "B", "C", "D", "E"],
+            pointValues: { A: 4, B: 3, C: 2, D: 1, E: 0 },
+            totalBudget: 10,
+            allowDuplicates: true,
+          },
+        },
+      ],
+      budgets: [],
+      constraints: [],
+      createdAt: "2025-01-01T00:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// calculatePriorityPointTotal
+// =============================================================================
+
+describe("calculatePriorityPointTotal", () => {
+  it("calculates standard priority total (A+B+C+D+E = 10)", () => {
+    const priorities = {
+      metatype: "A",
+      attributes: "B",
+      magic: "C",
+      skills: "D",
+      resources: "E",
+    };
+    expect(calculatePriorityPointTotal(priorities)).toBe(10);
+  });
+
+  it("calculates balanced build (B+B+B+D+E = 10)", () => {
+    const priorities = {
+      metatype: "B",
+      attributes: "B",
+      magic: "B",
+      skills: "D",
+      resources: "E",
+    };
+    expect(calculatePriorityPointTotal(priorities)).toBe(10);
+  });
+
+  it("calculates specialist build (A+C+C+C+E = 10)", () => {
+    const priorities = {
+      metatype: "A",
+      attributes: "C",
+      magic: "C",
+      skills: "C",
+      resources: "E",
+    };
+    expect(calculatePriorityPointTotal(priorities)).toBe(10);
+  });
+
+  it("detects over-budget (A+A+B+E+E = 11)", () => {
+    const priorities = {
+      metatype: "A",
+      attributes: "A",
+      magic: "B",
+      skills: "E",
+      resources: "E",
+    };
+    expect(calculatePriorityPointTotal(priorities)).toBe(11);
+  });
+
+  it("detects under-budget (E+E+E+E+E = 0)", () => {
+    const priorities = {
+      metatype: "E",
+      attributes: "E",
+      magic: "E",
+      skills: "E",
+      resources: "E",
+    };
+    expect(calculatePriorityPointTotal(priorities)).toBe(0);
+  });
+
+  it("returns null for unknown priority level", () => {
+    const priorities = {
+      metatype: "A",
+      attributes: "X",
+      magic: "C",
+      skills: "D",
+      resources: "E",
+    };
+    expect(calculatePriorityPointTotal(priorities)).toBeNull();
+  });
+
+  it("works with custom point values", () => {
+    const customPoints = { A: 5, B: 4, C: 3, D: 2, E: 1 };
+    const priorities = { metatype: "A", attributes: "E" };
+    expect(calculatePriorityPointTotal(priorities, customPoints)).toBe(6);
+  });
+
+  it("handles empty priorities", () => {
+    expect(calculatePriorityPointTotal({})).toBe(0);
+  });
+});
+
+// =============================================================================
+// validateSumToTenBudget
+// =============================================================================
+
+describe("validateSumToTenBudget", () => {
+  it("returns null for valid sum-to-ten (A+B+C+D+E = 10)", () => {
+    const context = makeContext({
+      metatype: "A",
+      attributes: "B",
+      magic: "C",
+      skills: "D",
+      resources: "E",
+    });
+    expect(validateSumToTenBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("returns null for valid duplicate levels (B+B+B+D+E = 10)", () => {
+    const context = makeContext({
+      metatype: "B",
+      attributes: "B",
+      magic: "B",
+      skills: "D",
+      resources: "E",
+    });
+    expect(validateSumToTenBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("returns null for valid specialist build (A+C+C+C+E = 10)", () => {
+    const context = makeContext({
+      metatype: "A",
+      attributes: "C",
+      magic: "C",
+      skills: "C",
+      resources: "E",
+    });
+    expect(validateSumToTenBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("returns null for valid all-C build (C+C+C+C+C = 10)", () => {
+    const context = makeContext({
+      metatype: "C",
+      attributes: "C",
+      magic: "C",
+      skills: "C",
+      resources: "C",
+    });
+    expect(validateSumToTenBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("returns error when total exceeds 10 (A+A+B+E+E = 11)", () => {
+    const context = makeContext({
+      metatype: "A",
+      attributes: "A",
+      magic: "B",
+      skills: "E",
+      resources: "E",
+    });
+    const result = validateSumToTenBudget(makeConstraint(), context);
+    expect(result).not.toBeNull();
+    expect(result!.severity).toBe("error");
+    expect(result!.message).toContain("currently 11");
+  });
+
+  it("returns error when total is under 10 (D+D+D+D+D = 5)", () => {
+    const context = makeContext({
+      metatype: "D",
+      attributes: "D",
+      magic: "D",
+      skills: "D",
+      resources: "D",
+    });
+    const result = validateSumToTenBudget(makeConstraint(), context);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("currently 5");
+  });
+
+  it("returns error when categories are missing", () => {
+    const context = makeContext({
+      metatype: "A",
+      attributes: "B",
+      // magic, skills, resources not assigned
+    });
+    const result = validateSumToTenBudget(makeConstraint(), context);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("Missing");
+    expect(result!.message).toContain("magic");
+  });
+
+  it("returns null when no priorities assigned yet (skip early)", () => {
+    const context = makeContext(undefined);
+    expect(validateSumToTenBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("returns null when priorities is empty object (skip early)", () => {
+    const context = makeContext({});
+    expect(validateSumToTenBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("returns error for unknown priority level", () => {
+    const context = makeContext({
+      metatype: "A",
+      attributes: "B",
+      magic: "C",
+      skills: "D",
+      resources: "Z",
+    });
+    const result = validateSumToTenBudget(makeConstraint(), context);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("Unknown priority level");
+  });
+
+  it("uses custom errorMessage from constraint", () => {
+    const context = makeContext({
+      metatype: "A",
+      attributes: "A",
+      magic: "A",
+      skills: "A",
+      resources: "A",
+    });
+    const constraint = makeConstraint({
+      errorMessage: "Points must equal 10, chummer!",
+    });
+    const result = validateSumToTenBudget(constraint, context);
+    expect(result).not.toBeNull();
+    expect(result!.message).toBe("Points must equal 10, chummer!");
+  });
+
+  it("uses constraint params for totalBudget override", () => {
+    const constraint = makeConstraint({
+      params: {
+        totalBudget: 12,
+        pointValues: { A: 4, B: 3, C: 2, D: 1, E: 0 },
+        categories: ["metatype", "attributes", "magic", "skills", "resources"],
+      },
+    });
+    // A+B+C+D+E = 10, but totalBudget is 12
+    const context = makeContext({
+      metatype: "A",
+      attributes: "B",
+      magic: "C",
+      skills: "D",
+      resources: "E",
+    });
+    const result = validateSumToTenBudget(constraint, context);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("12");
+  });
+});
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+describe("SUM_TO_TEN constants", () => {
+  it("has correct point values", () => {
+    expect(SUM_TO_TEN_POINT_VALUES).toEqual({
+      A: 4,
+      B: 3,
+      C: 2,
+      D: 1,
+      E: 0,
+    });
+  });
+
+  it("has correct total", () => {
+    expect(SUM_TO_TEN_TOTAL).toBe(10);
+  });
+
+  it("standard priority assignment sums to total", () => {
+    const standardTotal =
+      SUM_TO_TEN_POINT_VALUES.A +
+      SUM_TO_TEN_POINT_VALUES.B +
+      SUM_TO_TEN_POINT_VALUES.C +
+      SUM_TO_TEN_POINT_VALUES.D +
+      SUM_TO_TEN_POINT_VALUES.E;
+    expect(standardTotal).toBe(SUM_TO_TEN_TOTAL);
+  });
+});

--- a/data/editions/sr5/edition.json
+++ b/data/editions/sr5/edition.json
@@ -6,7 +6,7 @@
   "description": "The fifth edition of Shadowrun, published by Catalyst Game Labs in 2013. Features the Priority character creation system, Limits, and an updated Matrix.",
   "releaseYear": 2013,
   "bookIds": ["core-rulebook", "core-errata-2014-02-09", "run-faster"],
-  "creationMethodIds": ["priority"],
+  "creationMethodIds": ["priority", "sum-to-ten"],
   "defaultCreationMethodId": "priority",
   "philosophy": "Fifth Edition brings a streamlined approach to the classic Shadowrun experience, balancing narrative freedom with structured mechanical resolution. The Priority system provides clear trade-offs during character creation, while Limits ensure no single attribute dominates dice rolls.",
   "mechanicalHighlights": [

--- a/data/editions/sr5/run-faster.json
+++ b/data/editions/sr5/run-faster.json
@@ -1429,7 +1429,331 @@
         ]
       }
     },
-    "creationMethods": { "mergeStrategy": "append", "payload": { "creationMethods": [] } },
+    "creationMethods": {
+      "mergeStrategy": "append",
+      "payload": {
+        "creationMethods": [
+          {
+            "id": "sum-to-ten",
+            "editionId": "sr5",
+            "editionCode": "sr5",
+            "bookId": "run-faster",
+            "name": "Sum to Ten",
+            "type": "sum-to-ten",
+            "description": "A flexible variant of the Priority system. Assign priority levels A-E to five categories, where A=4, B=3, C=2, D=1, E=0 points. Levels may be repeated, but the total must equal exactly 10.",
+            "version": "1.0.0",
+            "steps": [
+              {
+                "id": "priorities",
+                "title": "Assign Priorities",
+                "type": "priority",
+                "payload": {
+                  "type": "priority",
+                  "categories": ["metatype", "attributes", "magic", "skills", "resources"],
+                  "levels": ["A", "B", "C", "D", "E"],
+                  "pointValues": { "A": 4, "B": 3, "C": 2, "D": 1, "E": 0 },
+                  "totalBudget": 10,
+                  "allowDuplicates": true
+                }
+              },
+              {
+                "id": "metatype",
+                "title": "Select Metatype",
+                "type": "select",
+                "payload": {
+                  "type": "select",
+                  "target": "metatype"
+                }
+              },
+              {
+                "id": "attributes",
+                "title": "Allocate Attributes",
+                "type": "allocate",
+                "payload": {
+                  "type": "allocate",
+                  "target": "attributes",
+                  "budgetId": "attribute-points"
+                }
+              },
+              {
+                "id": "magic",
+                "title": "Magic/Resonance",
+                "type": "select",
+                "optional": true,
+                "payload": {
+                  "type": "select",
+                  "target": "magical-path"
+                }
+              },
+              {
+                "id": "skills",
+                "title": "Allocate Skills",
+                "type": "allocate",
+                "payload": {
+                  "type": "allocate",
+                  "target": "skills",
+                  "budgetId": "skill-points"
+                }
+              },
+              {
+                "id": "qualities",
+                "title": "Select Qualities",
+                "type": "choose",
+                "payload": {
+                  "type": "choose",
+                  "target": "qualities",
+                  "budgetId": "karma"
+                }
+              },
+              {
+                "id": "spells",
+                "title": "Spells",
+                "type": "custom",
+                "description": "Select spells if you are a magician or mystic adept.",
+                "payload": {
+                  "type": "custom",
+                  "target": "spells"
+                }
+              },
+              {
+                "id": "rituals",
+                "title": "Rituals",
+                "type": "custom",
+                "description": "Learn ritual spellcasting if your magical path includes it.",
+                "payload": {
+                  "type": "custom",
+                  "target": "rituals"
+                }
+              },
+              {
+                "id": "adept-powers",
+                "title": "Adept Powers",
+                "type": "custom",
+                "description": "Select adept powers using your Power Points (equal to Magic for Adepts).",
+                "payload": {
+                  "type": "custom",
+                  "target": "adeptPowers"
+                }
+              },
+              {
+                "id": "contacts",
+                "title": "Build Contacts",
+                "type": "allocate",
+                "description": "Build your network of contacts using free Karma based on Charisma.",
+                "payload": {
+                  "type": "allocate",
+                  "target": "contacts",
+                  "budgetId": "contact-karma"
+                }
+              },
+              {
+                "id": "augmentations",
+                "title": "Augmentations",
+                "type": "purchase",
+                "description": "Install cyberware and bioware. Essence loss affects Magic rating.",
+                "payload": {
+                  "type": "purchase",
+                  "target": "augmentations",
+                  "budgetId": "nuyen",
+                  "availabilityLimit": 12
+                }
+              },
+              {
+                "id": "gear",
+                "title": "Purchase Gear",
+                "type": "purchase",
+                "payload": {
+                  "type": "purchase",
+                  "target": "gear",
+                  "budgetId": "nuyen",
+                  "availabilityLimit": 12
+                }
+              },
+              {
+                "id": "vehicles",
+                "title": "Vehicles & Drones",
+                "type": "purchase",
+                "payload": {
+                  "type": "purchase",
+                  "target": "vehicles",
+                  "budgetId": "nuyen",
+                  "availabilityLimit": 12
+                }
+              },
+              {
+                "id": "programs",
+                "title": "Matrix Programs",
+                "description": "Select Matrix programs for your cyberdeck",
+                "type": "purchase",
+                "payload": {
+                  "budget": "nuyen",
+                  "catalog": "programs"
+                }
+              },
+              {
+                "id": "karma",
+                "title": "Spend Karma",
+                "type": "allocate",
+                "description": "Spend remaining Karma on spells, complex forms, or stat improvements. Max 7 Karma carryover.",
+                "payload": {
+                  "type": "allocate",
+                  "target": "karma",
+                  "budgetId": "karma"
+                }
+              },
+              {
+                "id": "identities",
+                "title": "Identities & SINs",
+                "type": "choose",
+                "description": "Create identities with SINs (fake or real) and licenses. Each character must have at least one identity.",
+                "payload": {
+                  "type": "choose",
+                  "target": "identities"
+                }
+              },
+              {
+                "id": "review",
+                "title": "Review & Finalize",
+                "type": "validate",
+                "payload": {
+                  "type": "validate",
+                  "validations": ["all"]
+                }
+              }
+            ],
+            "budgets": [
+              {
+                "id": "attribute-points",
+                "label": "Attribute Points",
+                "initialValueFormula": "priorities.attributes"
+              },
+              {
+                "id": "special-attribute-points",
+                "label": "Special Attribute Points",
+                "initialValueFormula": "metatype.specialAttributePoints"
+              },
+              {
+                "id": "skill-points",
+                "label": "Skill Points",
+                "initialValueFormula": "priorities.skills.skillPoints"
+              },
+              {
+                "id": "skill-group-points",
+                "label": "Skill Group Points",
+                "initialValueFormula": "priorities.skills.skillGroupPoints"
+              },
+              {
+                "id": "karma",
+                "label": "Karma",
+                "initialValue": 25
+              },
+              {
+                "id": "nuyen",
+                "label": "Nuyen",
+                "initialValueFormula": "priorities.resources",
+                "displayFormat": "currency"
+              },
+              {
+                "id": "contact-karma",
+                "label": "Contact Karma",
+                "initialValueFormula": "charisma * 3",
+                "description": "Free Karma for contacts = CHA x 3"
+              }
+            ],
+            "constraints": [
+              {
+                "id": "sum-to-ten-budget",
+                "type": "sum-to-ten-budget",
+                "description": "Priority point values (A=4, B=3, C=2, D=1, E=0) must total exactly 10.",
+                "severity": "error",
+                "params": {
+                  "totalBudget": 10,
+                  "pointValues": { "A": 4, "B": 3, "C": 2, "D": 1, "E": 0 },
+                  "categories": ["metatype", "attributes", "magic", "skills", "resources"]
+                },
+                "errorMessage": "Priority points must total exactly 10."
+              },
+              {
+                "id": "max-one-attribute-at-max",
+                "type": "attribute-limit",
+                "description": "Only one attribute can be at natural maximum at creation.",
+                "severity": "error",
+                "params": {
+                  "maxAtMax": 1
+                },
+                "errorMessage": "Only one attribute can be at its natural maximum."
+              },
+              {
+                "id": "positive-quality-limit",
+                "type": "budget-balance",
+                "description": "Maximum 25 Karma in Positive Qualities.",
+                "severity": "error",
+                "params": {
+                  "budgetId": "positive-quality-karma",
+                  "max": 25
+                },
+                "errorMessage": "Cannot spend more than 25 Karma on positive qualities."
+              },
+              {
+                "id": "negative-quality-limit",
+                "type": "budget-balance",
+                "description": "Maximum 25 Karma from Negative Qualities.",
+                "severity": "error",
+                "params": {
+                  "budgetId": "negative-quality-karma",
+                  "max": 25
+                },
+                "errorMessage": "Cannot gain more than 25 Karma from negative qualities."
+              },
+              {
+                "id": "skill-max-at-creation",
+                "type": "skill-limit",
+                "description": "Skills capped at 6 at creation (7 with Aptitude).",
+                "severity": "error",
+                "params": {
+                  "max": 6,
+                  "maxWithAptitude": 7
+                },
+                "errorMessage": "Skill rating cannot exceed 6 at creation (7 with Aptitude)."
+              },
+              {
+                "id": "special-attribute-init",
+                "type": "special-attribute-init",
+                "description": "Edge starts at metatype value. Magic/Resonance start at priority value (0 for mundane).",
+                "severity": "error",
+                "params": {
+                  "validateEdge": true,
+                  "validateMagic": true,
+                  "validateResonance": true
+                },
+                "errorMessage": "Special attributes must meet minimum requirements."
+              },
+              {
+                "id": "gear-availability",
+                "type": "custom",
+                "description": "Gear availability cannot exceed 12 at creation.",
+                "severity": "error",
+                "params": {
+                  "maxAvailability": 12
+                },
+                "errorMessage": "Cannot purchase gear with availability higher than 12."
+              },
+              {
+                "id": "essence-minimum",
+                "type": "essence-minimum",
+                "description": "Essence cannot drop below 0.",
+                "severity": "error",
+                "params": {
+                  "min": 0
+                },
+                "errorMessage": "Essence cannot drop below 0."
+              }
+            ],
+            "createdAt": "2025-01-01T00:00:00.000Z"
+          }
+        ]
+      }
+    },
     "lifestyle": { "mergeStrategy": "merge", "payload": {} },
     "contactArchetypes": { "mergeStrategy": "append", "payload": { "archetypes": [] } },
     "contactTemplates": { "mergeStrategy": "append", "payload": { "templates": [] } },

--- a/lib/rules/constraint-validation.ts
+++ b/lib/rules/constraint-validation.ts
@@ -21,6 +21,7 @@ import { getModule } from "./merge";
 import { validateRating, validateRatingAvailability, convertLegacyRatingSpec } from "./ratings";
 import { validateAllQualities, validateKarmaLimits } from "./qualities";
 import { validateAllGear } from "./gear/validation";
+import { validateSumToTenBudget } from "./sum-to-ten-validation";
 import type {
   GearCatalogData,
   CyberwareCatalogData,
@@ -265,6 +266,7 @@ const constraintValidators: Record<ConstraintType, ConstraintValidator> = {
   "essence-minimum": validateEssenceMinimum,
   "equipment-rating": validateEquipmentRatings,
   "special-attribute-init": validateSpecialAttributeInit,
+  "sum-to-ten-budget": validateSumToTenBudget,
   custom: validateCustom,
 };
 

--- a/lib/rules/sum-to-ten-validation.ts
+++ b/lib/rules/sum-to-ten-validation.ts
@@ -1,0 +1,143 @@
+/**
+ * Sum-to-Ten Validation
+ *
+ * Validates the Sum-to-Ten character creation variant where priority levels
+ * are assigned point values (A=4, B=3, C=2, D=1, E=0) and must total exactly 10.
+ * Unlike standard Priority, duplicate levels are allowed.
+ */
+
+import type { CreationConstraint, CreationMethod, ValidationError } from "../types";
+import type { ValidationContext } from "./constraint-validation";
+
+/**
+ * Point values for each priority level in Sum-to-Ten
+ */
+export const SUM_TO_TEN_POINT_VALUES: Readonly<Record<string, number>> = {
+  A: 4,
+  B: 3,
+  C: 2,
+  D: 1,
+  E: 0,
+};
+
+/** Required total for Sum-to-Ten */
+export const SUM_TO_TEN_TOTAL = 10;
+
+/** The five categories that must each be assigned exactly once */
+export const PRIORITY_CATEGORIES = [
+  "metatype",
+  "attributes",
+  "magic",
+  "skills",
+  "resources",
+] as const;
+
+export type PriorityCategory = (typeof PRIORITY_CATEGORIES)[number];
+
+/**
+ * Calculate the total point value for a set of priority assignments.
+ *
+ * @param priorities - Map of category to priority level (e.g. { metatype: "B", attributes: "B" })
+ * @param pointValues - Map of level to point cost (defaults to SUM_TO_TEN_POINT_VALUES)
+ * @returns Total point value, or null if any assignment has an unknown level
+ */
+export function calculatePriorityPointTotal(
+  priorities: Readonly<Record<string, string>>,
+  pointValues: Readonly<Record<string, number>> = SUM_TO_TEN_POINT_VALUES
+): number | null {
+  let total = 0;
+  for (const level of Object.values(priorities)) {
+    const points = pointValues[level];
+    if (points === undefined) return null;
+    total += points;
+  }
+  return total;
+}
+
+/**
+ * Validate that all required categories are assigned and point values sum correctly.
+ *
+ * @param constraint - The constraint definition from the creation method
+ * @param context - Validation context containing creation state
+ * @returns ValidationError if invalid, null if valid
+ */
+export function validateSumToTenBudget(
+  constraint: CreationConstraint,
+  context: ValidationContext
+): ValidationError | null {
+  const { creationState, creationMethod } = context;
+  const priorities = creationState?.priorities;
+
+  // No priorities assigned yet — skip validation (will be caught by required-selection)
+  if (!priorities || Object.keys(priorities).length === 0) {
+    return null;
+  }
+
+  const params = constraint.params as {
+    totalBudget?: number;
+    pointValues?: Record<string, number>;
+    categories?: readonly string[];
+  };
+
+  const totalBudget = params.totalBudget ?? SUM_TO_TEN_TOTAL;
+  const pointValues = params.pointValues ? { ...params.pointValues } : SUM_TO_TEN_POINT_VALUES;
+  const requiredCategories = params.categories ?? getRequiredCategories(creationMethod);
+
+  // Check all required categories are assigned
+  const missingCategories = requiredCategories.filter((cat) => !priorities[cat]);
+  if (missingCategories.length > 0) {
+    return {
+      constraintId: constraint.id,
+      field: "priorities",
+      message:
+        constraint.errorMessage ||
+        `Missing priority assignments for: ${missingCategories.join(", ")}`,
+      severity: constraint.severity,
+    };
+  }
+
+  // Calculate total
+  const total = calculatePriorityPointTotal(priorities, pointValues);
+  if (total === null) {
+    const unknownLevels = Object.values(priorities).filter(
+      (level) => pointValues[level] === undefined
+    );
+    return {
+      constraintId: constraint.id,
+      field: "priorities",
+      message: `Unknown priority level(s): ${unknownLevels.join(", ")}`,
+      severity: "error",
+    };
+  }
+
+  // Validate total equals budget
+  if (total !== totalBudget) {
+    return {
+      constraintId: constraint.id,
+      field: "priorities",
+      message:
+        constraint.errorMessage ||
+        `Priority points must total exactly ${totalBudget} (currently ${total})`,
+      severity: constraint.severity,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Extract required categories from the creation method's priority step.
+ */
+function getRequiredCategories(creationMethod?: CreationMethod): readonly string[] {
+  if (!creationMethod) return PRIORITY_CATEGORIES;
+
+  const priorityStep = creationMethod.steps.find((s) => s.id === "priorities");
+  if (priorityStep?.payload && "categories" in priorityStep.payload) {
+    const categories = priorityStep.payload.categories;
+    if (Array.isArray(categories)) {
+      return categories.map((c) => (typeof c === "string" ? c : c.id));
+    }
+  }
+
+  return PRIORITY_CATEGORIES;
+}

--- a/lib/types/creation.ts
+++ b/lib/types/creation.ts
@@ -152,11 +152,29 @@ export interface SelectStepPayload {
 export interface PriorityStepPayload {
   type: "priority";
 
-  /** Priority categories to assign */
-  categories: PriorityCategory[];
+  /** Priority categories to assign (strings or full category objects) */
+  categories: (string | PriorityCategory)[];
 
   /** Available priority levels */
   levels: string[]; // ["A", "B", "C", "D", "E"]
+
+  /**
+   * Point values per priority level (for Sum-to-Ten variant).
+   * Maps level letter to point cost, e.g. { "A": 4, "B": 3, "C": 2, "D": 1, "E": 0 }
+   */
+  pointValues?: Record<string, number>;
+
+  /**
+   * Total point budget that assigned levels must sum to (for Sum-to-Ten variant).
+   * e.g. 10 for Sum-to-Ten
+   */
+  totalBudget?: number;
+
+  /**
+   * Whether duplicate priority levels are allowed (for Sum-to-Ten variant).
+   * Standard Priority = false (default), Sum-to-Ten = true
+   */
+  allowDuplicates?: boolean;
 }
 
 export interface PriorityCategory {
@@ -281,6 +299,7 @@ export type ConstraintType =
   | "essence-minimum" // Essence cannot drop below value
   | "equipment-rating" // Equipment ratings must be valid
   | "special-attribute-init" // Edge/Magic/Resonance starting values
+  | "sum-to-ten-budget" // Priority point values must sum to exact total
   | "custom"; // Custom validation function name
 
 /**


### PR DESCRIPTION
## Summary
- Add the **Sum-to-Ten** alternate character creation method from Run Faster (p. 62-63)
- Players get **10 points** to spend on priorities (A=4, B=3, C=2, D=1, E=0) with duplicate levels allowed
- New `sum-to-ten-budget` constraint type validates total equals exactly 10
- Extends `PriorityStepPayload` with `pointValues`, `totalBudget`, and `allowDuplicates` fields
- Reuses existing priority table data — same A-E levels with identical values per category

## Test plan
- [x] 23 unit tests for `calculatePriorityPointTotal` and `validateSumToTenBudget`
- [x] Valid builds: A/B/C/D/E, B/B/B/D/E, A/C/C/C/E, C/C/C/C/C
- [x] Over-budget, under-budget, missing categories, unknown levels
- [x] Custom error messages and totalBudget overrides
- [x] TypeScript type-check passes
- [x] All 315 rules tests pass
- [x] Full suite: 8766 passed (7 pre-existing timeouts in users.test.ts)

Closes #530