### PR TITLE
feat: Life Modules prerequisite enforcement

### DIFF
--- a/__tests__/lib/rules/life-modules/prerequisites.test.ts
+++ b/__tests__/lib/rules/life-modules/prerequisites.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkPrerequisites,
+  getUnmetPrerequisiteNames,
+  type PrerequisiteResult,
+} from "@/lib/rules/life-modules/prerequisites";
+import type { LifeModule, LifeModulesCatalog, LifeModuleSelection } from "@/lib/types/life-modules";
+
+// =============================================================================
+// TEST FIXTURES
+// =============================================================================
+
+const makeModule = (overrides: Partial<LifeModule> & { id: string }): LifeModule => ({
+  name: overrides.id,
+  phase: "career",
+  karmaCost: 100,
+  ...overrides,
+});
+
+const makeTourModule = (overrides: Partial<LifeModule> & { id: string }): LifeModule => ({
+  name: overrides.id,
+  phase: "tour",
+  karmaCost: 100,
+  yearsAdded: 5,
+  ...overrides,
+});
+
+const makeSelection = (
+  moduleId: string,
+  phase: LifeModule["phase"] = "career",
+  subModuleId?: string
+): LifeModuleSelection => ({
+  moduleId,
+  phase,
+  karmaCost: 100,
+  ...(subModuleId ? { subModuleId } : {}),
+});
+
+const piModule = makeModule({
+  id: "private-investigator",
+  name: "Private Investigator/Detective",
+  prerequisites: [
+    "tour-of-duty",
+    "law-enforcement",
+    "covert-operations",
+    "shadow-work",
+    "corporate",
+  ],
+});
+
+const tourMercenary = makeTourModule({
+  id: "tour-mercenary",
+  name: "Mercenary",
+  prerequisites: [
+    "tour-nan",
+    "tour-tir-tairngire",
+    "tour-ucas-cas-cfs",
+    "corporate",
+    "shadow-work",
+  ],
+});
+
+const medicalCorpsSub: LifeModule = {
+  id: "ucas-cas-cfs-medical-corps",
+  name: "Medical Corps",
+  phase: "tour",
+  karmaCost: 100,
+  prerequisites: ["ts-nurse", "cc-medicine", "su-medicine", "ivy-medicine", "ma-medicine"],
+};
+
+const tourUcas = makeTourModule({
+  id: "tour-ucas-cas-cfs",
+  name: "UCAS/CAS/CFS Military",
+  subModules: [medicalCorpsSub],
+  requiresSubModuleSelection: true,
+});
+
+const bountyHunter = makeModule({
+  id: "bounty-hunter",
+  name: "Bounty Hunter",
+  // no prerequisites
+});
+
+const lawEnforcement = makeModule({
+  id: "law-enforcement",
+  name: "Law Enforcement",
+});
+
+const shadowWork = makeModule({
+  id: "shadow-work",
+  name: "Shadow Work",
+});
+
+const corporate = makeModule({
+  id: "corporate",
+  name: "Corporate",
+  subModules: [
+    makeModule({ id: "corporate-company-man", name: "Company Man" }),
+    makeModule({ id: "corporate-hacker-decker", name: "Hacker/Decker" }),
+  ],
+});
+
+const tourNan = makeTourModule({
+  id: "tour-nan",
+  name: "NAN Military",
+});
+
+const tourTir = makeTourModule({
+  id: "tour-tir-tairngire",
+  name: "Tir Tairngire Military",
+});
+
+const minimalCatalog: LifeModulesCatalog = {
+  nationality: [],
+  formative: [],
+  teen: [],
+  education: [],
+  career: [bountyHunter, lawEnforcement, shadowWork, corporate, piModule],
+  tour: [tourMercenary, tourNan, tourTir, tourUcas],
+};
+
+// =============================================================================
+// checkPrerequisites
+// =============================================================================
+
+describe("checkPrerequisites", () => {
+  it("returns met=true for a module with no prerequisites", () => {
+    const result = checkPrerequisites(bountyHunter, [], minimalCatalog);
+    expect(result.met).toBe(true);
+    expect(result.missingPrerequisiteIds).toEqual([]);
+  });
+
+  it("returns met=true when prerequisites is undefined", () => {
+    const noPrereqs = makeModule({ id: "test" });
+    const result = checkPrerequisites(noPrereqs, [], minimalCatalog);
+    expect(result.met).toBe(true);
+    expect(result.missingPrerequisiteIds).toEqual([]);
+  });
+
+  it("returns met=true when prerequisites is empty array", () => {
+    const emptyPrereqs = makeModule({ id: "test", prerequisites: [] });
+    const result = checkPrerequisites(emptyPrereqs, [], minimalCatalog);
+    expect(result.met).toBe(true);
+    expect(result.missingPrerequisiteIds).toEqual([]);
+  });
+
+  it("returns met=false when no prerequisite modules are selected", () => {
+    const result = checkPrerequisites(piModule, [], minimalCatalog);
+    expect(result.met).toBe(false);
+    expect(result.missingPrerequisiteIds).toEqual([
+      "tour-of-duty",
+      "law-enforcement",
+      "covert-operations",
+      "shadow-work",
+      "corporate",
+    ]);
+  });
+
+  it("returns met=true when any one prerequisite module is selected (OR logic)", () => {
+    const selections = [makeSelection("law-enforcement")];
+    const result = checkPrerequisites(piModule, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+    expect(result.missingPrerequisiteIds).toEqual([]);
+  });
+
+  it("returns met=true when shadow-work prerequisite is satisfied", () => {
+    const selections = [makeSelection("shadow-work")];
+    const result = checkPrerequisites(piModule, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+  });
+
+  it("returns met=true when corporate prerequisite is satisfied", () => {
+    const selections = [makeSelection("corporate", "career", "corporate-company-man")];
+    const result = checkPrerequisites(piModule, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+  });
+
+  it("handles tour-of-duty phase alias - matches any tour module", () => {
+    const selections = [makeSelection("tour-nan", "tour")];
+    const result = checkPrerequisites(piModule, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+  });
+
+  it("handles tour-of-duty phase alias - matches another tour module", () => {
+    const selections = [makeSelection("tour-ucas-cas-cfs", "tour")];
+    const result = checkPrerequisites(piModule, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+  });
+
+  it("returns met=false when only unrelated modules are selected", () => {
+    const selections = [makeSelection("bounty-hunter")];
+    const result = checkPrerequisites(piModule, selections, minimalCatalog);
+    expect(result.met).toBe(false);
+  });
+
+  // Tour: Mercenary prerequisites
+  it("returns met=true for mercenary when another tour is selected", () => {
+    const selections = [makeSelection("tour-nan", "tour")];
+    const result = checkPrerequisites(tourMercenary, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+  });
+
+  it("returns met=true for mercenary when shadow-work is selected", () => {
+    const selections = [makeSelection("shadow-work")];
+    const result = checkPrerequisites(tourMercenary, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+  });
+
+  it("returns met=true for mercenary when corporate is selected", () => {
+    const selections = [makeSelection("corporate", "career", "corporate-company-man")];
+    const result = checkPrerequisites(tourMercenary, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+  });
+
+  it("returns met=false for mercenary with no prior selections", () => {
+    const result = checkPrerequisites(tourMercenary, [], minimalCatalog);
+    expect(result.met).toBe(false);
+  });
+
+  // Sub-module prerequisites (Medical Corps)
+  it("checks sub-module prerequisites against existing education selections", () => {
+    const result = checkPrerequisites(medicalCorpsSub, [], minimalCatalog);
+    expect(result.met).toBe(false);
+    expect(result.missingPrerequisiteIds.length).toBeGreaterThan(0);
+  });
+
+  it("returns met=true for sub-module when education sub-module was selected", () => {
+    // Player selected trade school nurse sub-module
+    const selections = [makeSelection("trade-school", "education", "ts-nurse")];
+    const result = checkPrerequisites(medicalCorpsSub, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+  });
+
+  it("matches prerequisites against both moduleId and subModuleId", () => {
+    // Player selected community college medicine sub-module
+    const selections = [makeSelection("community-college", "education", "cc-medicine")];
+    const result = checkPrerequisites(medicalCorpsSub, selections, minimalCatalog);
+    expect(result.met).toBe(true);
+  });
+
+  it("does not mutate inputs", () => {
+    const selections: LifeModuleSelection[] = [makeSelection("bounty-hunter")];
+    const originalSelections = [...selections];
+    checkPrerequisites(piModule, selections, minimalCatalog);
+    expect(selections).toEqual(originalSelections);
+  });
+});
+
+// =============================================================================
+// getUnmetPrerequisiteNames
+// =============================================================================
+
+describe("getUnmetPrerequisiteNames", () => {
+  it("returns empty array when prerequisites are met", () => {
+    const selections = [makeSelection("law-enforcement")];
+    const result = checkPrerequisites(piModule, selections, minimalCatalog);
+    const names = getUnmetPrerequisiteNames(result, minimalCatalog);
+    expect(names).toEqual([]);
+  });
+
+  it("returns human-readable names for unmet prerequisites", () => {
+    const result = checkPrerequisites(piModule, [], minimalCatalog);
+    const names = getUnmetPrerequisiteNames(result, minimalCatalog);
+    // Should include names from the catalog, not raw IDs
+    expect(names).toContain("Law Enforcement");
+    expect(names).toContain("Shadow Work");
+    expect(names).toContain("Corporate");
+  });
+
+  it("uses 'Any Tour of Duty' for tour-of-duty phase alias", () => {
+    const result = checkPrerequisites(piModule, [], minimalCatalog);
+    const names = getUnmetPrerequisiteNames(result, minimalCatalog);
+    expect(names).toContain("Any Tour of Duty");
+  });
+
+  it("falls back to ID when module not found in catalog", () => {
+    const moduleWithUnknown = makeModule({
+      id: "test",
+      prerequisites: ["nonexistent-module"],
+    });
+    const result = checkPrerequisites(moduleWithUnknown, [], minimalCatalog);
+    const names = getUnmetPrerequisiteNames(result, minimalCatalog);
+    expect(names).toContain("nonexistent-module");
+  });
+});

--- a/components/creation/life-modules/LifeModulesModal.tsx
+++ b/components/creation/life-modules/LifeModulesModal.tsx
@@ -9,10 +9,14 @@
  */
 
 import { useState, useMemo, useCallback } from "react";
-import { Search, ChevronRight, Check } from "lucide-react";
+import { Search, ChevronRight, Check, Lock } from "lucide-react";
 import { Heading } from "react-aria-components";
 import { BaseModalRoot, ModalFooter } from "@/components/ui/BaseModal";
 import type { LifeModule, LifeModulePhase, LifeModuleSelection } from "@/lib/types";
+import {
+  checkPrerequisites,
+  getUnmetPrerequisiteNames,
+} from "@/lib/rules/life-modules/prerequisites";
 import { PHASE_ORDER, PHASE_INFO } from "./constants";
 import { LifeModuleDetailPanel } from "./LifeModuleDetailPanel";
 import type { PhaseModules } from "./types";
@@ -50,6 +54,34 @@ export function LifeModulesModal({
         m.subModules?.some((sub) => sub.name.toLowerCase().includes(query))
     );
   }, [modules, activePhase, searchQuery]);
+
+  // Check prerequisites for all filtered modules
+  const prerequisiteResults = useMemo(() => {
+    const results = new Map<string, { met: boolean; names: readonly string[] }>();
+    for (const mod of filteredModules) {
+      const result = checkPrerequisites(mod, existingSelections, modules);
+      const names = result.met ? [] : getUnmetPrerequisiteNames(result, modules);
+      results.set(mod.id, { met: result.met, names });
+    }
+    return results;
+  }, [filteredModules, existingSelections, modules]);
+
+  // Check prerequisites for sub-modules of the highlighted module
+  const subModulePrerequisiteResults = useMemo(() => {
+    if (!highlightedModule?.subModules)
+      return new Map<string, { met: boolean; names: readonly string[] }>();
+    const results = new Map<string, { met: boolean; names: readonly string[] }>();
+    for (const sub of highlightedModule.subModules) {
+      if (!sub.prerequisites || sub.prerequisites.length === 0) {
+        results.set(sub.id, { met: true, names: [] });
+      } else {
+        const result = checkPrerequisites(sub, existingSelections, modules);
+        const names = result.met ? [] : getUnmetPrerequisiteNames(result, modules);
+        results.set(sub.id, { met: result.met, names });
+      }
+    }
+    return results;
+  }, [highlightedModule, existingSelections, modules]);
 
   // Check if a module is already selected in a phase
   const isModuleSelected = useCallback(
@@ -94,8 +126,20 @@ export function LifeModulesModal({
     setSearchQuery("");
   }, []);
 
+  // Check if the highlighted module's prerequisites are met
+  const highlightedPrereqMet = highlightedModule
+    ? (prerequisiteResults.get(highlightedModule.id)?.met ?? true)
+    : false;
+
+  // Check if the selected sub-module's prerequisites are met
+  const selectedSubPrereqMet = selectedSubModule
+    ? (subModulePrerequisiteResults.get(selectedSubModule.id)?.met ?? true)
+    : true;
+
   const canConfirm =
     highlightedModule &&
+    highlightedPrereqMet &&
+    selectedSubPrereqMet &&
     !isModuleSelected(highlightedModule.id) &&
     (!highlightedModule.requiresSubModuleSelection ||
       !highlightedModule.subModules?.length ||
@@ -191,6 +235,8 @@ export function LifeModulesModal({
                     {filteredModules.map((module) => {
                       const isSelected = isModuleSelected(module.id);
                       const isHighlighted = highlightedModule?.id === module.id;
+                      const prereq = prerequisiteResults.get(module.id);
+                      const isLocked = prereq ? !prereq.met : false;
 
                       return (
                         <button
@@ -203,26 +249,45 @@ export function LifeModulesModal({
                             isHighlighted
                               ? "bg-rose-50 dark:bg-rose-900/20"
                               : "hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
-                          } ${isSelected ? "opacity-50" : ""}`}
+                          } ${isSelected || isLocked ? "opacity-50" : ""}`}
                         >
                           <div className="min-w-0 flex-1">
                             <div className="flex items-center gap-1.5">
                               {isSelected && (
                                 <Check className="h-3 w-3 flex-shrink-0 text-emerald-500" />
                               )}
-                              <span className="truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">
+                              {isLocked && !isSelected && (
+                                <Lock className="h-3 w-3 flex-shrink-0 text-amber-500" />
+                              )}
+                              <span
+                                className={`truncate text-xs font-medium ${
+                                  isLocked
+                                    ? "text-zinc-500 dark:text-zinc-500"
+                                    : "text-zinc-900 dark:text-zinc-100"
+                                }`}
+                              >
                                 {module.name}
                               </span>
                             </div>
-                            <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
-                              {module.karmaCost} Karma
-                              {module.yearsAdded ? ` · +${module.yearsAdded}yr` : ""}
-                              {module.subModules?.length
-                                ? ` · ${module.subModules.length} specializations`
-                                : ""}
-                            </span>
+                            {isLocked && prereq ? (
+                              <span className="text-[10px] text-amber-600 dark:text-amber-400">
+                                Requires: {prereq.names.join(" or ")}
+                              </span>
+                            ) : (
+                              <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+                                {module.karmaCost} Karma
+                                {module.yearsAdded ? ` · +${module.yearsAdded}yr` : ""}
+                                {module.subModules?.length
+                                  ? ` · ${module.subModules.length} specializations`
+                                  : ""}
+                              </span>
+                            )}
                           </div>
-                          <ChevronRight className="h-3 w-3 flex-shrink-0 text-zinc-400" />
+                          {isLocked ? (
+                            <Lock className="h-3 w-3 flex-shrink-0 text-amber-500/50" />
+                          ) : (
+                            <ChevronRight className="h-3 w-3 flex-shrink-0 text-zinc-400" />
+                          )}
                         </button>
                       );
                     })}
@@ -235,6 +300,21 @@ export function LifeModulesModal({
             <div className="flex w-1/2 flex-col">
               {highlightedModule ? (
                 <div className="flex-1 overflow-y-auto p-4">
+                  {/* Prerequisite warning banner */}
+                  {!highlightedPrereqMet && (
+                    <div className="mb-3 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-900/20 px-3 py-2">
+                      <Lock className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
+                      <div>
+                        <p className="text-xs font-medium text-amber-400">Prerequisites Not Met</p>
+                        <p className="mt-0.5 text-[10px] text-amber-400/80">
+                          Requires prior:{" "}
+                          {(prerequisiteResults.get(highlightedModule.id)?.names ?? []).join(
+                            " or "
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                  )}
                   <LifeModuleDetailPanel
                     module={highlightedModule}
                     subModule={selectedSubModule ?? undefined}
@@ -249,27 +329,47 @@ export function LifeModulesModal({
                           : "Specializations"}
                       </h4>
                       <div className="space-y-1">
-                        {highlightedModule.subModules.map((sub) => (
-                          <button
-                            key={sub.id}
-                            onClick={() =>
-                              setSelectedSubModule(selectedSubModule?.id === sub.id ? null : sub)
-                            }
-                            className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs transition-colors ${
-                              selectedSubModule?.id === sub.id
-                                ? "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400"
-                                : "text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
-                            }`}
-                          >
-                            <span>{sub.name}</span>
-                            <span className="text-[10px] text-zinc-400">
-                              {sub.karmaCost != null &&
-                              sub.karmaCost !== highlightedModule.karmaCost
-                                ? `${sub.karmaCost}K`
-                                : ""}
-                            </span>
-                          </button>
-                        ))}
+                        {highlightedModule.subModules.map((sub) => {
+                          const subPrereq = subModulePrerequisiteResults.get(sub.id);
+                          const isSubLocked = subPrereq ? !subPrereq.met : false;
+
+                          return (
+                            <button
+                              key={sub.id}
+                              onClick={() => {
+                                if (isSubLocked) return;
+                                setSelectedSubModule(selectedSubModule?.id === sub.id ? null : sub);
+                              }}
+                              disabled={isSubLocked}
+                              className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-xs transition-colors ${
+                                isSubLocked
+                                  ? "cursor-not-allowed opacity-50"
+                                  : selectedSubModule?.id === sub.id
+                                    ? "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400"
+                                    : "text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                              }`}
+                            >
+                              <div className="flex items-center gap-1.5">
+                                {isSubLocked && (
+                                  <Lock className="h-2.5 w-2.5 flex-shrink-0 text-amber-500" />
+                                )}
+                                <span>{sub.name}</span>
+                              </div>
+                              {isSubLocked && subPrereq ? (
+                                <span className="text-[10px] text-amber-600 dark:text-amber-400">
+                                  Requires: {subPrereq.names.join(" or ")}
+                                </span>
+                              ) : (
+                                <span className="text-[10px] text-zinc-400">
+                                  {sub.karmaCost != null &&
+                                  sub.karmaCost !== highlightedModule.karmaCost
+                                    ? `${sub.karmaCost}K`
+                                    : ""}
+                                </span>
+                              )}
+                            </button>
+                          );
+                        })}
                       </div>
                     </div>
                   )}

--- a/data/editions/sr5/run-faster.json
+++ b/data/editions/sr5/run-faster.json
@@ -7571,8 +7571,15 @@
             "knowledgeSkills": {
               "foreign-military": 3
             },
+            "prerequisites": [
+              "tour-nan",
+              "tour-tir-tairngire",
+              "tour-ucas-cas-cfs",
+              "corporate",
+              "shadow-work"
+            ],
             "requiresSubModuleSelection": true,
-            "notes": "Basic Training (Firearms group +1, First Aid +1, Navigation +1, Professional Knowledge: Foreign Military +3) applies to all branches.",
+            "notes": "Must have completed another Tour of Duty, the Company Man (Corporate), or Shadow Work module.",
             "subModules": [
               {
                 "id": "mercenary-air-force",

--- a/lib/rules/life-modules/index.ts
+++ b/lib/rules/life-modules/index.ts
@@ -14,3 +14,9 @@ export {
   getEffectiveNegativeQualityKarma,
   type NegativeQualityKarmaBreakdown,
 } from "./buy-off";
+
+export {
+  checkPrerequisites,
+  getUnmetPrerequisiteNames,
+  type PrerequisiteResult,
+} from "./prerequisites";

--- a/lib/rules/life-modules/prerequisites.ts
+++ b/lib/rules/life-modules/prerequisites.ts
@@ -1,0 +1,180 @@
+/**
+ * Life Modules Prerequisite Checking
+ *
+ * Per Run Faster pp. 79-84, some career and tour modules require
+ * the character to have completed specific prior modules. Prerequisites
+ * use OR logic: at least one prerequisite must be satisfied.
+ *
+ * Pure functions — no side effects, no mutations.
+ */
+
+import type {
+  LifeModule,
+  LifeModulesCatalog,
+  LifeModuleSelection,
+  LifeModulePhase,
+} from "@/lib/types/life-modules";
+
+// =============================================================================
+// PHASE ALIASES
+// =============================================================================
+
+/**
+ * Phase alias IDs that match any module in a given phase.
+ * For example, "tour-of-duty" in a prerequisite list means "any tour module."
+ */
+const PHASE_ALIASES: Readonly<Record<string, LifeModulePhase>> = {
+  "tour-of-duty": "tour",
+};
+
+// =============================================================================
+// RESULT TYPE
+// =============================================================================
+
+/**
+ * Result of checking a module's prerequisites against existing selections.
+ */
+export interface PrerequisiteResult {
+  /** Whether all prerequisites are satisfied (OR logic: at least one must match) */
+  readonly met: boolean;
+
+  /** Prerequisite IDs that were not matched (empty when met=true) */
+  readonly missingPrerequisiteIds: readonly string[];
+}
+
+// =============================================================================
+// PREREQUISITE CHECKING
+// =============================================================================
+
+/**
+ * Collect all module and sub-module IDs from existing selections.
+ */
+function collectSelectedIds(selections: readonly LifeModuleSelection[]): ReadonlySet<string> {
+  const ids = new Set<string>();
+  for (const selection of selections) {
+    ids.add(selection.moduleId);
+    if (selection.subModuleId) {
+      ids.add(selection.subModuleId);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Check whether a phase alias prerequisite is satisfied by any selection in that phase.
+ */
+function isPhaseAliasMet(
+  aliasPhase: LifeModulePhase,
+  selections: readonly LifeModuleSelection[]
+): boolean {
+  return selections.some((s) => s.phase === aliasPhase);
+}
+
+/**
+ * Check whether a module's prerequisites are met by existing selections.
+ *
+ * Prerequisites use OR logic: the module is available if ANY ONE of its
+ * prerequisite IDs matches a selected module ID, sub-module ID, or phase alias.
+ *
+ * @param module - The module (or sub-module) to check
+ * @param existingSelections - Already-selected modules from creation state
+ * @param _catalog - The life modules catalog (reserved for future use)
+ * @returns Whether prerequisites are met and which are missing
+ */
+export function checkPrerequisites(
+  module: LifeModule,
+  existingSelections: readonly LifeModuleSelection[],
+  _catalog: LifeModulesCatalog
+): PrerequisiteResult {
+  const prerequisites = module.prerequisites;
+
+  // No prerequisites → always met
+  if (!prerequisites || prerequisites.length === 0) {
+    return { met: true, missingPrerequisiteIds: [] };
+  }
+
+  const selectedIds = collectSelectedIds(existingSelections);
+
+  // Check each prerequisite: if ANY is satisfied, the module is available
+  for (const prereqId of prerequisites) {
+    // Check direct ID match (module or sub-module)
+    if (selectedIds.has(prereqId)) {
+      return { met: true, missingPrerequisiteIds: [] };
+    }
+
+    // Check phase alias (e.g., "tour-of-duty" matches any tour)
+    const aliasPhase = PHASE_ALIASES[prereqId];
+    if (aliasPhase && isPhaseAliasMet(aliasPhase, existingSelections)) {
+      return { met: true, missingPrerequisiteIds: [] };
+    }
+  }
+
+  // None matched → return all as missing
+  return {
+    met: false,
+    missingPrerequisiteIds: prerequisites,
+  };
+}
+
+// =============================================================================
+// DISPLAY HELPERS
+// =============================================================================
+
+const PHASE_KEYS: readonly LifeModulePhase[] = [
+  "nationality",
+  "formative",
+  "teen",
+  "education",
+  "career",
+  "tour",
+];
+
+/**
+ * Look up a module's display name by ID in the catalog.
+ * Searches both top-level modules and sub-modules.
+ */
+function findModuleName(moduleId: string, catalog: LifeModulesCatalog): string | undefined {
+  for (const phase of PHASE_KEYS) {
+    const modules = catalog[phase];
+    if (!modules) continue;
+
+    for (const mod of modules) {
+      if (mod.id === moduleId) return mod.name;
+      if (mod.subModules) {
+        for (const sub of mod.subModules) {
+          if (sub.id === moduleId) return sub.name;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Human-readable labels for phase aliases */
+const PHASE_ALIAS_LABELS: Readonly<Record<string, string>> = {
+  "tour-of-duty": "Any Tour of Duty",
+};
+
+/**
+ * Convert unmet prerequisite IDs to human-readable names for display.
+ *
+ * @param result - The prerequisite check result
+ * @param catalog - The life modules catalog for name lookups
+ * @returns Array of human-readable prerequisite names
+ */
+export function getUnmetPrerequisiteNames(
+  result: PrerequisiteResult,
+  catalog: LifeModulesCatalog
+): readonly string[] {
+  if (result.met) return [];
+
+  return result.missingPrerequisiteIds.map((id) => {
+    // Check phase alias label first
+    const aliasLabel = PHASE_ALIAS_LABELS[id];
+    if (aliasLabel) return aliasLabel;
+
+    // Look up in catalog
+    const name = findModuleName(id, catalog);
+    return name ?? id;
+  });
+}


### PR DESCRIPTION
## Summary

Closes #578

- Add prerequisite checking for life modules during character creation (Run Faster pp. 79-84)
- Modules with unmet prerequisites are visually locked (amber lock icon, greyed out) but still visible so users can see what's required
- A warning banner in the detail panel explains which prior modules are needed
- Both top-level modules and sub-modules support prerequisites
- Add missing Mercenary Tour of Duty prerequisites to catalog data

## Changes

- **`lib/rules/life-modules/prerequisites.ts`** - Pure-function prerequisite checker with phase alias support (e.g., `tour-of-duty` matches any tour module)
- **`lib/rules/life-modules/index.ts`** - Export new prerequisite functions
- **`components/creation/life-modules/LifeModulesModal.tsx`** - Integrate prerequisite checking into module list and sub-module list UI
- **`data/editions/sr5/run-faster.json`** - Add prerequisites for Tour of Duty: Mercenary (requires other tour, Corporate, or Shadow Work)
- **`__tests__/lib/rules/life-modules/prerequisites.test.ts`** - 22 unit tests covering OR logic, phase aliases, sub-module prereqs, and edge cases

## Test plan

- [x] 22 new unit tests for `checkPrerequisites` and `getUnmetPrerequisiteNames`
- [x] All 9011 existing tests pass (423 test files)
- [x] TypeScript type-check passes
- [ ] Manual: verify Private Investigator shows locked without prior Law Enforcement/Tour/Covert Ops/Shadow Work/Corporate
- [ ] Manual: verify Mercenary Tour shows locked without prior tour or Corporate/Shadow Work
- [ ] Manual: verify Medical Corps sub-module shows locked without prior Nurse/Medicine education
- [ ] Manual: verify locked modules can be highlighted (to see details) but not confirmed