### PR TITLE
fix: require E2E_BYPASS_SECRET for rate-limit bypass

### DIFF
--- a/app/api/auth/signup/__tests__/route.test.ts
+++ b/app/api/auth/signup/__tests__/route.test.ts
@@ -522,6 +522,107 @@ describe("POST /api/auth/signup", () => {
       });
     });
 
+    it("should NOT bypass rate limiting when x-e2e-bypass is 'true' but E2E_BYPASS_SECRET is not set", async () => {
+      delete process.env.E2E_BYPASS_SECRET;
+
+      vi.mocked(RateLimiter.get).mockReturnValue({
+        isRateLimited: vi.fn().mockReturnValue(true),
+      } as unknown as RateLimiter);
+
+      const requestBody = {
+        email: "newuser@example.com",
+        username: "newuser",
+        password: "ValidPass123!",
+      };
+
+      const headers = new Headers();
+      headers.set("Content-Type", "application/json");
+      headers.set("x-e2e-bypass", "true");
+
+      const request = new NextRequest("http://localhost:3000/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify(requestBody),
+        headers,
+      });
+      (request as { json: () => Promise<unknown> }).json = async () => requestBody;
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(429);
+      expect(data.success).toBe(false);
+    });
+
+    it("should NOT bypass rate limiting when x-e2e-bypass header has wrong value", async () => {
+      process.env.E2E_BYPASS_SECRET = "correct-secret";
+
+      vi.mocked(RateLimiter.get).mockReturnValue({
+        isRateLimited: vi.fn().mockReturnValue(true),
+      } as unknown as RateLimiter);
+
+      const requestBody = {
+        email: "newuser@example.com",
+        username: "newuser",
+        password: "ValidPass123!",
+      };
+
+      const headers = new Headers();
+      headers.set("Content-Type", "application/json");
+      headers.set("x-e2e-bypass", "wrong-secret");
+
+      const request = new NextRequest("http://localhost:3000/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify(requestBody),
+        headers,
+      });
+      (request as { json: () => Promise<unknown> }).json = async () => requestBody;
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(429);
+      expect(data.success).toBe(false);
+
+      delete process.env.E2E_BYPASS_SECRET;
+    });
+
+    it("should bypass rate limiting when x-e2e-bypass header matches E2E_BYPASS_SECRET", async () => {
+      process.env.E2E_BYPASS_SECRET = "my-secret-token";
+
+      vi.mocked(RateLimiter.get).mockReturnValue({
+        isRateLimited: vi.fn().mockReturnValue(true),
+      } as unknown as RateLimiter);
+
+      const requestBody = {
+        email: "newuser@example.com",
+        username: "newuser",
+        password: "ValidPass123!",
+      };
+
+      vi.mocked(storageModule.getUserByEmail).mockResolvedValue(null);
+      vi.mocked(passwordModule.hashPassword).mockResolvedValue("hashed-password");
+      vi.mocked(storageModule.createUser).mockResolvedValue(mockUser);
+
+      const headers = new Headers();
+      headers.set("Content-Type", "application/json");
+      headers.set("x-e2e-bypass", "my-secret-token");
+
+      const request = new NextRequest("http://localhost:3000/api/auth/signup", {
+        method: "POST",
+        body: JSON.stringify(requestBody),
+        headers,
+      });
+      (request as { json: () => Promise<unknown> }).json = async () => requestBody;
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      delete process.env.E2E_BYPASS_SECRET;
+    });
+
     it("should use x-forwarded-for header for IP", async () => {
       const mockIsRateLimited = vi.fn().mockReturnValue(false);
       vi.mocked(RateLimiter.get).mockReturnValue({

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -25,8 +25,11 @@ export async function POST(request: NextRequest): Promise<NextResponse<AuthRespo
   try {
     // Rate limiting check (before parsing body)
     // E2E tests can bypass rate limiting in non-production environments
+    const bypassSecret = process.env.E2E_BYPASS_SECRET;
     const isE2EBypass =
-      process.env.NODE_ENV !== "production" && request.headers.get("x-e2e-bypass") === "true";
+      process.env.NODE_ENV !== "production" &&
+      Boolean(bypassSecret) &&
+      request.headers.get("x-e2e-bypass") === bypassSecret;
 
     if (!isE2EBypass) {
       const rateLimiter = RateLimiter.get("signup", SIGNUP_LIMIT);

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -31,7 +31,7 @@ export async function setupRateLimitBypass(page: Page): Promise<void> {
   await page.route("**/api/**", async (route) => {
     const headers = {
       ...route.request().headers(),
-      "x-e2e-bypass": "true",
+      "x-e2e-bypass": process.env.E2E_BYPASS_SECRET ?? "true",
     };
     await route.continue({ headers });
   });


### PR DESCRIPTION
## Summary
- Security fix: the `x-e2e-bypass` header previously accepted any `"true"` value in non-production environments, allowing unauthorized rate-limit bypass in staging
- Now requires `E2E_BYPASS_SECRET` env var to be set and the header value to match it exactly
- Updated `e2e/helpers/auth.ts` to send `process.env.E2E_BYPASS_SECRET` instead of hardcoded `"true"`
- Added 3 tests covering: no secret configured, wrong secret, correct secret

Closes #638

## Test plan
- [x] All 22 signup route tests pass
- [x] New tests verify bypass only works with matching secret
- [x] Type-check passes