### PR TITLE
fix: block suspended accounts from signing in via password

### DIFF
--- a/app/api/auth/signin/__tests__/route.test.ts
+++ b/app/api/auth/signin/__tests__/route.test.ts
@@ -275,6 +275,38 @@ describe("POST /api/auth/signin", () => {
     );
   });
 
+  it("should return 403 when account is suspended", async () => {
+    const suspendedUser = {
+      ...mockUser,
+      accountStatus: "suspended" as const,
+    };
+    const requestBody = {
+      email: "test@example.com",
+      password: "ValidPass123!",
+    };
+
+    vi.mocked(storageModule.getUserByEmail).mockResolvedValue(suspendedUser);
+    vi.mocked(passwordModule.verifyCredentials).mockResolvedValue({ valid: true, error: null });
+
+    const request = createMockRequest("http://localhost:3000/api/auth/signin", requestBody, "POST");
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Your account has been suspended.");
+    expect(sessionModule.createSession).not.toHaveBeenCalled();
+    expect(storageModule.updateUser).not.toHaveBeenCalled();
+    expect(AuditLogger.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "signin.failure",
+        userId: suspendedUser.id,
+        metadata: { reason: "account_suspended" },
+      })
+    );
+  });
+
   it("should return 403 when account is locked out", async () => {
     const lockedUser = {
       ...mockUser,

--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -83,7 +83,22 @@ export async function POST(request: NextRequest): Promise<NextResponse<AuthRespo
       return failResponse();
     }
 
-    // 8. Check lockout status
+    // 8. Check if account is suspended
+    if (user.accountStatus === "suspended") {
+      await AuditLogger.log({
+        event: "signin.failure",
+        userId: user.id,
+        email,
+        ip,
+        metadata: { reason: "account_suspended" },
+      });
+      return NextResponse.json(
+        { success: false, error: "Your account has been suspended." },
+        { status: 403 }
+      );
+    }
+
+    // 9. Check lockout status
     if (user.lockoutUntil && new Date(user.lockoutUntil) > new Date()) {
       await AuditLogger.log({ event: "lockout.triggered", userId: user.id, email, ip });
       return NextResponse.json(
@@ -92,7 +107,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<AuthRespo
       );
     }
 
-    // 9. Check password validity
+    // 10. Check password validity
     if (!valid) {
       await incrementFailedAttempts(user.id);
       await AuditLogger.log({
@@ -105,7 +120,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<AuthRespo
       return failResponse();
     }
 
-    // 10. Success - Reset attempts and create session
+    // 11. Success - Reset attempts and create session
     await resetFailedAttempts(user.id);
     const updatedUser = await updateUser(user.id, {
       lastLogin: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Adds `accountStatus === "suspended"` check to the signin route, matching the existing pattern in magic-link auth
- Returns 403 with audit logging when a suspended account attempts password signin
- Adds test verifying the behavior

Closes #631

## Test plan
- [x] New test: suspended account returns 403 with correct error message
- [x] Existing tests: all 9133 tests pass
- [x] Type-check: clean
- [x] Pre-commit hooks: pass (lint, format, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)