### PR TITLE
feat: redesign metatype selection modal with two-panel layout (#570)

### DIFF
--- a/__tests__/components/creation/MetatypeModal.test.tsx
+++ b/__tests__/components/creation/MetatypeModal.test.tsx
@@ -1,0 +1,472 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MetatypeModal } from "@/components/creation/metatype/MetatypeModal";
+import type { MetatypeOption } from "@/components/creation/metatype/types";
+
+// Mock lucide-react icons
+vi.mock("lucide-react", () => ({
+  Check: ({ className }: { className?: string }) => (
+    <svg data-testid="check-icon" className={className} />
+  ),
+  X: ({ className }: { className?: string }) => <svg data-testid="x-icon" className={className} />,
+  Search: ({ className }: { className?: string }) => (
+    <svg data-testid="search-icon" className={className} />
+  ),
+}));
+
+// ─── Test Data ───────────────────────────────────────────────────────────────
+
+const BASE_ATTRS = {
+  body: { min: 1, max: 6 },
+  agility: { min: 1, max: 6 },
+  reaction: { min: 1, max: 6 },
+  strength: { min: 1, max: 6 },
+  willpower: { min: 1, max: 6 },
+  logic: { min: 1, max: 6 },
+  intuition: { min: 1, max: 6 },
+  charisma: { min: 1, max: 6 },
+  edge: { min: 2, max: 7 },
+};
+
+const ELF_ATTRS = {
+  body: { min: 1, max: 6 },
+  agility: { min: 2, max: 7 },
+  reaction: { min: 1, max: 6 },
+  strength: { min: 1, max: 6 },
+  willpower: { min: 1, max: 6 },
+  logic: { min: 1, max: 6 },
+  intuition: { min: 1, max: 6 },
+  charisma: { min: 3, max: 8 },
+  edge: { min: 1, max: 6 },
+};
+
+const METATYPES: MetatypeOption[] = [
+  {
+    id: "human",
+    name: "Human",
+    baseMetatype: null,
+    description: "Standard human",
+    specialAttributePoints: 7,
+    racialTraits: [],
+    attributes: BASE_ATTRS,
+    priorityAvailability: { A: 9, B: 7, C: 5, D: 3, E: 1 },
+  },
+  {
+    id: "elf",
+    name: "Elf",
+    baseMetatype: null,
+    description: "Graceful and long-lived",
+    specialAttributePoints: 6,
+    racialTraits: ["Low-Light Vision"],
+    attributes: ELF_ATTRS,
+    priorityAvailability: { A: 8, B: 6, C: 3, D: 0, E: null },
+  },
+  {
+    id: "nocturna",
+    name: "Nocturna",
+    baseMetatype: "elf",
+    description: "Nocturnal elf variant",
+    specialAttributePoints: 3,
+    racialTraits: ["Allergy (Sunlight, Mild)", "Low-Light Vision", "Keen-eared"],
+    attributes: {
+      ...ELF_ATTRS,
+      agility: { min: 3, max: 8 },
+      charisma: { min: 2, max: 7 },
+    },
+    priorityAvailability: { A: 8, B: 6, C: 3, D: 0, E: null },
+  },
+  {
+    id: "dwarf",
+    name: "Dwarf",
+    baseMetatype: null,
+    description: "Stout and resilient",
+    specialAttributePoints: 4,
+    racialTraits: ["Thermographic Vision", "Resistance to Pathogens/Toxins"],
+    attributes: {
+      body: { min: 3, max: 8 },
+      agility: { min: 1, max: 6 },
+      reaction: { min: 1, max: 5 },
+      strength: { min: 3, max: 8 },
+      willpower: { min: 2, max: 7 },
+      logic: { min: 1, max: 6 },
+      intuition: { min: 1, max: 6 },
+      charisma: { min: 1, max: 5 },
+      edge: { min: 1, max: 6 },
+    },
+    priorityAvailability: { A: 7, B: 4, C: 1, D: null, E: null },
+  },
+  {
+    id: "centaur",
+    name: "Centaur",
+    baseMetatype: null,
+    description: "Four-legged metasapient",
+    specialAttributePoints: 3,
+    racialTraits: ["Astral Perception", "Natural Weapon (Kick)"],
+    attributes: BASE_ATTRS,
+    priorityAvailability: { A: 6, B: 3, C: 0, D: null, E: null },
+  },
+];
+
+const POINT_BUY_METATYPES: MetatypeOption[] = METATYPES.map((m) => ({
+  ...m,
+  specialAttributePoints: 0,
+  karmaCost: m.id === "human" ? 0 : m.id === "centaur" ? 25 : 15,
+  priorityAvailability: undefined,
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function defaultProps(overrides: Partial<Parameters<typeof MetatypeModal>[0]> = {}) {
+  return {
+    isOpen: true,
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+    metatypes: METATYPES,
+    priorityLevel: "B",
+    currentSelection: null,
+    ...overrides,
+  };
+}
+
+/** Get the left list panel */
+function getListPanel() {
+  return screen.getByTestId("metatype-list");
+}
+
+/** Get the right detail panel */
+function getDetailPanel() {
+  return screen.getByTestId("metatype-detail");
+}
+
+/** Get the filter pills container */
+function getFilterPills() {
+  return screen.getByTestId("filter-pills");
+}
+
+/** Click a metatype in the list panel by name */
+async function clickListItem(user: ReturnType<typeof userEvent.setup>, name: RegExp) {
+  const list = getListPanel();
+  const item = within(list).getByRole("button", { name });
+  await user.click(item);
+}
+
+/** Click a filter pill by name */
+async function clickFilterPill(user: ReturnType<typeof userEvent.setup>, name: string) {
+  const pills = getFilterPills();
+  await user.click(within(pills).getByRole("button", { name }));
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("MetatypeModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("renders nothing when closed", () => {
+      const { container } = render(<MetatypeModal {...defaultProps({ isOpen: false })} />);
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("renders the modal when open", () => {
+      render(<MetatypeModal {...defaultProps()} />);
+      expect(screen.getByText("Select Metatype")).toBeInTheDocument();
+    });
+
+    it("renders all metatype groups in the list panel", () => {
+      render(<MetatypeModal {...defaultProps()} />);
+      const list = getListPanel();
+      // Group labels have counts like "Human (2)" — check for those patterns
+      expect(within(list).getByText("(2)")).toBeInTheDocument(); // Human group: Human + (count)
+      expect(within(list).getByText("Metasapients")).toBeInTheDocument();
+      // At least 4 groups rendered (Human, Elf, Dwarf, Metasapients)
+      const groupHeaders = list.querySelectorAll(".sticky");
+      expect(groupHeaders.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it("renders all metatypes in the list", () => {
+      render(<MetatypeModal {...defaultProps()} />);
+      const list = getListPanel();
+      for (const m of METATYPES) {
+        expect(within(list).getByRole("button", { name: new RegExp(m.name) })).toBeInTheDocument();
+      }
+    });
+
+    it("shows filter pills", () => {
+      render(<MetatypeModal {...defaultProps()} />);
+      const pills = getFilterPills();
+      expect(within(pills).getByRole("button", { name: "All" })).toBeInTheDocument();
+      expect(within(pills).getByRole("button", { name: "Elf" })).toBeInTheDocument();
+      expect(within(pills).getByRole("button", { name: "Sapient" })).toBeInTheDocument();
+    });
+
+    it("shows search input", () => {
+      render(<MetatypeModal {...defaultProps()} />);
+      expect(screen.getByPlaceholderText("Search metatypes...")).toBeInTheDocument();
+    });
+
+    it("shows empty detail panel when nothing selected", () => {
+      render(<MetatypeModal {...defaultProps()} />);
+      expect(screen.getByText("Select a metatype to see details")).toBeInTheDocument();
+    });
+
+    it("shows priority info in footer when priorityLevel provided", () => {
+      render(<MetatypeModal {...defaultProps()} />);
+      expect(screen.getByText(/Priority B/)).toBeInTheDocument();
+    });
+
+    it("shows point buy info in footer when no priorityLevel", () => {
+      render(
+        <MetatypeModal
+          {...defaultProps({ priorityLevel: undefined, metatypes: POINT_BUY_METATYPES })}
+        />
+      );
+      expect(screen.getByText(/Karma cost from budget/)).toBeInTheDocument();
+    });
+  });
+
+  describe("selection", () => {
+    it("selects a metatype and shows detail panel", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickListItem(user, /^Elf/);
+
+      const detail = getDetailPanel();
+      // Description comes from METATYPE_DESCRIPTIONS constant or option.description
+      expect(within(detail).getByText(/Graceful and long-lived/)).toBeInTheDocument();
+      expect(within(detail).getByText("Low-Light Vision")).toBeInTheDocument();
+    });
+
+    it("shows attributes in the detail panel", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickListItem(user, /^Elf/);
+
+      const detail = getDetailPanel();
+      expect(within(detail).getByText("AGI")).toBeInTheDocument();
+      expect(within(detail).getByText("CHA")).toBeInTheDocument();
+      expect(within(detail).getByText("2 / 7")).toBeInTheDocument();
+      expect(within(detail).getByText("3 / 8")).toBeInTheDocument();
+    });
+
+    it("highlights above-range attributes", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickListItem(user, /^Elf/);
+
+      const detail = getDetailPanel();
+      const agiCell = within(detail).getByText("AGI").closest("div");
+      expect(agiCell?.className).toContain("amber");
+    });
+
+    it("shows priority availability table for priority-based creation", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickListItem(user, /^Elf/);
+
+      const detail = getDetailPanel();
+      expect(within(detail).getByText("Priority Availability")).toBeInTheDocument();
+    });
+
+    it("does not show priority availability for point buy", async () => {
+      const user = userEvent.setup();
+      render(
+        <MetatypeModal
+          {...defaultProps({ priorityLevel: undefined, metatypes: POINT_BUY_METATYPES })}
+        />
+      );
+
+      await clickListItem(user, /^Elf/);
+
+      const detail = getDetailPanel();
+      expect(within(detail).queryByText("Priority Availability")).not.toBeInTheDocument();
+    });
+
+    it("shows karma cost for point buy metatypes", async () => {
+      const user = userEvent.setup();
+      render(
+        <MetatypeModal
+          {...defaultProps({ priorityLevel: undefined, metatypes: POINT_BUY_METATYPES })}
+        />
+      );
+
+      await clickListItem(user, /Centaur/);
+
+      const detail = getDetailPanel();
+      expect(within(detail).getByText("25")).toBeInTheDocument();
+    });
+
+    it("shows footer preview when metatype selected", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickListItem(user, /Nocturna/);
+
+      expect(screen.getByText(/3 traits/)).toBeInTheDocument();
+    });
+
+    it("pre-selects currentSelection when provided", () => {
+      render(<MetatypeModal {...defaultProps({ currentSelection: "elf" })} />);
+
+      const detail = getDetailPanel();
+      expect(within(detail).getByText(/Graceful and long-lived/)).toBeInTheDocument();
+      expect(screen.getByText(/1 trait/)).toBeInTheDocument();
+    });
+  });
+
+  describe("search", () => {
+    it("filters metatypes by search query", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await user.type(screen.getByPlaceholderText("Search metatypes..."), "noct");
+
+      const list = getListPanel();
+      expect(within(list).getByRole("button", { name: /Nocturna/ })).toBeInTheDocument();
+      expect(within(list).queryByRole("button", { name: /^Human/ })).not.toBeInTheDocument();
+      expect(within(list).queryByRole("button", { name: /^Dwarf/ })).not.toBeInTheDocument();
+    });
+
+    it("shows empty state when no matches", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await user.type(screen.getByPlaceholderText("Search metatypes..."), "zzzzz");
+
+      expect(screen.getByText("No metatypes match")).toBeInTheDocument();
+    });
+  });
+
+  describe("filter pills", () => {
+    it("filters by metatype family when pill clicked", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickFilterPill(user, "Elf");
+
+      const list = getListPanel();
+      expect(within(list).getByRole("button", { name: /^Elf/ })).toBeInTheDocument();
+      expect(within(list).getByRole("button", { name: /Nocturna/ })).toBeInTheDocument();
+      expect(within(list).queryByRole("button", { name: /^Human/ })).not.toBeInTheDocument();
+      expect(within(list).queryByRole("button", { name: /Centaur/ })).not.toBeInTheDocument();
+    });
+
+    it("shows all when All pill clicked after filtering", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickFilterPill(user, "Elf");
+      await clickFilterPill(user, "All");
+
+      const list = getListPanel();
+      for (const m of METATYPES) {
+        expect(within(list).getByRole("button", { name: new RegExp(m.name) })).toBeInTheDocument();
+      }
+    });
+
+    it("filters sapient metatypes", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickFilterPill(user, "Sapient");
+
+      const list = getListPanel();
+      expect(within(list).getByRole("button", { name: /Centaur/ })).toBeInTheDocument();
+      expect(within(list).queryByRole("button", { name: /^Elf/ })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("confirm and cancel", () => {
+    it("calls onConfirm and onClose when Confirm clicked", async () => {
+      const user = userEvent.setup();
+      const props = defaultProps();
+      render(<MetatypeModal {...props} />);
+
+      await clickListItem(user, /^Elf/);
+      await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+      expect(props.onConfirm).toHaveBeenCalledWith("elf");
+      expect(props.onClose).toHaveBeenCalled();
+    });
+
+    it("disables Confirm when nothing selected", () => {
+      render(<MetatypeModal {...defaultProps()} />);
+
+      const confirmBtn = screen.getByRole("button", { name: "Confirm" });
+      expect(confirmBtn).toBeDisabled();
+    });
+
+    it("calls onClose when Cancel clicked", async () => {
+      const user = userEvent.setup();
+      const props = defaultProps();
+      render(<MetatypeModal {...props} />);
+
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+      expect(props.onClose).toHaveBeenCalled();
+      expect(props.onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("calls onClose when backdrop clicked", async () => {
+      const user = userEvent.setup();
+      const props = defaultProps();
+      const { container } = render(<MetatypeModal {...props} />);
+
+      const backdrop = container.querySelector(".backdrop-blur-sm");
+      if (backdrop) {
+        await user.click(backdrop);
+      }
+
+      expect(props.onClose).toHaveBeenCalled();
+    });
+
+    it("does not call onConfirm on cancel even after selecting", async () => {
+      const user = userEvent.setup();
+      const props = defaultProps({ currentSelection: "human" });
+      render(<MetatypeModal {...props} />);
+
+      await clickListItem(user, /^Elf/);
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+      expect(props.onConfirm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("type badges", () => {
+    it("shows Base badge for base metatypes", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickListItem(user, /^Human/);
+
+      const detail = getDetailPanel();
+      expect(within(detail).getByText("Base")).toBeInTheDocument();
+    });
+
+    it("shows Variant badge for metavariants", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickListItem(user, /Nocturna/);
+
+      const detail = getDetailPanel();
+      expect(within(detail).getByText("Elf Variant")).toBeInTheDocument();
+    });
+
+    it("shows Metasapient badge for metasapients", async () => {
+      const user = userEvent.setup();
+      render(<MetatypeModal {...defaultProps()} />);
+
+      await clickListItem(user, /Centaur/);
+
+      const detail = getDetailPanel();
+      expect(within(detail).getByText("Metasapient")).toBeInTheDocument();
+    });
+  });
+});

--- a/components/creation/metatype/MetatypeCard.tsx
+++ b/components/creation/metatype/MetatypeCard.tsx
@@ -64,19 +64,40 @@ export function MetatypeCard({ state, updateState }: MetatypeCardProps) {
         const hasPriorityAvail = !!m.priorityAvailability?.[metatypePriority];
         return inPriorityTable || hasPriorityAvail;
       })
-      .map((m) => ({
-        id: m.id,
-        name: m.name,
-        baseMetatype: m.baseMetatype ?? null,
-        description: m.description,
-        specialAttributePoints:
-          priorityData.specialAttributePoints?.[m.id] ??
-          m.priorityAvailability?.[metatypePriority]?.specialAttributePoints ??
-          0,
-        racialTraits: m.racialTraits || [],
-        attributes: m.attributes as Record<string, { min: number; max: number }>,
-        karmaCost: m.karmaCost,
-      }));
+      .map((m) => {
+        // Build full priority availability map (A–E) for detail panel
+        const allLevels = ["A", "B", "C", "D", "E"];
+        const fullPriorityAvail: Record<string, number | null> = {};
+        for (const level of allLevels) {
+          const levelData = priorityTable?.table[level]?.metatype as
+            | { available: string[]; specialAttributePoints: Record<string, number> }
+            | undefined;
+          const inLevel = levelData?.available?.includes(m.id);
+          const variantAvail = m.priorityAvailability?.[level];
+          if (inLevel) {
+            fullPriorityAvail[level] = levelData?.specialAttributePoints?.[m.id] ?? 0;
+          } else if (variantAvail) {
+            fullPriorityAvail[level] = variantAvail.specialAttributePoints ?? 0;
+          } else {
+            fullPriorityAvail[level] = null;
+          }
+        }
+
+        return {
+          id: m.id,
+          name: m.name,
+          baseMetatype: m.baseMetatype ?? null,
+          description: m.description,
+          specialAttributePoints:
+            priorityData.specialAttributePoints?.[m.id] ??
+            m.priorityAvailability?.[metatypePriority]?.specialAttributePoints ??
+            0,
+          racialTraits: m.racialTraits || [],
+          attributes: m.attributes as Record<string, { min: number; max: number }>,
+          karmaCost: m.karmaCost,
+          priorityAvailability: fullPriorityAvail,
+        };
+      });
   }, [isPointBuy, metatypePriority, priorityTable, metatypes]);
 
   // Get selected metatype data

--- a/components/creation/metatype/MetatypeModal.tsx
+++ b/components/creation/metatype/MetatypeModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
-import { Check, X } from "lucide-react";
+import { useCallback, useMemo, useState, useEffect } from "react";
+import { Check, X, Search } from "lucide-react";
 import { METATYPE_DESCRIPTIONS } from "./constants";
 import type { MetatypeModalProps, MetatypeOption } from "./types";
 
@@ -14,10 +14,40 @@ const BASE_METATYPE_LABELS: Record<string, string> = {
   troll: "Troll",
 };
 
+/** Filter pill options */
+const FILTER_OPTIONS = [
+  { id: "all", label: "All" },
+  { id: "human", label: "Human" },
+  { id: "elf", label: "Elf" },
+  { id: "dwarf", label: "Dwarf" },
+  { id: "ork", label: "Ork" },
+  { id: "troll", label: "Troll" },
+  { id: "sapient", label: "Sapient" },
+] as const;
+
 interface MetatypeGroup {
+  readonly id: string;
   readonly label: string;
   readonly metatypes: readonly MetatypeOption[];
 }
+
+/** Standard human attribute range — attributes exceeding max 6 are highlighted */
+const STANDARD_MAX = 6;
+
+/** Attribute display abbreviations */
+const ATTRIBUTE_ABBREVS: Record<string, string> = {
+  body: "BOD",
+  agility: "AGI",
+  reaction: "REA",
+  strength: "STR",
+  willpower: "WIL",
+  logic: "LOG",
+  intuition: "INT",
+  charisma: "CHA",
+  edge: "EDG",
+  magic: "MAG",
+  resonance: "RES",
+};
 
 /** Group metatypes: base types first, then variants nested under parent, then metasapients */
 function groupMetatypes(metatypes: readonly MetatypeOption[]): readonly MetatypeGroup[] {
@@ -26,23 +56,213 @@ function groupMetatypes(metatypes: readonly MetatypeOption[]): readonly Metatype
 
   const groups: MetatypeGroup[] = [];
 
-  // Group base metatypes with their variants
   for (const base of baseTypes) {
     const label = BASE_METATYPE_LABELS[base.id];
     if (label) {
       const children = variants.filter((v) => v.baseMetatype === base.id);
-      groups.push({ label, metatypes: [base, ...children] });
+      groups.push({ id: base.id, label, metatypes: [base, ...children] });
     }
   }
 
-  // Metasapients: base types without a known label (centaur, naga, pixie, sasquatch)
   const metasapients = baseTypes.filter((m) => !BASE_METATYPE_LABELS[m.id]);
   if (metasapients.length > 0) {
-    groups.push({ label: "Metasapients", metatypes: metasapients });
+    groups.push({ id: "sapient", label: "Metasapients", metatypes: metasapients });
   }
 
   return groups;
 }
+
+/** Get the group id a metatype belongs to (for filtering) */
+function getMetatypeGroupId(metatype: MetatypeOption): string {
+  if (!metatype.baseMetatype && !BASE_METATYPE_LABELS[metatype.id]) {
+    return "sapient";
+  }
+  return metatype.baseMetatype || metatype.id;
+}
+
+/** Get the type badge for a metatype */
+function getTypeBadge(metatype: MetatypeOption): { label: string; className: string } {
+  if (!metatype.baseMetatype && BASE_METATYPE_LABELS[metatype.id]) {
+    return { label: "Base", className: "bg-zinc-700 text-zinc-300" };
+  }
+  if (metatype.baseMetatype) {
+    const parentLabel = BASE_METATYPE_LABELS[metatype.baseMetatype] || metatype.baseMetatype;
+    return { label: `${parentLabel} Variant`, className: "bg-sky-900/60 text-sky-300" };
+  }
+  return { label: "Metasapient", className: "bg-purple-900/60 text-purple-300" };
+}
+
+// ─── Detail Panel ────────────────────────────────────────────────────────────
+
+function MetatypeDetailPanel({
+  metatype,
+  priorityLevel,
+}: {
+  metatype: MetatypeOption | null;
+  priorityLevel?: string;
+}) {
+  if (!metatype) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm italic text-zinc-500">
+        Select a metatype to see details
+      </div>
+    );
+  }
+
+  const description = METATYPE_DESCRIPTIONS[metatype.id] || metatype.description || "";
+  const badge = getTypeBadge(metatype);
+  const attrs = Object.entries(metatype.attributes);
+
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div>
+        <h3 className="text-xl font-extrabold uppercase tracking-wide text-zinc-100">
+          {metatype.name}
+        </h3>
+        <div className="mt-1.5 flex gap-1.5">
+          <span
+            className={`inline-flex rounded px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${badge.className}`}
+          >
+            {badge.label}
+          </span>
+        </div>
+      </div>
+
+      {/* Cost chips */}
+      <div className="flex flex-wrap gap-2">
+        {metatype.karmaCost !== undefined && (
+          <div className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1 text-sm">
+            <span className="text-zinc-500">Karma</span>
+            <span
+              className={`font-mono font-semibold ${metatype.karmaCost > 0 ? "text-amber-400" : "text-emerald-400"}`}
+            >
+              {metatype.karmaCost > 0 ? metatype.karmaCost : "+0"}
+            </span>
+          </div>
+        )}
+        <div className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1 text-sm">
+          <span className="text-zinc-500">SAP</span>
+          <span className="font-mono font-semibold text-zinc-200">
+            {metatype.specialAttributePoints}
+          </span>
+        </div>
+      </div>
+
+      {/* Description */}
+      {description && <p className="text-sm leading-relaxed text-zinc-400">{description}</p>}
+
+      {/* Attributes */}
+      <div>
+        <div className="mb-2 border-b border-zinc-700 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500">
+          Attributes
+        </div>
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-3">
+          {attrs.map(([name, range]) => {
+            const abbrev = ATTRIBUTE_ABBREVS[name] || name.slice(0, 3).toUpperCase();
+            const isAboveRange = range.max > STANDARD_MAX;
+            return (
+              <div
+                key={name}
+                className={`flex items-center justify-between rounded-md border px-3 py-2 ${
+                  isAboveRange ? "border-amber-800/60 bg-zinc-900" : "border-zinc-700 bg-zinc-900"
+                }`}
+              >
+                <span
+                  className={`text-xs font-semibold uppercase ${
+                    isAboveRange ? "text-amber-400/80" : "text-zinc-500"
+                  }`}
+                >
+                  {abbrev}
+                </span>
+                <span
+                  className={`font-mono text-sm font-semibold ${
+                    isAboveRange ? "text-amber-400" : "text-zinc-300"
+                  }`}
+                >
+                  {range.min} / {range.max}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Racial Traits */}
+      <div>
+        <div className="mb-2 border-b border-zinc-700 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500">
+          Racial Traits
+        </div>
+        {metatype.racialTraits.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {metatype.racialTraits.map((trait) => (
+              <span
+                key={trait}
+                className="inline-flex rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1 text-xs text-zinc-300"
+              >
+                {trait}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <span className="text-sm text-zinc-500">None</span>
+        )}
+      </div>
+
+      {/* Priority Availability (only for priority-based, not point buy) */}
+      {metatype.priorityAvailability && priorityLevel && (
+        <div>
+          <div className="mb-2 border-b border-zinc-700 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500">
+            Priority Availability
+          </div>
+          <div className="flex gap-2">
+            {["A", "B", "C", "D", "E"].map((level) => {
+              const sap = metatype.priorityAvailability?.[level];
+              const isCurrent = level === priorityLevel;
+              const isUnavailable = sap === null || sap === undefined;
+              return (
+                <div
+                  key={level}
+                  className={`flex flex-1 flex-col items-center rounded-md border px-2 py-2 ${
+                    isCurrent
+                      ? "border-emerald-600 bg-emerald-900/30"
+                      : isUnavailable
+                        ? "border-zinc-800 bg-zinc-900 opacity-30"
+                        : "border-zinc-700 bg-zinc-900"
+                  }`}
+                >
+                  <span
+                    className={`text-[11px] font-bold uppercase ${
+                      isCurrent ? "text-emerald-400" : "text-zinc-500"
+                    }`}
+                  >
+                    {level}
+                  </span>
+                  <span
+                    className={`font-mono text-base font-bold ${
+                      isCurrent
+                        ? "text-emerald-300"
+                        : isUnavailable
+                          ? "text-zinc-600"
+                          : "text-zinc-300"
+                    }`}
+                  >
+                    {isUnavailable ? "-" : sap}
+                  </span>
+                  {!isUnavailable && (
+                    <span className="text-[9px] uppercase text-zinc-600">SAP</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Modal ──────────────────────────────────────────────────────────────
 
 export function MetatypeModal({
   isOpen,
@@ -53,10 +273,20 @@ export function MetatypeModal({
   currentSelection,
 }: MetatypeModalProps) {
   const [selectedId, setSelectedId] = useState<string | null>(currentSelection);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeFilter, setActiveFilter] = useState("all");
 
   const groups = useMemo(() => groupMetatypes(metatypes), [metatypes]);
 
-  // Reset selection when modal opens
+  // Reset state when modal opens with new data
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedId(currentSelection);
+      setSearchQuery("");
+      setActiveFilter("all");
+    }
+  }, [isOpen, currentSelection]);
+
   const handleClose = useCallback(() => {
     setSelectedId(currentSelection);
     onClose();
@@ -69,165 +299,208 @@ export function MetatypeModal({
     }
   }, [selectedId, onConfirm, onClose]);
 
+  // Filter metatypes by search + group filter
+  const filteredGroups = useMemo(() => {
+    const query = searchQuery.toLowerCase().trim();
+    return groups
+      .map((group) => {
+        const filtered = group.metatypes.filter((m) => {
+          const matchesSearch = !query || m.name.toLowerCase().includes(query);
+          const matchesFilter = activeFilter === "all" || getMetatypeGroupId(m) === activeFilter;
+          return matchesSearch && matchesFilter;
+        });
+        return { ...group, metatypes: filtered };
+      })
+      .filter((group) => group.metatypes.length > 0);
+  }, [groups, searchQuery, activeFilter]);
+
+  // Get the metatype for detail panel (selected or first available)
+  const detailMetatype = useMemo(() => {
+    if (selectedId) {
+      return metatypes.find((m) => m.id === selectedId) ?? null;
+    }
+    return null;
+  }, [selectedId, metatypes]);
+
+  // Selected metatype data for footer preview
+  const selectedMetatype = useMemo(() => {
+    return selectedId ? metatypes.find((m) => m.id === selectedId) : null;
+  }, [selectedId, metatypes]);
+
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={handleClose} />
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
 
       {/* Modal */}
-      <div className="relative max-h-[90vh] w-full max-w-2xl overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-zinc-900">
+      <div className="relative flex max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-xl bg-zinc-900 shadow-2xl">
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-            SELECT METATYPE
+        <div className="flex items-center justify-between border-b border-zinc-700 px-6 py-4">
+          <h2 className="text-lg font-bold uppercase tracking-wide text-zinc-100">
+            Select Metatype
           </h2>
           <button
             onClick={handleClose}
-            className="rounded-lg p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+            className="rounded-lg p-2 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-300"
           >
             <X className="h-5 w-5" />
           </button>
         </div>
 
-        {/* Priority / Point Buy info */}
-        <div className="border-b border-zinc-100 bg-zinc-50 px-6 py-3 dark:border-zinc-800 dark:bg-zinc-800/50">
-          <p className="text-sm text-zinc-600 dark:text-zinc-400">
-            {priorityLevel ? (
-              <>
-                Available at Priority {priorityLevel}:{" "}
-                <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                  {metatypes.length} metatype{metatypes.length !== 1 ? "s" : ""}
-                </span>
-              </>
-            ) : (
-              <>
-                All metatypes available —{" "}
-                <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                  Karma cost deducted from budget
-                </span>
-              </>
-            )}
-          </p>
-        </div>
+        {/* Toolbar: search + filter pills */}
+        <div className="flex items-center gap-3 border-b border-zinc-700 bg-zinc-800/50 px-6 py-3">
+          {/* Search */}
+          <div className="flex flex-1 items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2">
+            <Search className="h-4 w-4 shrink-0 text-zinc-500" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search metatypes..."
+              className="w-full bg-transparent text-sm text-zinc-200 placeholder-zinc-600 outline-none"
+            />
+          </div>
 
-        {/* Metatype list grouped by base type */}
-        <div className="max-h-[60vh] overflow-y-auto p-4">
-          <div className="space-y-4">
-            {groups.map((group) => (
-              <div key={group.label}>
-                {/* Group header */}
-                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                  {group.label}
-                  {group.metatypes.length > 1 && (
-                    <span className="ml-1 font-normal">({group.metatypes.length})</span>
-                  )}
-                </h3>
-                <div className="space-y-2">
-                  {group.metatypes.map((metatype) => {
-                    const isSelected = selectedId === metatype.id;
-                    const isVariant = !!metatype.baseMetatype;
-                    const description =
-                      METATYPE_DESCRIPTIONS[metatype.id] || metatype.description || "";
-
-                    return (
-                      <button
-                        key={metatype.id}
-                        onClick={() => setSelectedId(metatype.id)}
-                        className={`w-full rounded-lg border-2 p-4 text-left transition-all ${
-                          isVariant ? "ml-4" : ""
-                        } ${
-                          isSelected
-                            ? "border-emerald-500 bg-emerald-50 dark:border-emerald-500 dark:bg-emerald-900/20"
-                            : "border-zinc-200 bg-white hover:border-emerald-400 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:border-emerald-500"
-                        }`}
-                      >
-                        {/* Header row */}
-                        <div className="flex items-center gap-3">
-                          {/* Radio indicator */}
-                          <div
-                            className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
-                              isSelected
-                                ? "border-emerald-500 bg-emerald-500 text-white"
-                                : "border-zinc-300 dark:border-zinc-600"
-                            }`}
-                          >
-                            {isSelected && <Check className="h-3 w-3" />}
-                          </div>
-
-                          <div className="flex items-center gap-2">
-                            <span
-                              className={`text-base font-semibold uppercase ${
-                                isSelected
-                                  ? "text-emerald-900 dark:text-emerald-100"
-                                  : "text-zinc-900 dark:text-zinc-100"
-                              }`}
-                            >
-                              {metatype.name}
-                            </span>
-                            {isVariant && (
-                              <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium uppercase text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400">
-                                Variant
-                              </span>
-                            )}
-                          </div>
-                        </div>
-
-                        {/* Description */}
-                        {description && (
-                          <p className="mt-2 pl-8 text-sm text-zinc-600 dark:text-zinc-400">
-                            {description}
-                          </p>
-                        )}
-
-                        {/* Stats */}
-                        <div className="mt-3 space-y-1 pl-8 text-sm">
-                          {metatype.karmaCost !== undefined && metatype.karmaCost > 0 && (
-                            <div className="text-zinc-700 dark:text-zinc-300">
-                              <span className="font-medium">Karma Cost:</span>{" "}
-                              <span className="font-mono">{metatype.karmaCost}</span>
-                            </div>
-                          )}
-                          <div className="text-zinc-700 dark:text-zinc-300">
-                            <span className="font-medium">Special Attribute Points:</span>{" "}
-                            {metatype.specialAttributePoints}
-                          </div>
-                          <div className="text-zinc-700 dark:text-zinc-300">
-                            <span className="font-medium">Racial Traits:</span>{" "}
-                            {metatype.racialTraits.length > 0
-                              ? metatype.racialTraits.join(", ")
-                              : "None"}
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
+          {/* Filter pills */}
+          <div className="hidden gap-1 sm:flex" data-testid="filter-pills">
+            {FILTER_OPTIONS.map((opt) => (
+              <button
+                key={opt.id}
+                onClick={() => setActiveFilter(opt.id)}
+                className={`rounded-md px-2.5 py-1 text-xs font-semibold uppercase tracking-wide transition-colors ${
+                  activeFilter === opt.id
+                    ? "bg-emerald-600 text-white"
+                    : "border border-zinc-700 text-zinc-400 hover:border-zinc-600 hover:text-zinc-300"
+                }`}
+              >
+                {opt.label}
+              </button>
             ))}
           </div>
         </div>
 
+        {/* Two-panel body */}
+        <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
+          {/* Left panel: browse list */}
+          <div
+            data-testid="metatype-list"
+            className="max-h-[200px] w-full shrink-0 overflow-y-auto border-b border-zinc-700 bg-zinc-800/30 sm:max-h-none sm:w-60 sm:border-b-0 sm:border-r [scrollbar-width:thin]"
+          >
+            {filteredGroups.length === 0 ? (
+              <div className="p-4 text-center text-sm italic text-zinc-500">No metatypes match</div>
+            ) : (
+              filteredGroups.map((group) => (
+                <div key={group.label}>
+                  {/* Group header */}
+                  <div className="sticky top-0 z-10 bg-zinc-800/80 px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-zinc-500 backdrop-blur-sm">
+                    {group.label}
+                    <span className="ml-1 font-normal text-zinc-600">
+                      ({group.metatypes.length})
+                    </span>
+                  </div>
+
+                  {/* Metatype items */}
+                  {group.metatypes.map((metatype) => {
+                    const isSelected = selectedId === metatype.id;
+                    const isVariant = !!metatype.baseMetatype;
+                    return (
+                      <button
+                        key={metatype.id}
+                        onClick={() => setSelectedId(metatype.id)}
+                        className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors ${
+                          isSelected
+                            ? "bg-emerald-900/30 text-emerald-300"
+                            : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+                        }`}
+                      >
+                        {/* Radio dot */}
+                        <div
+                          className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border-2 ${
+                            isSelected ? "border-emerald-500 bg-emerald-500" : "border-zinc-600"
+                          }`}
+                        >
+                          {isSelected && <Check className="h-2.5 w-2.5 text-white" />}
+                        </div>
+
+                        {/* Name */}
+                        <span className={`flex-1 font-medium ${isVariant ? "pl-2" : ""}`}>
+                          {metatype.name}
+                        </span>
+
+                        {/* SAP */}
+                        <span
+                          className={`font-mono text-xs ${
+                            isSelected ? "text-emerald-400" : "text-zinc-600"
+                          }`}
+                        >
+                          {metatype.specialAttributePoints}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Right panel: detail */}
+          <div
+            data-testid="metatype-detail"
+            className="flex-1 overflow-y-auto p-5 [scrollbar-width:thin]"
+          >
+            <MetatypeDetailPanel metatype={detailMetatype} priorityLevel={priorityLevel} />
+          </div>
+        </div>
+
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 border-t border-zinc-200 px-6 py-4 dark:border-zinc-700">
-          <button
-            onClick={handleClose}
-            className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleConfirm}
-            disabled={!selectedId}
-            className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
-              selectedId
-                ? "bg-emerald-600 text-white hover:bg-emerald-700"
-                : "cursor-not-allowed bg-zinc-200 text-zinc-400 dark:bg-zinc-700 dark:text-zinc-500"
-            }`}
-          >
-            Confirm
-          </button>
+        <div className="flex items-center justify-between border-t border-zinc-700 bg-zinc-800/50 px-6 py-3">
+          <div className="text-sm text-zinc-500">
+            {selectedMetatype ? (
+              <div className="flex items-center gap-2">
+                <div className="h-2 w-2 rounded-full bg-emerald-500" />
+                <span>
+                  Selected: <strong className="text-zinc-300">{selectedMetatype.name}</strong>
+                  <span className="text-zinc-600"> · </span>
+                  {selectedMetatype.specialAttributePoints} SAP
+                  {selectedMetatype.racialTraits.length > 0 && (
+                    <>
+                      <span className="text-zinc-600"> · </span>
+                      {selectedMetatype.racialTraits.length} trait
+                      {selectedMetatype.racialTraits.length !== 1 ? "s" : ""}
+                    </>
+                  )}
+                </span>
+              </div>
+            ) : (
+              <span>
+                {priorityLevel
+                  ? `Priority ${priorityLevel}: ${metatypes.length} metatype${metatypes.length !== 1 ? "s" : ""}`
+                  : `All metatypes available — Karma cost from budget`}
+              </span>
+            )}
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              onClick={handleClose}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-400 hover:bg-zinc-800 hover:text-zinc-300"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirm}
+              disabled={!selectedId}
+              className={`rounded-lg px-4 py-2 text-sm font-semibold transition-colors ${
+                selectedId
+                  ? "bg-emerald-600 text-white hover:bg-emerald-700"
+                  : "cursor-not-allowed bg-zinc-700 text-zinc-500"
+              }`}
+            >
+              Confirm
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/components/creation/metatype/types.ts
+++ b/components/creation/metatype/types.ts
@@ -15,6 +15,8 @@ export interface MetatypeOption {
   attributes: Record<string, { min: number; max: number }>;
   /** Karma cost for Point Buy creation (undefined for priority-based methods) */
   karmaCost?: number;
+  /** SAP at each priority level (A–E). null = unavailable at that level. */
+  priorityAvailability?: Record<string, number | null>;
 }
 
 export interface MetatypeModalProps {

--- a/lib/storage/__tests__/characters.test.ts
+++ b/lib/storage/__tests__/characters.test.ts
@@ -2,64 +2,84 @@
  * Tests for character storage layer
  *
  * Tests character CRUD operations, filtering, and gameplay functions.
- *
- * NOTE: These tests use the actual data directory. For proper isolation,
- * the storage layer should be refactored to support configurable data paths.
- * These tests use unique test user IDs to minimize conflicts with real data.
+ * Uses a temporary directory via CHARACTER_DATA_DIR env var for full isolation.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { promises as fs } from "fs";
 import path from "path";
-import {
-  getCharacter,
-  getUserCharacters,
-  getAllCharacters,
-  getCharactersByStatus,
-  getDraftCharacters,
-  getActiveCharacters,
-  getCharactersByEdition,
-  getCharactersByCampaign,
-  createCharacterDraft,
-  updateCharacter,
-  finalizeCharacter,
-  deleteCharacter,
-  updateCharacterAttributes,
-  updateCharacterSkills,
-  updateCharacterQualities,
-  updateCharacterGear,
-  applyDamage,
-  healCharacter,
-  spendKarma,
-  awardKarma,
-  setCharacterCampaign,
-  retireCharacter,
-  killCharacter,
-} from "../characters";
+import os from "os";
 
-const TEST_DATA_DIR = path.join(process.cwd(), "__tests__", "temp-characters");
+let testDir: string;
+
+// Dynamic imports so we can set CHARACTER_DATA_DIR before module evaluation
+let getCharacter: typeof import("../characters").getCharacter;
+let getUserCharacters: typeof import("../characters").getUserCharacters;
+let getAllCharacters: typeof import("../characters").getAllCharacters;
+let getCharactersByStatus: typeof import("../characters").getCharactersByStatus;
+let getDraftCharacters: typeof import("../characters").getDraftCharacters;
+let getActiveCharacters: typeof import("../characters").getActiveCharacters;
+let getCharactersByEdition: typeof import("../characters").getCharactersByEdition;
+let getCharactersByCampaign: typeof import("../characters").getCharactersByCampaign;
+let createCharacterDraft: typeof import("../characters").createCharacterDraft;
+let updateCharacter: typeof import("../characters").updateCharacter;
+let finalizeCharacter: typeof import("../characters").finalizeCharacter;
+let deleteCharacter: typeof import("../characters").deleteCharacter;
+let updateCharacterAttributes: typeof import("../characters").updateCharacterAttributes;
+let updateCharacterSkills: typeof import("../characters").updateCharacterSkills;
+let updateCharacterQualities: typeof import("../characters").updateCharacterQualities;
+let updateCharacterGear: typeof import("../characters").updateCharacterGear;
+let applyDamage: typeof import("../characters").applyDamage;
+let healCharacter: typeof import("../characters").healCharacter;
+let spendKarma: typeof import("../characters").spendKarma;
+let awardKarma: typeof import("../characters").awardKarma;
+let setCharacterCampaign: typeof import("../characters").setCharacterCampaign;
+let retireCharacter: typeof import("../characters").retireCharacter;
+let killCharacter: typeof import("../characters").killCharacter;
 
 describe("Character Storage", () => {
-  // Use unique test user IDs with timestamp to avoid conflicts
-  const timestamp = Date.now();
-  const userId1 = `test-user-1-${timestamp}`;
-  const userId2 = `test-user-2-${timestamp}`;
+  const userId1 = "test-user-1";
+  const userId2 = "test-user-2";
 
   beforeEach(async () => {
-    // Clean up test directory
-    try {
-      await fs.rm(TEST_DATA_DIR, { recursive: true, force: true });
-    } catch {
-      // Ignore
-    }
+    // Create isolated temp directory for each test
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), "character-storage-test-"));
+    process.env.CHARACTER_DATA_DIR = testDir;
+
+    // Reset module cache so characters.ts picks up the new env var
+    vi.resetModules();
+    const chars = await import("../characters");
+    getCharacter = chars.getCharacter;
+    getUserCharacters = chars.getUserCharacters;
+    getAllCharacters = chars.getAllCharacters;
+    getCharactersByStatus = chars.getCharactersByStatus;
+    getDraftCharacters = chars.getDraftCharacters;
+    getActiveCharacters = chars.getActiveCharacters;
+    getCharactersByEdition = chars.getCharactersByEdition;
+    getCharactersByCampaign = chars.getCharactersByCampaign;
+    createCharacterDraft = chars.createCharacterDraft;
+    updateCharacter = chars.updateCharacter;
+    finalizeCharacter = chars.finalizeCharacter;
+    deleteCharacter = chars.deleteCharacter;
+    updateCharacterAttributes = chars.updateCharacterAttributes;
+    updateCharacterSkills = chars.updateCharacterSkills;
+    updateCharacterQualities = chars.updateCharacterQualities;
+    updateCharacterGear = chars.updateCharacterGear;
+    applyDamage = chars.applyDamage;
+    healCharacter = chars.healCharacter;
+    spendKarma = chars.spendKarma;
+    awardKarma = chars.awardKarma;
+    setCharacterCampaign = chars.setCharacterCampaign;
+    retireCharacter = chars.retireCharacter;
+    killCharacter = chars.killCharacter;
   });
 
   afterEach(async () => {
-    // Clean up test directory
+    delete process.env.CHARACTER_DATA_DIR;
     try {
-      await fs.rm(TEST_DATA_DIR, { recursive: true, force: true });
+      await fs.rm(testDir, { recursive: true, force: true });
     } catch {
-      // Ignore
+      // Ignore cleanup errors
     }
   });
 
@@ -133,31 +153,27 @@ describe("Character Storage", () => {
 
       const characters = await getUserCharacters(userId1);
 
-      // Should include our test characters
-      const testCharIds = [char1.id, char2.id];
-      const foundChars = characters.filter((c) => testCharIds.includes(c.id));
-      expect(foundChars.length).toBe(2);
+      expect(characters.length).toBe(2);
       expect(characters.map((c) => c.id)).toContain(char1.id);
       expect(characters.map((c) => c.id)).toContain(char2.id);
     });
 
     it("should return empty array for user with no characters", async () => {
-      // Use a unique user ID that definitely has no characters
-      const uniqueUserId = `test-empty-user-${Date.now()}`;
-      const characters = await getUserCharacters(uniqueUserId);
+      const characters = await getUserCharacters("nonexistent-user");
       expect(characters).toEqual([]);
     });
 
     it("should only return characters for specified user", async () => {
-      const char1 = await createCharacterDraft(userId1, "sr5", "sr5", "priority", "User1");
-      const char2 = await createCharacterDraft(userId2, "sr5", "sr5", "priority", "User2");
+      await createCharacterDraft(userId1, "sr5", "sr5", "priority", "User1");
+      await createCharacterDraft(userId2, "sr5", "sr5", "priority", "User2");
 
       const user1Chars = await getUserCharacters(userId1);
       const user2Chars = await getUserCharacters(userId2);
 
-      // Should find our test characters
-      expect(user1Chars.find((c) => c.id === char1.id)?.name).toBe("User1");
-      expect(user2Chars.find((c) => c.id === char2.id)?.name).toBe("User2");
+      expect(user1Chars.length).toBe(1);
+      expect(user1Chars[0].name).toBe("User1");
+      expect(user2Chars.length).toBe(1);
+      expect(user2Chars[0].name).toBe("User2");
     });
   });
 
@@ -170,11 +186,12 @@ describe("Character Storage", () => {
       const drafts = await getCharactersByStatus(userId1, "draft");
       const active = await getCharactersByStatus(userId1, "active");
 
-      // Should find our test characters
-      expect(drafts.find((c) => c.id === draft2.id)).toBeDefined();
-      expect(active.find((c) => c.id === draft1.id)).toBeDefined();
-      expect(drafts.find((c) => c.id === draft2.id)?.status).toBe("draft");
-      expect(active.find((c) => c.id === draft1.id)?.status).toBe("active");
+      expect(drafts.length).toBe(1);
+      expect(drafts[0].id).toBe(draft2.id);
+      expect(drafts[0].status).toBe("draft");
+      expect(active.length).toBe(1);
+      expect(active[0].id).toBe(draft1.id);
+      expect(active[0].status).toBe("active");
     });
   });
 
@@ -185,10 +202,9 @@ describe("Character Storage", () => {
       await finalizeCharacter(userId1, draft2.id);
 
       const drafts = await getDraftCharacters(userId1);
-      // Should include our test draft character
-      const testDraft = drafts.find((c) => c.id === draft1.id);
-      expect(testDraft).toBeDefined();
-      expect(testDraft?.status).toBe("draft");
+      expect(drafts.length).toBe(1);
+      expect(drafts[0].id).toBe(draft1.id);
+      expect(drafts[0].status).toBe("draft");
     });
 
     it("should return active characters", async () => {
@@ -196,26 +212,24 @@ describe("Character Storage", () => {
       await finalizeCharacter(userId1, char.id);
 
       const active = await getActiveCharacters(userId1);
-      // Should include our test active character
-      const testActive = active.find((c) => c.id === char.id);
-      expect(testActive).toBeDefined();
-      expect(testActive?.status).toBe("active");
+      expect(active.length).toBe(1);
+      expect(active[0].id).toBe(char.id);
+      expect(active[0].status).toBe("active");
     });
   });
 
   describe("getCharactersByEdition", () => {
     it("should filter characters by edition", async () => {
-      const sr5Char = await createCharacterDraft(userId1, "sr5", "sr5", "priority", "SR5 Char");
-      const sr6Char = await createCharacterDraft(userId1, "sr6", "sr6", "priority", "SR6 Char");
+      await createCharacterDraft(userId1, "sr5", "sr5", "priority", "SR5 Char");
+      await createCharacterDraft(userId1, "sr6", "sr6", "priority", "SR6 Char");
 
       const sr5Chars = await getCharactersByEdition(userId1, "sr5");
       const sr6Chars = await getCharactersByEdition(userId1, "sr6");
 
-      // Should include our test characters
-      expect(sr5Chars.find((c) => c.id === sr5Char.id)).toBeDefined();
-      expect(sr5Chars.find((c) => c.id === sr5Char.id)?.editionCode).toBe("sr5");
-      expect(sr6Chars.find((c) => c.id === sr6Char.id)).toBeDefined();
-      expect(sr6Chars.find((c) => c.id === sr6Char.id)?.editionCode).toBe("sr6");
+      expect(sr5Chars.length).toBe(1);
+      expect(sr5Chars[0].editionCode).toBe("sr5");
+      expect(sr6Chars.length).toBe(1);
+      expect(sr6Chars[0].editionCode).toBe("sr6");
     });
   });
 
@@ -477,11 +491,11 @@ describe("Character Storage", () => {
       const char2 = await createCharacterDraft(userId2, "sr5", "sr5", "priority", "User2");
 
       const all = await getAllCharacters();
-      // Should include our test characters
+      expect(all.length).toBe(2);
       expect(all.find((c) => c.id === char1.id)).toBeDefined();
       expect(all.find((c) => c.id === char2.id)).toBeDefined();
       expect(all.find((c) => c.id === char1.id)?.name).toBe("User1");
       expect(all.find((c) => c.id === char2.id)?.name).toBe("User2");
-    }, 10000); // File I/O across multiple user directories can be slow
+    });
   });
 });

--- a/lib/storage/characters.ts
+++ b/lib/storage/characters.ts
@@ -88,7 +88,9 @@ export interface CharacterSummary {
 }
 import { ensureDirectory, readJsonFile, writeJsonFile, deleteFile, readAllJsonFiles } from "./base";
 
-const CHARACTERS_DIR = path.join(process.cwd(), "data", "characters");
+function getCharactersDir(): string {
+  return process.env.CHARACTER_DATA_DIR || path.join(process.cwd(), "data", "characters");
+}
 
 // =============================================================================
 // DATA NORMALIZATION
@@ -127,7 +129,7 @@ function ensureItemIds(character: Character): Character {
  * Get the directory path for a user's characters
  */
 function getUserCharactersDir(userId: ID): string {
-  return path.join(CHARACTERS_DIR, userId);
+  return path.join(getCharactersDir(), userId);
 }
 
 /**
@@ -173,7 +175,7 @@ export async function getUserCharacters(userId: ID): Promise<Character[]> {
  */
 export async function getAllCharacters(): Promise<Character[]> {
   const { listSubdirectories } = await import("./base");
-  const userDirs = await listSubdirectories(CHARACTERS_DIR);
+  const userDirs = await listSubdirectories(getCharactersDir());
   const allCharacters: Character[] = [];
 
   for (const userId of userDirs) {


### PR DESCRIPTION
## Summary
- Redesigns the metatype selection modal from a single-column card scroll to a two-panel browse + detail layout to handle 26+ metatypes
- Left panel: compact grouped list with search input and filter pills (All/Human/Elf/Dwarf/Ork/Troll/Sapient)
- Right panel: full detail view with name, type badge, SAP/karma chips, description, attribute grid (with above-range highlighting), racial trait chips, and priority availability table
- Responsive: stacks vertically on mobile (<640px)
- Fixes flaky `getAllCharacters` test by adding `CHARACTER_DATA_DIR` env var support and migrating character storage tests to isolated temp directories
- Created #571 to track remaining storage tests that still hit real `data/` directory

## Test plan
- [x] 30 new MetatypeModal tests covering rendering, selection, search, filters, confirm/cancel, type badges
- [x] All 38 character storage tests pass with temp directory isolation (268ms, previously timing out at 10s+)
- [x] Full test suite: 415/415 files, 8855/8855 tests pass
- [x] TypeScript type-check clean
- [x] Lint + knip pass

Closes #570