### PR TITLE
feat: replace ruleset browser pagination with infinite scroll

### DIFF
--- a/app/rulesets/components/ContentPreview.tsx
+++ b/app/rulesets/components/ContentPreview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { Loader2, ChevronLeft, ChevronRight, Search, X } from "lucide-react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Loader2, Search, X } from "lucide-react";
 import type { ContentPreviewItem, EditionCode } from "@/lib/types";
 
 interface ContentPreviewProps {
@@ -33,18 +33,22 @@ const CATEGORY_LABELS: Record<string, string> = {
   actions: "Actions",
 };
 
+const PAGE_SIZE = 50;
+
 export default function ContentPreview({ editionCode, category }: ContentPreviewProps) {
   const [items, setItems] = useState<ContentPreviewItem[]>([]);
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>(category);
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
-  const limit = 10;
+  const hasMore = items.length < total;
 
   // Debounce search input
   useEffect(() => {
@@ -54,18 +58,29 @@ export default function ContentPreview({ editionCode, category }: ContentPreview
     return () => clearTimeout(timer);
   }, [searchInput]);
 
-  // Reset pagination when search changes
+  // Reset when search or category changes
   useEffect(() => {
+    setItems([]);
     setOffset(0);
-  }, [debouncedSearch]);
+    setTotal(0);
+  }, [debouncedSearch, selectedCategory]);
 
+  // Fetch content (initial load or next page)
   useEffect(() => {
+    let cancelled = false;
+
     async function fetchContent() {
-      setLoading(true);
+      const isFirstPage = offset === 0;
+      if (isFirstPage) {
+        setLoading(true);
+      } else {
+        setLoadingMore(true);
+      }
       setError(null);
+
       try {
         const params = new URLSearchParams({
-          limit: limit.toString(),
+          limit: PAGE_SIZE.toString(),
           offset: offset.toString(),
         });
         if (selectedCategory) {
@@ -78,30 +93,65 @@ export default function ContentPreview({ editionCode, category }: ContentPreview
         const res = await fetch(`/api/editions/${editionCode}/content?${params}`);
         const data = await res.json();
 
+        if (cancelled) return;
+
         if (data.success) {
-          setItems(data.items);
+          setItems((prev) => (isFirstPage ? data.items : [...prev, ...data.items]));
           setTotal(data.total);
         } else {
           setError(data.error || "Failed to load content");
         }
       } catch (err) {
-        setError("An error occurred while loading content");
-        console.error(err);
+        if (!cancelled) {
+          setError("An error occurred while loading content");
+          console.error(err);
+        }
       } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
       }
     }
 
     fetchContent();
+
+    return () => {
+      cancelled = true;
+    };
   }, [editionCode, offset, selectedCategory, debouncedSearch]);
+
+  // Load next page
+  const loadMore = useCallback(() => {
+    if (!loadingMore && !loading && hasMore) {
+      setOffset((prev) => prev + PAGE_SIZE);
+    }
+  }, [loadingMore, loading, hasMore]);
+
+  // IntersectionObserver for infinite scroll sentinel
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          loadMore();
+        }
+      },
+      { rootMargin: "200px" }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [loadMore]);
 
   const handleCategoryChange = (cat: string | undefined) => {
     setSelectedCategory(cat);
-    setOffset(0);
   };
-
-  const hasNext = offset + limit < total;
-  const hasPrev = offset > 0;
 
   return (
     <div className="space-y-4">
@@ -182,73 +232,66 @@ export default function ContentPreview({ editionCode, category }: ContentPreview
           {selectedCategory ? ` in ${CATEGORY_LABELS[selectedCategory] || selectedCategory}` : ""}.
         </div>
       ) : (
-        <div className="space-y-2">
-          {items.map((item) => (
-            <div
-              key={`${item.category}-${item.id}`}
-              className="p-3 rounded-lg bg-muted/30 border border-border hover:border-emerald-500/30 transition-colors"
-            >
-              <div className="flex items-start justify-between">
-                <div>
-                  <h4 className="font-medium text-foreground">{item.name}</h4>
-                  {item.summary && (
-                    <p className="text-sm text-muted-foreground mt-0.5 line-clamp-2">
-                      {item.summary}
-                    </p>
-                  )}
+        <>
+          <div className="space-y-2">
+            {items.map((item) => (
+              <div
+                key={`${item.category}-${item.id}`}
+                className="p-3 rounded-lg bg-muted/30 border border-border hover:border-emerald-500/30 transition-colors"
+              >
+                <div className="flex items-start justify-between">
+                  <div>
+                    <h4 className="font-medium text-foreground">{item.name}</h4>
+                    {item.summary && (
+                      <p className="text-sm text-muted-foreground mt-0.5 line-clamp-2">
+                        {item.summary}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex gap-1.5 shrink-0 ml-2">
+                    {item.subcategory && (
+                      <span className="text-xs bg-zinc-500/10 text-zinc-500 dark:text-zinc-400 px-2 py-0.5 rounded font-mono">
+                        {item.subcategory}
+                      </span>
+                    )}
+                    {item.category && (
+                      <span className="text-xs bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 px-2 py-0.5 rounded font-mono">
+                        {CATEGORY_LABELS[item.category] || item.category}
+                      </span>
+                    )}
+                  </div>
                 </div>
-                <div className="flex gap-1.5 shrink-0 ml-2">
-                  {item.subcategory && (
-                    <span className="text-xs bg-zinc-500/10 text-zinc-500 dark:text-zinc-400 px-2 py-0.5 rounded font-mono">
-                      {item.subcategory}
-                    </span>
-                  )}
-                  {item.category && (
-                    <span className="text-xs bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 px-2 py-0.5 rounded font-mono">
-                      {CATEGORY_LABELS[item.category] || item.category}
-                    </span>
-                  )}
-                </div>
+                {item.source && (
+                  <p className="text-xs text-muted-foreground mt-2 font-mono">
+                    Source: {item.source}
+                  </p>
+                )}
               </div>
-              {item.source && (
-                <p className="text-xs text-muted-foreground mt-2 font-mono">
-                  Source: {item.source}
-                </p>
+            ))}
+          </div>
+
+          {/* Scroll sentinel + loading indicator */}
+          {hasMore && (
+            <div
+              ref={sentinelRef}
+              data-testid="scroll-loader"
+              className="flex items-center justify-center py-4"
+            >
+              {loadingMore && (
+                <Loader2 className="w-5 h-5 animate-spin text-emerald-500" aria-hidden="true" />
               )}
             </div>
-          ))}
-        </div>
-      )}
+          )}
 
-      {/* Pagination */}
-      {total > limit && (
-        <div className="flex items-center justify-between pt-2 border-t border-border">
-          <span className="text-sm text-muted-foreground">
-            Showing <span className="font-mono font-semibold text-foreground">{offset + 1}</span>-
-            <span className="font-mono font-semibold text-foreground">
-              {Math.min(offset + limit, total)}
-            </span>{" "}
-            of <span className="font-mono font-semibold text-foreground">{total}</span>
-          </span>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setOffset(Math.max(0, offset - limit))}
-              disabled={!hasPrev}
-              className="p-2 rounded-lg bg-muted hover:bg-muted/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              aria-label="Previous page"
-            >
-              <ChevronLeft className="w-4 h-4" aria-hidden="true" />
-            </button>
-            <button
-              onClick={() => setOffset(offset + limit)}
-              disabled={!hasNext}
-              className="p-2 rounded-lg bg-muted hover:bg-muted/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              aria-label="Next page"
-            >
-              <ChevronRight className="w-4 h-4" aria-hidden="true" />
-            </button>
+          {/* Item count footer */}
+          <div className="text-center pt-2 border-t border-border">
+            <span className="text-sm text-muted-foreground">
+              Showing{" "}
+              <span className="font-mono font-semibold text-foreground">{items.length}</span> of{" "}
+              <span className="font-mono font-semibold text-foreground">{total}</span> items
+            </span>
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/app/rulesets/components/__tests__/ContentPreview.test.tsx
+++ b/app/rulesets/components/__tests__/ContentPreview.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Tests for ContentPreview component — infinite scroll behavior
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ContentPreview from "../ContentPreview";
+import type { EditionCode } from "@/lib/types";
+
+// ---------- IntersectionObserver mock ----------
+
+type IntersectionCallback = (entries: IntersectionObserverEntry[]) => void;
+
+let intersectionCallback: IntersectionCallback;
+const observedElements = new Set<Element>();
+
+class MockIntersectionObserver {
+  constructor(callback: IntersectionCallback) {
+    intersectionCallback = callback;
+  }
+  observe(el: Element) {
+    observedElements.add(el);
+  }
+  unobserve(el: Element) {
+    observedElements.delete(el);
+  }
+  disconnect() {
+    observedElements.clear();
+  }
+}
+
+async function triggerIntersection(isIntersecting: boolean) {
+  const entries = Array.from(observedElements).map(
+    (target) =>
+      ({
+        isIntersecting,
+        target,
+        intersectionRatio: isIntersecting ? 1 : 0,
+      }) as unknown as IntersectionObserverEntry
+  );
+  await act(async () => {
+    intersectionCallback(entries);
+  });
+}
+
+// ---------- Helpers ----------
+
+function makeItems(count: number, startIndex = 0) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `item-${startIndex + i}`,
+    name: `Item ${startIndex + i}`,
+    category: "gear",
+    subcategory: "Pistols",
+    summary: `Summary for item ${startIndex + i}`,
+    source: "Core Rulebook",
+  }));
+}
+
+function mockFetchPages(totalItems: number, pageSize: number) {
+  const allItems = makeItems(totalItems);
+  return vi.fn().mockImplementation((url: string) => {
+    const parsed = new URL(url, "http://localhost");
+    const offset = parseInt(parsed.searchParams.get("offset") || "0");
+    const limit = parseInt(parsed.searchParams.get("limit") || String(pageSize));
+    const items = allItems.slice(offset, offset + limit);
+    return Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          items,
+          total: totalItems,
+          offset,
+          limit,
+        }),
+    });
+  });
+}
+
+// ---------- Tests ----------
+
+describe("ContentPreview", () => {
+  const editionCode: EditionCode = "sr5";
+
+  beforeEach(() => {
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+    observedElements.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders initial batch of items on mount", async () => {
+    global.fetch = mockFetchPages(50, 50);
+
+    render(<ContentPreview editionCode={editionCode} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Item 0")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Item 49")).toBeInTheDocument();
+  });
+
+  it("does not show pagination controls", async () => {
+    global.fetch = mockFetchPages(50, 50);
+
+    render(<ContentPreview editionCode={editionCode} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Item 0")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText("Previous page")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Next page")).not.toBeInTheDocument();
+  });
+
+  it("loads more items when sentinel becomes visible", async () => {
+    global.fetch = mockFetchPages(80, 50);
+
+    render(<ContentPreview editionCode={editionCode} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Item 0")).toBeInTheDocument();
+    });
+
+    // Trigger intersection — sentinel visible
+    await triggerIntersection(true);
+
+    await waitFor(() => {
+      expect(screen.getByText("Item 50")).toBeInTheDocument();
+    });
+
+    // All 80 items should now be rendered
+    expect(screen.getByText("Item 79")).toBeInTheDocument();
+  });
+
+  it("shows scroll sentinel when more items available", async () => {
+    global.fetch = mockFetchPages(80, 50);
+
+    render(<ContentPreview editionCode={editionCode} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Item 0")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("scroll-loader")).toBeInTheDocument();
+  });
+
+  it("does not fetch more when all items are loaded", async () => {
+    global.fetch = mockFetchPages(30, 50);
+
+    render(<ContentPreview editionCode={editionCode} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Item 0")).toBeInTheDocument();
+    });
+
+    // All 30 items fit in one page — sentinel should not be rendered
+    expect(screen.queryByTestId("scroll-loader")).not.toBeInTheDocument();
+
+    // Only one fetch should have been made
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
+
+  it("resets items when search changes", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    global.fetch = mockFetchPages(50, 50);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(<ContentPreview editionCode={editionCode} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Item 0")).toBeInTheDocument();
+    });
+
+    // Swap mock to return different items for search
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          items: [{ id: "search-1", name: "Ares Predator", category: "gear" }],
+          total: 1,
+          offset: 0,
+          limit: 50,
+          search: "ares",
+        }),
+    });
+
+    const input = screen.getByLabelText("Search content");
+    await user.type(input, "ares");
+
+    // Advance past debounce
+    await act(async () => {
+      vi.advanceTimersByTime(350);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Ares Predator")).toBeInTheDocument();
+    });
+
+    // Old items should be gone
+    expect(screen.queryByText("Item 0")).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("resets items when category changes", async () => {
+    global.fetch = mockFetchPages(50, 50);
+
+    render(<ContentPreview editionCode={editionCode} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Item 0")).toBeInTheDocument();
+    });
+
+    // Swap mock for category filter
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          items: [{ id: "magic-1", name: "Fireball", category: "magic" }],
+          total: 1,
+          offset: 0,
+          limit: 50,
+          category: "magic",
+        }),
+    });
+
+    const magicButton = screen.getByRole("button", { name: "Magic" });
+    await act(async () => {
+      magicButton.click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Fireball")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Item 0")).not.toBeInTheDocument();
+  });
+
+  it("shows total count in footer", async () => {
+    global.fetch = mockFetchPages(150, 50);
+
+    render(<ContentPreview editionCode={editionCode} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Item 0")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/150/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Replaced offset-based pagination (10 items/page with prev/next buttons) with IntersectionObserver-powered infinite scroll
- Items load progressively in chunks of 50 as the user scrolls down
- Search and category filter changes reset the accumulated items
- Shows a loading spinner at the bottom while fetching the next chunk
- Displays "Showing X of Y items" footer

Closes #554

## Test plan
- [x] Unit tests for initial load, infinite scroll trigger, search reset, category reset, no-fetch-when-complete
- [x] All 9035 tests passing
- [x] Type-check clean
- [ ] Manual: browse SR5 content, scroll to bottom, verify more items load
- [ ] Manual: search for "fireball", verify list resets and loads filtered results
- [ ] Manual: switch category filter, verify list resets
- [ ] Manual: verify no pagination buttons appear