### PR TITLE
feat: Life Modules duplicate quality resolution

### DIFF
--- a/__tests__/components/creation/LifeModulesCard.test.tsx
+++ b/__tests__/components/creation/LifeModulesCard.test.tsx
@@ -21,6 +21,7 @@ vi.mock("lucide-react", () => {
     X: createIcon("X"),
     ChevronRight: createIcon("ChevronRight"),
     Check: createIcon("Check"),
+    ArrowRightLeft: createIcon("ArrowRightLeft"),
   };
 });
 
@@ -109,6 +110,7 @@ const mockCatalog: LifeModulesCatalog = {
 
 vi.mock("@/lib/rules/RulesetContext", () => ({
   useLifeModules: () => mockCatalog,
+  useQualities: () => ({ positive: [], negative: [] }),
 }));
 
 function makeState(overrides: Partial<CreationState> = {}): CreationState {

--- a/__tests__/lib/rules/life-modules/grant-resolver.test.ts
+++ b/__tests__/lib/rules/life-modules/grant-resolver.test.ts
@@ -3,8 +3,16 @@ import {
   resolveLifeModuleGrants,
   lookupModule,
   EMPTY_GRANTS,
+  detectDuplicateQualities,
+  applyQualityReplacements,
+  type DuplicateQualityInfo,
 } from "@/lib/rules/life-modules/grant-resolver";
-import type { LifeModulesCatalog, LifeModuleSelection, LifeModule } from "@/lib/types/life-modules";
+import type {
+  LifeModulesCatalog,
+  LifeModuleSelection,
+  LifeModule,
+  LifeModuleQualityGrant,
+} from "@/lib/types/life-modules";
 
 // =============================================================================
 // TEST CATALOG FIXTURES
@@ -124,7 +132,24 @@ const testCatalog: LifeModulesCatalog = {
       knowledgeSkills: { "military-tactics": 8 },
     }),
   ],
-  tour: [],
+  tour: [
+    // Module that also grants toughness — for duplicate testing
+    makeModule({
+      id: "combat-tour",
+      phase: "tour",
+      karmaCost: 60,
+      yearsAdded: 2,
+      qualities: [{ id: "toughness", type: "positive" }],
+    }),
+    // Module that grants a unique quality
+    makeModule({
+      id: "diplomatic-tour",
+      phase: "tour",
+      karmaCost: 60,
+      yearsAdded: 2,
+      qualities: [{ id: "first-impression", type: "positive" }],
+    }),
+  ],
 };
 
 // =============================================================================
@@ -444,5 +469,176 @@ describe("resolveLifeModuleGrants", () => {
       // Age: 0 + 10 + 7 + 4 = 21
       expect(result.calculatedAge).toBe(21);
     });
+  });
+});
+
+// =============================================================================
+// detectDuplicateQualities
+// =============================================================================
+
+describe("detectDuplicateQualities", () => {
+  it("returns empty array when no duplicates exist", () => {
+    const accumulated: readonly LifeModuleQualityGrant[] = [{ id: "toughness", type: "positive" }];
+    const incoming: readonly LifeModuleQualityGrant[] = [
+      { id: "first-impression", type: "positive" },
+    ];
+
+    const result = detectDuplicateQualities(accumulated, incoming);
+    expect(result).toEqual([]);
+  });
+
+  it("detects a duplicate quality between accumulated and incoming", () => {
+    const accumulated: readonly LifeModuleQualityGrant[] = [{ id: "toughness", type: "positive" }];
+    const incoming: readonly LifeModuleQualityGrant[] = [{ id: "toughness", type: "positive" }];
+
+    const result = detectDuplicateQualities(accumulated, incoming);
+    expect(result).toHaveLength(1);
+    expect(result[0].qualityId).toBe("toughness");
+    expect(result[0].type).toBe("positive");
+  });
+
+  it("detects duplicates against existing character qualities", () => {
+    const accumulated: readonly LifeModuleQualityGrant[] = [];
+    const incoming: readonly LifeModuleQualityGrant[] = [{ id: "toughness", type: "positive" }];
+    const existingCharacterQualityIds = ["toughness"];
+
+    const result = detectDuplicateQualities(accumulated, incoming, existingCharacterQualityIds);
+    expect(result).toHaveLength(1);
+    expect(result[0].qualityId).toBe("toughness");
+  });
+
+  it("detects multiple duplicates in one incoming batch", () => {
+    const accumulated: readonly LifeModuleQualityGrant[] = [
+      { id: "toughness", type: "positive" },
+      { id: "sinner-national", type: "negative" },
+    ];
+    const incoming: readonly LifeModuleQualityGrant[] = [
+      { id: "toughness", type: "positive" },
+      { id: "sinner-national", type: "negative" },
+      { id: "first-impression", type: "positive" },
+    ];
+
+    const result = detectDuplicateQualities(accumulated, incoming);
+    expect(result).toHaveLength(2);
+    expect(result.map((d) => d.qualityId)).toEqual(["toughness", "sinner-national"]);
+  });
+
+  it("does not flag the same quality within incoming only (no prior accumulation)", () => {
+    const accumulated: readonly LifeModuleQualityGrant[] = [];
+    const incoming: readonly LifeModuleQualityGrant[] = [{ id: "toughness", type: "positive" }];
+
+    const result = detectDuplicateQualities(accumulated, incoming);
+    expect(result).toEqual([]);
+  });
+
+  it("excludes already-replaced quality IDs from detection", () => {
+    const accumulated: readonly LifeModuleQualityGrant[] = [{ id: "toughness", type: "positive" }];
+    const incoming: readonly LifeModuleQualityGrant[] = [{ id: "toughness", type: "positive" }];
+    const alreadyReplacedIds = ["toughness"];
+
+    const result = detectDuplicateQualities(accumulated, incoming, [], alreadyReplacedIds);
+    expect(result).toEqual([]);
+  });
+});
+
+// =============================================================================
+// applyQualityReplacements
+// =============================================================================
+
+describe("applyQualityReplacements", () => {
+  it("returns qualities unchanged when no replacements", () => {
+    const qualities: readonly LifeModuleQualityGrant[] = [
+      { id: "toughness", type: "positive" },
+      { id: "sinner-national", type: "negative" },
+    ];
+
+    const result = applyQualityReplacements(qualities, []);
+    expect(result).toEqual(qualities);
+  });
+
+  it("replaces a duplicate quality with the chosen replacement", () => {
+    const qualities: readonly LifeModuleQualityGrant[] = [
+      { id: "toughness", type: "positive" },
+      { id: "toughness", type: "positive" }, // duplicate from second module
+    ];
+    const replacements = [
+      { originalQualityId: "toughness", replacementQualityId: "natural-athlete" },
+    ];
+
+    const result = applyQualityReplacements(qualities, replacements);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ id: "toughness", type: "positive" });
+    // Second occurrence replaced
+    expect(result[1]).toEqual({ id: "natural-athlete", type: "positive" });
+  });
+
+  it("replaces only the second occurrence (keeps first)", () => {
+    const qualities: readonly LifeModuleQualityGrant[] = [
+      { id: "first-impression", type: "positive" },
+      { id: "toughness", type: "positive" },
+      { id: "sinner-national", type: "negative" },
+      { id: "toughness", type: "positive" }, // dup
+    ];
+    const replacements = [{ originalQualityId: "toughness", replacementQualityId: "guts" }];
+
+    const result = applyQualityReplacements(qualities, replacements);
+    expect(result).toHaveLength(4);
+    expect(result[1]).toEqual({ id: "toughness", type: "positive" }); // first kept
+    expect(result[3]).toEqual({ id: "guts", type: "positive" }); // second replaced
+  });
+
+  it("handles multiple replacements", () => {
+    const qualities: readonly LifeModuleQualityGrant[] = [
+      { id: "toughness", type: "positive" },
+      { id: "sinner-national", type: "negative" },
+      { id: "toughness", type: "positive" },
+      { id: "sinner-national", type: "negative" },
+    ];
+    const replacements = [
+      { originalQualityId: "toughness", replacementQualityId: "guts" },
+      { originalQualityId: "sinner-national", replacementQualityId: "bad-luck" },
+    ];
+
+    const result = applyQualityReplacements(qualities, replacements);
+    expect(result[0]).toEqual({ id: "toughness", type: "positive" });
+    expect(result[1]).toEqual({ id: "sinner-national", type: "negative" });
+    expect(result[2]).toEqual({ id: "guts", type: "positive" });
+    expect(result[3]).toEqual({ id: "bad-luck", type: "negative" });
+  });
+});
+
+// =============================================================================
+// resolveLifeModuleGrants with quality replacements
+// =============================================================================
+
+describe("resolveLifeModuleGrants with quality replacements", () => {
+  it("applies quality replacements from selections", () => {
+    const selections: LifeModuleSelection[] = [
+      { moduleId: "gang-member", phase: "teen", karmaCost: 50 },
+      {
+        moduleId: "combat-tour",
+        phase: "tour",
+        karmaCost: 60,
+        qualityReplacements: [{ originalQualityId: "toughness", replacementQualityId: "guts" }],
+      },
+    ];
+    const result = resolveLifeModuleGrants(selections, testCatalog);
+
+    // toughness from gang-member kept, toughness from combat-tour replaced with guts
+    const qualityIds = result.qualities.map((q) => q.id);
+    expect(qualityIds).toContain("toughness");
+    expect(qualityIds).toContain("guts");
+    expect(qualityIds.filter((id) => id === "toughness")).toHaveLength(1);
+  });
+
+  it("does not modify qualities when no replacements needed", () => {
+    const selections: LifeModuleSelection[] = [
+      { moduleId: "gang-member", phase: "teen", karmaCost: 50 },
+      { moduleId: "diplomatic-tour", phase: "tour", karmaCost: 60 },
+    ];
+    const result = resolveLifeModuleGrants(selections, testCatalog);
+
+    const qualityIds = result.qualities.map((q) => q.id);
+    expect(qualityIds).toEqual(["toughness", "first-impression"]);
   });
 });

--- a/components/creation/life-modules/LifeModulesCard.tsx
+++ b/components/creation/life-modules/LifeModulesCard.tsx
@@ -9,14 +9,20 @@
  */
 
 import { useMemo, useCallback, useState } from "react";
-import { Plus, Route, Trash2 } from "lucide-react";
+import { Plus, Route, Trash2, ArrowRightLeft } from "lucide-react";
 import { CreationCard } from "../shared";
-import { useLifeModules } from "@/lib/rules/RulesetContext";
+import { useLifeModules, useQualities } from "@/lib/rules/RulesetContext";
 import { PHASE_ORDER, PHASE_INFO } from "./constants";
 import { LifeModulesModal } from "./LifeModulesModal";
+import { QualityReplacementModal } from "./QualityReplacementModal";
 import type { LifeModulesCardProps, PhaseModules } from "./types";
-import type { LifeModuleSelection, LifeModulesCatalog } from "@/lib/types";
+import type { LifeModuleSelection, LifeModulesCatalog, QualityReplacement } from "@/lib/types";
 import { LIFE_MODULES_KARMA_BUDGET } from "@/lib/types";
+import {
+  detectDuplicateQualities,
+  lookupModule,
+  type DuplicateQualityInfo,
+} from "@/lib/rules/life-modules";
 
 /**
  * Build phase-organized module map from catalog data
@@ -66,7 +72,14 @@ function findModuleName(
 
 export function LifeModulesCard({ state, updateState }: LifeModulesCardProps) {
   const catalog = useLifeModules();
+  const { positive: positiveQualities, negative: negativeQualities } = useQualities();
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Duplicate quality replacement state
+  const [pendingSelection, setPendingSelection] = useState<LifeModuleSelection | null>(null);
+  const [pendingDuplicates, setPendingDuplicates] = useState<readonly DuplicateQualityInfo[]>([]);
+  const [pendingReplacements, setPendingReplacements] = useState<QualityReplacement[]>([]);
+  const [currentDuplicateIndex, setCurrentDuplicateIndex] = useState(0);
 
   const existingSelections: readonly LifeModuleSelection[] = useMemo(
     () => state.selections.lifeModules || [],
@@ -102,10 +115,30 @@ export function LifeModulesCard({ state, updateState }: LifeModulesCardProps) {
     return age > 0 ? age : null;
   }, [catalog, existingSelections]);
 
-  const handleAddModule = useCallback(
-    (selection: LifeModuleSelection) => {
-      const updatedModules = [...existingSelections, selection];
+  // All quality IDs already accumulated from existing selections
+  const accumulatedQualityIds = useMemo(() => {
+    if (!catalog) return [];
+    const ids: string[] = [];
+    for (const sel of existingSelections) {
+      const mod = lookupModule(sel.moduleId, sel.subModuleId, catalog);
+      if (mod?.qualities) {
+        for (const q of mod.qualities) {
+          // If this quality was replaced, use the replacement ID
+          const replacement = sel.qualityReplacements?.find((r) => r.originalQualityId === q.id);
+          ids.push(replacement ? replacement.replacementQualityId : q.id);
+        }
+      }
+    }
+    return ids;
+  }, [catalog, existingSelections]);
 
+  // Finalize adding a module (with any replacements already resolved)
+  const finalizeAddModule = useCallback(
+    (selection: LifeModuleSelection, replacements: readonly QualityReplacement[]) => {
+      const finalSelection: LifeModuleSelection =
+        replacements.length > 0 ? { ...selection, qualityReplacements: replacements } : selection;
+
+      const updatedModules = [...existingSelections, finalSelection];
       updateState({
         selections: {
           ...state.selections,
@@ -115,6 +148,86 @@ export function LifeModulesCard({ state, updateState }: LifeModulesCardProps) {
     },
     [existingSelections, state.selections, updateState]
   );
+
+  const handleAddModule = useCallback(
+    (selection: LifeModuleSelection) => {
+      if (!catalog) {
+        finalizeAddModule(selection, []);
+        return;
+      }
+
+      // Look up the module to get its quality grants
+      const mod = lookupModule(selection.moduleId, selection.subModuleId, catalog);
+      const moduleQualities = mod?.qualities ?? [];
+
+      if (moduleQualities.length === 0) {
+        finalizeAddModule(selection, []);
+        return;
+      }
+
+      // Build accumulated qualities from all prior selections
+      const accumulatedQualities = existingSelections.flatMap((sel) => {
+        const m = lookupModule(sel.moduleId, sel.subModuleId, catalog);
+        return m?.qualities ?? [];
+      });
+
+      const duplicates = detectDuplicateQualities(accumulatedQualities, moduleQualities);
+
+      if (duplicates.length === 0) {
+        finalizeAddModule(selection, []);
+        return;
+      }
+
+      // Start the sequential replacement flow
+      setPendingSelection(selection);
+      setPendingDuplicates(duplicates);
+      setPendingReplacements([]);
+      setCurrentDuplicateIndex(0);
+    },
+    [catalog, existingSelections, finalizeAddModule]
+  );
+
+  // Handle a replacement choice for the current duplicate
+  const handleReplacementSelect = useCallback(
+    (replacementQualityId: string) => {
+      if (!pendingSelection || pendingDuplicates.length === 0) return;
+
+      const currentDup = pendingDuplicates[currentDuplicateIndex];
+      const newReplacements = [
+        ...pendingReplacements,
+        { originalQualityId: currentDup.qualityId, replacementQualityId },
+      ];
+
+      const nextIndex = currentDuplicateIndex + 1;
+      if (nextIndex < pendingDuplicates.length) {
+        // More duplicates to resolve
+        setPendingReplacements(newReplacements);
+        setCurrentDuplicateIndex(nextIndex);
+      } else {
+        // All duplicates resolved — finalize
+        finalizeAddModule(pendingSelection, newReplacements);
+        setPendingSelection(null);
+        setPendingDuplicates([]);
+        setPendingReplacements([]);
+        setCurrentDuplicateIndex(0);
+      }
+    },
+    [
+      pendingSelection,
+      pendingDuplicates,
+      currentDuplicateIndex,
+      pendingReplacements,
+      finalizeAddModule,
+    ]
+  );
+
+  const handleReplacementCancel = useCallback(() => {
+    // Cancel the entire module addition
+    setPendingSelection(null);
+    setPendingDuplicates([]);
+    setPendingReplacements([]);
+    setCurrentDuplicateIndex(0);
+  }, []);
 
   const handleRemoveModule = useCallback(
     (index: number) => {
@@ -213,28 +326,44 @@ export function LifeModulesCard({ state, updateState }: LifeModulesCardProps) {
                       {info.label}
                     </h4>
                     {items.map(({ selection, index }) => (
-                      <div
-                        key={index}
-                        className="flex items-center justify-between rounded px-2 py-1 hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
-                      >
-                        <div className="flex items-center gap-2 min-w-0">
-                          <Route className="h-3 w-3 flex-shrink-0 text-rose-500" />
-                          <span className="truncate text-xs text-zinc-700 dark:text-zinc-300">
-                            {findModuleName(catalog, selection)}
-                          </span>
+                      <div key={index}>
+                        <div className="flex items-center justify-between rounded px-2 py-1 hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <Route className="h-3 w-3 flex-shrink-0 text-rose-500" />
+                            <span className="truncate text-xs text-zinc-700 dark:text-zinc-300">
+                              {findModuleName(catalog, selection)}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2 flex-shrink-0">
+                            <span className="text-[10px] font-mono text-zinc-400">
+                              {selection.karmaCost}K
+                            </span>
+                            <button
+                              onClick={() => handleRemoveModule(index)}
+                              className="rounded p-0.5 text-zinc-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20"
+                              title="Remove module"
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </button>
+                          </div>
                         </div>
-                        <div className="flex items-center gap-2 flex-shrink-0">
-                          <span className="text-[10px] font-mono text-zinc-400">
-                            {selection.karmaCost}K
-                          </span>
-                          <button
-                            onClick={() => handleRemoveModule(index)}
-                            className="rounded p-0.5 text-zinc-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20"
-                            title="Remove module"
-                          >
-                            <Trash2 className="h-3 w-3" />
-                          </button>
-                        </div>
+                        {/* Show quality replacements if any */}
+                        {selection.qualityReplacements &&
+                          selection.qualityReplacements.length > 0 && (
+                            <div className="ml-7 space-y-0.5 pb-1">
+                              {selection.qualityReplacements.map((r) => (
+                                <div
+                                  key={r.originalQualityId}
+                                  className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400"
+                                >
+                                  <ArrowRightLeft className="h-2.5 w-2.5" />
+                                  <span>
+                                    {r.originalQualityId} → {r.replacementQualityId}
+                                  </span>
+                                </div>
+                              ))}
+                            </div>
+                          )}
                       </div>
                     ))}
                   </div>
@@ -279,6 +408,19 @@ export function LifeModulesCard({ state, updateState }: LifeModulesCardProps) {
         modules={phaseModules}
         existingSelections={existingSelections}
       />
+
+      {/* Quality replacement modal — shown when a module grants a duplicate quality */}
+      {pendingDuplicates.length > 0 && currentDuplicateIndex < pendingDuplicates.length && (
+        <QualityReplacementModal
+          isOpen={true}
+          onClose={handleReplacementCancel}
+          onSelect={handleReplacementSelect}
+          duplicateQualityId={pendingDuplicates[currentDuplicateIndex].qualityId}
+          duplicateQualityType={pendingDuplicates[currentDuplicateIndex].type}
+          availableQualities={[...positiveQualities, ...negativeQualities]}
+          alreadySelectedIds={accumulatedQualityIds}
+        />
+      )}
     </>
   );
 }

--- a/components/creation/life-modules/QualityReplacementModal.tsx
+++ b/components/creation/life-modules/QualityReplacementModal.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+/**
+ * QualityReplacementModal
+ *
+ * When a life module grants a quality the character already has (non-stackable),
+ * Run Faster p.67 says they may pick a replacement quality of the same karma value.
+ * This modal lets the player browse and pick that replacement.
+ */
+
+import { useState, useMemo, useCallback } from "react";
+import { Search, ArrowRightLeft } from "lucide-react";
+import { Heading } from "react-aria-components";
+import { BaseModalRoot, ModalFooter } from "@/components/ui/BaseModal";
+import type { QualityData } from "@/lib/rules/loader-types";
+import { getQualityCost } from "@/components/creation/qualities/utils";
+import type { QualityReplacementModalProps } from "./types";
+
+export function QualityReplacementModal({
+  isOpen,
+  onClose,
+  onSelect,
+  duplicateQualityId,
+  duplicateQualityType,
+  availableQualities,
+  alreadySelectedIds,
+}: QualityReplacementModalProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // Find the duplicate quality in the catalog
+  const duplicateQuality = useMemo(
+    () => availableQualities.find((q) => q.id === duplicateQualityId),
+    [availableQualities, duplicateQualityId]
+  );
+
+  const targetCost = duplicateQuality ? getQualityCost(duplicateQuality, 1) : 0;
+
+  // Filter qualities: same type, same karma cost, not already selected, not the duplicate itself
+  const filteredQualities = useMemo(() => {
+    const excludeIds = new Set([duplicateQualityId, ...(alreadySelectedIds ?? [])]);
+
+    return availableQualities.filter((q) => {
+      if (excludeIds.has(q.id)) return false;
+
+      // Must match the type (positive/negative) — infer from karmaCost vs karmaBonus
+      const isPositive = (q.karmaCost ?? 0) > 0 || (!q.karmaBonus && !q.karmaCost);
+      const wantPositive = duplicateQualityType === "positive";
+      if (isPositive !== wantPositive && !q.karmaCost && !q.karmaBonus) return false;
+      if (wantPositive && q.karmaBonus && !q.karmaCost) return false;
+      if (!wantPositive && q.karmaCost && !q.karmaBonus) return false;
+
+      // Must match cost
+      const cost = getQualityCost(q, 1);
+      if (cost !== targetCost) return false;
+
+      // Search filter
+      if (searchQuery.trim()) {
+        const query = searchQuery.toLowerCase();
+        if (!q.name.toLowerCase().includes(query) && !q.summary?.toLowerCase().includes(query)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [
+    availableQualities,
+    duplicateQualityId,
+    duplicateQualityType,
+    targetCost,
+    alreadySelectedIds,
+    searchQuery,
+  ]);
+
+  const selectedQuality = useMemo(
+    () => (selectedId ? filteredQualities.find((q) => q.id === selectedId) : null),
+    [filteredQualities, selectedId]
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (!selectedId) return;
+    onSelect(selectedId);
+    setSelectedId(null);
+    setSearchQuery("");
+  }, [selectedId, onSelect]);
+
+  return (
+    <BaseModalRoot isOpen={isOpen} onClose={onClose} size="lg" className="bg-zinc-900">
+      {({ close }) => (
+        <>
+          {/* Header */}
+          <div className="border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
+            <Heading
+              slot="title"
+              className="text-lg font-semibold text-zinc-900 dark:text-zinc-100"
+            >
+              REPLACE DUPLICATE QUALITY
+            </Heading>
+            <div className="mt-1 flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+              <ArrowRightLeft className="h-3 w-3" />
+              <span>
+                <span className="font-medium text-amber-600 dark:text-amber-400">
+                  {duplicateQuality?.name ?? duplicateQualityId}
+                </span>{" "}
+                is already granted. Pick a{" "}
+                {duplicateQualityType === "positive" ? "positive" : "negative"} quality worth{" "}
+                <span className="font-mono font-medium">{targetCost}</span> Karma.
+              </span>
+            </div>
+          </div>
+
+          {/* Body: two-panel */}
+          <div className="flex min-h-0 flex-1" style={{ minHeight: "300px" }}>
+            {/* Left: quality list */}
+            <div className="flex w-1/2 flex-col border-r border-zinc-200 dark:border-zinc-700">
+              {/* Search */}
+              <div className="border-b border-zinc-200 px-3 py-2 dark:border-zinc-700">
+                <div className="relative">
+                  <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-zinc-400" />
+                  <input
+                    type="text"
+                    placeholder="Search qualities..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="w-full rounded bg-zinc-100 py-1 pl-7 pr-2 text-xs text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-1 focus:ring-amber-500 dark:bg-zinc-800 dark:text-zinc-100"
+                  />
+                </div>
+              </div>
+
+              {/* List */}
+              <div className="flex-1 overflow-y-auto">
+                {filteredQualities.length === 0 ? (
+                  <p className="p-4 text-center text-xs text-zinc-400">
+                    No matching qualities found at {targetCost} Karma.
+                  </p>
+                ) : (
+                  <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                    {filteredQualities.map((q) => {
+                      const isSelected = selectedId === q.id;
+                      return (
+                        <button
+                          key={q.id}
+                          onClick={() => setSelectedId(q.id)}
+                          className={`flex w-full items-center justify-between px-3 py-2 text-left transition-colors ${
+                            isSelected
+                              ? "bg-amber-50 dark:bg-amber-900/20"
+                              : "hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+                          }`}
+                        >
+                          <div className="min-w-0 flex-1">
+                            <span className="truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">
+                              {q.name}
+                            </span>
+                            <p className="truncate text-[10px] text-zinc-500 dark:text-zinc-400">
+                              {q.summary}
+                            </p>
+                          </div>
+                          <span className="ml-2 flex-shrink-0 text-[10px] font-mono text-zinc-400">
+                            {getQualityCost(q, 1)}K
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Right: detail panel */}
+            <div className="flex w-1/2 flex-col p-4">
+              {selectedQuality ? (
+                <div>
+                  <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                    {selectedQuality.name}
+                  </h3>
+                  <p className="mt-1 text-[10px] font-mono text-zinc-400">
+                    {getQualityCost(selectedQuality, 1)} Karma ·{" "}
+                    {duplicateQualityType === "positive" ? "Positive" : "Negative"}
+                  </p>
+                  <p className="mt-2 text-xs text-zinc-600 dark:text-zinc-300">
+                    {selectedQuality.summary}
+                  </p>
+                  {selectedQuality.description && (
+                    <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
+                      {selectedQuality.description}
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <div className="flex flex-1 items-center justify-center">
+                  <p className="text-xs text-zinc-400">
+                    Select a replacement quality to see details.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <ModalFooter>
+            <p className="text-[10px] text-zinc-400">
+              Run Faster p.67: duplicate non-stackable qualities must be replaced with same-cost
+              alternatives.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={close}
+                className="rounded-lg px-3 py-1.5 text-xs font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={!selectedId}
+                className="rounded-lg bg-amber-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Replace Quality
+              </button>
+            </div>
+          </ModalFooter>
+        </>
+      )}
+    </BaseModalRoot>
+  );
+}

--- a/components/creation/life-modules/index.ts
+++ b/components/creation/life-modules/index.ts
@@ -1,3 +1,4 @@
 export { LifeModulesCard } from "./LifeModulesCard";
 export { LifeModulesModal } from "./LifeModulesModal";
 export { LifeModuleDetailPanel } from "./LifeModuleDetailPanel";
+export { QualityReplacementModal } from "./QualityReplacementModal";

--- a/components/creation/life-modules/types.ts
+++ b/components/creation/life-modules/types.ts
@@ -21,3 +21,18 @@ export interface LifeModuleDetailPanelProps {
 
 /** Modules organized by phase for the selection UI */
 export type PhaseModules = Record<LifeModulePhase, readonly LifeModule[]>;
+
+export interface QualityReplacementModalProps {
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
+  /** Called with the chosen replacement quality ID */
+  readonly onSelect: (replacementQualityId: string) => void;
+  /** The duplicate quality ID that needs replacing */
+  readonly duplicateQualityId: string;
+  /** Whether the duplicate is positive or negative */
+  readonly duplicateQualityType: "positive" | "negative";
+  /** Full quality catalog to pick replacements from */
+  readonly availableQualities: readonly import("@/lib/rules/loader-types").QualityData[];
+  /** Quality IDs already on the character (to exclude from choices) */
+  readonly alreadySelectedIds?: readonly string[];
+}

--- a/lib/rules/life-modules/grant-resolver.ts
+++ b/lib/rules/life-modules/grant-resolver.ts
@@ -19,6 +19,7 @@ import type {
   LifeModuleQualityGrant,
   LifeModuleContactGrant,
   LifeModulePhase,
+  QualityReplacement,
 } from "@/lib/types/life-modules";
 import {
   LIFE_MODULES_MAX_ACTIVE_SKILL,
@@ -172,6 +173,88 @@ function mergeModuleGrants(
 }
 
 // =============================================================================
+// DUPLICATE QUALITY DETECTION
+// =============================================================================
+
+/**
+ * Info about a quality that was granted by a module but already exists.
+ * Used to prompt the player for a replacement of equal karma value.
+ */
+export interface DuplicateQualityInfo {
+  /** The quality ID that is duplicated */
+  readonly qualityId: string;
+  /** Whether this is a positive or negative quality */
+  readonly type: "positive" | "negative";
+}
+
+/**
+ * Detect incoming qualities that duplicate already-accumulated or existing character qualities.
+ *
+ * Per Run Faster p.67: if a character receives a quality they already have that does not
+ * have cumulative effects, they may instead take a quality of the same value.
+ *
+ * @param accumulated - Qualities already granted by prior modules
+ * @param incoming - Qualities from the current module being resolved
+ * @param existingCharacterQualityIds - Quality IDs the character already has (from other sources)
+ * @param alreadyReplacedIds - Quality IDs that have already been replaced (skip these)
+ * @returns Array of duplicate quality info for qualities needing replacement
+ */
+export function detectDuplicateQualities(
+  accumulated: readonly LifeModuleQualityGrant[],
+  incoming: readonly LifeModuleQualityGrant[],
+  existingCharacterQualityIds: readonly string[] = [],
+  alreadyReplacedIds: readonly string[] = []
+): readonly DuplicateQualityInfo[] {
+  const knownIds = new Set([...accumulated.map((q) => q.id), ...existingCharacterQualityIds]);
+  const replacedSet = new Set(alreadyReplacedIds);
+
+  const duplicates: DuplicateQualityInfo[] = [];
+  for (const grant of incoming) {
+    if (replacedSet.has(grant.id)) continue;
+    if (knownIds.has(grant.id)) {
+      duplicates.push({ qualityId: grant.id, type: grant.type });
+    }
+  }
+  return duplicates;
+}
+
+/**
+ * Apply quality replacements to a list of quality grants.
+ *
+ * For each replacement, the *second* occurrence of the original quality ID
+ * is swapped to the replacement ID. The first occurrence is kept intact.
+ *
+ * @param qualities - All accumulated quality grants
+ * @param replacements - Replacements chosen by the player
+ * @returns New array with replacements applied (immutable)
+ */
+export function applyQualityReplacements(
+  qualities: readonly LifeModuleQualityGrant[],
+  replacements: readonly QualityReplacement[]
+): readonly LifeModuleQualityGrant[] {
+  if (replacements.length === 0) return qualities;
+
+  // Track how many times we've seen each quality ID that has a replacement
+  const replacementMap = new Map(
+    replacements.map((r) => [r.originalQualityId, r.replacementQualityId])
+  );
+  const seenCount = new Map<string, number>();
+
+  return qualities.map((q) => {
+    if (!replacementMap.has(q.id)) return q;
+
+    const count = (seenCount.get(q.id) ?? 0) + 1;
+    seenCount.set(q.id, count);
+
+    // Keep first occurrence, replace subsequent
+    if (count > 1) {
+      return { ...q, id: replacementMap.get(q.id)! };
+    }
+    return q;
+  });
+}
+
+// =============================================================================
 // MAIN RESOLVER
 // =============================================================================
 
@@ -196,6 +279,9 @@ export function resolveLifeModuleGrants(
   // Accumulate grants from all modules
   let accumulated = EMPTY_GRANTS;
 
+  // Collect all quality replacements from selections
+  const allReplacements = selections.flatMap((s) => s.qualityReplacements ?? []);
+
   for (const selection of selections) {
     const module = lookupModule(selection.moduleId, selection.subModuleId, catalog);
     if (!module) continue;
@@ -203,9 +289,13 @@ export function resolveLifeModuleGrants(
     accumulated = mergeModuleGrants(accumulated, module);
   }
 
+  // Apply quality replacements (Run Faster p. 67 — duplicate non-stackable qualities)
+  const resolvedQualities = applyQualityReplacements(accumulated.qualities, allReplacements);
+
   // Apply skill caps (Run Faster p. 67)
   return {
     ...accumulated,
+    qualities: resolvedQualities,
     activeSkills: capValues(accumulated.activeSkills, LIFE_MODULES_MAX_ACTIVE_SKILL),
     knowledgeSkills: capValues(accumulated.knowledgeSkills, LIFE_MODULES_MAX_KNOWLEDGE_SKILL),
   };

--- a/lib/rules/life-modules/index.ts
+++ b/lib/rules/life-modules/index.ts
@@ -1,6 +1,9 @@
 export {
   resolveLifeModuleGrants,
   lookupModule,
+  detectDuplicateQualities,
+  applyQualityReplacements,
   EMPTY_GRANTS,
   type ResolvedLifeModuleGrants,
+  type DuplicateQualityInfo,
 } from "./grant-resolver";


### PR DESCRIPTION
## Summary
- Add `detectDuplicateQualities()` and `applyQualityReplacements()` pure functions to the grant resolver
- Create `QualityReplacementModal` — two-panel picker filtered to same-cost qualities of matching type
- Wire duplicate detection into `LifeModulesCard` — when a module grants a quality already accumulated, the replacement modal opens sequentially for each duplicate
- Display quality replacements in the timeline with arrow indicators
- Store replacements in `LifeModuleSelection.qualityReplacements` (type already existed, now populated)

Closes #577

## Test plan
- [x] `detectDuplicateQualities` — no dups, single dup, multiple dups, already-replaced exclusion, character existing qualities
- [x] `applyQualityReplacements` — no replacements, single replace (keeps first occurrence), multiple replacements
- [x] `resolveLifeModuleGrants` integration — replacements from selections applied correctly
- [x] Existing LifeModulesCard tests updated and passing (mock `useQualities`)
- [x] Type-check clean
- [ ] Manual: select modules granting same quality → replacement modal appears → pick replacement → verify timeline shows swap