### PR TITLE
fix: type editionCode as EditionCode instead of string in 3 files

### DIFF
--- a/__tests__/lib/types/edition-code-constraints.test.ts
+++ b/__tests__/lib/types/edition-code-constraints.test.ts
@@ -1,0 +1,17 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { CombatSession, EditionCode, FavorCostTable, RuleReferenceData } from "@/lib/types";
+
+describe("EditionCode type constraints", () => {
+  it("CombatSession.editionCode is EditionCode", () => {
+    expectTypeOf<CombatSession["editionCode"]>().toEqualTypeOf<EditionCode>();
+  });
+
+  it("FavorCostTable.editionCode is EditionCode", () => {
+    expectTypeOf<FavorCostTable["editionCode"]>().toEqualTypeOf<EditionCode>();
+  });
+
+  it("RuleReferenceData.editionCode is EditionCode", () => {
+    expectTypeOf<RuleReferenceData["editionCode"]>().toEqualTypeOf<EditionCode>();
+  });
+});

--- a/lib/types/combat.ts
+++ b/lib/types/combat.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ID, ISODateString } from "./core";
+import type { EditionCode } from "./edition";
 
 // =============================================================================
 // COMBAT SESSION TYPES
@@ -66,7 +67,7 @@ export interface CombatSession {
   /** User who created/owns the session */
   ownerId: ID;
   /** Edition code for rules lookup */
-  editionCode: string;
+  editionCode: EditionCode;
   /** Display name for the combat */
   name?: string;
   /** All participants in this combat */

--- a/lib/types/contacts.ts
+++ b/lib/types/contacts.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ID, ISODateString, Metadata } from "./core";
+import type { EditionCode } from "./edition";
 
 // =============================================================================
 // CONTACT CORE TYPES
@@ -646,7 +647,7 @@ export interface SocialAction {
  */
 export interface FavorCostTable {
   /** Edition code this table applies to */
-  editionCode: string;
+  editionCode: EditionCode;
 
   /** All defined services */
   services: FavorServiceDefinition[];

--- a/lib/types/rule-reference.ts
+++ b/lib/types/rule-reference.ts
@@ -6,6 +6,8 @@
  * and category-based filtering.
  */
 
+import type { EditionCode } from "./edition";
+
 export type RuleReferenceCategory =
   | "combat"
   | "magic"
@@ -35,6 +37,6 @@ export interface RuleReferenceEntry {
 
 export interface RuleReferenceData {
   version: string;
-  editionCode: string;
+  editionCode: EditionCode;
   entries: RuleReferenceEntry[];
 }


### PR DESCRIPTION
## Summary
- Changed `editionCode: string` to `editionCode: EditionCode` in `CombatSession`, `FavorCostTable`, and `RuleReferenceData` interfaces
- Added `import type { EditionCode } from "./edition"` to `combat.ts`, `contacts.ts`, and `rule-reference.ts`
- Added `expectTypeOf` compile-time tests to verify the type constraints

Closes #657

## Test plan
- [x] `pnpm type-check` passes with no errors
- [x] New type constraint tests pass (3 tests)
- [x] Existing type tests pass with no regressions (24 total)
- [x] Pre-commit hooks pass