### PR TITLE
fix: use canonical 12-round hashPassword for password resets

### DIFF
--- a/lib/auth/__tests__/password-reset.test.ts
+++ b/lib/auth/__tests__/password-reset.test.ts
@@ -315,14 +315,14 @@ describe("password-reset", () => {
       expect(result.userId).toBe(mockUser.id);
     });
 
-    it("should update password with new hash", async () => {
+    it("should update password with new hash using 12 bcrypt rounds", async () => {
       vi.mocked(usersStorage.getUserByPasswordResetToken).mockResolvedValue(mockUser);
 
       await resetPassword("valid-token", "NewPassword123!");
 
       expect(usersStorage.updateUserPassword).toHaveBeenCalledWith(
         mockUser.id,
-        expect.stringMatching(/^\$2[ab]\$/) // bcrypt hash
+        expect.stringMatching(/^\$2[ab]\$12\$/) // bcrypt hash with 12 rounds
       );
     });
 

--- a/lib/auth/password-reset.ts
+++ b/lib/auth/password-reset.ts
@@ -27,6 +27,7 @@ import { AuditLogger } from "@/lib/security/audit-logger";
 import { sendPasswordChangedEmail } from "@/lib/email/security-alerts";
 import { sendAdminPasswordResetNotification } from "@/lib/email/admin-notifications";
 import { isStrongPassword } from "./validation";
+import { hashPassword } from "./password";
 
 /** Token size in bytes (32 bytes = 256 bits of entropy) */
 const TOKEN_BYTES = 32;
@@ -34,8 +35,8 @@ const TOKEN_BYTES = 32;
 /** Token expiration time in hours */
 const TOKEN_EXPIRY_HOURS = 1;
 
-/** bcrypt rounds for token hashing */
-const BCRYPT_ROUNDS = 10;
+/** bcrypt rounds for token hashing (lower than password rounds since tokens are single-use random) */
+const TOKEN_BCRYPT_ROUNDS = 10;
 
 /**
  * Result of token generation
@@ -88,7 +89,7 @@ export async function generatePasswordResetToken(): Promise<GeneratedResetToken>
   const token = tokenBuffer.toString("base64url");
 
   // Hash the token for storage (don't store plain text)
-  const tokenHash = await bcrypt.hash(token, BCRYPT_ROUNDS);
+  const tokenHash = await bcrypt.hash(token, TOKEN_BCRYPT_ROUNDS);
 
   // Calculate expiration time (1 hour)
   const expiresAt = new Date();
@@ -291,8 +292,8 @@ export async function resetPassword(
       return { success: false, error: "weak_password" };
     }
 
-    // Hash the new password
-    const passwordHash = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
+    // Hash the new password (uses canonical 12 rounds from hashPassword)
+    const passwordHash = await hashPassword(newPassword);
 
     // Update password and invalidate all sessions
     await updateUserPassword(user.id, passwordHash);


### PR DESCRIPTION
## Summary
- Password reset was hashing new passwords with 10 bcrypt rounds (the token-hashing constant) instead of the canonical 12 rounds used by `hashPassword()`
- Now delegates to `hashPassword()` from `lib/auth/password.ts` for user password hashing
- Renamed ambiguous `BCRYPT_ROUNDS` to `TOKEN_BCRYPT_ROUNDS` for clarity

Closes #634

## Test plan
- [x] Tightened existing test to assert `$2[ab]$12$` pattern (12 rounds)
- [x] All 31 password-reset tests pass
- [x] Type-check passes
- [x] Pre-commit hooks pass