### PR TITLE
fix: correct Gel Rounds AP modifier from 2 to 1

### DIFF
--- a/data/editions/sr5/core-rulebook.json
+++ b/data/editions/sr5/core-rulebook.json
@@ -12750,7 +12750,7 @@
             "stackable": true,
             "consumable": true,
             "damageModifier": "+0S",
-            "apModifier": 2,
+            "apModifier": 1,
             "availability": 2,
             "legality": "restricted",
             "description": "Non-lethal rounds (Stun damage).",


### PR DESCRIPTION
## Summary

- Corrects the `apModifier` for Gel Rounds in `data/editions/sr5/core-rulebook.json` from `2` to `1`
- Per SR5 Core Rulebook p. 434, Gel Rounds have an AP modifier of +1 (not +2)
- The `damageModifier` (`+0S`) remains unchanged — Gel Rounds convert damage type to Stun but do not modify DV via this field

Closes #595

## Validation Checklist

- [x] Located `gel-rounds` entry in `modules.gear.payload.ammunition`
- [x] Confirmed `apModifier` was incorrectly set to `2`
- [x] Changed `apModifier` to `1` (correct per rulebook)
- [x] Verified no other fields were modified
- [x] `damageModifier` field reviewed — `+0S` indicates Stun conversion with no DV change (separate from the -2S(e) notation which combines both effects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)