### PR TITLE
fix: add dark/light mode to MetatypeModal and two-column layout to MagicPathModal

### DIFF
--- a/components/creation/magic-path/MagicPathModal.tsx
+++ b/components/creation/magic-path/MagicPathModal.tsx
@@ -7,6 +7,143 @@ import { BaseModalRoot, ModalFooter } from "@/components/ui/BaseModal";
 import { PATH_INFO, AWAKENED_PATHS, EMERGED_PATHS } from "./constants";
 import type { MagicPathModalProps, PathOption } from "./types";
 
+// ─── Detail Panel ────────────────────────────────────────────────────────────
+
+function PathDetailPanel({
+  option,
+  magicPaths,
+}: {
+  option: PathOption | null;
+  magicPaths: Array<{ id: string; name: string; hasResonance?: boolean }>;
+}) {
+  if (!option) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm italic text-zinc-500">
+        Select a path to see details
+      </div>
+    );
+  }
+
+  const pathInfo = magicPaths.find((p) => p.id === option.path);
+  const info = PATH_INFO[option.path];
+  const isResonance = EMERGED_PATHS.includes(option.path);
+  const rating = option.magicRating || option.resonanceRating || 0;
+
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div>
+        <h3 className="text-xl font-extrabold uppercase tracking-wide text-zinc-900 dark:text-zinc-100">
+          {pathInfo?.name || option.path}
+        </h3>
+        <div className="mt-1.5 flex gap-1.5">
+          <span
+            className={`inline-flex rounded px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${
+              isResonance
+                ? "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300"
+                : "bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300"
+            }`}
+          >
+            {isResonance ? "Emerged" : "Awakened"}
+          </span>
+        </div>
+      </div>
+
+      {/* Rating chip */}
+      <div className="flex flex-wrap gap-2">
+        <div className="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 bg-white px-3 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-900">
+          <span className="text-zinc-500">{isResonance ? "Resonance" : "Magic"}</span>
+          <span
+            className={`font-mono font-semibold ${
+              isResonance
+                ? "text-cyan-600 dark:text-cyan-400"
+                : "text-purple-600 dark:text-purple-400"
+            }`}
+          >
+            {rating}
+          </span>
+        </div>
+      </div>
+
+      {/* Description */}
+      {info && (
+        <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+          {info.description}
+        </p>
+      )}
+
+      {/* Features */}
+      {info && info.features.length > 0 && (
+        <div>
+          <div className="mb-2 border-b border-zinc-200 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500 dark:border-zinc-700">
+            Features
+          </div>
+          <ul className="space-y-1.5">
+            {info.features.map((feature) => (
+              <li
+                key={feature}
+                className="flex items-start gap-2 text-sm text-zinc-600 dark:text-zinc-400"
+              >
+                <span
+                  className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${
+                    isResonance ? "bg-cyan-500" : "bg-purple-500"
+                  }`}
+                />
+                {feature}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MundaneDetailPanel() {
+  const info = PATH_INFO.mundane;
+
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div>
+        <h3 className="text-xl font-extrabold uppercase tracking-wide text-zinc-900 dark:text-zinc-100">
+          No Magical Abilities
+        </h3>
+        <div className="mt-1.5 flex gap-1.5">
+          <span className="inline-flex rounded bg-zinc-200 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
+            Mundane
+          </span>
+        </div>
+      </div>
+
+      {/* Description */}
+      <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">{info.description}</p>
+
+      {/* Features */}
+      {info.features.length > 0 && (
+        <div>
+          <div className="mb-2 border-b border-zinc-200 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500 dark:border-zinc-700">
+            Features
+          </div>
+          <ul className="space-y-1.5">
+            {info.features.map((feature) => (
+              <li
+                key={feature}
+                className="flex items-start gap-2 text-sm text-zinc-600 dark:text-zinc-400"
+              >
+                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
+                {feature}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Modal ──────────────────────────────────────────────────────────────
+
 export function MagicPathModal({
   isOpen,
   onClose,
@@ -47,89 +184,23 @@ export function MagicPathModal({
     return { awakened, emerged };
   }, [availableOptions]);
 
-  const renderPathOption = (option: PathOption, isResonance: boolean) => {
-    const pathInfo = magicPaths.find((p) => p.id === option.path);
-    if (!pathInfo) return null;
-
-    const info = PATH_INFO[option.path];
-    const isSelected = selectedId === option.path;
-    const rating = option.magicRating || option.resonanceRating || 0;
-
-    return (
-      <button
-        key={option.path}
-        onClick={() => setSelectedId(option.path)}
-        className={`w-full rounded-lg border-2 p-4 text-left transition-all ${
-          isSelected
-            ? isResonance
-              ? "border-cyan-500 bg-cyan-50 dark:border-cyan-500 dark:bg-cyan-900/20"
-              : "border-purple-500 bg-purple-50 dark:border-purple-500 dark:bg-purple-900/20"
-            : "border-zinc-200 bg-white hover:border-purple-400 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:border-purple-500"
-        }`}
-      >
-        {/* Header row */}
-        <div className="flex items-center gap-3">
-          {/* Radio indicator */}
-          <div
-            className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
-              isSelected
-                ? isResonance
-                  ? "border-cyan-500 bg-cyan-500 text-white"
-                  : "border-purple-500 bg-purple-500 text-white"
-                : "border-zinc-300 dark:border-zinc-600"
-            }`}
-          >
-            {isSelected && <Check className="h-3 w-3" />}
-          </div>
-
-          <span
-            className={`text-base font-semibold uppercase ${
-              isSelected
-                ? isResonance
-                  ? "text-cyan-900 dark:text-cyan-100"
-                  : "text-purple-900 dark:text-purple-100"
-                : "text-zinc-900 dark:text-zinc-100"
-            }`}
-          >
-            {pathInfo.name}
-          </span>
-
-          {/* Rating badge */}
-          <span
-            className={`ml-auto rounded px-2 py-0.5 text-xs font-medium ${
-              isResonance
-                ? "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300"
-                : "bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300"
-            }`}
-          >
-            {isResonance ? "Resonance" : "Magic"} {rating}
-          </span>
-        </div>
-
-        {/* Description */}
-        {info && (
-          <>
-            <p className="mt-2 pl-8 text-sm text-zinc-600 dark:text-zinc-400">{info.description}</p>
-            <p className="mt-1 pl-8 text-xs text-zinc-500 dark:text-zinc-500">
-              {info.features.join(" • ")}
-            </p>
-          </>
-        )}
-      </button>
-    );
-  };
+  // Get the selected option for detail panel
+  const selectedOption = useMemo(() => {
+    if (!selectedId || selectedId === "mundane") return null;
+    return availableOptions.find((opt) => opt.path === selectedId) ?? null;
+  }, [selectedId, availableOptions]);
 
   return (
-    <BaseModalRoot isOpen={isOpen} onClose={handleClose} size="2xl">
+    <BaseModalRoot isOpen={isOpen} onClose={handleClose} size="full">
       {({ close }) => (
         <>
           {/* Header */}
           <div className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
             <Heading
               slot="title"
-              className="text-lg font-semibold text-zinc-900 dark:text-zinc-100"
+              className="text-lg font-bold uppercase tracking-wide text-zinc-900 dark:text-zinc-100"
             >
-              SELECT MAGICAL PATH
+              Select Magical Path
             </Heading>
             <button
               onClick={close}
@@ -152,7 +223,7 @@ export function MagicPathModal({
             </button>
           </div>
 
-          {/* Priority info */}
+          {/* Priority info bar */}
           {priorityLevel && (
             <div className="border-b border-zinc-100 bg-zinc-50 px-6 py-3 dark:border-zinc-800 dark:bg-zinc-800/50">
               <p className="text-sm text-zinc-600 dark:text-zinc-400">
@@ -161,100 +232,198 @@ export function MagicPathModal({
             </div>
           )}
 
-          {/* Path list */}
-          <div className="max-h-[60vh] overflow-y-auto p-4">
-            <div className="space-y-4">
+          {/* Two-panel body */}
+          <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
+            {/* Left panel: browse list */}
+            <div className="max-h-[200px] w-full shrink-0 overflow-y-auto border-b border-zinc-200 bg-zinc-50 sm:max-h-none sm:w-60 sm:border-b-0 sm:border-r dark:border-zinc-700 dark:bg-zinc-800/30 [scrollbar-width:thin]">
               {/* AWAKENED section */}
               {groupedPaths.awakened.length > 0 && (
                 <div>
-                  <div className="mb-2 flex items-center gap-2">
-                    <Sparkles className="h-4 w-4 text-purple-500" />
-                    <span className="text-xs font-semibold uppercase tracking-wider text-purple-600 dark:text-purple-400">
+                  <div className="sticky top-0 z-10 flex items-center gap-1.5 bg-zinc-100/80 px-4 py-2 backdrop-blur-sm dark:bg-zinc-800/80">
+                    <Sparkles className="h-3 w-3 text-purple-500" />
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-purple-600 dark:text-purple-400">
                       Awakened
                     </span>
+                    <span className="text-[10px] font-normal text-zinc-400 dark:text-zinc-600">
+                      ({groupedPaths.awakened.length})
+                    </span>
                   </div>
-                  <div className="space-y-2">
-                    {groupedPaths.awakened.map((opt) => renderPathOption(opt, false))}
-                  </div>
+                  {groupedPaths.awakened.map((opt) => {
+                    const pathInfo = magicPaths.find((p) => p.id === opt.path);
+                    const isSelected = selectedId === opt.path;
+                    const rating = opt.magicRating || opt.resonanceRating || 0;
+                    return (
+                      <button
+                        key={opt.path}
+                        onClick={() => setSelectedId(opt.path)}
+                        className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors ${
+                          isSelected
+                            ? "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+                            : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                        }`}
+                      >
+                        <div
+                          className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border-2 ${
+                            isSelected
+                              ? "border-purple-500 bg-purple-500"
+                              : "border-zinc-300 dark:border-zinc-600"
+                          }`}
+                        >
+                          {isSelected && <Check className="h-2.5 w-2.5 text-white" />}
+                        </div>
+                        <span className="flex-1 font-medium">{pathInfo?.name || opt.path}</span>
+                        <span
+                          className={`font-mono text-xs ${
+                            isSelected
+                              ? "text-purple-600 dark:text-purple-400"
+                              : "text-zinc-400 dark:text-zinc-600"
+                          }`}
+                        >
+                          {rating}
+                        </span>
+                      </button>
+                    );
+                  })}
                 </div>
               )}
 
               {/* EMERGED section */}
               {groupedPaths.emerged.length > 0 && (
                 <div>
-                  <div className="mb-2 flex items-center gap-2">
-                    <Zap className="h-4 w-4 text-cyan-500" />
-                    <span className="text-xs font-semibold uppercase tracking-wider text-cyan-600 dark:text-cyan-400">
+                  <div className="sticky top-0 z-10 flex items-center gap-1.5 bg-zinc-100/80 px-4 py-2 backdrop-blur-sm dark:bg-zinc-800/80">
+                    <Zap className="h-3 w-3 text-cyan-500" />
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-cyan-600 dark:text-cyan-400">
                       Emerged
                     </span>
+                    <span className="text-[10px] font-normal text-zinc-400 dark:text-zinc-600">
+                      ({groupedPaths.emerged.length})
+                    </span>
                   </div>
-                  <div className="space-y-2">
-                    {groupedPaths.emerged.map((opt) => renderPathOption(opt, true))}
-                  </div>
+                  {groupedPaths.emerged.map((opt) => {
+                    const pathInfo = magicPaths.find((p) => p.id === opt.path);
+                    const isSelected = selectedId === opt.path;
+                    const rating = opt.magicRating || opt.resonanceRating || 0;
+                    return (
+                      <button
+                        key={opt.path}
+                        onClick={() => setSelectedId(opt.path)}
+                        className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors ${
+                          isSelected
+                            ? "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300"
+                            : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                        }`}
+                      >
+                        <div
+                          className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border-2 ${
+                            isSelected
+                              ? "border-cyan-500 bg-cyan-500"
+                              : "border-zinc-300 dark:border-zinc-600"
+                          }`}
+                        >
+                          {isSelected && <Check className="h-2.5 w-2.5 text-white" />}
+                        </div>
+                        <span className="flex-1 font-medium">{pathInfo?.name || opt.path}</span>
+                        <span
+                          className={`font-mono text-xs ${
+                            isSelected
+                              ? "text-cyan-600 dark:text-cyan-400"
+                              : "text-zinc-400 dark:text-zinc-600"
+                          }`}
+                        >
+                          {rating}
+                        </span>
+                      </button>
+                    );
+                  })}
                 </div>
               )}
 
               {/* MUNDANE section */}
               <div>
-                <div className="mb-2 flex items-center gap-2">
-                  <User className="h-4 w-4 text-zinc-500" />
-                  <span className="text-xs font-semibold uppercase tracking-wider text-zinc-600 dark:text-zinc-400">
+                <div className="sticky top-0 z-10 flex items-center gap-1.5 bg-zinc-100/80 px-4 py-2 backdrop-blur-sm dark:bg-zinc-800/80">
+                  <User className="h-3 w-3 text-zinc-500" />
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500 dark:text-zinc-400">
                     Mundane
                   </span>
                 </div>
                 <button
                   onClick={() => setSelectedId("mundane")}
-                  className={`w-full rounded-lg border-2 p-4 text-left transition-all ${
+                  className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors ${
                     selectedId === "mundane"
-                      ? "border-emerald-500 bg-emerald-50 dark:border-emerald-500 dark:bg-emerald-900/20"
-                      : "border-zinc-200 bg-white hover:border-emerald-400 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:border-emerald-500"
+                      ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                      : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
                   }`}
                 >
-                  <div className="flex items-center gap-3">
-                    <div
-                      className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
-                        selectedId === "mundane"
-                          ? "border-emerald-500 bg-emerald-500 text-white"
-                          : "border-zinc-300 dark:border-zinc-600"
-                      }`}
-                    >
-                      {selectedId === "mundane" && <Check className="h-3 w-3" />}
-                    </div>
-                    <span
-                      className={`text-base font-semibold uppercase ${
-                        selectedId === "mundane"
-                          ? "text-emerald-900 dark:text-emerald-100"
-                          : "text-zinc-900 dark:text-zinc-100"
-                      }`}
-                    >
-                      No Magical Abilities
-                    </span>
+                  <div
+                    className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border-2 ${
+                      selectedId === "mundane"
+                        ? "border-emerald-500 bg-emerald-500"
+                        : "border-zinc-300 dark:border-zinc-600"
+                    }`}
+                  >
+                    {selectedId === "mundane" && <Check className="h-2.5 w-2.5 text-white" />}
                   </div>
-                  <p className="mt-2 pl-8 text-sm text-zinc-600 dark:text-zinc-400">
-                    {PATH_INFO.mundane.description}
-                  </p>
-                  <p className="mt-1 pl-8 text-xs text-zinc-500 dark:text-zinc-500">
-                    {PATH_INFO.mundane.features.join(" • ")}
-                  </p>
+                  <span className="flex-1 font-medium">No Magical Abilities</span>
                 </button>
               </div>
+            </div>
+
+            {/* Right panel: detail */}
+            <div className="flex-1 overflow-y-auto p-5 [scrollbar-width:thin]">
+              {selectedId === "mundane" ? (
+                <MundaneDetailPanel />
+              ) : (
+                <PathDetailPanel option={selectedOption} magicPaths={magicPaths} />
+              )}
             </div>
           </div>
 
           {/* Footer */}
-          <ModalFooter>
-            <div />
-            <button
-              onClick={handleConfirm}
-              disabled={!selectedId}
-              className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
-                selectedId
-                  ? "bg-emerald-600 text-white hover:bg-emerald-700"
-                  : "cursor-not-allowed bg-zinc-200 text-zinc-400 dark:bg-zinc-700 dark:text-zinc-500"
-              }`}
-            >
-              Confirm
-            </button>
+          <ModalFooter className="bg-zinc-50 dark:bg-zinc-800/50">
+            <div className="text-sm text-zinc-500">
+              {selectedId ? (
+                <div className="flex items-center gap-2">
+                  <div
+                    className={`h-2 w-2 rounded-full ${
+                      selectedId === "mundane"
+                        ? "bg-emerald-500"
+                        : EMERGED_PATHS.includes(selectedId)
+                          ? "bg-cyan-500"
+                          : "bg-purple-500"
+                    }`}
+                  />
+                  <span>
+                    Selected:{" "}
+                    <strong className="text-zinc-700 dark:text-zinc-300">
+                      {selectedId === "mundane"
+                        ? "Mundane"
+                        : magicPaths.find((p) => p.id === selectedId)?.name || selectedId}
+                    </strong>
+                  </span>
+                </div>
+              ) : (
+                <span>Choose a magical path</span>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={close}
+                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={!selectedId}
+                className={`rounded-lg px-4 py-2 text-sm font-semibold transition-colors ${
+                  selectedId
+                    ? "bg-emerald-600 text-white hover:bg-emerald-700"
+                    : "cursor-not-allowed bg-zinc-200 text-zinc-400 dark:bg-zinc-700 dark:text-zinc-500"
+                }`}
+              >
+                Confirm
+              </button>
+            </div>
           </ModalFooter>
         </>
       )}

--- a/components/creation/metatype/MetatypeModal.tsx
+++ b/components/creation/metatype/MetatypeModal.tsx
@@ -85,13 +85,22 @@ function getMetatypeGroupId(metatype: MetatypeOption): string {
 /** Get the type badge for a metatype */
 function getTypeBadge(metatype: MetatypeOption): { label: string; className: string } {
   if (!metatype.baseMetatype && BASE_METATYPE_LABELS[metatype.id]) {
-    return { label: "Base", className: "bg-zinc-700 text-zinc-300" };
+    return {
+      label: "Base",
+      className: "bg-zinc-200 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300",
+    };
   }
   if (metatype.baseMetatype) {
     const parentLabel = BASE_METATYPE_LABELS[metatype.baseMetatype] || metatype.baseMetatype;
-    return { label: `${parentLabel} Variant`, className: "bg-sky-900/60 text-sky-300" };
+    return {
+      label: `${parentLabel} Variant`,
+      className: "bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-300",
+    };
   }
-  return { label: "Metasapient", className: "bg-purple-900/60 text-purple-300" };
+  return {
+    label: "Metasapient",
+    className: "bg-purple-100 text-purple-700 dark:bg-purple-900/60 dark:text-purple-300",
+  };
 }
 
 // ─── Detail Panel ────────────────────────────────────────────────────────────
@@ -119,7 +128,7 @@ function MetatypeDetailPanel({
     <div className="space-y-5">
       {/* Header */}
       <div>
-        <h3 className="text-xl font-extrabold uppercase tracking-wide text-zinc-100">
+        <h3 className="text-xl font-extrabold uppercase tracking-wide text-zinc-900 dark:text-zinc-100">
           {metatype.name}
         </h3>
         <div className="mt-1.5 flex gap-1.5">
@@ -134,29 +143,31 @@ function MetatypeDetailPanel({
       {/* Cost chips */}
       <div className="flex flex-wrap gap-2">
         {metatype.karmaCost !== undefined && (
-          <div className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1 text-sm">
+          <div className="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 bg-white px-3 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-900">
             <span className="text-zinc-500">Karma</span>
             <span
-              className={`font-mono font-semibold ${metatype.karmaCost > 0 ? "text-amber-400" : "text-emerald-400"}`}
+              className={`font-mono font-semibold ${metatype.karmaCost > 0 ? "text-amber-600 dark:text-amber-400" : "text-emerald-600 dark:text-emerald-400"}`}
             >
               {metatype.karmaCost > 0 ? metatype.karmaCost : "+0"}
             </span>
           </div>
         )}
-        <div className="inline-flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1 text-sm">
+        <div className="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 bg-white px-3 py-1 text-sm dark:border-zinc-700 dark:bg-zinc-900">
           <span className="text-zinc-500">SAP</span>
-          <span className="font-mono font-semibold text-zinc-200">
+          <span className="font-mono font-semibold text-zinc-700 dark:text-zinc-200">
             {metatype.specialAttributePoints}
           </span>
         </div>
       </div>
 
       {/* Description */}
-      {description && <p className="text-sm leading-relaxed text-zinc-400">{description}</p>}
+      {description && (
+        <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">{description}</p>
+      )}
 
       {/* Attributes */}
       <div>
-        <div className="mb-2 border-b border-zinc-700 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500">
+        <div className="mb-2 border-b border-zinc-200 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500 dark:border-zinc-700">
           Attributes
         </div>
         <div className="grid grid-cols-3 gap-2 sm:grid-cols-3">
@@ -167,19 +178,23 @@ function MetatypeDetailPanel({
               <div
                 key={name}
                 className={`flex items-center justify-between rounded-md border px-3 py-2 ${
-                  isAboveRange ? "border-amber-800/60 bg-zinc-900" : "border-zinc-700 bg-zinc-900"
+                  isAboveRange
+                    ? "border-amber-300 bg-amber-50 dark:border-amber-800/60 dark:bg-zinc-900"
+                    : "border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900"
                 }`}
               >
                 <span
                   className={`text-xs font-semibold uppercase ${
-                    isAboveRange ? "text-amber-400/80" : "text-zinc-500"
+                    isAboveRange ? "text-amber-600 dark:text-amber-400/80" : "text-zinc-500"
                   }`}
                 >
                   {abbrev}
                 </span>
                 <span
                   className={`font-mono text-sm font-semibold ${
-                    isAboveRange ? "text-amber-400" : "text-zinc-300"
+                    isAboveRange
+                      ? "text-amber-600 dark:text-amber-400"
+                      : "text-zinc-700 dark:text-zinc-300"
                   }`}
                 >
                   {range.min} / {range.max}
@@ -192,7 +207,7 @@ function MetatypeDetailPanel({
 
       {/* Racial Traits */}
       <div>
-        <div className="mb-2 border-b border-zinc-700 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500">
+        <div className="mb-2 border-b border-zinc-200 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500 dark:border-zinc-700">
           Racial Traits
         </div>
         {metatype.racialTraits.length > 0 ? (
@@ -200,7 +215,7 @@ function MetatypeDetailPanel({
             {metatype.racialTraits.map((trait) => (
               <span
                 key={trait}
-                className="inline-flex rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1 text-xs text-zinc-300"
+                className="inline-flex rounded-md border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-xs text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300"
               >
                 {trait}
               </span>
@@ -214,7 +229,7 @@ function MetatypeDetailPanel({
       {/* Priority Availability (only for priority-based, not point buy) */}
       {metatype.priorityAvailability && priorityLevel && (
         <div>
-          <div className="mb-2 border-b border-zinc-700 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500">
+          <div className="mb-2 border-b border-zinc-200 pb-1.5 text-[11px] font-bold uppercase tracking-widest text-zinc-500 dark:border-zinc-700">
             Priority Availability
           </div>
           <div className="flex gap-2">
@@ -227,15 +242,15 @@ function MetatypeDetailPanel({
                   key={level}
                   className={`flex flex-1 flex-col items-center rounded-md border px-2 py-2 ${
                     isCurrent
-                      ? "border-emerald-600 bg-emerald-900/30"
+                      ? "border-emerald-400 bg-emerald-50 dark:border-emerald-600 dark:bg-emerald-900/30"
                       : isUnavailable
-                        ? "border-zinc-800 bg-zinc-900 opacity-30"
-                        : "border-zinc-700 bg-zinc-900"
+                        ? "border-zinc-200 bg-zinc-50 opacity-30 dark:border-zinc-800 dark:bg-zinc-900"
+                        : "border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900"
                   }`}
                 >
                   <span
                     className={`text-[11px] font-bold uppercase ${
-                      isCurrent ? "text-emerald-400" : "text-zinc-500"
+                      isCurrent ? "text-emerald-600 dark:text-emerald-400" : "text-zinc-500"
                     }`}
                   >
                     {level}
@@ -243,16 +258,18 @@ function MetatypeDetailPanel({
                   <span
                     className={`font-mono text-base font-bold ${
                       isCurrent
-                        ? "text-emerald-300"
+                        ? "text-emerald-600 dark:text-emerald-300"
                         : isUnavailable
-                          ? "text-zinc-600"
-                          : "text-zinc-300"
+                          ? "text-zinc-400 dark:text-zinc-600"
+                          : "text-zinc-700 dark:text-zinc-300"
                     }`}
                   >
                     {isUnavailable ? "-" : sap}
                   </span>
                   {!isUnavailable && (
-                    <span className="text-[9px] uppercase text-zinc-600">SAP</span>
+                    <span className="text-[9px] uppercase text-zinc-400 dark:text-zinc-600">
+                      SAP
+                    </span>
                   )}
                 </div>
               );
@@ -325,21 +342,21 @@ export function MetatypeModal({
   }, [selectedId, metatypes]);
 
   return (
-    <BaseModalRoot isOpen={isOpen} onClose={onClose} size="full" className="bg-zinc-900">
+    <BaseModalRoot isOpen={isOpen} onClose={onClose} size="full">
       {({ close }) => (
         <>
           {/* Header */}
-          <div className="flex items-center justify-between border-b border-zinc-700 px-6 py-4">
+          <div className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-700">
             <Heading
               slot="title"
-              className="text-lg font-bold uppercase tracking-wide text-zinc-100"
+              className="text-lg font-bold uppercase tracking-wide text-zinc-900 dark:text-zinc-100"
             >
               Select Metatype
             </Heading>
             <button
               onClick={close}
               aria-label="Close modal"
-              className="rounded-lg p-2 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-300"
+              className="rounded-lg p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
             >
               <span className="sr-only">Close</span>
               <svg
@@ -358,16 +375,16 @@ export function MetatypeModal({
           </div>
 
           {/* Toolbar: search + filter pills */}
-          <div className="flex items-center gap-3 border-b border-zinc-700 bg-zinc-800/50 px-6 py-3">
+          <div className="flex items-center gap-3 border-b border-zinc-200 bg-zinc-50 px-6 py-3 dark:border-zinc-700 dark:bg-zinc-800/50">
             {/* Search */}
-            <div className="flex flex-1 items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2">
-              <Search className="h-4 w-4 shrink-0 text-zinc-500" />
+            <div className="flex flex-1 items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-900">
+              <Search className="h-4 w-4 shrink-0 text-zinc-400 dark:text-zinc-500" />
               <input
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search metatypes..."
-                className="w-full bg-transparent text-sm text-zinc-200 placeholder-zinc-600 outline-none"
+                className="w-full bg-transparent text-sm text-zinc-900 placeholder-zinc-400 outline-none dark:text-zinc-200 dark:placeholder-zinc-600"
               />
             </div>
 
@@ -380,7 +397,7 @@ export function MetatypeModal({
                   className={`rounded-md px-2.5 py-1 text-xs font-semibold uppercase tracking-wide transition-colors ${
                     activeFilter === opt.id
                       ? "bg-emerald-600 text-white"
-                      : "border border-zinc-700 text-zinc-400 hover:border-zinc-600 hover:text-zinc-300"
+                      : "border border-zinc-200 text-zinc-500 hover:border-zinc-300 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-600 dark:hover:text-zinc-300"
                   }`}
                 >
                   {opt.label}
@@ -394,7 +411,7 @@ export function MetatypeModal({
             {/* Left panel: browse list */}
             <div
               data-testid="metatype-list"
-              className="max-h-[200px] w-full shrink-0 overflow-y-auto border-b border-zinc-700 bg-zinc-800/30 sm:max-h-none sm:w-60 sm:border-b-0 sm:border-r [scrollbar-width:thin]"
+              className="max-h-[200px] w-full shrink-0 overflow-y-auto border-b border-zinc-200 bg-zinc-50 sm:max-h-none sm:w-60 sm:border-b-0 sm:border-r dark:border-zinc-700 dark:bg-zinc-800/30 [scrollbar-width:thin]"
             >
               {filteredGroups.length === 0 ? (
                 <div className="p-4 text-center text-sm italic text-zinc-500">
@@ -404,9 +421,9 @@ export function MetatypeModal({
                 filteredGroups.map((group) => (
                   <div key={group.label}>
                     {/* Group header */}
-                    <div className="sticky top-0 z-10 bg-zinc-800/80 px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-zinc-500 backdrop-blur-sm">
+                    <div className="sticky top-0 z-10 bg-zinc-100/80 px-4 py-2 text-[10px] font-bold uppercase tracking-widest text-zinc-500 backdrop-blur-sm dark:bg-zinc-800/80">
                       {group.label}
-                      <span className="ml-1 font-normal text-zinc-600">
+                      <span className="ml-1 font-normal text-zinc-400 dark:text-zinc-600">
                         ({group.metatypes.length})
                       </span>
                     </div>
@@ -421,14 +438,16 @@ export function MetatypeModal({
                           onClick={() => setSelectedId(metatype.id)}
                           className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm transition-colors ${
                             isSelected
-                              ? "bg-emerald-900/30 text-emerald-300"
-                              : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+                              ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                              : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
                           }`}
                         >
                           {/* Radio dot */}
                           <div
                             className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border-2 ${
-                              isSelected ? "border-emerald-500 bg-emerald-500" : "border-zinc-600"
+                              isSelected
+                                ? "border-emerald-500 bg-emerald-500"
+                                : "border-zinc-300 dark:border-zinc-600"
                             }`}
                           >
                             {isSelected && <Check className="h-2.5 w-2.5 text-white" />}
@@ -442,7 +461,9 @@ export function MetatypeModal({
                           {/* SAP */}
                           <span
                             className={`font-mono text-xs ${
-                              isSelected ? "text-emerald-400" : "text-zinc-600"
+                              isSelected
+                                ? "text-emerald-600 dark:text-emerald-400"
+                                : "text-zinc-400 dark:text-zinc-600"
                             }`}
                           >
                             {metatype.specialAttributePoints}
@@ -465,18 +486,21 @@ export function MetatypeModal({
           </div>
 
           {/* Footer */}
-          <ModalFooter className="bg-zinc-800/50">
+          <ModalFooter className="bg-zinc-50 dark:bg-zinc-800/50">
             <div className="text-sm text-zinc-500">
               {selectedMetatype ? (
                 <div className="flex items-center gap-2">
                   <div className="h-2 w-2 rounded-full bg-emerald-500" />
                   <span>
-                    Selected: <strong className="text-zinc-300">{selectedMetatype.name}</strong>
-                    <span className="text-zinc-600"> · </span>
+                    Selected:{" "}
+                    <strong className="text-zinc-700 dark:text-zinc-300">
+                      {selectedMetatype.name}
+                    </strong>
+                    <span className="text-zinc-300 dark:text-zinc-600"> · </span>
                     {selectedMetatype.specialAttributePoints} SAP
                     {selectedMetatype.racialTraits.length > 0 && (
                       <>
-                        <span className="text-zinc-600"> · </span>
+                        <span className="text-zinc-300 dark:text-zinc-600"> · </span>
                         {selectedMetatype.racialTraits.length} trait
                         {selectedMetatype.racialTraits.length !== 1 ? "s" : ""}
                       </>
@@ -495,7 +519,7 @@ export function MetatypeModal({
             <div className="flex gap-2">
               <button
                 onClick={close}
-                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-400 hover:bg-zinc-800 hover:text-zinc-300"
+                className="rounded-lg px-4 py-2 text-sm font-medium text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
               >
                 Cancel
               </button>
@@ -505,7 +529,7 @@ export function MetatypeModal({
                 className={`rounded-lg px-4 py-2 text-sm font-semibold transition-colors ${
                   selectedId
                     ? "bg-emerald-600 text-white hover:bg-emerald-700"
-                    : "cursor-not-allowed bg-zinc-700 text-zinc-500"
+                    : "cursor-not-allowed bg-zinc-200 text-zinc-400 dark:bg-zinc-700 dark:text-zinc-500"
                 }`}
               >
                 Confirm


### PR DESCRIPTION
## Summary
- **MetatypeModal**: Added proper dark/light mode support — was hardcoded with dark-only styles (zero `dark:` classes), now matches the QualitySelectionModal pattern with light-first + `dark:` variants
- **MagicPathModal**: Converted from single-column card list to two-panel layout (left browse list + right detail panel) matching MetatypeModal's two-column pattern, with full dark/light mode support

## Test plan
- [ ] Open MetatypeModal in light mode — verify readable backgrounds, borders, text
- [ ] Open MetatypeModal in dark mode — verify existing appearance preserved
- [ ] Open MagicPathModal — verify two-column layout with left list and right detail panel
- [ ] Select Awakened/Emerged/Mundane paths and verify detail panel updates
- [ ] Test responsive behavior (mobile should stack vertically)
- [ ] All 9035 tests pass, type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)