### PR TITLE
feat: add Point Buy character creation method

### DIFF
--- a/__tests__/lib/rules/point-buy-validation.test.ts
+++ b/__tests__/lib/rules/point-buy-validation.test.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect } from "vitest";
+import {
+  validatePointBuyBudget,
+  calculatePointBuyKarmaSpent,
+  calculateGearKarmaSpent,
+  getMetatypeKarmaCost,
+  calculateAttributeAdvancementCost,
+  calculateSkillAdvancementCost,
+  POINT_BUY_KARMA_BUDGET,
+  POINT_BUY_MAX_GEAR_KARMA,
+  POINT_BUY_NUYEN_PER_KARMA,
+  POINT_BUY_MAX_LEFTOVER_NUYEN,
+  POINT_BUY_METATYPE_COSTS,
+  POINT_BUY_MAGIC_QUALITY_COSTS,
+} from "@/lib/rules/point-buy-validation";
+import type { PointBuyKarmaData } from "@/lib/rules/point-buy-validation";
+import type { CreationConstraint } from "@/lib/types";
+import type { ValidationContext } from "@/lib/rules/constraint-validation";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function makeConstraint(overrides: Partial<CreationConstraint> = {}): CreationConstraint {
+  return {
+    id: "point-buy-budget",
+    type: "point-buy-budget",
+    description: "Karma budget must not exceed 800.",
+    severity: "error",
+    params: {
+      totalBudget: 800,
+      maxGearKarma: 200,
+      nuyenPerKarma: 2000,
+      maxLeftoverNuyen: 5000,
+      metatypeCosts: {
+        human: 0,
+        elf: 40,
+        dwarf: 50,
+        ork: 50,
+        troll: 90,
+      },
+      magicQualityCosts: {
+        adept: 20,
+        "aspected-magician": 15,
+        magician: 30,
+        "mystic-adept": 35,
+        technomancer: 15,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeContext(
+  budgets: Record<string, number>,
+  selections: Record<string, unknown> = {},
+  overrides: Partial<ValidationContext> = {}
+): ValidationContext {
+  return {
+    character: { metatype: "human", name: "Test" } as ValidationContext["character"],
+    ruleset: {} as ValidationContext["ruleset"],
+    creationState: {
+      characterId: "test-char",
+      creationMethodId: "point-buy",
+      currentStep: 0,
+      completedSteps: [],
+      budgets,
+      selections: selections as ValidationContext["creationState"] extends {
+        selections: infer S;
+      }
+        ? S
+        : never,
+      errors: [],
+      warnings: [],
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    },
+    creationMethod: {
+      id: "point-buy",
+      editionId: "sr5",
+      editionCode: "sr5" as const,
+      name: "Point Buy",
+      type: "point-buy",
+      version: "1.0.0",
+      steps: [],
+      budgets: [],
+      constraints: [],
+      createdAt: "2025-01-01T00:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+function makeContextUndefined(overrides: Partial<ValidationContext> = {}): ValidationContext {
+  return {
+    character: { metatype: "human", name: "Test" } as ValidationContext["character"],
+    ruleset: {} as ValidationContext["ruleset"],
+    creationState: undefined,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+describe("POINT_BUY constants", () => {
+  it("has correct karma budget", () => {
+    expect(POINT_BUY_KARMA_BUDGET).toBe(800);
+  });
+
+  it("has correct max gear karma", () => {
+    expect(POINT_BUY_MAX_GEAR_KARMA).toBe(200);
+  });
+
+  it("has correct nuyen per karma", () => {
+    expect(POINT_BUY_NUYEN_PER_KARMA).toBe(2000);
+  });
+
+  it("has correct max leftover nuyen", () => {
+    expect(POINT_BUY_MAX_LEFTOVER_NUYEN).toBe(5000);
+  });
+
+  it("has correct metatype costs", () => {
+    expect(POINT_BUY_METATYPE_COSTS).toEqual({
+      human: 0,
+      elf: 40,
+      dwarf: 50,
+      ork: 50,
+      troll: 90,
+    });
+  });
+
+  it("has correct magic quality costs", () => {
+    expect(POINT_BUY_MAGIC_QUALITY_COSTS).toEqual({
+      adept: 20,
+      "aspected-magician": 15,
+      magician: 30,
+      "mystic-adept": 35,
+      technomancer: 15,
+    });
+  });
+});
+
+// =============================================================================
+// getMetatypeKarmaCost
+// =============================================================================
+
+describe("getMetatypeKarmaCost", () => {
+  it("returns 0 for human", () => {
+    expect(getMetatypeKarmaCost("human")).toBe(0);
+  });
+
+  it("returns 40 for elf", () => {
+    expect(getMetatypeKarmaCost("elf")).toBe(40);
+  });
+
+  it("returns 50 for dwarf", () => {
+    expect(getMetatypeKarmaCost("dwarf")).toBe(50);
+  });
+
+  it("returns 50 for ork", () => {
+    expect(getMetatypeKarmaCost("ork")).toBe(50);
+  });
+
+  it("returns 90 for troll", () => {
+    expect(getMetatypeKarmaCost("troll")).toBe(90);
+  });
+
+  it("returns null for unknown metatype", () => {
+    expect(getMetatypeKarmaCost("pixie")).toBeNull();
+  });
+
+  it("uses custom cost table", () => {
+    const custom = { human: 10, pixie: 5 };
+    expect(getMetatypeKarmaCost("pixie", custom)).toBe(5);
+    expect(getMetatypeKarmaCost("human", custom)).toBe(10);
+  });
+});
+
+// =============================================================================
+// calculateAttributeAdvancementCost
+// =============================================================================
+
+describe("calculateAttributeAdvancementCost", () => {
+  it("returns 0 when target equals base", () => {
+    expect(calculateAttributeAdvancementCost(3, 3)).toBe(0);
+  });
+
+  it("returns 0 when target is below base", () => {
+    expect(calculateAttributeAdvancementCost(3, 1)).toBe(0);
+  });
+
+  it("calculates cost for raising 1 to 2 (2 × 5 = 10)", () => {
+    expect(calculateAttributeAdvancementCost(1, 2)).toBe(10);
+  });
+
+  it("calculates cost for raising 1 to 3 (2×5 + 3×5 = 25)", () => {
+    expect(calculateAttributeAdvancementCost(1, 3)).toBe(25);
+  });
+
+  it("calculates cost for raising 1 to 6 (2+3+4+5+6)×5 = 100", () => {
+    expect(calculateAttributeAdvancementCost(1, 6)).toBe(100);
+  });
+
+  it("calculates cost for raising 3 to 6 (4+5+6)×5 = 75", () => {
+    expect(calculateAttributeAdvancementCost(3, 6)).toBe(75);
+  });
+
+  it("uses custom multiplier", () => {
+    // Raising 1 to 3 with multiplier 3: (2×3 + 3×3 = 15)
+    expect(calculateAttributeAdvancementCost(1, 3, 3)).toBe(15);
+  });
+});
+
+// =============================================================================
+// calculateSkillAdvancementCost
+// =============================================================================
+
+describe("calculateSkillAdvancementCost", () => {
+  it("returns 0 for rating 0", () => {
+    expect(calculateSkillAdvancementCost(0)).toBe(0);
+  });
+
+  it("returns 0 for negative rating", () => {
+    expect(calculateSkillAdvancementCost(-1)).toBe(0);
+  });
+
+  it("calculates cost for rating 1 (1×2 = 2)", () => {
+    expect(calculateSkillAdvancementCost(1)).toBe(2);
+  });
+
+  it("calculates cost for rating 3 (1+2+3)×2 = 12", () => {
+    expect(calculateSkillAdvancementCost(3)).toBe(12);
+  });
+
+  it("calculates cost for rating 6 (1+2+3+4+5+6)×2 = 42", () => {
+    expect(calculateSkillAdvancementCost(6)).toBe(42);
+  });
+
+  it("uses custom multiplier (skill group: ×5)", () => {
+    // Rating 3: (1+2+3)×5 = 30
+    expect(calculateSkillAdvancementCost(3, 5)).toBe(30);
+  });
+});
+
+// =============================================================================
+// calculateGearKarmaSpent
+// =============================================================================
+
+describe("calculateGearKarmaSpent", () => {
+  it("returns 0 when no gear karma tracked", () => {
+    expect(calculateGearKarmaSpent({})).toBe(0);
+  });
+
+  it("returns gear karma value", () => {
+    expect(calculateGearKarmaSpent({ gearKarma: 150 })).toBe(150);
+  });
+
+  it("returns 0 for undefined gear karma", () => {
+    expect(calculateGearKarmaSpent({ gearKarma: undefined })).toBe(0);
+  });
+});
+
+// =============================================================================
+// calculatePointBuyKarmaSpent
+// =============================================================================
+
+describe("calculatePointBuyKarmaSpent", () => {
+  it("returns 0 for empty data", () => {
+    expect(calculatePointBuyKarmaSpent({})).toBe(0);
+  });
+
+  it("includes metatype cost for human (0)", () => {
+    expect(calculatePointBuyKarmaSpent({ metatypeId: "human" })).toBe(0);
+  });
+
+  it("includes metatype cost for troll (90)", () => {
+    expect(calculatePointBuyKarmaSpent({ metatypeId: "troll" })).toBe(90);
+  });
+
+  it("includes magic quality cost", () => {
+    expect(calculatePointBuyKarmaSpent({ magicalPath: "magician" })).toBe(30);
+  });
+
+  it("sums all karma sources", () => {
+    const data: PointBuyKarmaData = {
+      metatypeId: "elf", // 40
+      magicalPath: "adept", // 20
+      attributeKarma: 100,
+      skillKarma: 50,
+      qualityKarma: 10,
+      contactKarma: 15,
+      gearKarma: 100,
+      spellKarma: 25,
+      powerPointKarma: 0,
+    };
+    // 40 + 20 + 100 + 50 + 10 + 15 + 100 + 25 + 0 = 360
+    expect(calculatePointBuyKarmaSpent(data)).toBe(360);
+  });
+
+  it("ignores undefined values", () => {
+    const data: PointBuyKarmaData = {
+      metatypeId: "human",
+      attributeKarma: undefined,
+      skillKarma: undefined,
+    };
+    expect(calculatePointBuyKarmaSpent(data)).toBe(0);
+  });
+
+  it("handles unknown metatype (costs 0)", () => {
+    expect(calculatePointBuyKarmaSpent({ metatypeId: "pixie" })).toBe(0);
+  });
+
+  it("uses custom metatype costs from params", () => {
+    const params = { metatypeCosts: { human: 10 } };
+    expect(calculatePointBuyKarmaSpent({ metatypeId: "human" }, params)).toBe(10);
+  });
+
+  it("uses custom magic quality costs from params", () => {
+    const params = { magicQualityCosts: { magician: 50 } };
+    expect(calculatePointBuyKarmaSpent({ magicalPath: "magician" }, params)).toBe(50);
+  });
+});
+
+// =============================================================================
+// validatePointBuyBudget
+// =============================================================================
+
+describe("validatePointBuyBudget", () => {
+  it("returns null when no creation state", () => {
+    const context = makeContextUndefined();
+    expect(validatePointBuyBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("returns null when under budget", () => {
+    const context = makeContext(
+      { "point-buy-attributes": 200, "point-buy-skills": 100 },
+      { metatypeId: "human" }
+    );
+    expect(validatePointBuyBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("returns null when exactly at budget (800)", () => {
+    const context = makeContext(
+      {
+        "point-buy-attributes": 280,
+        "point-buy-skills": 200,
+        "point-buy-qualities": 50,
+        "point-buy-contacts": 50,
+        "point-buy-gear": 100,
+      },
+      { metatypeId: "troll", magicalPath: "magician" }
+      // troll=90, magician=30, 280+200+50+50+100 = 680, total = 800
+    );
+    expect(validatePointBuyBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("returns error when over budget", () => {
+    const context = makeContext(
+      {
+        "point-buy-attributes": 400,
+        "point-buy-skills": 200,
+        "point-buy-gear": 200,
+      },
+      { metatypeId: "troll" }
+    );
+    // troll=90, 400+200+200 = 800, total = 890 > 800
+    const result = validatePointBuyBudget(makeConstraint(), context);
+    expect(result).not.toBeNull();
+    expect(result!.severity).toBe("error");
+    expect(result!.field).toBe("karma-budget");
+    expect(result!.message).toContain("890");
+    expect(result!.message).toContain("800");
+  });
+
+  it("returns error when gear karma exceeds cap", () => {
+    const context = makeContext({ "point-buy-gear": 250 }, { metatypeId: "human" });
+    const result = validatePointBuyBudget(makeConstraint(), context);
+    expect(result).not.toBeNull();
+    expect(result!.field).toBe("gear-karma");
+    expect(result!.message).toContain("250");
+    expect(result!.message).toContain("200");
+  });
+
+  it("checks total budget before gear cap", () => {
+    // Both over total and over gear cap — total is checked first
+    const context = makeContext(
+      {
+        "point-buy-attributes": 600,
+        "point-buy-gear": 250,
+      },
+      { metatypeId: "human" }
+    );
+    const result = validatePointBuyBudget(makeConstraint(), context);
+    expect(result).not.toBeNull();
+    expect(result!.field).toBe("karma-budget");
+  });
+
+  it("uses custom errorMessage from constraint", () => {
+    const context = makeContext({ "point-buy-attributes": 900 }, { metatypeId: "human" });
+    const constraint = makeConstraint({
+      errorMessage: "Too much karma, omae!",
+    });
+    const result = validatePointBuyBudget(constraint, context);
+    expect(result).not.toBeNull();
+    expect(result!.message).toBe("Too much karma, omae!");
+  });
+
+  it("uses custom totalBudget from params", () => {
+    const constraint = makeConstraint({
+      params: {
+        totalBudget: 500,
+        maxGearKarma: 200,
+      },
+    });
+    const context = makeContext({ "point-buy-attributes": 501 }, { metatypeId: "human" });
+    const result = validatePointBuyBudget(constraint, context);
+    expect(result).not.toBeNull();
+    expect(result!.message).toContain("501");
+    expect(result!.message).toContain("500");
+  });
+
+  it("uses custom maxGearKarma from params", () => {
+    const constraint = makeConstraint({
+      params: {
+        totalBudget: 800,
+        maxGearKarma: 100,
+      },
+    });
+    const context = makeContext({ "point-buy-gear": 150 }, { metatypeId: "human" });
+    const result = validatePointBuyBudget(constraint, context);
+    expect(result).not.toBeNull();
+    expect(result!.field).toBe("gear-karma");
+    expect(result!.message).toContain("150");
+    expect(result!.message).toContain("100");
+  });
+
+  it("returns null for gear karma exactly at cap", () => {
+    const context = makeContext({ "point-buy-gear": 200 }, { metatypeId: "human" });
+    expect(validatePointBuyBudget(makeConstraint(), context)).toBeNull();
+  });
+
+  it("validates realistic troll street samurai build", () => {
+    const context = makeContext(
+      {
+        "point-buy-attributes": 250,
+        "point-buy-skills": 150,
+        "point-buy-qualities": 15,
+        "point-buy-contacts": 20,
+        "point-buy-gear": 175,
+      },
+      { metatypeId: "troll" }
+    );
+    // troll=90, 250+150+15+20+175 = 610, total = 700 (under 800)
+    expect(validatePointBuyBudget(makeConstraint(), context)).toBeNull();
+  });
+});

--- a/data/editions/sr5/edition.json
+++ b/data/editions/sr5/edition.json
@@ -6,7 +6,7 @@
   "description": "The fifth edition of Shadowrun, published by Catalyst Game Labs in 2013. Features the Priority character creation system, Limits, and an updated Matrix.",
   "releaseYear": 2013,
   "bookIds": ["core-rulebook", "core-errata-2014-02-09", "run-faster"],
-  "creationMethodIds": ["priority", "sum-to-ten"],
+  "creationMethodIds": ["priority", "sum-to-ten", "point-buy"],
   "defaultCreationMethodId": "priority",
   "philosophy": "Fifth Edition brings a streamlined approach to the classic Shadowrun experience, balancing narrative freedom with structured mechanical resolution. The Priority system provides clear trade-offs during character creation, while Limits ensure no single attribute dominates dice rolls.",
   "mechanicalHighlights": [

--- a/data/editions/sr5/run-faster.json
+++ b/data/editions/sr5/run-faster.json
@@ -1750,6 +1750,304 @@
               }
             ],
             "createdAt": "2025-01-01T00:00:00.000Z"
+          },
+          {
+            "id": "point-buy",
+            "editionId": "sr5",
+            "editionCode": "sr5",
+            "bookId": "run-faster",
+            "name": "Point Buy",
+            "type": "point-buy",
+            "description": "A fully karma-based creation system with 800 Karma. Purchase metatype, attributes, skills, qualities, gear, and more using advancement costs. Offers maximum flexibility at the cost of more time-consuming creation.",
+            "version": "1.0.0",
+            "steps": [
+              {
+                "id": "metatype",
+                "title": "Select Metatype",
+                "type": "select",
+                "description": "Choose your metatype. Cost is deducted from your 800 Karma budget.",
+                "payload": {
+                  "type": "select",
+                  "target": "metatype"
+                }
+              },
+              {
+                "id": "magic",
+                "title": "Magic/Resonance",
+                "type": "select",
+                "optional": true,
+                "description": "Purchase a magical or resonance quality to gain access to Magic or Resonance attributes.",
+                "payload": {
+                  "type": "select",
+                  "target": "magical-path"
+                }
+              },
+              {
+                "id": "attributes",
+                "title": "Allocate Attributes",
+                "type": "allocate",
+                "description": "Raise attributes from metatype minimums using advancement costs (New Rating × 5 Karma).",
+                "payload": {
+                  "type": "allocate",
+                  "target": "attributes",
+                  "budgetId": "karma"
+                }
+              },
+              {
+                "id": "skills",
+                "title": "Allocate Skills",
+                "type": "allocate",
+                "description": "Purchase skills using advancement costs (New Rating × 2 Karma for active, × 5 for groups, × 1 for knowledge).",
+                "payload": {
+                  "type": "allocate",
+                  "target": "skills",
+                  "budgetId": "karma"
+                }
+              },
+              {
+                "id": "qualities",
+                "title": "Select Qualities",
+                "type": "choose",
+                "description": "Purchase positive qualities and take negative qualities (refunds Karma).",
+                "payload": {
+                  "type": "choose",
+                  "target": "qualities",
+                  "budgetId": "karma"
+                }
+              },
+              {
+                "id": "spells",
+                "title": "Spells",
+                "type": "custom",
+                "description": "Select spells if you are a magician or mystic adept (5 Karma each).",
+                "payload": {
+                  "type": "custom",
+                  "target": "spells"
+                }
+              },
+              {
+                "id": "rituals",
+                "title": "Rituals",
+                "type": "custom",
+                "description": "Learn ritual spellcasting if your magical path includes it.",
+                "payload": {
+                  "type": "custom",
+                  "target": "rituals"
+                }
+              },
+              {
+                "id": "adept-powers",
+                "title": "Adept Powers",
+                "type": "custom",
+                "description": "Select adept powers using your Power Points (equal to Magic for Adepts; Mystic Adepts buy power points at 5 Karma each).",
+                "payload": {
+                  "type": "custom",
+                  "target": "adeptPowers"
+                }
+              },
+              {
+                "id": "contacts",
+                "title": "Build Contacts",
+                "type": "allocate",
+                "description": "Build your network of contacts using Karma (Connection + Loyalty per contact).",
+                "payload": {
+                  "type": "allocate",
+                  "target": "contacts",
+                  "budgetId": "karma"
+                }
+              },
+              {
+                "id": "augmentations",
+                "title": "Augmentations",
+                "type": "purchase",
+                "description": "Install cyberware and bioware. Essence loss affects Magic rating. Purchased with nuyen from gear karma.",
+                "payload": {
+                  "type": "purchase",
+                  "target": "augmentations",
+                  "budgetId": "nuyen",
+                  "availabilityLimit": 12
+                }
+              },
+              {
+                "id": "gear",
+                "title": "Purchase Gear",
+                "type": "purchase",
+                "description": "Purchase gear using nuyen (1 Karma = 2,000¥, max 200 Karma on gear).",
+                "payload": {
+                  "type": "purchase",
+                  "target": "gear",
+                  "budgetId": "nuyen",
+                  "availabilityLimit": 12
+                }
+              },
+              {
+                "id": "vehicles",
+                "title": "Vehicles & Drones",
+                "type": "purchase",
+                "payload": {
+                  "type": "purchase",
+                  "target": "vehicles",
+                  "budgetId": "nuyen",
+                  "availabilityLimit": 12
+                }
+              },
+              {
+                "id": "programs",
+                "title": "Matrix Programs",
+                "description": "Select Matrix programs for your cyberdeck.",
+                "type": "purchase",
+                "payload": {
+                  "budget": "nuyen",
+                  "catalog": "programs"
+                }
+              },
+              {
+                "id": "identities",
+                "title": "Identities & SINs",
+                "type": "choose",
+                "description": "Create identities with SINs (fake or real) and licenses.",
+                "payload": {
+                  "type": "choose",
+                  "target": "identities"
+                }
+              },
+              {
+                "id": "review",
+                "title": "Review & Finalize",
+                "type": "validate",
+                "description": "Review your character. All 800 Karma must be spent — no leftover Karma allowed.",
+                "payload": {
+                  "type": "validate",
+                  "validations": ["all"]
+                }
+              }
+            ],
+            "budgets": [
+              {
+                "id": "karma",
+                "label": "Karma",
+                "initialValue": 800,
+                "description": "Starting Karma budget for Point Buy creation"
+              },
+              {
+                "id": "nuyen",
+                "label": "Nuyen",
+                "initialValue": 0,
+                "displayFormat": "currency",
+                "description": "Nuyen from karma-to-nuyen conversion (1 Karma = 2,000¥)"
+              },
+              {
+                "id": "gear-karma",
+                "label": "Gear Karma",
+                "initialValue": 0,
+                "max": 200,
+                "description": "Karma spent on gear (max 200)"
+              }
+            ],
+            "constraints": [
+              {
+                "id": "point-buy-budget",
+                "type": "point-buy-budget",
+                "description": "Total Karma spent cannot exceed 800. Gear karma capped at 200.",
+                "severity": "error",
+                "params": {
+                  "totalBudget": 800,
+                  "maxGearKarma": 200,
+                  "nuyenPerKarma": 2000,
+                  "maxLeftoverNuyen": 5000,
+                  "metatypeCosts": {
+                    "human": 0,
+                    "elf": 40,
+                    "dwarf": 50,
+                    "ork": 50,
+                    "troll": 90
+                  },
+                  "magicQualityCosts": {
+                    "adept": 20,
+                    "aspected-magician": 15,
+                    "magician": 30,
+                    "mystic-adept": 35,
+                    "technomancer": 15
+                  }
+                },
+                "errorMessage": "Karma budget exceeded (800 Karma total, 200 max on gear)."
+              },
+              {
+                "id": "max-one-attribute-at-max",
+                "type": "attribute-limit",
+                "description": "Only one Physical or Mental attribute can be at natural maximum at creation. Special attributes (Edge, Magic, Resonance) are exempt.",
+                "severity": "error",
+                "params": {
+                  "maxAtMax": 1
+                },
+                "errorMessage": "Only one Physical or Mental attribute can be at its natural maximum."
+              },
+              {
+                "id": "positive-quality-limit",
+                "type": "budget-balance",
+                "description": "Maximum 25 Karma in Positive Qualities.",
+                "severity": "error",
+                "params": {
+                  "budgetId": "positive-quality-karma",
+                  "max": 25
+                },
+                "errorMessage": "Cannot spend more than 25 Karma on positive qualities."
+              },
+              {
+                "id": "negative-quality-limit",
+                "type": "budget-balance",
+                "description": "Maximum 25 Karma from Negative Qualities.",
+                "severity": "error",
+                "params": {
+                  "budgetId": "negative-quality-karma",
+                  "max": 25
+                },
+                "errorMessage": "Cannot gain more than 25 Karma from negative qualities."
+              },
+              {
+                "id": "skill-max-at-creation",
+                "type": "skill-limit",
+                "description": "Skills capped at 6 at creation (7 with Aptitude).",
+                "severity": "error",
+                "params": {
+                  "max": 6,
+                  "maxWithAptitude": 7
+                },
+                "errorMessage": "Skill rating cannot exceed 6 at creation (7 with Aptitude)."
+              },
+              {
+                "id": "gear-availability",
+                "type": "custom",
+                "description": "Gear availability cannot exceed 12 at creation.",
+                "severity": "error",
+                "params": {
+                  "maxAvailability": 12
+                },
+                "errorMessage": "Cannot purchase gear with availability higher than 12."
+              },
+              {
+                "id": "essence-minimum",
+                "type": "essence-minimum",
+                "description": "Essence cannot drop below 0.",
+                "severity": "error",
+                "params": {
+                  "min": 0
+                },
+                "errorMessage": "Essence cannot drop below 0."
+              },
+              {
+                "id": "no-leftover-karma",
+                "type": "budget-balance",
+                "description": "All Karma must be spent — no leftover Karma allowed.",
+                "severity": "warning",
+                "params": {
+                  "budgetId": "karma",
+                  "max": 0
+                },
+                "errorMessage": "Leftover Karma cannot be carried over from Point Buy creation."
+              }
+            ],
+            "createdAt": "2025-01-01T00:00:00.000Z"
           }
         ]
       }

--- a/lib/rules/constraint-validation.ts
+++ b/lib/rules/constraint-validation.ts
@@ -22,6 +22,7 @@ import { validateRating, validateRatingAvailability, convertLegacyRatingSpec } f
 import { validateAllQualities, validateKarmaLimits } from "./qualities";
 import { validateAllGear } from "./gear/validation";
 import { validateSumToTenBudget } from "./sum-to-ten-validation";
+import { validatePointBuyBudget } from "./point-buy-validation";
 import type {
   GearCatalogData,
   CyberwareCatalogData,
@@ -267,6 +268,7 @@ const constraintValidators: Record<ConstraintType, ConstraintValidator> = {
   "equipment-rating": validateEquipmentRatings,
   "special-attribute-init": validateSpecialAttributeInit,
   "sum-to-ten-budget": validateSumToTenBudget,
+  "point-buy-budget": validatePointBuyBudget,
   custom: validateCustom,
 };
 

--- a/lib/rules/point-buy-validation.ts
+++ b/lib/rules/point-buy-validation.ts
@@ -1,0 +1,257 @@
+/**
+ * Point Buy Validation
+ *
+ * Validates the Point Buy (Karma-based) character creation method from Run Faster.
+ * Characters start with 800 Karma and purchase everything using advancement costs.
+ *
+ * Key rules:
+ * - 800 Karma starting budget
+ * - Metatype costs deducted from budget (Human: 0, Elf: 40, Dwarf: 50, Ork: 50, Troll: 90)
+ * - Gear: 1 Karma per 2,000 nuyen, max 200 Karma on gear
+ * - Only 1 Physical or Mental attribute at natural max (special attributes exempt)
+ * - Leftover Karma cannot be carried over; max 5,000¥ leftover nuyen
+ */
+
+import type { CreationConstraint, CreationState, ValidationError } from "../types";
+import type { ValidationContext } from "./constraint-validation";
+
+/** Default starting Karma for Point Buy creation */
+export const POINT_BUY_KARMA_BUDGET = 800;
+
+/** Maximum Karma that can be spent on gear (converted to nuyen) */
+export const POINT_BUY_MAX_GEAR_KARMA = 200;
+
+/** Nuyen per 1 Karma when converting to gear */
+export const POINT_BUY_NUYEN_PER_KARMA = 2000;
+
+/** Maximum leftover nuyen at end of creation */
+export const POINT_BUY_MAX_LEFTOVER_NUYEN = 5000;
+
+/**
+ * Metatype Karma costs for Point Buy creation (Run Faster p. 64)
+ */
+export const POINT_BUY_METATYPE_COSTS: Readonly<Record<string, number>> = {
+  human: 0,
+  elf: 40,
+  dwarf: 50,
+  ork: 50,
+  troll: 90,
+};
+
+/**
+ * Magic/Resonance quality Karma costs for Point Buy creation (Run Faster p. 65)
+ */
+export const POINT_BUY_MAGIC_QUALITY_COSTS: Readonly<Record<string, number>> = {
+  adept: 20,
+  "aspected-magician": 15,
+  magician: 30,
+  "mystic-adept": 35,
+  technomancer: 15,
+};
+
+/**
+ * Point Buy budget constraint parameters (from JSON data)
+ */
+interface PointBuyBudgetParams {
+  readonly totalBudget?: number;
+  readonly maxGearKarma?: number;
+  readonly nuyenPerKarma?: number;
+  readonly maxLeftoverNuyen?: number;
+  readonly metatypeCosts?: Readonly<Record<string, number>>;
+  readonly magicQualityCosts?: Readonly<Record<string, number>>;
+}
+
+/**
+ * Karma spending data extracted from creation state budgets.
+ * Each field represents karma spent in a category, tracked via creationState.budgets.
+ */
+export interface PointBuyKarmaData {
+  readonly metatypeId?: string;
+  readonly magicalPath?: string;
+  readonly attributeKarma?: number;
+  readonly skillKarma?: number;
+  readonly qualityKarma?: number;
+  readonly contactKarma?: number;
+  readonly gearKarma?: number;
+  readonly spellKarma?: number;
+  readonly powerPointKarma?: number;
+}
+
+/**
+ * Extract Point Buy karma data from CreationState budgets.
+ */
+function extractKarmaData(creationState: CreationState): PointBuyKarmaData {
+  const { budgets, selections } = creationState;
+  return {
+    metatypeId: selections?.metatypeId as string | undefined,
+    magicalPath: selections?.magicalPath as string | undefined,
+    attributeKarma: budgets["point-buy-attributes"],
+    skillKarma: budgets["point-buy-skills"],
+    qualityKarma: budgets["point-buy-qualities"],
+    contactKarma: budgets["point-buy-contacts"],
+    gearKarma: budgets["point-buy-gear"],
+    spellKarma: budgets["point-buy-spells"],
+    powerPointKarma: budgets["point-buy-power-points"],
+  };
+}
+
+/**
+ * Validate the Point Buy karma budget.
+ *
+ * Checks that:
+ * 1. Total karma spent does not exceed the budget (800)
+ * 2. Gear karma spending does not exceed the cap (200)
+ *
+ * @param constraint - The constraint definition from the creation method
+ * @param context - Validation context containing creation state
+ * @returns ValidationError if invalid, null if valid
+ */
+export function validatePointBuyBudget(
+  constraint: CreationConstraint,
+  context: ValidationContext
+): ValidationError | null {
+  const { creationState } = context;
+
+  // No state yet — skip (will be caught by required-selection constraints)
+  if (!creationState) {
+    return null;
+  }
+
+  const params = constraint.params as PointBuyBudgetParams;
+  const totalBudget = params.totalBudget ?? POINT_BUY_KARMA_BUDGET;
+  const maxGearKarma = params.maxGearKarma ?? POINT_BUY_MAX_GEAR_KARMA;
+
+  const karmaData = extractKarmaData(creationState);
+
+  // Calculate total karma spent
+  const karmaSpent = calculatePointBuyKarmaSpent(karmaData, params);
+
+  // Validate total budget
+  if (karmaSpent > totalBudget) {
+    return {
+      constraintId: constraint.id,
+      field: "karma-budget",
+      message:
+        constraint.errorMessage ||
+        `Karma budget exceeded: spent ${karmaSpent} of ${totalBudget} Karma.`,
+      severity: constraint.severity,
+    };
+  }
+
+  // Validate gear karma cap
+  const gearKarma = calculateGearKarmaSpent(karmaData);
+  if (gearKarma > maxGearKarma) {
+    return {
+      constraintId: constraint.id,
+      field: "gear-karma",
+      message: `Gear karma cap exceeded: spent ${gearKarma} of ${maxGearKarma} maximum Karma on gear.`,
+      severity: constraint.severity,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Calculate total Karma spent during Point Buy creation.
+ *
+ * Includes: metatype cost, attributes, skills, qualities, magic/resonance qualities,
+ * contacts, gear (karma-to-nuyen), spells, power points.
+ */
+export function calculatePointBuyKarmaSpent(
+  data: PointBuyKarmaData,
+  params?: PointBuyBudgetParams
+): number {
+  const metatypeCosts = params?.metatypeCosts ?? POINT_BUY_METATYPE_COSTS;
+  const magicQualityCosts = params?.magicQualityCosts ?? POINT_BUY_MAGIC_QUALITY_COSTS;
+
+  let total = 0;
+
+  // Metatype cost
+  if (data.metatypeId) {
+    total += metatypeCosts[data.metatypeId] ?? 0;
+  }
+
+  // Magic/Resonance quality cost
+  if (data.magicalPath) {
+    total += magicQualityCosts[data.magicalPath] ?? 0;
+  }
+
+  // Sum all numeric karma categories
+  if (typeof data.attributeKarma === "number") total += data.attributeKarma;
+  if (typeof data.skillKarma === "number") total += data.skillKarma;
+  if (typeof data.qualityKarma === "number") total += data.qualityKarma;
+  if (typeof data.contactKarma === "number") total += data.contactKarma;
+  if (typeof data.spellKarma === "number") total += data.spellKarma;
+  if (typeof data.powerPointKarma === "number") total += data.powerPointKarma;
+
+  // Gear karma (karma-to-nuyen conversion)
+  total += calculateGearKarmaSpent(data);
+
+  return total;
+}
+
+/**
+ * Calculate Karma spent on gear (nuyen conversion).
+ * 1 Karma = 2,000¥ (configurable via params).
+ */
+export function calculateGearKarmaSpent(data: PointBuyKarmaData): number {
+  return typeof data.gearKarma === "number" ? data.gearKarma : 0;
+}
+
+/**
+ * Calculate the total Karma cost for a metatype.
+ *
+ * @param metatypeId - The metatype identifier (e.g., "human", "elf")
+ * @param metatypeCosts - Optional override for metatype cost table
+ * @returns Karma cost, or null if metatype is unknown
+ */
+export function getMetatypeKarmaCost(
+  metatypeId: string,
+  metatypeCosts: Readonly<Record<string, number>> = POINT_BUY_METATYPE_COSTS
+): number | null {
+  const cost = metatypeCosts[metatypeId];
+  return cost !== undefined ? cost : null;
+}
+
+/**
+ * Calculate the cumulative Karma cost to raise an attribute from a base rating
+ * to a target rating using advancement costs (New Rating × multiplier).
+ *
+ * @param baseRating - Starting rating (metatype minimum)
+ * @param targetRating - Desired rating
+ * @param multiplier - Cost multiplier (default 5 for attributes)
+ * @returns Total karma cost for all increases
+ */
+export function calculateAttributeAdvancementCost(
+  baseRating: number,
+  targetRating: number,
+  multiplier: number = 5
+): number {
+  if (targetRating <= baseRating) return 0;
+  let cost = 0;
+  for (let rating = baseRating + 1; rating <= targetRating; rating++) {
+    cost += rating * multiplier;
+  }
+  return cost;
+}
+
+/**
+ * Calculate the cumulative Karma cost to raise a skill from 0 to a target rating
+ * using advancement costs (New Rating × multiplier).
+ *
+ * @param targetRating - Desired skill rating
+ * @param multiplier - Cost multiplier (default 2 for active skills)
+ * @returns Total karma cost for all increases
+ */
+export function calculateSkillAdvancementCost(
+  targetRating: number,
+  multiplier: number = 2
+): number {
+  if (targetRating <= 0) return 0;
+  let cost = 0;
+  for (let rating = 1; rating <= targetRating; rating++) {
+    cost += rating * multiplier;
+  }
+  return cost;
+}

--- a/lib/types/creation.ts
+++ b/lib/types/creation.ts
@@ -300,6 +300,7 @@ export type ConstraintType =
   | "equipment-rating" // Equipment ratings must be valid
   | "special-attribute-init" // Edge/Magic/Resonance starting values
   | "sum-to-ten-budget" // Priority point values must sum to exact total
+  | "point-buy-budget" // Karma budget tracking for point-buy creation
   | "custom"; // Custom validation function name
 
 /**


### PR DESCRIPTION
## Summary
- Add the karma-based Point Buy creation method from Run Faster (p. 64-65) with 800 Karma starting budget
- Create `point-buy-validation.ts` with budget tracking, metatype/magic costs, and advancement cost calculators
- Register `point-buy-budget` constraint type and validator in the constraint validation engine
- Add full creation method data definition (15 steps, 3 budgets, 8 constraints) to `run-faster.json`

## Changes
| File | Change |
|------|--------|
| `lib/types/creation.ts` | Add `point-buy-budget` to `ConstraintType` union |
| `lib/rules/point-buy-validation.ts` | **New** - Point Buy validation module |
| `lib/rules/constraint-validation.ts` | Register Point Buy validator |
| `data/editions/sr5/run-faster.json` | Add Point Buy creation method definition |
| `data/editions/sr5/edition.json` | Register `point-buy` in `creationMethodIds` |
| `__tests__/lib/rules/point-buy-validation.test.ts` | **New** - 38 tests |

## Test plan
- [x] 38 unit tests covering all validation logic (constants, metatype costs, advancement costs, budget validation, gear cap)
- [x] TypeScript type-check passes
- [x] All 8821 existing tests still pass
- [x] JSON data validation passes (no naming issues)
- [x] knip dead code check passes

Closes #531