### PR TITLE
fix: validate and clamp pagination inputs in admin routes (#642)

### DIFF
--- a/app/api/users/[id]/audit/__tests__/route.test.ts
+++ b/app/api/users/[id]/audit/__tests__/route.test.ts
@@ -200,4 +200,42 @@ describe("GET /api/users/[id]/audit", () => {
     expect(response.status).toBe(403);
     expect(data.success).toBe(false);
   });
+
+  describe("pagination bounds validation", () => {
+    beforeEach(() => {
+      vi.mocked(middlewareModule.requireAdmin).mockResolvedValue(mockAdminUser);
+      vi.mocked(storageModule.getUserById).mockResolvedValue(mockTargetUser);
+      vi.mocked(auditModule.getUserAuditLog).mockResolvedValue({
+        entries: [],
+        total: 0,
+      });
+    });
+
+    it("should clamp limit=0 to minimum of 1", async () => {
+      const request = createMockRequest({ limit: "0" });
+      const { params } = createMockParams("target-user-id");
+      await GET(request, { params });
+
+      const callArgs = vi.mocked(auditModule.getUserAuditLog).mock.calls[0]?.[1];
+      expect(callArgs?.limit).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should clamp limit above 100 to maximum of 100", async () => {
+      const request = createMockRequest({ limit: "99999999" });
+      const { params } = createMockParams("target-user-id");
+      await GET(request, { params });
+
+      const callArgs = vi.mocked(auditModule.getUserAuditLog).mock.calls[0]?.[1];
+      expect(callArgs?.limit).toBeLessThanOrEqual(100);
+    });
+
+    it("should clamp negative offset to minimum of 0", async () => {
+      const request = createMockRequest({ offset: "-1" });
+      const { params } = createMockParams("target-user-id");
+      await GET(request, { params });
+
+      const callArgs = vi.mocked(auditModule.getUserAuditLog).mock.calls[0][1];
+      expect(callArgs?.offset).toBeGreaterThanOrEqual(0);
+    });
+  });
 });

--- a/app/api/users/[id]/audit/route.ts
+++ b/app/api/users/[id]/audit/route.ts
@@ -20,8 +20,8 @@ export async function GET(
 
     // Get query parameters for pagination
     const searchParams = request.nextUrl.searchParams;
-    const limit = parseInt(searchParams.get("limit") || "50", 10);
-    const offset = parseInt(searchParams.get("offset") || "0", 10);
+    const limit = Math.max(1, Math.min(100, parseInt(searchParams.get("limit") || "50", 10) || 50));
+    const offset = Math.max(0, parseInt(searchParams.get("offset") || "0", 10) || 0);
     const order = (searchParams.get("order") || "desc") as "asc" | "desc";
 
     // Validate user exists

--- a/app/api/users/__tests__/route.test.ts
+++ b/app/api/users/__tests__/route.test.ts
@@ -368,4 +368,48 @@ describe("GET /api/users", () => {
 
     consoleErrorSpy.mockRestore();
   });
+
+  describe("pagination bounds validation", () => {
+    beforeEach(() => {
+      vi.mocked(middlewareModule.requireAdmin).mockResolvedValue(mockAdminUser);
+      vi.mocked(usersModule.getAllUsers).mockResolvedValue(mockUsers);
+    });
+
+    it("should clamp limit=0 to minimum of 1", async () => {
+      const request = createMockRequest({ limit: "0" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.pagination.limit).toBeGreaterThanOrEqual(1);
+      expect(Number.isFinite(data.pagination.totalPages)).toBe(true);
+    });
+
+    it("should clamp limit above 100 to maximum of 100", async () => {
+      const request = createMockRequest({ limit: "99999999" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.pagination.limit).toBeLessThanOrEqual(100);
+    });
+
+    it("should clamp page=0 to minimum of 1", async () => {
+      const request = createMockRequest({ page: "0" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.pagination.page).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should clamp negative page to minimum of 1", async () => {
+      const request = createMockRequest({ page: "-5" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.pagination.page).toBeGreaterThanOrEqual(1);
+    });
+  });
 });

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -11,8 +11,8 @@ export async function GET(request: NextRequest) {
     // Get query parameters
     const searchParams = request.nextUrl.searchParams;
     const search = searchParams.get("search") || "";
-    const page = parseInt(searchParams.get("page") || "1", 10);
-    const limit = parseInt(searchParams.get("limit") || "20", 10);
+    const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10) || 1);
+    const limit = Math.max(1, Math.min(100, parseInt(searchParams.get("limit") || "20", 10) || 20));
     const sortBy = searchParams.get("sortBy") || "createdAt";
     const sortOrder = searchParams.get("sortOrder") || "asc";
 


### PR DESCRIPTION
## Summary
- Clamp `limit` to [1, 100] and `page` to min 1 in `GET /api/users` to prevent division-by-zero (`Infinity` totalPages) and unbounded memory load
- Clamp `limit` to [1, 100] and `offset` to min 0 in `GET /api/users/[id]/audit`
- Added 7 regression tests across both route test files

Closes #642

## Test plan
- [x] 4 tests for users route: limit=0, limit=99999999, page=0, page=-5
- [x] 3 tests for audit route: limit=0, limit=99999999, offset=-1
- [x] All existing tests still pass (17 users + 7 audit)
- [x] Type-check passes