### PR TITLE
fix: return 401 instead of 403 for unauthenticated admin requests

### DIFF
--- a/app/api/audit/users/__tests__/route.test.ts
+++ b/app/api/audit/users/__tests__/route.test.ts
@@ -14,7 +14,13 @@ import type { User } from "@/lib/types/user";
 import type { UserAuditEntry } from "@/lib/types/audit";
 
 // Mock dependencies
-vi.mock("@/lib/auth/middleware");
+vi.mock("@/lib/auth/middleware", async (importOriginal) => {
+  const actual = await importOriginal<typeof middlewareModule>();
+  return {
+    ...actual,
+    requireAdmin: vi.fn(),
+  };
+});
 vi.mock("@/lib/storage/user-audit");
 
 describe("GET /api/audit/users", () => {
@@ -214,7 +220,7 @@ describe("GET /api/audit/users", () => {
     expect(data.success).toBe(false);
   });
 
-  it("should return 403 if not authenticated", async () => {
+  it("should return 401 if not authenticated", async () => {
     vi.mocked(middlewareModule.requireAdmin).mockRejectedValue(
       new Error("Authentication required")
     );
@@ -223,7 +229,7 @@ describe("GET /api/audit/users", () => {
     const response = await GET(request);
     const data = await response.json();
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(401);
     expect(data.success).toBe(false);
   });
 });

--- a/app/api/audit/users/route.ts
+++ b/app/api/audit/users/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/auth/middleware";
+import { requireAdmin, handleAdminAuthError } from "@/lib/auth/middleware";
 import { getAllUserAuditEntries } from "@/lib/storage/user-audit";
 import type { UserAuditAction, UserAuditEntry } from "@/lib/types/audit";
 
@@ -61,15 +61,8 @@ export async function GET(request: NextRequest): Promise<NextResponse<SystemAudi
       total,
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     console.error("Get system audit log error:", error);
     return NextResponse.json(

--- a/app/api/users/[id]/__tests__/route.test.ts
+++ b/app/api/users/[id]/__tests__/route.test.ts
@@ -117,7 +117,7 @@ describe("PUT /api/users/[id]", () => {
     vi.mocked(validationModule.isValidUsername).mockReturnValue(true);
   });
 
-  it("should return 403 when not authenticated", async () => {
+  it("should return 401 when not authenticated", async () => {
     vi.mocked(middlewareModule.requireAdmin).mockRejectedValue(
       new Error("Authentication required")
     );
@@ -127,7 +127,7 @@ describe("PUT /api/users/[id]", () => {
     const response = await PUT(request, { params });
     const data = await response.json();
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(401);
     expect(data.success).toBe(false);
     expect(data.error).toBe("Authentication required");
   });
@@ -468,7 +468,7 @@ describe("DELETE /api/users/[id]", () => {
     vi.clearAllMocks();
   });
 
-  it("should return 403 when not authenticated", async () => {
+  it("should return 401 when not authenticated", async () => {
     vi.mocked(middlewareModule.requireAdmin).mockRejectedValue(
       new Error("Authentication required")
     );
@@ -478,7 +478,7 @@ describe("DELETE /api/users/[id]", () => {
     const response = await DELETE(request, { params });
     const data = await response.json();
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(401);
     expect(data.success).toBe(false);
     expect(data.error).toBe("Authentication required");
   });

--- a/app/api/users/[id]/audit/__tests__/route.test.ts
+++ b/app/api/users/[id]/audit/__tests__/route.test.ts
@@ -15,7 +15,13 @@ import type { User } from "@/lib/types/user";
 import type { UserAuditEntry } from "@/lib/types/audit";
 
 // Mock dependencies
-vi.mock("@/lib/auth/middleware");
+vi.mock("@/lib/auth/middleware", async (importOriginal) => {
+  const actual = await importOriginal<typeof middlewareModule>();
+  return {
+    ...actual,
+    requireAdmin: vi.fn(),
+  };
+});
 vi.mock("@/lib/storage/users");
 vi.mock("@/lib/storage/user-audit");
 

--- a/app/api/users/[id]/audit/route.ts
+++ b/app/api/users/[id]/audit/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/auth/middleware";
+import { requireAdmin, handleAdminAuthError } from "@/lib/auth/middleware";
 import { getUserById } from "@/lib/storage/users";
 import { getUserAuditLog } from "@/lib/storage/user-audit";
 import type { UserAuditLogResponse } from "@/lib/types/user";
@@ -39,15 +39,8 @@ export async function GET(
       total,
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     console.error("Get user audit log error:", error);
     return NextResponse.json(

--- a/app/api/users/[id]/lockout/__tests__/route.test.ts
+++ b/app/api/users/[id]/lockout/__tests__/route.test.ts
@@ -225,7 +225,7 @@ describe("User Lockout API", () => {
       expect(data.success).toBe(false);
     });
 
-    it("should return 403 if not authenticated", async () => {
+    it("should return 401 if not authenticated", async () => {
       vi.mocked(middlewareModule.requireAdmin).mockRejectedValue(
         new Error("Authentication required")
       );
@@ -235,7 +235,7 @@ describe("User Lockout API", () => {
       const response = await DELETE(request, { params });
       const data = await response.json();
 
-      expect(response.status).toBe(403);
+      expect(response.status).toBe(401);
       expect(data.success).toBe(false);
     });
   });

--- a/app/api/users/[id]/lockout/route.ts
+++ b/app/api/users/[id]/lockout/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin, toPublicUser } from "@/lib/auth/middleware";
+import { requireAdmin, toPublicUser, handleAdminAuthError } from "@/lib/auth/middleware";
 import { getUserById, resetFailedAttempts } from "@/lib/storage/users";
 import { createUserAuditEntry } from "@/lib/storage/user-audit";
 import type { PublicUser } from "@/lib/types/user";
@@ -67,15 +67,8 @@ export async function DELETE(
       user: toPublicUser(updatedUser),
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     console.error("Unlock user error:", error);
     return NextResponse.json(

--- a/app/api/users/[id]/resend-verification/route.ts
+++ b/app/api/users/[id]/resend-verification/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/auth/middleware";
+import { requireAdmin, handleAdminAuthError } from "@/lib/auth/middleware";
 import { getUserById } from "@/lib/storage/users";
 import { sendVerificationEmail } from "@/lib/auth/email-verification";
 import { createUserAuditEntry } from "@/lib/storage/user-audit";
@@ -86,15 +86,8 @@ export async function POST(
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     console.error("Resend verification error:", error);
     return NextResponse.json(

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin, toPublicUser } from "@/lib/auth/middleware";
+import { requireAdmin, toPublicUser, handleAdminAuthError } from "@/lib/auth/middleware";
 import {
   getUserById,
   getAllUsers,
@@ -134,17 +134,11 @@ export async function PUT(
       user: toPublicUser(updatedUser),
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     // Handle last-admin protection errors
+    const errorMessage = error instanceof Error ? error.message : "An error occurred";
     if (errorMessage.includes("last administrator")) {
       return NextResponse.json({ success: false, error: errorMessage }, { status: 400 });
     }
@@ -194,15 +188,8 @@ export async function DELETE(
       success: true,
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     console.error("Delete user error:", error);
     return NextResponse.json(

--- a/app/api/users/[id]/suspend/route.ts
+++ b/app/api/users/[id]/suspend/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin, toPublicUser } from "@/lib/auth/middleware";
+import { requireAdmin, toPublicUser, handleAdminAuthError } from "@/lib/auth/middleware";
 import { getUserById, suspendUser, reactivateUser } from "@/lib/storage/users";
 import type { SuspendUserRequest, SuspendUserResponse } from "@/lib/types/user";
 
@@ -48,17 +48,11 @@ export async function POST(
       user: toPublicUser(updatedUser),
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     // Handle last-admin protection
+    const errorMessage = error instanceof Error ? error.message : "An error occurred";
     if (errorMessage.includes("last administrator")) {
       return NextResponse.json({ success: false, error: errorMessage }, { status: 400 });
     }
@@ -107,15 +101,8 @@ export async function DELETE(
       user: toPublicUser(updatedUser),
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     console.error("Reactivate user error:", error);
     return NextResponse.json(

--- a/app/api/users/[id]/verify-email/__tests__/route.test.ts
+++ b/app/api/users/[id]/verify-email/__tests__/route.test.ts
@@ -223,7 +223,7 @@ describe("Manual Verify Email API", () => {
       expect(data.success).toBe(false);
     });
 
-    it("should return 403 if not authenticated", async () => {
+    it("should return 401 if not authenticated", async () => {
       vi.mocked(middlewareModule.requireAdmin).mockRejectedValue(
         new Error("Authentication required")
       );
@@ -233,7 +233,7 @@ describe("Manual Verify Email API", () => {
       const response = await POST(request, { params });
       const data = await response.json();
 
-      expect(response.status).toBe(403);
+      expect(response.status).toBe(401);
       expect(data.success).toBe(false);
     });
   });

--- a/app/api/users/[id]/verify-email/route.ts
+++ b/app/api/users/[id]/verify-email/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin, toPublicUser } from "@/lib/auth/middleware";
+import { requireAdmin, toPublicUser, handleAdminAuthError } from "@/lib/auth/middleware";
 import { getUserById, markEmailVerified } from "@/lib/storage/users";
 import { createUserAuditEntry } from "@/lib/storage/user-audit";
 import type { PublicUser } from "@/lib/types/user";
@@ -59,15 +59,8 @@ export async function POST(
       user: toPublicUser(updatedUser),
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     console.error("Manual verify email error:", error);
     return NextResponse.json(

--- a/app/api/users/__tests__/route.test.ts
+++ b/app/api/users/__tests__/route.test.ts
@@ -182,7 +182,7 @@ describe("GET /api/users", () => {
     vi.clearAllMocks();
   });
 
-  it("should return 403 when not authenticated", async () => {
+  it("should return 401 when not authenticated", async () => {
     vi.mocked(middlewareModule.requireAdmin).mockRejectedValue(
       new Error("Authentication required")
     );
@@ -191,7 +191,7 @@ describe("GET /api/users", () => {
     const response = await GET(request);
     const data = await response.json();
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(401);
     expect(data.success).toBe(false);
     expect(data.error).toBe("Authentication required");
   });

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin, toPublicUser } from "@/lib/auth/middleware";
+import { requireAdmin, toPublicUser, handleAdminAuthError } from "@/lib/auth/middleware";
 import { getAllUsers } from "@/lib/storage/users";
 import type { PublicUser } from "@/lib/types/user";
 
@@ -87,15 +87,8 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "An error occurred";
-
-    // Check if it's an authentication/authorization error
-    if (
-      errorMessage === "Authentication required" ||
-      errorMessage === "Administrator access required"
-    ) {
-      return NextResponse.json({ success: false, error: errorMessage }, { status: 403 });
-    }
+    const authResponse = handleAdminAuthError(error);
+    if (authResponse) return authResponse;
 
     console.error("Get users error:", error);
     return NextResponse.json(

--- a/lib/auth/middleware.ts
+++ b/lib/auth/middleware.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from "next/server";
 import { getSession } from "./session";
 import { getUserById } from "../storage/users";
 import type { User, PublicUser } from "../types/user";
@@ -73,4 +74,22 @@ export async function requireAdmin(): Promise<PublicUser> {
     throw new Error("Administrator access required");
   }
   return user;
+}
+
+/**
+ * Returns the appropriate error response for auth/admin errors.
+ * Use in catch blocks after requireAdmin() calls.
+ * Returns 401 for unauthenticated, 403 for unauthorized, or null if unrecognized.
+ */
+export function handleAdminAuthError(
+  error: unknown
+): NextResponse<{ success: false; error: string }> | null {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message === "Authentication required") {
+    return NextResponse.json({ success: false, error: message }, { status: 401 });
+  }
+  if (message === "Administrator access required") {
+    return NextResponse.json({ success: false, error: message }, { status: 403 });
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary
- Added `handleAdminAuthError` helper to `lib/auth/middleware.ts` that returns 401 for unauthenticated and 403 for unauthorized
- Updated 8 admin route files to use the shared helper instead of inline error mapping
- Updated 7 test assertions to expect 401 for "Authentication required" errors
- Fixed 2 test files that used bare `vi.mock()` to preserve the real `handleAdminAuthError` implementation

Closes #632

## Test plan
- [x] All 9132 tests pass
- [x] Type-check: clean
- [x] Pre-commit hooks: pass (lint, format, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)