### PR TITLE
feat: add 46 sample contact archetypes from Run Faster (#535)

### DIFF
--- a/data/editions/sr5/run-faster.json
+++ b/data/editions/sr5/run-faster.json
@@ -6450,13 +6450,1022 @@
     "contactArchetypes": {
       "mergeStrategy": "append",
       "payload": {
-        "archetypes": []
+        "archetypes": [
+          {
+            "id": "rf-arms-dealer",
+            "name": "Arms Dealer",
+            "description": "A weapons supplier who offers firearms, ammunition, and military gear to those willing to barter.",
+            "suggestedConnection": [3, 5],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "weapon-procurement",
+              "ammunition-supply",
+              "military-gear",
+              "weapon-modification"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "weapon-procurement": 500,
+              "ammunition-supply": 100,
+              "military-gear": 1000,
+              "weapon-modification": 300
+            },
+            "commonLocations": ["Gun ranges", "Military surplus stores", "Private warehouses"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-bartender",
+            "name": "Bartender",
+            "description": "A social hub who hears everything and knows everyone in the neighborhood. Run Faster expanded version.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": ["rumors", "introduction", "meeting-place", "street-intel"],
+            "riskProfile": "low",
+            "typicalCosts": {
+              "rumors": 20,
+              "introduction": 50,
+              "meeting-place": 0,
+              "street-intel": 30
+            },
+            "commonLocations": ["Any bar or nightclub"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-bodyguard",
+            "name": "Bodyguard",
+            "description": "A private sector security professional who provides physical protection and extra muscle.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "physical-protection",
+              "security-assessment",
+              "extra-muscle",
+              "surveillance"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "physical-protection": 500,
+              "security-assessment": 200,
+              "extra-muscle": 300
+            },
+            "commonLocations": ["Corporate lobbies", "Private security firms", "Gyms"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-bookie",
+            "name": "Bookie",
+            "description": "A gambling operator who takes bets, loans money, and knows the odds on everything.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "gambling",
+              "loans",
+              "sports-information",
+              "underground-connections"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "loans": 0,
+              "sports-information": 50,
+              "underground-connections": 100
+            },
+            "commonLocations": ["Sports bars", "Underground gambling dens", "Race tracks"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-border-patrol-agent",
+            "name": "Border Patrol Agent",
+            "description": "A border officer who can verify SINs, provide geographic intelligence, and assist with border crossings.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "border-crossing",
+              "sin-verification",
+              "geographic-intel",
+              "smuggling-routes"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "border-crossing": 500,
+              "sin-verification": 100,
+              "geographic-intel": 50
+            },
+            "commonLocations": ["Border checkpoints", "Rural areas"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-bounty-hunter",
+            "name": "Bounty Hunter",
+            "description": "A professional tracker who chases down subjects for the right price.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": ["tracking", "skip-tracing", "bounty-collection", "street-intel"],
+            "riskProfile": "high",
+            "typicalCosts": { "tracking": 1000, "skip-tracing": 500, "street-intel": 100 },
+            "commonLocations": ["Bail bond offices", "Dive bars"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-chop-shop-mechanic",
+            "name": "Chop Shop Mechanic",
+            "description": "A skilled vehicle mechanic who handles illegal modifications, repairs, and stolen parts.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "vehicle-repair",
+              "vehicle-modification",
+              "stolen-parts",
+              "loaner-vehicle"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "vehicle-repair": 300,
+              "vehicle-modification": 500,
+              "loaner-vehicle": 200
+            },
+            "commonLocations": ["Back-alley garages", "Industrial districts", "Junkyards"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-church-pastor",
+            "name": "Church Pastor",
+            "description": "A community spiritual leader who provides emotional support, counseling, and sanctuary.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [2, 5],
+            "commonServices": [
+              "counseling",
+              "sanctuary",
+              "community-connections",
+              "emotional-support"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": { "counseling": 0, "sanctuary": 0, "community-connections": 50 },
+            "commonLocations": ["Churches", "Community centers", "Homeless shelters"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-city-official",
+            "name": "City Official",
+            "description": "A bureaucrat who leverages political power for personal gain and can offer government resources.",
+            "suggestedConnection": [5, 7],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "political-favors",
+              "government-info",
+              "legal-leverage",
+              "resource-allocation"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": {
+              "political-favors": 2000,
+              "government-info": 500,
+              "legal-leverage": 1000
+            },
+            "commonLocations": ["City hall", "Upscale restaurants", "Private clubs"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-club-kid",
+            "name": "Club Kid",
+            "description": "A fashion-forward socialite who knows everyone on the club scene and can network with the powerful.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "social-networking",
+              "fashion-trends",
+              "club-scene-intel",
+              "celebrity-connections"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": {
+              "social-networking": 100,
+              "club-scene-intel": 50,
+              "celebrity-connections": 200
+            },
+            "commonLocations": ["Nightclubs", "Fashion boutiques", "Gallery openings"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-company-suit",
+            "name": "Company Suit",
+            "description": "A corporate executive agent with access to intelligence and dirty secrets, fiercely loyal to her company.",
+            "suggestedConnection": [3, 5],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "corporate-intel",
+              "corporate-access",
+              "legal-resources",
+              "corporate-connections"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": {
+              "corporate-intel": 1000,
+              "corporate-access": 500,
+              "legal-resources": 800
+            },
+            "commonLocations": ["Corporate offices", "Executive lounges", "High-end bars"],
+            "commonOrganizations": ["Ares", "Aztechnology", "Renraku", "Saeder-Krupp"]
+          },
+          {
+            "id": "rf-con-fanatic",
+            "name": "Con Fanatic",
+            "description": "An obsessive convention-goer who can help with travel arrangements and cover stories through their fandom networks.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "travel-arrangements",
+              "cover-stories",
+              "pop-culture-knowledge",
+              "convention-networking"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": {
+              "travel-arrangements": 100,
+              "cover-stories": 50,
+              "convention-networking": 25
+            },
+            "commonLocations": ["Gaming stores", "Convention centers"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-corporate-administrator",
+            "name": "Corporate Administrator",
+            "description": "A corporate office scheduler and social hub who knows all the gossip and office politics.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "corporate-gossip",
+              "office-access",
+              "schedule-info",
+              "internal-connections"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": { "corporate-gossip": 50, "office-access": 200, "schedule-info": 100 },
+            "commonLocations": ["Corporate lobbies", "Break rooms", "Coffee shops"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-corporate-wageslave",
+            "name": "Corporate Wageslave",
+            "description": "A faceless corporate worker who can provide routine corporate access and an inside perspective.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "corporate-access",
+              "routine-info",
+              "cover-identity",
+              "inside-perspective"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": { "corporate-access": 100, "routine-info": 50, "cover-identity": 200 },
+            "commonLocations": ["Corporate cafeterias", "Commuter trains", "Suburban bars"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-coyote",
+            "name": "Coyote",
+            "description": "A smuggler who specializes in moving people across borders through tunnels, bribes, and alternative routes.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "border-smuggling",
+              "safe-passage",
+              "fake-sin-connections",
+              "underground-routes"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": {
+              "border-smuggling": 2000,
+              "safe-passage": 1000,
+              "fake-sin-connections": 500
+            },
+            "commonLocations": ["Border towns", "Safe houses", "Truck stops"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-cybernetic-technician",
+            "name": "Cybernetic Technician",
+            "description": "A body shop tech who repairs and installs cyberware, with discounts on used parts.",
+            "suggestedConnection": [3, 5],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "cyberware-installation",
+              "cyberware-repair",
+              "used-cyberware",
+              "tech-consultation"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "cyberware-installation": 1000,
+              "cyberware-repair": 500,
+              "used-cyberware": 750
+            },
+            "commonLocations": ["Body shops", "Medical clinics", "Tech labs"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-gang-boss",
+            "name": "Gang Boss",
+            "description": "A criminal organization leader with an army of thugs and deep underworld knowledge.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "muscle",
+              "criminal-info",
+              "territory-access",
+              "underground-connections"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": { "muscle": 500, "criminal-info": 200, "territory-access": 100 },
+            "commonLocations": ["Gang hangouts", "Back alleys", "Abandoned buildings"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-government-official",
+            "name": "Government Official",
+            "description": "A mysterious spook with government connections who trades knowledge for odd jobs.",
+            "suggestedConnection": [5, 7],
+            "suggestedLoyalty": [1, 2],
+            "commonServices": [
+              "government-intel",
+              "classified-info",
+              "political-connections",
+              "odd-jobs"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": {
+              "government-intel": 2000,
+              "classified-info": 3000,
+              "political-connections": 1500
+            },
+            "commonLocations": ["Anonymous locations", "Public parks"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-id-manufacturer",
+            "name": "ID Manufacturer",
+            "description": "A Matrix-savvy forger who creates fake SINs and data trails for the SINless.",
+            "suggestedConnection": [4, 6],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": ["fake-sin", "fake-license", "identity-verification", "sin-analysis"],
+            "riskProfile": "high",
+            "typicalCosts": { "fake-sin": 2500, "fake-license": 200, "identity-verification": 500 },
+            "commonLocations": ["Matrix-only meetings", "Secure data havens"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-informant",
+            "name": "Informant",
+            "description": "A stool pigeon with privileged inside information about criminal organizations.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 2],
+            "commonServices": [
+              "inside-info",
+              "organization-intel",
+              "undercover-access",
+              "criminal-connections"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": {
+              "inside-info": 200,
+              "organization-intel": 500,
+              "criminal-connections": 100
+            },
+            "commonLocations": ["Discreet locations", "Public spaces"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-international-courier",
+            "name": "International Courier",
+            "description": "A trusted transporter with legitimate paperwork who moves goods across international borders.",
+            "suggestedConnection": [5, 7],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "international-smuggling",
+              "package-delivery",
+              "cross-border-transport",
+              "travel-assistance"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": {
+              "international-smuggling": 5000,
+              "package-delivery": 2000,
+              "cross-border-transport": 3000
+            },
+            "commonLocations": ["Airports", "Shipping docks", "Hotel lobbies"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-knight-errant-dispatcher",
+            "name": "Knight Errant Dispatcher",
+            "description": "A law enforcement dispatcher who monitors security alarms and can warn runners of incoming responses.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "law-enforcement-alerts",
+              "police-response-timing",
+              "security-monitoring",
+              "active-event-tracking"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "law-enforcement-alerts": 200,
+              "police-response-timing": 300,
+              "security-monitoring": 150
+            },
+            "commonLocations": ["Off-duty cop bars", "Coffee shops near precincts"],
+            "commonOrganizations": ["Knight Errant"]
+          },
+          {
+            "id": "rf-lone-star-detective",
+            "name": "Lone Star Detective",
+            "description": "An investigator with access to criminal records, old cases, and cultivated sources.",
+            "suggestedConnection": [4, 6],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "criminal-investigation",
+              "evidence-examination",
+              "criminal-records",
+              "case-tracking"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": {
+              "criminal-investigation": 500,
+              "evidence-examination": 300,
+              "criminal-records": 200
+            },
+            "commonLocations": ["Precinct offices", "Crime scenes", "Late-night diners"],
+            "commonOrganizations": ["Lone Star"]
+          },
+          {
+            "id": "rf-mafia-consigliere",
+            "name": "Mafia Consigliere",
+            "description": "A high-ranking Mafia advisor with legal knowledge and political influence.",
+            "suggestedConnection": [4, 6],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "organized-crime-connections",
+              "legal-advice",
+              "political-influence",
+              "protection"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": {
+              "legal-advice": 1000,
+              "political-influence": 2000,
+              "protection": 1500
+            },
+            "commonLocations": ["Italian restaurants", "Private social clubs", "Luxury vehicles"],
+            "commonOrganizations": ["Mafia"]
+          },
+          {
+            "id": "rf-media-mogul",
+            "name": "Media Mogul",
+            "description": "A corporate media power broker who controls what information reaches the masses.",
+            "suggestedConnection": [4, 6],
+            "suggestedLoyalty": [1, 2],
+            "commonServices": [
+              "media-manipulation",
+              "news-suppression",
+              "corporate-intel",
+              "public-relations"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "media-manipulation": 2000,
+              "news-suppression": 3000,
+              "public-relations": 1000
+            },
+            "commonLocations": ["Media studios", "Corporate towers", "Exclusive restaurants"],
+            "commonOrganizations": ["Horizon"]
+          },
+          {
+            "id": "rf-metahuman-rights-activist",
+            "name": "Metahuman Rights Activist",
+            "description": "A passionate activist who fights for metahuman equality and can organize protests as distractions.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "protest-organization",
+              "community-connections",
+              "media-attention",
+              "distraction-ops"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "protest-organization": 500,
+              "community-connections": 100,
+              "distraction-ops": 300
+            },
+            "commonLocations": ["Community centers", "Underground bars", "Protest sites"],
+            "commonOrganizations": ["Ork Rights Committee", "Mothers of Metahumans"]
+          },
+          {
+            "id": "rf-news-reporter",
+            "name": "News Reporter",
+            "description": "An aggressive journalist who trades information for scoops and has access to databases.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "news-and-rumors",
+              "surveillance",
+              "information-trade",
+              "media-coverage"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "news-and-rumors": 50,
+              "surveillance": 300,
+              "information-trade": 200
+            },
+            "commonLocations": ["News offices", "Crime scenes", "Local bars"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-parazoologist",
+            "name": "Parazoologist",
+            "description": "A scientist who studies Awakened creatures and can identify paracritter threats and weaknesses.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "paracritter-identification",
+              "creature-weaknesses",
+              "field-research",
+              "training-advice"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": {
+              "paracritter-identification": 50,
+              "creature-weaknesses": 100,
+              "field-research": 200
+            },
+            "commonLocations": ["University labs", "Nature preserves", "Museums"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-pawn-broker",
+            "name": "Pawn Broker",
+            "description": "A neighborhood trader who buys and sells used goods and knows everyone's routines.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": ["buy-sell-goods", "neighborhood-intel", "used-gear", "quick-cash"],
+            "riskProfile": "low",
+            "typicalCosts": { "neighborhood-intel": 20, "used-gear": 0, "quick-cash": 0 },
+            "commonLocations": ["Pawn shops", "Flea markets"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-pharmacy-tech",
+            "name": "Pharmacy Tech",
+            "description": "A chemical and pharmaceutical expert who can create, deconstruct, and supply drugs and medical supplies.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "drug-procurement",
+              "pharmaceutical-knowledge",
+              "medkit-supplies",
+              "drug-analysis"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "drug-procurement": 200,
+              "medkit-supplies": 100,
+              "drug-analysis": 150
+            },
+            "commonLocations": ["Pharmacies", "Clinics", "University labs"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-popular-mefeed-personality",
+            "name": "Popular MeFeed Personality",
+            "description": "A Matrix social media personality with a following who can influence opinions and gather information.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "social-media-influence",
+              "public-opinion",
+              "matrix-connections",
+              "information-gathering"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": {
+              "social-media-influence": 100,
+              "matrix-connections": 50,
+              "information-gathering": 75
+            },
+            "commonLocations": ["Trendy cafes", "Public events"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-recicladore",
+            "name": "Recicladore",
+            "description": "A trash dump scavenger who salvages low-tech goods and knows where to hide bodies.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "salvaged-goods",
+              "body-disposal",
+              "low-tech-equipment",
+              "barter-goods"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": { "salvaged-goods": 0, "body-disposal": 500, "low-tech-equipment": 0 },
+            "commonLocations": ["Trash dumps", "Recycling centers", "Barrens outskirts"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-rent-a-cop",
+            "name": "Rent-a-Cop",
+            "description": "A low-budget security guard with building access and eyes on his assigned beat.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "security-patrol-info",
+              "building-access",
+              "local-intel",
+              "lookout-duty"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": {
+              "security-patrol-info": 50,
+              "building-access": 100,
+              "lookout-duty": 75
+            },
+            "commonLocations": ["Shopping malls", "Corporate parking lots", "Fast food joints"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-rockstar",
+            "name": "Rockstar",
+            "description": "A wildly popular musician who can connect runners with influential people worldwide.",
+            "suggestedConnection": [3, 5],
+            "suggestedLoyalty": [1, 2],
+            "commonServices": [
+              "celebrity-access",
+              "social-influence",
+              "media-connections",
+              "vip-introductions"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "celebrity-access": 500,
+              "social-influence": 1000,
+              "vip-introductions": 750
+            },
+            "commonLocations": ["Backstage areas", "Private parties", "Recording studios"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-safehouse-master",
+            "name": "Safehouse Master",
+            "description": "A disciplined protector who manages safehouses and keeps their residents hidden.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "safe-lodging",
+              "security",
+              "low-profile-ops",
+              "fugitive-protection"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": { "safe-lodging": 300, "security": 200, "fugitive-protection": 500 },
+            "commonLocations": ["Safehouses", "Secure locations"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-script-kiddie",
+            "name": "Script Kiddie",
+            "description": "A wannabe decker with homemade gear who can provide cheap Matrix services.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "matrix-recon",
+              "malware-deployment",
+              "cheap-hacking",
+              "matrix-rumors"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "matrix-recon": 100,
+              "malware-deployment": 200,
+              "cheap-hacking": 150
+            },
+            "commonLocations": ["Coffee shops", "Hacker spaces", "Matrix cafes"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-sprawl-ganger",
+            "name": "Sprawl Ganger",
+            "description": "A street-tough gang member who can shake trees and see what falls out.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": ["street-muscle", "neighborhood-watch", "gang-intel", "intimidation"],
+            "riskProfile": "medium",
+            "typicalCosts": { "street-muscle": 100, "gang-intel": 50, "intimidation": 75 },
+            "commonLocations": ["Street corners", "Gang hangouts", "Barrens bars"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-squatter",
+            "name": "Squatter",
+            "description": "A SINless street dweller who leverages anonymity for surveillance and local intelligence.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": ["surveillance", "barrens-knowledge", "anonymity", "local-rumors"],
+            "riskProfile": "low",
+            "typicalCosts": { "surveillance": 50, "barrens-knowledge": 20, "local-rumors": 10 },
+            "commonLocations": ["Under bridges", "Abandoned buildings", "Soup kitchens"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-store-owner",
+            "name": "Store Owner",
+            "description": "A neighborhood fixture who observes comings and goings and provides friendly advice.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "local-intel",
+              "meeting-point",
+              "small-goods",
+              "community-connections"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": { "local-intel": 20, "meeting-point": 0, "small-goods": 0 },
+            "commonLocations": ["Their store", "Local markets"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-street-doc",
+            "name": "Street Doc",
+            "description": "An underground medical professional. Run Faster expanded version with different specializations.",
+            "suggestedConnection": [3, 5],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "medical-care",
+              "cyberware-installation",
+              "drug-knowledge",
+              "emergency-treatment"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": {
+              "medical-care": 200,
+              "cyberware-installation": 1000,
+              "emergency-treatment": 500
+            },
+            "commonLocations": ["Back-alley clinics", "Body shops"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-street-kid",
+            "name": "Street Kid",
+            "description": "A young barrens survivor who is small enough to be ignored but useful for running messages and watching.",
+            "suggestedConnection": [1, 2],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": ["surveillance", "message-running", "street-info", "distraction"],
+            "riskProfile": "low",
+            "typicalCosts": { "surveillance": 20, "message-running": 10, "street-info": 15 },
+            "commonLocations": ["Street corners", "Abandoned lots", "Soup kitchens"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-talismonger",
+            "name": "Talismonger",
+            "description": "A magical supplies dealer. Run Faster expanded version with alchemy and sorcery skills.",
+            "suggestedConnection": [2, 4],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "magical-supplies",
+              "arcane-knowledge",
+              "spell-components",
+              "magical-identification"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": {
+              "magical-supplies": 100,
+              "spell-components": 200,
+              "magical-identification": 50
+            },
+            "commonLocations": ["Talismonger shops", "Magical supply stores"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-taxi-driver",
+            "name": "Taxi Driver",
+            "description": "A city navigator who works long hours and can provide transportation, even into dangerous areas.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "transportation",
+              "city-navigation",
+              "surveillance-platform",
+              "quick-getaway"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": {
+              "transportation": 50,
+              "quick-getaway": 200,
+              "surveillance-platform": 100
+            },
+            "commonLocations": ["Taxi stands", "Hotels", "Airports"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-terrafirst-activist",
+            "name": "TerraFirst! Activist",
+            "description": "An eco-terrorist devoted to opposing environmental destruction through extreme measures.",
+            "suggestedConnection": [3, 5],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "demolitions-expertise",
+              "eco-terrorism-connections",
+              "protest-organization",
+              "underground-networks"
+            ],
+            "riskProfile": "high",
+            "typicalCosts": {
+              "demolitions-expertise": 1000,
+              "protest-organization": 500,
+              "underground-networks": 300
+            },
+            "commonLocations": ["Nature preserves", "Underground bunkers", "Eco-communes"],
+            "commonOrganizations": ["TerraFirst!"]
+          },
+          {
+            "id": "rf-trid-pirate",
+            "name": "Trid Pirate",
+            "description": "An old-school Pink Mohawk rebel who disrupts corporate media and broadcasts hidden truths.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 4],
+            "commonServices": [
+              "media-disruption",
+              "signal-jamming",
+              "propaganda-broadcasting",
+              "electronic-warfare"
+            ],
+            "riskProfile": "medium",
+            "typicalCosts": {
+              "media-disruption": 200,
+              "signal-jamming": 300,
+              "propaganda-broadcasting": 150
+            },
+            "commonLocations": ["Pirate radio stations", "Underground studios", "Hacker dens"],
+            "commonOrganizations": []
+          },
+          {
+            "id": "rf-used-car-salesman",
+            "name": "Used Car Salesman",
+            "description": "A smooth-talking vehicle dealer who sells anonymous vehicles and can switch grid IDs.",
+            "suggestedConnection": [1, 3],
+            "suggestedLoyalty": [1, 3],
+            "commonServices": [
+              "vehicle-sales",
+              "vehicle-rental",
+              "grid-id-switching",
+              "anonymous-transportation"
+            ],
+            "riskProfile": "low",
+            "typicalCosts": { "vehicle-sales": 0, "vehicle-rental": 200, "grid-id-switching": 500 },
+            "commonLocations": ["Used car lots", "Parking garages", "Auto repair shops"],
+            "commonOrganizations": []
+          }
+        ]
       }
     },
     "contactTemplates": {
       "mergeStrategy": "append",
       "payload": {
-        "templates": []
+        "templates": [],
+        "randomGeneratorTables": {
+          "source": "Run Faster",
+          "page": "180-181",
+          "gender": {
+            "diceFormula": "1d6",
+            "results": [
+              { "roll": [1, 3], "result": "Male" },
+              { "roll": [4, 6], "result": "Female" }
+            ]
+          },
+          "age": {
+            "diceFormula": "1d6",
+            "results": [
+              { "roll": [1, 2], "result": "Young" },
+              { "roll": [3, 4], "result": "Middle-aged" },
+              { "roll": [5, 6], "result": "Old" }
+            ]
+          },
+          "metatype": {
+            "diceFormula": "2d6",
+            "results": [
+              { "roll": [2, 5], "result": "Human" },
+              { "roll": [6, 7], "result": "Ork" },
+              { "roll": [8, 9], "result": "Elf" },
+              { "roll": [10, 11], "result": "Dwarf" },
+              { "roll": [12, 12], "result": "Troll" }
+            ]
+          },
+          "personalLife": {
+            "diceFormula": "1d6",
+            "results": [
+              { "roll": 1, "result": "Single" },
+              { "roll": 2, "result": "In a Relationship" },
+              { "roll": 3, "result": "Familial Relationships" },
+              { "roll": 4, "result": "Divorced" },
+              { "roll": 5, "result": "Widowed" },
+              { "roll": 6, "result": "None of Your Damn Business" }
+            ]
+          },
+          "preferredPayment": {
+            "diceFormula": "2d6",
+            "results": [
+              { "roll": 2, "result": "Cash (hard currency)" },
+              { "roll": 3, "result": "Service (drek jobs)" },
+              { "roll": 4, "result": "Cash (corp scrip)" },
+              { "roll": 5, "result": "Barter (items needed for the profession)" },
+              { "roll": 6, "result": "Service (shadowrunner job)" },
+              { "roll": 7, "result": "Cash (credstick)" },
+              { "roll": 8, "result": "Cash (credstick)" },
+              { "roll": 9, "result": "Barter (easy-to-sell items)" },
+              { "roll": 10, "result": "Service (free-labor jobs)" },
+              { "roll": 11, "result": "Barter (hobby/vice items)" },
+              { "roll": 12, "result": "Cash (ECC or other foreign electronic currency)" }
+            ]
+          },
+          "hobbiesVices": {
+            "diceFormula": "2d6",
+            "results": [
+              { "roll": 2, "result": "Gamemaster's choice" },
+              { "roll": 3, "result": "Family obligations (children, parents, siblings, etc.)" },
+              { "roll": 4, "result": "Gambling (cards, horses, etc.)" },
+              { "roll": 5, "result": "Bad habits (illegal drugs, BTLs)" },
+              {
+                "roll": 6,
+                "result": "Personal grooming (clothes/fashion, shoes, perfumes, cosmetic treatments)"
+              },
+              { "roll": 7, "result": "Nothing of interest or of use" },
+              { "roll": 8, "result": "Social habits (drinking, smoking)" },
+              { "roll": 9, "result": "Entertainment (trid shows, movies, music)" },
+              { "roll": 10, "result": "Weapons (guns, blades, military, etc.)" },
+              { "roll": 11, "result": "Vehicles (cars, drones, etc.)" },
+              { "roll": 12, "result": "Gamemaster's choice" }
+            ]
+          },
+          "mentalQuirks": [
+            "Absent-minded",
+            "Believes himself to be an expert in some trivia or another",
+            "Believes himself to be sexy and flirts constantly",
+            "Chauvinist (male or female)",
+            "Compulsive liar",
+            "Disdain for SINless",
+            "Disdain when working with someone from a specific lifestyle",
+            "Fear of touching people",
+            "Fear of trolls/orks, but tries not to show it",
+            "Hates to be corrected",
+            "Hoarder of materials",
+            "Illiterate, but won't admit it",
+            "Mistrusts technological devices (paranoid or too old school)",
+            "Nervous habits (bites fingernails, wrings hands together, flop sweat, fidgety, etc.)",
+            "Obsessive-compulsive habits",
+            "Paranoid habits (insists on sitting with back toward wall, constantly checks sensors linked to commlink, etc.)",
+            "Racist toward a specific metatype (gamemaster choice)",
+            "Suffering from some obvious phobia (agoraphobia, mysophobia, acrophobia, claustrophobia, etc.)",
+            "Talks to himself (and sometimes answers)",
+            "Thin skinned",
+            "Tightwad",
+            "Unusual food preferences"
+          ],
+          "verbalQuirks": [
+            "Mangles metaphors",
+            "Memorable voice (deep, gravelly, light accent, sultry)",
+            "Over-explains",
+            "Speaks too loudly, or mumbles",
+            "Speaks with a lisp",
+            "Speaks with a thick accent that makes it hard to understand",
+            "Sprinkles profanities in every sentence",
+            "Talks too much"
+          ],
+          "physicalQuirks": [
+            "Allergic to a team member's perfume/aftershave",
+            "Bad breath",
+            "Chromed or plated features (any cybernetics, teeth, etc.)",
+            "Clothes don't fit (like they were made for another person)",
+            "Constantly sick/death warmed over",
+            "Crushing handshake",
+            "Distinctive facial hair (bicycle handle mustache, braided beard, etc.)",
+            "Distinctive style of clothing",
+            "Exceptionally clean/hygienic",
+            "Exceptionally skinny or overweight",
+            "Exceptionally soiled (stained clothes, dirty hands, scuffed/sticky devices, etc.)",
+            "Facial tick",
+            "Habitually handles some small item on his person",
+            "Memorable/unique smell (exotic perfume, incense, etc.)",
+            "Strong odor (BO, aftershave, perfume, smoke, disinfectant, etc.)",
+            "Two different eye colors",
+            "Visible scarring (face, hands, etc.)",
+            "Visible tattoos/inserts",
+            "Walks with a limp",
+            "War wounds (lost fingers, cauliflower ear, bullet scars, etc.)"
+          ]
+        }
       }
     },
     "equipmentPacks": {

--- a/data/editions/sr5/sample-contacts/rf-arms-dealer.json
+++ b/data/editions/sr5/sample-contacts/rf-arms-dealer.json
@@ -1,0 +1,53 @@
+{
+  "id": "rf-sample-contact-arms-dealer",
+  "editionCode": "sr5",
+  "name": "Arms Dealer",
+  "description": "What are you looking for? Armor piercing? Range? How about a chainsaw accessory or a pearl handle with a clamshell holster? The Arms Dealer offers a variety of firearms, from the hold-out pistol to assault cannon along with a rainbow of ammo flavors. The Arms Dealer does business with a number of organizations. Instead of selling to the highest bidder, he makes sure there's plenty to go around. Pricing depends on how much he likes you and what permits you already have. As a favor, he might let you borrow or purchase one of the bigger toys.",
+  "uses": ["Weapons procurement", "Ammunition", "Military gear", "Information on arms trade"],
+  "meetingPlaces": ["Gun ranges", "Military surplus stores", "Private warehouses"],
+  "similarContacts": ["Military Supply Officer", "Terrorist"],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 5,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 5
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Armorer", "rating": 4 },
+    { "name": "Computers", "rating": 3 },
+    { "name": "Etiquette", "rating": 4, "specialization": "Corporate" },
+    { "name": "Firearms", "rating": 4 },
+    { "name": "Gunnery", "rating": 3 },
+    { "name": "Instruction", "rating": 2 },
+    { "name": "Negotiation", "rating": 5 },
+    { "name": "Perception", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Chemistry", "rating": 4 },
+    { "name": "Firearms", "rating": 4 },
+    { "name": "Mercenary Groups", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "182",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-bartender.json
+++ b/data/editions/sr5/sample-contacts/rf-bartender.json
@@ -1,0 +1,51 @@
+{
+  "id": "rf-sample-contact-bartender",
+  "editionCode": "sr5",
+  "name": "Bartender",
+  "description": "(p. 390, SR5)",
+  "uses": ["Information", "Street rumors", "Meeting place", "Additional contacts"],
+  "meetingPlaces": ["Any bar or nightclub"],
+  "similarContacts": ["Bouncer", "Nightclub Owner", "Stripper", "Waitress"],
+  "attributes": {
+    "body": 3,
+    "agility": 4,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 4,
+    "charisma": 5
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 5,
+    "social": 7
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Automatics", "rating": 1 },
+    { "name": "Clubs", "rating": 3 },
+    { "name": "Etiquette", "rating": 4, "specialization": "Street" },
+    { "name": "Intimidation", "rating": 2 },
+    { "name": "Negotiation", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Alcohol", "rating": 4 },
+    { "name": "Media Stars", "rating": 4 },
+    { "name": "Sports", "rating": 4 },
+    { "name": "Street Rumors", "rating": 2 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "182",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-bodyguard.json
+++ b/data/editions/sr5/sample-contacts/rf-bodyguard.json
@@ -1,0 +1,47 @@
+{
+  "id": "rf-sample-contact-bodyguard",
+  "editionCode": "sr5",
+  "name": "Bodyguard",
+  "description": "She has a job to do in protecting someone else's life even if it means taking a bullet for them. She works in the private sector, picking up temp jobs for visiting travelers or acting as extra security during events or private parties. While not in the shadowrunning business, she can always lend a pair of eyes or ears.",
+  "uses": ["Physical protection", "Security assessment", "Extra muscle"],
+  "meetingPlaces": ["Corporate lobbies", "Private security firms", "Gyms"],
+  "similarContacts": ["Bounty Hunter", "Rent-a-Cop"],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 4,
+    "strength": 4,
+    "willpower": 3,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 6,
+    "mental": 4,
+    "social": 5
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Etiquette", "rating": 2, "specialization": "Corporate" },
+    { "name": "Leadership", "rating": 2 },
+    { "name": "Perception", "rating": 3 },
+    { "name": "Pistols", "rating": 4 },
+    { "name": "Running", "rating": 2 },
+    { "name": "Unarmed Combat", "rating": 4 }
+  ],
+  "knowledgeSkills": [],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "182",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-bookie.json
+++ b/data/editions/sr5/sample-contacts/rf-bookie.json
@@ -1,0 +1,51 @@
+{
+  "id": "rf-sample-contact-bookie",
+  "editionCode": "sr5",
+  "name": "Bookie",
+  "description": "May the odds be ever in your favor—that's what he says every time you place a bet. His comment is not, of course, sincere. He's good at knowing the odds in the various games of sport across the grids and balancing them so whatever the matchup, he'll get money put down on either side. He is also good at knowing the statistics of the sports players and who's open for other games of chance (pool, darts, etc.). You can borrow money from him, but expect substantial interest to be added.",
+  "uses": ["Gambling", "Loans", "Sports information", "Underground connections"],
+  "meetingPlaces": ["Sports bars", "Underground gambling dens", "Race tracks"],
+  "similarContacts": ["Loan Shark"],
+  "attributes": {
+    "body": 5,
+    "agility": 4,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 5,
+    "intuition": 4,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 6,
+    "social": 5
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Computers", "rating": 3 },
+    { "name": "Con", "rating": 3 },
+    { "name": "Etiquette", "rating": 3 },
+    { "name": "Negotiation", "rating": 4 },
+    { "name": "Perception", "rating": 5 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Currency Exchange Rates", "rating": 3 },
+    { "name": "Gambling Sites", "rating": 6 },
+    { "name": "Horse Breeds", "rating": 3 },
+    { "name": "Sport Statistics", "rating": 6 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "183",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-border-patrol-agent.json
+++ b/data/editions/sr5/sample-contacts/rf-border-patrol-agent.json
@@ -1,0 +1,56 @@
+{
+  "id": "rf-sample-contact-border-patrol-agent",
+  "editionCode": "sr5",
+  "name": "Border Patrol Agent",
+  "description": "Every nation hires officers to keep the riffraff from other countries from commingling with their own riffraff. A Border Patrol Agent has access to scanned SINs and checks on their authenticity. They are also physically on duty watching the borders. Border Patrol Agents can do this by horse, car, boat, or with drones watching the skies above. Besides the intel on who's who moving in or out of a nation, he could also do the character a favor by helping him cross the very border he's supposed to be guarding.",
+  "uses": [
+    "Border crossing assistance",
+    "SIN verification",
+    "Smuggling routes",
+    "Geographic information"
+  ],
+  "meetingPlaces": ["Border checkpoints", "Rural diners", "Outdoor supply stores"],
+  "similarContacts": ["Travel Agent", "Tour Guide"],
+  "attributes": {
+    "body": 8,
+    "agility": 3,
+    "reaction": 5,
+    "strength": 5,
+    "willpower": 3,
+    "logic": 3,
+    "intuition": 5,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 10,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 8,
+    "mental": 5,
+    "social": 5
+  },
+  "conditionMonitor": 12,
+  "skills": [
+    { "name": "Intimidation", "rating": 3 },
+    { "name": "Longarms", "rating": 3, "specialization": "Long-Range Shots" },
+    { "name": "Perception", "rating": 5 },
+    { "name": "Survival", "rating": 2 },
+    { "name": "Tracking", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Botany", "rating": 3, "specialization": "Edible Wild Plants" },
+    { "name": "Border Security", "rating": 5 },
+    { "name": "Geology", "rating": 3, "specialization": "Terrain" },
+    { "name": "Local Border Language", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "183",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-bounty-hunter.json
+++ b/data/editions/sr5/sample-contacts/rf-bounty-hunter.json
@@ -1,0 +1,53 @@
+{
+  "id": "rf-sample-contact-bounty-hunter",
+  "editionCode": "sr5",
+  "name": "Bounty Hunter",
+  "description": "A Bounty Hunter will chase down a subject provided the price is right. She can track down anyone anywhere given enough time, money, and details on the person. Pricing also depends on if you want just a location, a corpse, or a still breathing subject. She is not subtle in her techniques as she works fast to get to the next target. She is one of the more refreshingly straightforward contacts with ten percent cash up front. There are also the arcane bounty hunters, who can use their Awakened talents to find people on little more than a cigarette stub or drop of blood. Of course their prices tend to be higher.",
+  "uses": ["Tracking people", "Skip tracing", "Bounty collection", "Street-level intelligence"],
+  "meetingPlaces": ["Bail bond offices", "Dive bars", "Parked vehicles on stakeout"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 5,
+    "agility": 3,
+    "reaction": 5,
+    "strength": 5,
+    "willpower": 5,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 7,
+    "mental": 5,
+    "social": 7
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Athletics skill group", "rating": 2 },
+    { "name": "Con", "rating": 3 },
+    { "name": "Etiquette", "rating": 2 },
+    { "name": "Intimidation", "rating": 3 },
+    { "name": "Negotiation", "rating": 3 },
+    { "name": "Perception", "rating": 4 },
+    { "name": "Pistols", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Local Streets", "rating": 3 },
+    { "name": "Local Coyotes", "rating": 3 },
+    { "name": "Organized Crime", "rating": 3 },
+    { "name": "Safe Houses", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "183",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-chop-shop-mechanic.json
+++ b/data/editions/sr5/sample-contacts/rf-chop-shop-mechanic.json
@@ -1,0 +1,51 @@
+{
+  "id": "rf-sample-contact-chop-shop-mechanic",
+  "editionCode": "sr5",
+  "name": "Chop Shop Mechanic",
+  "description": "She is gifted in taking apart and putting back together vehicles of various shapes and sizes. She takes advantage of her talent by selling parts of stolen vehicles on the black market and making illegal modifications to her clients' vehicles. For you, she can take out those bullet holes with no questions asked; she can also provide a loaner for the evening, provided you don't tell anyone where you got it and remember to ditch it as soon as possible.",
+  "uses": ["Vehicle repair", "Vehicle modifications", "Stolen vehicle parts", "Loaner vehicles"],
+  "meetingPlaces": ["Back-alley garages", "Industrial districts", "Junkyards"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 5,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 5,
+    "intuition": 3,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 6,
+    "social": 5
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Automotive Mechanic", "rating": 8 },
+    { "name": "Computers", "rating": 4 },
+    { "name": "Gunnery", "rating": 4 },
+    { "name": "Influence skill group", "rating": 2 },
+    { "name": "Pilot Ground Craft", "rating": 6 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Car Dealers", "rating": 4 },
+    { "name": "Combat Biking", "rating": 4 },
+    { "name": "Junkyards", "rating": 4 },
+    { "name": "Vehicles", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "183",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-church-pastor.json
+++ b/data/editions/sr5/sample-contacts/rf-church-pastor.json
@@ -1,0 +1,50 @@
+{
+  "id": "rf-sample-contact-church-pastor",
+  "editionCode": "sr5",
+  "name": "Church Pastor",
+  "description": "You always need someone to talk to just to get things off your chest. Maybe you question why you are shooting people in the face for money and want some sort of sign or guidance. Your local pastor can give you that help. Maybe not everything can be worked out, but if you are trying to kick the habit, he's got your back.",
+  "uses": ["Emotional support", "Counseling", "Community connections", "Sanctuary"],
+  "meetingPlaces": ["Churches", "Community centers", "Homeless shelters"],
+  "similarContacts": ["Life Coach", "Psychologist"],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 4,
+    "intuition": 5,
+    "charisma": 5
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 6,
+    "social": 7
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Computers", "rating": 2 },
+    { "name": "Etiquette", "rating": 4 },
+    { "name": "Leadership", "rating": 5 },
+    { "name": "Negotiation", "rating": 4 },
+    { "name": "Performance", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Magic Theory", "rating": 4 },
+    { "name": "Music", "rating": 4 },
+    { "name": "Religion", "rating": 8 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "184",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-city-official.json
+++ b/data/editions/sr5/sample-contacts/rf-city-official.json
@@ -1,0 +1,54 @@
+{
+  "id": "rf-sample-contact-city-official",
+  "editionCode": "sr5",
+  "name": "City Official",
+  "description": "The City Official is a typical bureaucrat who has used his charms and public image to sway the voters to elect him into a position of power. He is, however, more concerned about the needs of his boss and sponsors than those of the masses. He's the most honest con artist you'll ever meet. Always good for offering dirt on his political rivals and can possibly be persuaded to leverage the city's resources for a runner if it offers a career advantage.",
+  "uses": ["Political favors", "Government information", "Legal leverage", "Resource allocation"],
+  "meetingPlaces": ["City hall", "Upscale restaurants", "Private clubs"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 4,
+    "strength": 4,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 4,
+    "charisma": 6
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 6,
+    "mental": 5,
+    "social": 8
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Acting skill group", "rating": 4 },
+    { "name": "Computers", "rating": 4 },
+    { "name": "Etiquette", "rating": 5, "specialization": "Corporate" },
+    { "name": "Leadership", "rating": 5 },
+    { "name": "Negotiation", "rating": 5 },
+    { "name": "Pistols", "rating": 3 },
+    { "name": "Sneaking", "rating": 3 },
+    { "name": "Unarmed Combat", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Drugs", "rating": 3 },
+    { "name": "Drug Dealers", "rating": 2 },
+    { "name": "Law", "rating": 6 },
+    { "name": "Street Rumors", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "184",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-club-kid.json
+++ b/data/editions/sr5/sample-contacts/rf-club-kid.json
@@ -1,0 +1,56 @@
+{
+  "id": "rf-sample-contact-club-kid",
+  "editionCode": "sr5",
+  "name": "Club Kid",
+  "description": "She stays on the bleeding edge of fashion, keeping a finger on the pulse of the city so she always knows where the party is. She thinks she knows everybody who's anybody and might have rubbed elbows with a few mega-power players. The club is her escape from her mundane wageslave existence.",
+  "uses": [
+    "Social networking",
+    "Fashion and trends",
+    "Club scene information",
+    "Celebrity connections"
+  ],
+  "meetingPlaces": ["Nightclubs", "Fashion boutiques", "Gallery openings"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 4,
+    "charisma": 5
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 5,
+    "social": 7
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Artisan", "rating": 4, "specialization": "Fashion" },
+    { "name": "Con", "rating": 4, "specialization": "Seduction" },
+    { "name": "Negotiation", "rating": 4 },
+    { "name": "Performance", "rating": 5, "specialization": "Dance" },
+    { "name": "Pistols", "rating": 2 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Current Fashion", "rating": 4 },
+    { "name": "Night Clubs", "rating": 3 },
+    { "name": "Simstars", "rating": 3 },
+    { "name": "Street Rumors", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "184",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-company-suit.json
+++ b/data/editions/sr5/sample-contacts/rf-company-suit.json
@@ -1,0 +1,59 @@
+{
+  "id": "rf-sample-contact-company-suit",
+  "editionCode": "sr5",
+  "name": "Company Suit",
+  "description": "The Company Suit is a special executive agent for the corporation. She is the Law above corporate security and will most often take care of corporate matters, where shadowrunners aren't required. She has access to most of the corporations intelligence when required and some of its dirty secrets. However she is loyal to a fault and will not let shame fall on her corporation. She'll even die for her company, with the belief that they can fix it. While she will not work against her company, she will provide any intelligence that the corporation has to help take down a rival corp or help her beloved parent corp.",
+  "uses": [
+    "Corporate intelligence",
+    "Corporate access",
+    "Legal resources",
+    "Corporate connections"
+  ],
+  "meetingPlaces": ["Corporate offices", "Executive lounges", "High-end bars"],
+  "similarContacts": ["Corporate Security Officer", "Executive Wageslave"],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 5,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Blades", "rating": 5 },
+    { "name": "Clubs", "rating": 3 },
+    { "name": "Con", "rating": 4, "specialization": "Fast-talking" },
+    { "name": "Electronics skill group", "rating": 4 },
+    { "name": "Leadership", "rating": 4 },
+    { "name": "Negotiation", "rating": 3 },
+    { "name": "Pilot Ground Craft", "rating": 2 },
+    { "name": "Pistols", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Corporate Rumors", "rating": 4 },
+    { "name": "Corporate Safehouses", "rating": 4 },
+    { "name": "Organized Criminals", "rating": 4 },
+    { "name": "City Streets", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "184",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-con-fanatic.json
+++ b/data/editions/sr5/sample-contacts/rf-con-fanatic.json
@@ -1,0 +1,55 @@
+{
+  "id": "rf-sample-contact-con-fanatic",
+  "editionCode": "sr5",
+  "name": "Con Fanatic",
+  "description": "They know all the episodes of Neil the Ork Barbarian; they can explain the controversial history around the actors; they even have bootlegged copies of the short-lived Selena the Ork Amazon Princess. They have hardcopies of many rare graphic novels throughout the century (or digital copies when the hard stuff isn't affordable). They have customized agent software on their commlink designed to build characters based on personal/min maxing preferences and to track loot. And they have logged thousands of hours on the Gaming Grids to amass an army of toons and mules that even a decker would be jealous of. Is this of any use to a shadowrunner? Probably not, but these contacts work through all the bureaucratic paperwork to drive/fly to every convention possible across the different nations. Such a contact can help get the character to a location nearest the next convention with a convincing cover story. As a favor, he might allow the character to crash on the couch in the hotel or use his spare steampunk costume.",
+  "uses": [
+    "Travel arrangements",
+    "Cover stories",
+    "Pop culture knowledge",
+    "Convention networking"
+  ],
+  "meetingPlaces": ["Gaming stores", "Convention centers", "Online Matrix forums"],
+  "similarContacts": ["Music or Sports Fanatic"],
+  "attributes": {
+    "body": 2,
+    "agility": 3,
+    "reaction": 4,
+    "strength": 3,
+    "willpower": 3,
+    "logic": 4,
+    "intuition": 4,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 4,
+    "social": 5
+  },
+  "conditionMonitor": 9,
+  "skills": [
+    { "name": "Artisan", "rating": 3 },
+    { "name": "Con", "rating": 2 },
+    { "name": "Impersonation", "rating": 2 },
+    { "name": "Leadership", "rating": 2 },
+    { "name": "Negotiation", "rating": 2 },
+    { "name": "Performance", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Hobby-Related Rules", "rating": 4 },
+    { "name": "Hobby-Related Trivia", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "185",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-corporate-administrator.json
+++ b/data/editions/sr5/sample-contacts/rf-corporate-administrator.json
@@ -1,0 +1,54 @@
+{
+  "id": "rf-sample-contact-corporate-administrator",
+  "editionCode": "sr5",
+  "name": "Corporate Administrator",
+  "description": "Found in many corporate offices, the Corporate Administrator is the human version of Matrix software that schedules appointments, greets guests, sets up celebrations and retirements, and plans out the daily schedule for individuals or groups. While the profession is archaic, the intuition and metahuman connection it provides cannot be substituted by software. Because of his position, he is the go-to person for help with both personal and business subjects. This makes the Administrator the center of gossip and rumors and news around the office. You want to know who is sleeping with who in the copy room or what new project has been handed down from above, or who to talk to at some other corporate office? Call the Corporate Admin. Corporate Administrators live on gossip and office supplies as it's how he works the system and makes himself invaluable to the other wageslaves.",
+  "uses": ["Corporate gossip", "Office access", "Schedule information", "Internal connections"],
+  "meetingPlaces": ["Corporate lobbies", "Break rooms", "Nearby coffee shops"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 4,
+    "strength": 5,
+    "willpower": 4,
+    "logic": 4,
+    "intuition": 4,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 6,
+    "mental": 6,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Computers", "rating": 4 },
+    { "name": "Con", "rating": 2 },
+    { "name": "Etiquette", "rating": 4, "specialization": "Corporate" },
+    { "name": "First Aid", "rating": 3 },
+    { "name": "Instruction", "rating": 3 },
+    { "name": "Leadership", "rating": 2 },
+    { "name": "Negotiation", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "City Knowledge", "rating": 3 },
+    { "name": "Corporate Rumors", "rating": 5 },
+    { "name": "Food Delivery Services", "rating": 3 },
+    { "name": "Hardware", "rating": 2 },
+    { "name": "Security Systems", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "185",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-corporate-wageslave.json
+++ b/data/editions/sr5/sample-contacts/rf-corporate-wageslave.json
@@ -1,0 +1,58 @@
+{
+  "id": "rf-sample-contact-corporate-wageslave",
+  "editionCode": "sr5",
+  "name": "Corporate Wageslave",
+  "description": "He is one of the faceless masses that works ten or more hours a day, six or more days a week for the great corporation. The benefits, as the corporation cheerfully states, include a corporate home, access to corporate-sponsored food, and the luxurious twice-a-decade corporate-sponsored vacations. He may feel stifled, confined, and limited, but he keeps at it in pursuit of better things. He believes if he works hard and long enough, he will move up the corporate ladder.",
+  "uses": [
+    "Corporate access",
+    "Routine information",
+    "Cover identity support",
+    "Inside perspective"
+  ],
+  "meetingPlaces": ["Corporate cafeterias", "Commuter trains", "Suburban bars"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 4,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 4,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Clubs", "rating": 1 },
+    { "name": "Computers", "rating": 4 },
+    { "name": "Con", "rating": 2 },
+    { "name": "Etiquette", "rating": 4, "specialization": "Corp" },
+    { "name": "Running", "rating": 2 },
+    { "name": "Software", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "City Knowledge", "rating": 3 },
+    { "name": "Corporate Rumor", "rating": 3 },
+    { "name": "Local Bars", "rating": 2 },
+    { "name": "Sports Cars", "rating": 3 },
+    { "name": "Trid Shows", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "186",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-coyote.json
+++ b/data/editions/sr5/sample-contacts/rf-coyote.json
@@ -1,0 +1,53 @@
+{
+  "id": "rf-sample-contact-coyote",
+  "editionCode": "sr5",
+  "name": "Coyote",
+  "description": "For every security border, there's someone who knows how to bypass it. For a hefty fee, she brings individuals or groups through tunnels, under fences, and/or by bribed guards from one nation to the next. For a favor, she might direct them to someone to get them the proper paperwork (fake SIN/permits) to be able to work and live in the new place.",
+  "uses": ["Border smuggling", "Safe passage", "Fake SIN connections", "Underground routes"],
+  "meetingPlaces": ["Border towns", "Safe houses", "Truck stops"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 5,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Athletics skill group", "rating": 2 },
+    { "name": "Computers", "rating": 2 },
+    { "name": "Con", "rating": 3 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Street" },
+    { "name": "Impersonation", "rating": 3 },
+    { "name": "Leadership", "rating": 2 },
+    { "name": "Negotiation", "rating": 4 },
+    { "name": "Pistols", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "City Knowledge", "rating": 5 },
+    { "name": "Magical Threats", "rating": 3 },
+    { "name": "Security Systems", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "186",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-cybernetic-technician.json
+++ b/data/editions/sr5/sample-contacts/rf-cybernetic-technician.json
@@ -1,0 +1,60 @@
+{
+  "id": "rf-sample-contact-cybernetic-technician",
+  "editionCode": "sr5",
+  "name": "Cybernetic Technician",
+  "description": "While the street doc works the flesh, the cybernetic technician repairs the metal. Her knowledge and interest in neuro-connections and micro-optical process has her working in a body shop. She's good at fixing worn-out and damaged parts, and if you're tired of looking through flesh eyes, she has a discount on Rating 3 cybernetic ones.",
+  "uses": [
+    "Cyberware installation",
+    "Cyberware repair",
+    "Used cyberware deals",
+    "Technical consultation"
+  ],
+  "meetingPlaces": ["Body shops", "Medical clinics", "Tech labs"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 6,
+    "agility": 4,
+    "reaction": 5,
+    "strength": 6,
+    "willpower": 4,
+    "logic": 5,
+    "intuition": 4,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 9,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 8,
+    "mental": 6,
+    "social": 6
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Biotechnology", "rating": 4 },
+    { "name": "Computers", "rating": 3 },
+    { "name": "Cybertechnology", "rating": 5 },
+    { "name": "First Aid", "rating": 3 },
+    { "name": "Industrial Mechanic", "rating": 3 },
+    { "name": "Influence skill group", "rating": 4 },
+    { "name": "Medicine", "rating": 4 },
+    { "name": "Software", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Chemistry", "rating": 2 },
+    { "name": "Cybernetics", "rating": 5 },
+    { "name": "Drugs", "rating": 4 },
+    { "name": "Golf", "rating": 4 },
+    { "name": "Medical Specialists", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "186",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-gang-boss.json
+++ b/data/editions/sr5/sample-contacts/rf-gang-boss.json
@@ -1,0 +1,57 @@
+{
+  "id": "rf-sample-contact-gang-boss",
+  "editionCode": "sr5",
+  "name": "Gang Boss",
+  "description": "A Gang Boss has worked his way up with cunning and a gun to gain his piece of the world. He has intimidated an army of thugs, and in turn they respect him and his power. As a leader of a criminal organization, he has dealt with other criminals, so he knows more about the underworld than law enforcement. With a wealth of information and people to get it for him, a character must understand that a favor from the Gang Boss comes at a price.",
+  "uses": [
+    "Street-level muscle",
+    "Criminal information",
+    "Territory access",
+    "Underground connections"
+  ],
+  "meetingPlaces": ["Gang hangouts", "Back alleys", "Abandoned buildings"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 5,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Blades", "rating": 4 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Street" },
+    { "name": "Intimidation", "rating": 4 },
+    { "name": "Leadership", "rating": 4 },
+    { "name": "Negotiation", "rating": 3 },
+    { "name": "Sneaking", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "BTLs", "rating": 2 },
+    { "name": "City Knowledge", "rating": 4 },
+    { "name": "Drugs", "rating": 2 },
+    { "name": "Street Gang Identification", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "187",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-government-official.json
+++ b/data/editions/sr5/sample-contacts/rf-government-official.json
@@ -1,0 +1,57 @@
+{
+  "id": "rf-sample-contact-government-official",
+  "editionCode": "sr5",
+  "name": "Government Official",
+  "description": "Sometimes called a Spook or Man in Black, the Government Official is annoyingly enigmatic about why or how he knows things. Rumors have him working for the CIA, FBI, or some other agency, but no one officially acknowledges his existence in any of those places. Even your relationship is somewhat of a mystery as he offers knowledge in exchange for odd jobs, which make you wonder if you're seeing the bigger picture.",
+  "uses": [
+    "Government intelligence",
+    "Classified information",
+    "Political connections",
+    "Odd jobs"
+  ],
+  "meetingPlaces": ["Anonymous locations", "Public parks", "Nondescript vehicles"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 4,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 3,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Con", "rating": 2 },
+    { "name": "Disguise", "rating": 4 },
+    { "name": "Etiquette", "rating": 5, "specialization": "Street" },
+    { "name": "Firearms skill group", "rating": 5 },
+    { "name": "Intimidation", "rating": 5 },
+    { "name": "Leadership", "rating": 4 },
+    { "name": "Negotiation", "rating": 5 },
+    { "name": "Sneaking", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Corporate Rumors", "rating": 6 },
+    { "name": "Street Rumors", "rating": 6 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "186",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-id-manufacturer.json
+++ b/data/editions/sr5/sample-contacts/rf-id-manufacturer.json
@@ -1,0 +1,54 @@
+{
+  "id": "rf-sample-contact-id-manufacturer",
+  "editionCode": "sr5",
+  "name": "ID Manufacturer",
+  "description": "The ID Manufacturer works behind the scenes using agents to gather and create data trails as she codes new SINs for clients. With plenty of demand for people wanting to be able to have their existence acknowledged so they can buy those corporate-advertised toys and get out of the barrens, she can pick and choose her clientele. If you have her as a contact, you were one of the fortunate that she will work for. Besides Fake SINs and licenses, she knows how to get real licenses, and since behind every SIN there's an artist, she can probably tell you the general seller of a specific SIN.",
+  "uses": ["Fake SINs", "Fake licenses", "Identity verification", "SIN analysis"],
+  "meetingPlaces": ["Matrix-only meetings", "Secure data havens", "Anonymous drops"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 4,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 5,
+    "intuition": 6,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 9,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 7,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Artisan", "rating": 4, "specialization": "Writing" },
+    { "name": "Con", "rating": 3 },
+    { "name": "Electronics skill group", "rating": 4 },
+    { "name": "Electronic Warfare", "rating": 5 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Media" },
+    { "name": "Hacking", "rating": 5 },
+    { "name": "Negotiation", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Grids", "rating": 5 },
+    { "name": "Matrix Security", "rating": 4 },
+    { "name": "Organized Crime", "rating": 5 },
+    { "name": "SIN Databases", "rating": 4 },
+    { "name": "Software", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "187",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-informant.json
+++ b/data/editions/sr5/sample-contacts/rf-informant.json
@@ -1,0 +1,57 @@
+{
+  "id": "rf-sample-contact-informant",
+  "editionCode": "sr5",
+  "name": "Informant",
+  "description": "The informant, also known as a stool pigeon, is a person of interest with privileged information about an organization or person. She has been working with some very bad men doing very bad things. Instead of leaving, she has decided to sell what she knows. How long this will last before she is found out is hard to tell.",
+  "uses": [
+    "Inside information",
+    "Organization intelligence",
+    "Undercover access",
+    "Criminal connections"
+  ],
+  "meetingPlaces": ["Discreet locations", "Public spaces", "Parked cars"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 2,
+    "reaction": 2,
+    "strength": 3,
+    "willpower": 5,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 5,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 4,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Con", "rating": 5 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Yakuza" },
+    { "name": "Negotiation", "rating": 3 },
+    { "name": "Palming", "rating": 2 },
+    { "name": "Pistols", "rating": 2 },
+    { "name": "Sneaking", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Drugs", "rating": 2 },
+    { "name": "Gang Identification", "rating": 3 },
+    { "name": "Organized Crime", "rating": 5 },
+    { "name": "Tattoo Identification", "rating": 2 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "188",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-international-courier.json
+++ b/data/editions/sr5/sample-contacts/rf-international-courier.json
@@ -1,0 +1,60 @@
+{
+  "id": "rf-sample-contact-international-courier",
+  "editionCode": "sr5",
+  "name": "International Courier",
+  "description": "Need pistols in Peoria? How about armored jackets in Amazonia or orichalcum in Hong Kong? The International Courier is a trusted transporter of various goods with the licensing and paperwork so he will not get stopped at checkpoints like other travelers. He's also good with alternative methods where bureaucracy fails. He is on the go 24/7 with some package. His time and services are valuable, so pricing goes up depending on the three words: what, where, and when.",
+  "uses": [
+    "International smuggling",
+    "Package delivery",
+    "Cross-border transport",
+    "Travel assistance"
+  ],
+  "meetingPlaces": ["Airports", "Shipping docks", "Hotel lobbies"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 5,
+    "strength": 4,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 6,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Con", "rating": 5 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Corporate" },
+    { "name": "Impersonation", "rating": 4 },
+    { "name": "Longarms", "rating": 3 },
+    { "name": "Negotiation", "rating": 4 },
+    { "name": "Pistols", "rating": 4 },
+    { "name": "Running", "rating": 2 },
+    { "name": "Stealth skill group", "rating": 5 },
+    { "name": "Unarmed Combat", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Corporate Rumors", "rating": 2 },
+    { "name": "Geography", "rating": 2 },
+    { "name": "Language", "rating": 4 },
+    { "name": "Language", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "188",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-knight-errant-dispatcher.json
+++ b/data/editions/sr5/sample-contacts/rf-knight-errant-dispatcher.json
@@ -1,0 +1,54 @@
+{
+  "id": "rf-sample-contact-knight-errant-dispatcher",
+  "editionCode": "sr5",
+  "name": "Knight Errant Dispatcher",
+  "description": "They don't walk the streets, but they have a finger on the pulse of the city. They monitor security alarms, law-enforcement radios, and panic buttons. They have their fellow officer's back as they coordinate backup to high-threat situations. A dispatcher can be very useful for shadowrunners, possibly telling them when they've been spotted or how long and from what direction that Lone Star response is coming. Most of this would be under special circumstances that there will not be a fight. A dispatcher is also good in tracking active events in a city: stakeouts, SWAT teams, and chases.",
+  "uses": [
+    "Law enforcement alerts",
+    "Police response timing",
+    "Security monitoring",
+    "Active event tracking"
+  ],
+  "meetingPlaces": ["Off-duty cop bars", "Coffee shops near precincts", "Matrix calls"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 4,
+    "strength": 5,
+    "willpower": 5,
+    "logic": 4,
+    "intuition": 4,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 6,
+    "mental": 6,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Computers", "rating": 4 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Street" },
+    { "name": "Leadership", "rating": 3 },
+    { "name": "Perception", "rating": 4 },
+    { "name": "Pistols", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Law Enforcement", "rating": 4 },
+    { "name": "Security Systems", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "188",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-lone-star-detective.json
+++ b/data/editions/sr5/sample-contacts/rf-lone-star-detective.json
@@ -1,0 +1,59 @@
+{
+  "id": "rf-sample-contact-lone-star-detective",
+  "editionCode": "sr5",
+  "name": "Lone Star Detective",
+  "description": "More than just a beat cop, the Lone Star Detective follows up on leads and suspects after the crime has occurred. A detective is good at observation, and unlike a simple beat cop she has access to old cases to go along with rap sheets and criminal SINs. While the Lone Star Detective's job is slightly more difficult with the SINless masses and a corporate jurisdiction quagmire, she has her cultivated sources. Through her, one can follow cases, examine evidence, or see who's in town.",
+  "uses": [
+    "Criminal investigation access",
+    "Evidence examination",
+    "Criminal records",
+    "Case tracking"
+  ],
+  "meetingPlaces": ["Precinct offices", "Crime scenes", "Late-night diners"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 5,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 5,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 6,
+    "mental": 5,
+    "social": 5
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Clubs", "rating": 4 },
+    { "name": "Computers", "rating": 3 },
+    { "name": "Con", "rating": 2 },
+    { "name": "Etiquette", "rating": 4, "specialization": "Street" },
+    { "name": "Intimidation", "rating": 3 },
+    { "name": "Perception", "rating": 5 },
+    { "name": "Pistols", "rating": 4 },
+    { "name": "Stealth skill group", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Crime Syndicates", "rating": 4 },
+    { "name": "Law Enforcement", "rating": 4 },
+    { "name": "Street Gang Identification", "rating": 4 },
+    { "name": "Street Rumors", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "188",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-mafia-consigliere.json
+++ b/data/editions/sr5/sample-contacts/rf-mafia-consigliere.json
@@ -1,0 +1,52 @@
+{
+  "id": "rf-sample-contact-mafia-consigliere",
+  "editionCode": "sr5",
+  "name": "Mafia Consigliere",
+  "description": "(p. 391, SR5)",
+  "uses": ["Organized crime connections", "Legal advice", "Political influence", "Protection"],
+  "meetingPlaces": ["Italian restaurants", "Private social clubs", "Luxury vehicles"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Electronics skill group", "rating": 4 },
+    { "name": "Etiquette", "rating": 4, "specialization": "Mafia" },
+    { "name": "Intimidation", "rating": 4 },
+    { "name": "Leadership", "rating": 6 },
+    { "name": "Perception", "rating": 4 },
+    { "name": "Pistols", "rating": 5 },
+    { "name": "Unarmed Combat", "rating": 2 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Corporate Business", "rating": 4 },
+    { "name": "Law", "rating": 4 },
+    { "name": "Local Politics", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "189",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-media-mogul.json
+++ b/data/editions/sr5/sample-contacts/rf-media-mogul.json
@@ -1,0 +1,52 @@
+{
+  "id": "rf-sample-contact-media-mogul",
+  "editionCode": "sr5",
+  "name": "Media Mogul",
+  "description": "The Media Mogul decides what information is deemed worthy to be broadcast to the subscribers on the corporate grid. It doesn't really matter how accurate it is, as long as the masses eat it up. The Media Mogul channels the voice of the corporation in promoting corporate products, trids, and newsworthy stories. Things happen fast for those who want to stay popular, so he has an army of news journalists, glitterati drones, and corporate spies to make sure his masses are the first to know when news drops. This also means that time is money to him, so you have to be succinct and make it worth his while in order to keep his attention for more than two seconds.",
+  "uses": ["Media manipulation", "News suppression", "Corporate intelligence", "Public relations"],
+  "meetingPlaces": ["Media studios", "Corporate towers", "Exclusive restaurants"],
+  "similarContacts": ["Horizon Spin Doctor", "KSAF Showrunner"],
+  "attributes": {
+    "body": 4,
+    "agility": 4,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 5,
+    "charisma": 6
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 8
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Artisan", "rating": 4, "specialization": "Writing" },
+    { "name": "Con", "rating": 4 },
+    { "name": "Electronics skill group", "rating": 4 },
+    { "name": "Etiquette", "rating": 5, "specialization": "Media" },
+    { "name": "Intimidation", "rating": 4 },
+    { "name": "Negotiation", "rating": 6 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Corporate Rumors", "rating": 5 },
+    { "name": "Elven Wines", "rating": 4 },
+    { "name": "Expensive Restaurants", "rating": 4 },
+    { "name": "Street Rumors", "rating": 5 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "189",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-metahuman-rights-activist.json
+++ b/data/editions/sr5/sample-contacts/rf-metahuman-rights-activist.json
@@ -1,0 +1,58 @@
+{
+  "id": "rf-sample-contact-metahuman-rights-activist",
+  "editionCode": "sr5",
+  "name": "Metahuman Rights Activist",
+  "description": "Always fighting for equal rights, the Metahuman Rights Activist travels around to bring light on vital issues and shame to those denying rights to their fellow metahuman. While not as visibly present as they were twenty years ago, they are still around, and we're easy to spot during recent Seattle events involving the Ork Underground. Metahuman Rights Activists know people in various positions that can help them get around security, know where to set up a protest, or get critical information out there. Like-minded shadowrunners can exploit such information for their own ends, provided they fund the cause. Based on their relationship with the character, the Metahuman Rights Activist may be able to put together a protest as a distraction to other activities.",
+  "uses": [
+    "Protest organization",
+    "Community connections",
+    "Media attention",
+    "Distraction operations"
+  ],
+  "meetingPlaces": ["Community centers", "Underground bars", "Protest sites"],
+  "similarContacts": ["Green Peace", "Sapient Rights"],
+  "attributes": {
+    "body": 6,
+    "agility": 5,
+    "reaction": 5,
+    "strength": 5,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 7,
+    "mental": 5,
+    "social": 5
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Clubs", "rating": 3 },
+    { "name": "Etiquette", "rating": 4, "specialization": "Media" },
+    { "name": "Leadership", "rating": 4 },
+    { "name": "Negotiation", "rating": 3 },
+    { "name": "Performance", "rating": 3, "specialization": "Acting" },
+    { "name": "Running", "rating": 3 },
+    { "name": "Stealth skill group", "rating": 2 }
+  ],
+  "knowledgeSkills": [
+    { "name": "[City] Knowledge", "rating": 3 },
+    { "name": "Local Gangs", "rating": 3 },
+    { "name": "Safehouses", "rating": 3 },
+    { "name": "Street Rumor", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "189",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-news-reporter.json
+++ b/data/editions/sr5/sample-contacts/rf-news-reporter.json
@@ -1,0 +1,51 @@
+{
+  "id": "rf-sample-contact-news-reporter",
+  "editionCode": "sr5",
+  "name": "News Reporter",
+  "description": "News Reporters are always in the face of newsworthy events with an electronic eye or ear, be it their own or a drone. And they don't take no for an answer, especially if pursuing the answer puts nuyen on the table. They have their own host of people and databases from which they can get rumors and statistics, but it's the real dirt, hidden in safes or behind closed doors, that they are after. So with a little trade in services, the news reporter may share vital intel in return for the runner's hand in retrieving paydata, tailing, or wiretapping a conversation.",
+  "uses": ["News and rumors", "Surveillance", "Information trade", "Media coverage"],
+  "meetingPlaces": ["News offices", "Crime scenes", "Local bars"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 4,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Computers", "rating": 2 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Media" },
+    { "name": "Perception", "rating": 4 },
+    { "name": "Sneaking", "rating": 4 },
+    { "name": "Tracking", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "[City] Knowledge", "rating": 3 },
+    { "name": "Gang Identification", "rating": 3 },
+    { "name": "Local Bars", "rating": 3 },
+    { "name": "Street Rumors", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "190",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-parazoologist.json
+++ b/data/editions/sr5/sample-contacts/rf-parazoologist.json
@@ -1,0 +1,55 @@
+{
+  "id": "rf-sample-contact-parazoologist",
+  "editionCode": "sr5",
+  "name": "Parazoologist",
+  "description": "The Parazoologist has had his nose in the books since the Sixth World arrived, studying and cataloging all the various new critters and variations. His study includes their habits, abilities, weaknesses, and sometimes how to train them. Some Parazoologists work with zoos or review collected specimens, while others are out in the field collecting and observing critters in their natural habitat. He's always happy to help in identifying the next Awakened thing that the shadowrunner comes across. He also loves to get specimens from time to time.",
+  "uses": [
+    "Paracritter identification",
+    "Creature weaknesses",
+    "Field research",
+    "Animal training advice"
+  ],
+  "meetingPlaces": ["University labs", "Nature preserves", "Museums"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 2,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 5,
+    "intuition": 3,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 6,
+    "social": 6
+  },
+  "conditionMonitor": 9,
+  "skills": [
+    { "name": "Animal Handling", "rating": 3 },
+    { "name": "Biotechnology", "rating": 4 },
+    { "name": "Instruction", "rating": 4 },
+    { "name": "Perception", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Law", "rating": 3 },
+    { "name": "Magic Theory", "rating": 2 },
+    { "name": "Parazoology", "rating": 6 },
+    { "name": "Wildlife Areas", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "190",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-pawn-broker.json
+++ b/data/editions/sr5/sample-contacts/rf-pawn-broker.json
@@ -1,0 +1,50 @@
+{
+  "id": "rf-sample-contact-pawn-broker",
+  "editionCode": "sr5",
+  "name": "Pawn Broker",
+  "description": "Part of the neighborhood's eyes and ears, the Pawn Broker sees people come in and out, hears their stories of hardship, and knows a few of their routines. While she's good at buying and selling goods, she also has knowledge of her customers' habits or changes in routine. And sometimes she has some wiz, if used, gear.",
+  "uses": ["Buy and sell goods", "Neighborhood intelligence", "Used gear", "Quick cash"],
+  "meetingPlaces": ["Pawn shops", "Flea markets", "Neighborhood streets"],
+  "similarContacts": ["Antique Dealer"],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 4,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Computers", "rating": 2 },
+    { "name": "Etiquette", "rating": 2, "specialization": "Street" },
+    { "name": "Longarms", "rating": 3 },
+    { "name": "Negotiation", "rating": 5 },
+    { "name": "Perception", "rating": 5 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Item Appraisal", "rating": 3 },
+    { "name": "Street Rumors", "rating": 2 },
+    { "name": "Tech Trends", "rating": 2 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "190",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-pharmacy-tech.json
+++ b/data/editions/sr5/sample-contacts/rf-pharmacy-tech.json
@@ -1,0 +1,54 @@
+{
+  "id": "rf-sample-contact-pharmacy-tech",
+  "editionCode": "sr5",
+  "name": "Pharmacy Tech",
+  "description": "These days, the technology to create drugs has exceeded the ability for any government to regulate them. Only the hostilities between corporations over patents keep most drugs on the market in check. A Pharmacy Tech has the chemical and biological knowledge to create, deconstruct, and in some cases neutralize drug effects. Some even have knowledge of bad combinations or their effects on other sapient species. A Pharmacy Tech can provide illegal drugs without a prescription, refill a medkit's painkillers or antibiotics, or supply those handy slap patches.",
+  "uses": ["Drug procurement", "Pharmaceutical knowledge", "Medkit supplies", "Drug analysis"],
+  "meetingPlaces": ["Pharmacies", "Clinics", "University labs"],
+  "similarContacts": ["High School Chemistry Teacher"],
+  "attributes": {
+    "body": 2,
+    "agility": 5,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 6,
+    "intuition": 5,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 7,
+    "social": 6
+  },
+  "conditionMonitor": 9,
+  "skills": [
+    { "name": "Biotechnology", "rating": 4 },
+    { "name": "Chemistry", "rating": 5 },
+    { "name": "Electronics skill group", "rating": 2 },
+    { "name": "Etiquette", "rating": 2 },
+    { "name": "Medicine", "rating": 5 },
+    { "name": "Negotiation", "rating": 2 },
+    { "name": "Perception", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Botany", "rating": 2 },
+    { "name": "Chemistry", "rating": 4 },
+    { "name": "Corporate Business", "rating": 5 },
+    { "name": "Drugs", "rating": 6 },
+    { "name": "Law", "rating": 5 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "190",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-popular-mefeed-personality.json
+++ b/data/editions/sr5/sample-contacts/rf-popular-mefeed-personality.json
@@ -1,0 +1,55 @@
+{
+  "id": "rf-sample-contact-popular-mefeed-personality",
+  "editionCode": "sr5",
+  "name": "Popular MeFeed Personality",
+  "description": "Ranting and raving on the Matrix is nothing new. Popular MeFeed Personalities share photos, audio clips, and text from their grid subscription as they mingle with their public and bask in their adoring (though occasionally angry) glow. Subscriptions to dancing cats or lists of what's for dinner are cute and all, but some people are talented enough to find the right words and images to create a following. They are rarely anonymous and mostly harmless in what they do, but they can influence some opinions. Depending on the following, you can ask the contact if any of his subscribers can help. In the vast wasteland of Matrix entertainment, it's always possible that someone knows something.",
+  "uses": [
+    "Social media influence",
+    "Public opinion",
+    "Matrix connections",
+    "Information gathering"
+  ],
+  "meetingPlaces": ["Trendy cafes", "Public events", "Matrix streams"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Artisan", "rating": 3, "specialization": "Writing" },
+    { "name": "Computers", "rating": 4 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Media" },
+    { "name": "Perception", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Local Bars", "rating": 3 },
+    { "name": "Local Restaurants", "rating": 3 },
+    { "name": "Sports", "rating": 3 },
+    { "name": "Street Rumors", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "191",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-recicladore.json
+++ b/data/editions/sr5/sample-contacts/rf-recicladore.json
@@ -1,0 +1,51 @@
+{
+  "id": "rf-sample-contact-recicladore",
+  "editionCode": "sr5",
+  "name": "Recicladore",
+  "description": "The current trend of what to do with trash is to bury it to make it go away. But like information on the Matrix, it doesn't always stay buried. A Recicladore lives and works from trash dumps, making a living recycling and using what's been buried for generations. Need a DVD player? Readers Digest in paper form? How about a twentieth-century car engine? A Recicladore collects many low-tech items or raw materials. Communities of recicladores trade recyclables for foodstuffs and medicine, and this Recicladore is no exception. Standard currency can be used to buy his stuff, but it's not preferred as most communities are barter societies. Recicladores have the advantage of knowing just where a body—dead or alive—can be stashed and never found.",
+  "uses": ["Salvaged goods", "Body disposal", "Low-tech equipment", "Barter goods"],
+  "meetingPlaces": ["Trash dumps", "Recycling centers", "Barrens outskirts"],
+  "similarContacts": ["Junkyard Operator", "Water/Sewage Treatment Worker"],
+  "attributes": {
+    "body": 7,
+    "agility": 4,
+    "reaction": 3,
+    "strength": 7,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 8,
+    "mental": 5,
+    "social": 5
+  },
+  "conditionMonitor": 12,
+  "skills": [
+    { "name": "Clubs", "rating": 3 },
+    { "name": "Etiquette", "rating": 2, "specialization": "Street" },
+    { "name": "First Aid", "rating": 3 },
+    { "name": "Perception", "rating": 3 },
+    { "name": "Survival", "rating": 2 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Biotechnology", "rating": 3 },
+    { "name": "BTLs", "rating": 3 },
+    { "name": "Chemistry", "rating": 4 },
+    { "name": "Twentieth Century Technology", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "191",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-rent-a-cop.json
+++ b/data/editions/sr5/sample-contacts/rf-rent-a-cop.json
@@ -1,0 +1,51 @@
+{
+  "id": "rf-sample-contact-rent-a-cop",
+  "editionCode": "sr5",
+  "name": "Rent-a-Cop",
+  "description": "While he has been given a gun and a badge, he does not have the same training or discipline as those employed with Lone Star or Knight Errant. He has been hired cheaply by some mall or minor corporation to have a presence that will deter criminals. He believes that chicks dig the uniform. Unfortunately if the shit hits the fan, his contract does not cover taking a bullet for the company. While on the job, he keeps his eyes and ears open to what is going on, plus he's given authorization to walk around and access most spots in his assigned beat.",
+  "uses": ["Security patrol information", "Building access", "Local intelligence", "Lookout duty"],
+  "meetingPlaces": ["Shopping malls", "Corporate parking lots", "Fast food joints"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 5,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 4
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Etiquette", "rating": 3, "specialization": "Street" },
+    { "name": "Intimidation", "rating": 3 },
+    { "name": "Perception", "rating": 3 },
+    { "name": "Pilot Ground Craft", "rating": 2 },
+    { "name": "Pistols", "rating": 2 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Gang Identification", "rating": 3 },
+    { "name": "Local Cheap Food", "rating": 4 },
+    { "name": "Security Systems", "rating": 2 },
+    { "name": "Street Rumors", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "192",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-rockstar.json
+++ b/data/editions/sr5/sample-contacts/rf-rockstar.json
@@ -1,0 +1,54 @@
+{
+  "id": "rf-sample-contact-rockstar",
+  "editionCode": "sr5",
+  "name": "Rockstar",
+  "description": "Millions of fans follow every move she makes on the matrix and pour over every detail on her MeFeed. Corporations fight to the death for her to promote or sponsor their products. She is wildly popular with the masses, and everybody wants to be her friend. This allows her to meet with virtually anyone when she travels the globe to play her music. This makes her a worthy contact to use in order to contact influential people. The trick is staying out of the spotlight when meeting her and making sure any actions don't get tied back to her—otherwise that's another burned bridge.",
+  "uses": ["Celebrity access", "Social influence", "Media connections", "VIP introductions"],
+  "meetingPlaces": ["Backstage areas", "Private parties", "Recording studios"],
+  "similarContacts": ["Simsense Star", "Trid Star"],
+  "attributes": {
+    "body": 3,
+    "agility": 5,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 2,
+    "intuition": 3,
+    "charisma": 5
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 4,
+    "social": 7
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Clubs", "rating": 2 },
+    { "name": "Computers", "rating": 3 },
+    { "name": "Etiquette", "rating": 4, "specialization": "Media" },
+    { "name": "Negotiation", "rating": 4 },
+    { "name": "Perception", "rating": 4 },
+    { "name": "Performance", "rating": 5, "specialization": "Singing" },
+    { "name": "Pilot Ground Craft", "rating": 3 },
+    { "name": "Stealth skill group", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "(Language)", "rating": 3 },
+    { "name": "Music Industry", "rating": 3 },
+    { "name": "Musical Instruments", "rating": 3 },
+    { "name": "Street Rumors", "rating": 2 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "192",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-safehouse-master.json
+++ b/data/editions/sr5/sample-contacts/rf-safehouse-master.json
@@ -1,0 +1,54 @@
+{
+  "id": "rf-sample-contact-safehouse-master",
+  "editionCode": "sr5",
+  "name": "Safehouse Master",
+  "description": "As his title states, he is the master of the safehouse. His objective is to protect the people temporarily residing there. This sometimes means protecting these people against themselves. He makes sure that they keep a low profile, including avoiding the Grid and any Demi-GODs roaming around. He is disciplined, keeps strict hours, and monitors those who enter and leave the house.",
+  "uses": ["Safe lodging", "Security", "Low-profile operations", "Fugitive protection"],
+  "meetingPlaces": ["Safehouses", "Secure locations", "Anonymous cafes"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 5,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 5,
+    "willpower": 5,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 6,
+    "mental": 5,
+    "social": 7
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Computers", "rating": 3 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Corp" },
+    { "name": "First Aid", "rating": 3 },
+    { "name": "Leadership", "rating": 3 },
+    { "name": "Negotiation", "rating": 2 },
+    { "name": "Perception", "rating": 4 },
+    { "name": "Pistols", "rating": 3 },
+    { "name": "Stealth skill group", "rating": 2 }
+  ],
+  "knowledgeSkills": [
+    { "name": "[City] Knowledge", "rating": 2 },
+    { "name": "Corporate Politics", "rating": 3 },
+    { "name": "(Language)", "rating": 3 },
+    { "name": "Security Systems", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "192",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-script-kiddie.json
+++ b/data/editions/sr5/sample-contacts/rf-script-kiddie.json
@@ -1,0 +1,54 @@
+{
+  "id": "rf-sample-contact-script-kiddie",
+  "editionCode": "sr5",
+  "name": "Script Kiddie",
+  "description": "There are deckers, and then there are wannabe deckers, often known as Script Kiddies. They're clever, often using homemade decks assembled from commlink parts, sweat, and chutzpah. They load them up with malware programs and coded viruses, then set about causing chaos wherever they can. While not as sophisticated or dangerous as a decker, she can still surprise you with what she can access in the Matrix.",
+  "uses": ["Matrix reconnaissance", "Malware deployment", "Cheap hacking", "Matrix rumors"],
+  "meetingPlaces": ["Coffee shops", "Hacker spaces", "Matrix cafes"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 2,
+    "agility": 2,
+    "reaction": 4,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 5,
+    "intuition": 4,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 6,
+    "social": 6
+  },
+  "conditionMonitor": 9,
+  "skills": [
+    { "name": "Computers", "rating": 3 },
+    { "name": "Cybercombat", "rating": 1 },
+    { "name": "Electronic Warfare", "rating": 4 },
+    { "name": "Etiquette", "rating": 2, "specialization": "Matrix" },
+    { "name": "Hacking", "rating": 3 },
+    { "name": "Hardware", "rating": 2 },
+    { "name": "Negotiation", "rating": 2 }
+  ],
+  "knowledgeSkills": [
+    { "name": "[City] Knowledge", "rating": 3 },
+    { "name": "Decker Hangouts", "rating": 4 },
+    { "name": "Malware", "rating": 3 },
+    { "name": "Street Rumors", "rating": 4 },
+    { "name": "Trideos", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "192",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-sprawl-ganger.json
+++ b/data/editions/sr5/sample-contacts/rf-sprawl-ganger.json
@@ -1,0 +1,49 @@
+{
+  "id": "rf-sample-contact-sprawl-ganger",
+  "editionCode": "sr5",
+  "name": "Sprawl Ganger",
+  "description": "The Sprawl Ganger survived the barrens and found a family in the form of a gang. He's uncouth and arrogant in the way of street toughs. He's also someone that you can trust to walk the streets, shake a few trees, and see what falls out.",
+  "uses": ["Street-level muscle", "Neighborhood watch", "Gang intelligence", "Intimidation"],
+  "meetingPlaces": ["Street corners", "Gang hangouts", "Barrens bars"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 6,
+    "agility": 3,
+    "reaction": 5,
+    "strength": 5,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 2
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 8,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 7,
+    "mental": 5,
+    "social": 5
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Clubs", "rating": 2 },
+    { "name": "Perception", "rating": 3 },
+    { "name": "Pistols", "rating": 3 },
+    { "name": "Survival", "rating": 3 },
+    { "name": "Unarmed Combat", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "[City] Knowledge", "rating": 3 },
+    { "name": "Gang Territory", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "193",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-squatter.json
+++ b/data/editions/sr5/sample-contacts/rf-squatter.json
@@ -1,0 +1,53 @@
+{
+  "id": "rf-sample-contact-squatter",
+  "editionCode": "sr5",
+  "name": "Squatter",
+  "description": "Squatters have no money and no residence—like the thousands of other SINless who live in the city. Can't loan you any money and probably aren't educated or literate enough to help with legwork. But with so many around, many people tend to ignore them. This is their asset: anonymity. As a contact, the Squatter can sit and watch a place for days, reporting who's coming and going—provided that the character keeps him fed.",
+  "uses": ["Surveillance", "Barrens knowledge", "Anonymity", "Local rumors"],
+  "meetingPlaces": ["Under bridges", "Abandoned buildings", "Soup kitchens"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 5
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Blades", "rating": 2 },
+    { "name": "Con", "rating": 1 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Street" },
+    { "name": "Intimidation", "rating": 1 },
+    { "name": "Perception", "rating": 3 },
+    { "name": "Sneaking", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "[City] Knowledge", "rating": 3 },
+    { "name": "Drugs", "rating": 2 },
+    { "name": "Dumpster Diving", "rating": 3 },
+    { "name": "Gang Identification", "rating": 3 },
+    { "name": "Street Rumors", "rating": 2 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "193",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-store-owner.json
+++ b/data/editions/sr5/sample-contacts/rf-store-owner.json
@@ -1,0 +1,51 @@
+{
+  "id": "rf-sample-contact-store-owner",
+  "editionCode": "sr5",
+  "name": "Store Owner",
+  "description": "A Store Owner is always good for friendly advice and, depending on the store, a free meal or help with fixing something. A Store Owner is also a fixed point in a city, regularly in a spot where she can observe the comings and goings of residents around her, know the word on the street, and what changes may be coming.",
+  "uses": ["Local intelligence", "Meeting point", "Small goods", "Community connections"],
+  "meetingPlaces": ["Their store", "Local markets", "Neighborhood streets"],
+  "similarContacts": ["Mobile Food Truck Operator", "Street Vendor"],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Artisan", "rating": 2 },
+    { "name": "Blades", "rating": 2 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Corp" },
+    { "name": "Negotiation", "rating": 3 },
+    { "name": "Perception", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "[City] Politics", "rating": 3 },
+    { "name": "Media Trivia", "rating": 3 },
+    { "name": "Street Rumors", "rating": 3 },
+    { "name": "Thrift Stores", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "193",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-street-doc.json
+++ b/data/editions/sr5/sample-contacts/rf-street-doc.json
@@ -1,0 +1,54 @@
+{
+  "id": "rf-sample-contact-street-doc",
+  "editionCode": "sr5",
+  "name": "Street Doc",
+  "description": "(p. 392, SR5)",
+  "uses": ["Medical care", "Cyberware installation", "Drug knowledge", "Emergency treatment"],
+  "meetingPlaces": ["Back-alley clinics", "Body shops", "Mobile medical vans"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 4,
+    "intuition": 3,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Chemistry", "rating": 4 },
+    { "name": "Computers", "rating": 4 },
+    { "name": "Con", "rating": 2 },
+    { "name": "Cybertechnology", "rating": 3 },
+    { "name": "First Aid", "rating": 4 },
+    { "name": "Influence skill group", "rating": 4 },
+    { "name": "Medicine", "rating": 6 },
+    { "name": "Pistols", "rating": 4 }
+  ],
+  "knowledgeSkills": [
+    { "name": "BTLs", "rating": 3 },
+    { "name": "Drugs", "rating": 4 },
+    { "name": "Medical Centers", "rating": 4 },
+    { "name": "Street Rumors", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "193",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-street-kid.json
+++ b/data/editions/sr5/sample-contacts/rf-street-kid.json
@@ -1,0 +1,49 @@
+{
+  "id": "rf-sample-contact-street-kid",
+  "editionCode": "sr5",
+  "name": "Street Kid",
+  "description": "The Street Kid was born, naturally, on the streets. Quite literally, in fact. There are many like him in the barrens. His family are people he's found whom he can trust, and they are few. He's small enough to be ignored, but don't give him the brush-off as he might know something useful. Also be careful—in his eyes, you are somebody, and that's more than he can say for his parents.",
+  "uses": ["Surveillance", "Message running", "Street-level information", "Distraction"],
+  "meetingPlaces": ["Street corners", "Abandoned lots", "Soup kitchens"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 2,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 2,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 6,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 4,
+    "social": 5
+  },
+  "conditionMonitor": 9,
+  "skills": [
+    { "name": "Etiquette", "rating": 2, "specialization": "Street" },
+    { "name": "Palming", "rating": 2 },
+    { "name": "Perception", "rating": 2 },
+    { "name": "Sneaking", "rating": 4 },
+    { "name": "Survival", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "(City) Knowledge", "rating": 3 },
+    { "name": "Street Rumors", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "194",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-talismonger.json
+++ b/data/editions/sr5/sample-contacts/rf-talismonger.json
@@ -1,0 +1,52 @@
+{
+  "id": "rf-sample-contact-talismonger",
+  "editionCode": "sr5",
+  "name": "Talismonger",
+  "description": "(p. 392, SR5)",
+  "uses": ["Magical supplies", "Arcane knowledge", "Spell components", "Magical identification"],
+  "meetingPlaces": ["Talismonger shops", "Magical supply stores", "Ley line locations"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 5,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 7
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Alchemy", "rating": 4 },
+    { "name": "Arcana", "rating": 4 },
+    { "name": "Assensing", "rating": 3 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Magic" },
+    { "name": "Negotiation", "rating": 4 },
+    { "name": "Perception", "rating": 3 },
+    { "name": "Sorcery skill group", "rating": 2 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Magical Threats", "rating": 5 },
+    { "name": "Magic Theory", "rating": 5 },
+    { "name": "Parabotany", "rating": 2 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "194",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-taxi-driver.json
+++ b/data/editions/sr5/sample-contacts/rf-taxi-driver.json
@@ -1,0 +1,51 @@
+{
+  "id": "rf-sample-contact-taxi-driver",
+  "editionCode": "sr5",
+  "name": "Taxi Driver",
+  "description": "Need to travel around and don't have the wheels or know all the shortcuts in the city? The Taxi Driver can help you get around. He works most of the day and his ride blends in to almost any surrounding, especially in sprawls. As a favor, the driver could pick up the contact if he's in trouble, even if that trouble is in the barrens. But you'd better tip well.",
+  "uses": ["Transportation", "City navigation", "Surveillance platform", "Quick getaway"],
+  "meetingPlaces": ["Taxi stands", "Hotels", "Airports"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 4,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 3,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 5,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Automotive Mechanic", "rating": 2 },
+    { "name": "Blades", "rating": 2 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Street" },
+    { "name": "Negotiation", "rating": 2 },
+    { "name": "Perception", "rating": 3 },
+    { "name": "Pilot Ground Craft", "rating": 5 }
+  ],
+  "knowledgeSkills": [
+    { "name": "(City) Knowledge", "rating": 4 },
+    { "name": "(City) Streets", "rating": 4 },
+    { "name": "Street Rumors", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "194",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-terrafirst-activist.json
+++ b/data/editions/sr5/sample-contacts/rf-terrafirst-activist.json
@@ -1,0 +1,61 @@
+{
+  "id": "rf-sample-contact-terrafirst-activist",
+  "editionCode": "sr5",
+  "name": "TerraFirst! Activist",
+  "description": "The TerraFirst! Activist is totally devoted to her cause—namely, opposition to environmental destruction. She believes the extreme actions she takes are the only actions available to her. She targets those who she believes are enemies to her cause. Collateral damage is justified as those who should not have turned a blind eye to the damage being done to the environment.",
+  "uses": [
+    "Demolitions expertise",
+    "Eco-terrorism connections",
+    "Protest organization",
+    "Underground networks"
+  ],
+  "meetingPlaces": ["Nature preserves", "Underground bunkers", "Eco-communes"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 5,
+    "agility": 3,
+    "reaction": 4,
+    "strength": 5,
+    "willpower": 5,
+    "logic": 5,
+    "intuition": 3,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 1,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 7,
+    "mental": 6,
+    "social": 6
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Acting skill group", "rating": 4 },
+    { "name": "Armorer", "rating": 3 },
+    { "name": "Automatics", "rating": 4 },
+    { "name": "Computers", "rating": 3 },
+    { "name": "Demolitions", "rating": 6 },
+    { "name": "Etiquette", "rating": 3, "specialization": "Media" },
+    { "name": "Intimidation", "rating": 3 },
+    { "name": "Perception", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Chemistry", "rating": 3 },
+    { "name": "Corporate Politics", "rating": 3 },
+    { "name": "Corporate Rumors", "rating": 3 },
+    { "name": "(Language)", "rating": 3 },
+    { "name": "Safehouses", "rating": 3 },
+    { "name": "Street Rumors", "rating": 3 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "194",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-trid-pirate.json
+++ b/data/editions/sr5/sample-contacts/rf-trid-pirate.json
@@ -1,0 +1,53 @@
+{
+  "id": "rf-sample-contact-trid-pirate",
+  "editionCode": "sr5",
+  "name": "Trid Pirate",
+  "description": "The Trid Pirate is the icon of old-school Pink Mohawk runners. He rebels against the corporations by disrupting media broadcasts with his own version of the truth. Most often he can get away with generating noise to \"wake the wageslave zombie from doing work for the Man.\" He's always good for distraction or a laugh, and sometimes the \"hidden truths\" he says he knows have the virtue of actually being true.",
+  "uses": ["Media disruption", "Signal jamming", "Propaganda broadcasting", "Electronic warfare"],
+  "meetingPlaces": ["Pirate radio stations", "Underground studios", "Hacker dens"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 6,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 5,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 4,
+    "charisma": 3
+  },
+  "specialAttributes": {
+    "edge": 4,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 7,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 7,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 11,
+  "skills": [
+    { "name": "Computers", "rating": 5 },
+    { "name": "Electronic Warfare", "rating": 5 },
+    { "name": "Hacking", "rating": 3 },
+    { "name": "Hardware", "rating": 3 },
+    { "name": "Influence skill group", "rating": 2 },
+    { "name": "Performance", "rating": 3 },
+    { "name": "Software", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Grids", "rating": 4 },
+    { "name": "Media Stars", "rating": 3 },
+    { "name": "Street Rumors", "rating": 3 },
+    { "name": "Wired Technology", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "195",
+    "category": "Sample Contact"
+  }
+}

--- a/data/editions/sr5/sample-contacts/rf-used-car-salesman.json
+++ b/data/editions/sr5/sample-contacts/rf-used-car-salesman.json
@@ -1,0 +1,50 @@
+{
+  "id": "rf-sample-contact-used-car-salesman",
+  "editionCode": "sr5",
+  "name": "Used Car Salesman",
+  "description": "The Used Car Salesman has all kinds of used, anonymous vehicles for you to buy or rent. He has the charm of a low-budget trid star and can make you believe that you are getting a great deal. Careful, though, as he is a master of selling a sow's ear as a silk purse. Hot cars are not a problem—just slap on a new coat of paint and switch grid IDs. He doesn't remember faces too well unless they owe him money, but he never forgets a car.",
+  "uses": ["Vehicle sales", "Vehicle rental", "Grid ID switching", "Anonymous transportation"],
+  "meetingPlaces": ["Used car lots", "Parking garages", "Auto repair shops"],
+  "similarContacts": [],
+  "attributes": {
+    "body": 3,
+    "agility": 3,
+    "reaction": 3,
+    "strength": 3,
+    "willpower": 4,
+    "logic": 3,
+    "intuition": 3,
+    "charisma": 4
+  },
+  "specialAttributes": {
+    "edge": 2,
+    "essence": 6
+  },
+  "initiative": {
+    "base": 6,
+    "dice": 1
+  },
+  "limits": {
+    "physical": 4,
+    "mental": 5,
+    "social": 6
+  },
+  "conditionMonitor": 10,
+  "skills": [
+    { "name": "Automotive Mechanic", "rating": 3 },
+    { "name": "Con", "rating": 5 },
+    { "name": "Etiquette", "rating": 4, "specialization": "Street" },
+    { "name": "Negotiation", "rating": 6 },
+    { "name": "Perception", "rating": 3 }
+  ],
+  "knowledgeSkills": [
+    { "name": "Cars", "rating": 4 },
+    { "name": "Grid Guide", "rating": 4 },
+    { "name": "Street Rumors", "rating": 4 }
+  ],
+  "metadata": {
+    "source": "Run Faster",
+    "page": "195",
+    "category": "Sample Contact"
+  }
+}


### PR DESCRIPTION
## Summary
- Add all **46 contact archetypes** from Run Faster (pp. 182-195) as individual sample contact JSON files with full NPC stat blocks
- Add **46 archetype catalog entries** to the `contactArchetypes` module in `run-faster.json`
- Add **random generator tables** for contact creation (gender, age, metatype, personal life, preferred payment, hobbies/vices, mental/verbal/physical quirks)

## Contact Archetypes Added
Arms Dealer, Bartender, Bodyguard, Bookie, Border Patrol Agent, Bounty Hunter, Chop Shop Mechanic, Church Pastor, City Official, Club Kid, Company Suit, Con Fanatic, Corporate Administrator, Corporate Wageslave, Coyote, Cybernetic Technician, Gang Boss, Government Official, ID Manufacturer, Informant, International Courier, Knight Errant Dispatcher, Lone Star Detective, Mafia Consigliere, Media Mogul, Metahuman Rights Activist, News Reporter, Parazoologist, Pawn Broker, Pharmacy Tech, Popular MeFeed Personality, Recicladore, Rent-a-Cop, Rockstar, Safehouse Master, Script Kiddie, Sprawl Ganger, Squatter, Store Owner, Street Doc, Street Kid, Talismonger, Taxi Driver, TerraFirst! Activist, Trid Pirate, Used Car Salesman

## Data Per Archetype
Each sample contact includes: attributes (BOD/AGI/REA/STR/WIL/LOG/INT/CHA), special attributes (Edge/Essence), initiative, limits (Physical/Mental/Social), condition monitor, active skills with specializations, knowledge skills, description, uses, meeting places, and similar contacts.

## Test plan
- [x] All 46 JSON files validate as valid JSON
- [x] TypeScript type-check passes
- [x] All 9095 unit tests pass
- [x] Data verification (`pnpm verify-data`) runs without new issues
- [x] Naming conventions verified (`pnpm verify-naming`)
- [ ] Verify Connection ratings match issue table
- [ ] Verify service types match the 6-type taxonomy
- [ ] Spot-check stat blocks against sourcebook PDF
- [ ] Verify preferred payment types match the 2D6 payment table

Closes #535