### PR TITLE
fix: propagate deleteUserCharacters errors in deleteUser

### DIFF
--- a/lib/storage/__tests__/users.test.ts
+++ b/lib/storage/__tests__/users.test.ts
@@ -303,6 +303,26 @@ describe("User Storage", () => {
     it("should throw error for non-existent user", async () => {
       await expect(deleteUser("nonexistent-id")).rejects.toThrow("not found");
     });
+
+    it("should propagate error when deleteUserCharacters fails", async () => {
+      const user = await createUser({
+        email: "char-fail@example.com",
+        passwordHash: "hash",
+        username: "CharFail",
+        role: ["user" as UserRole],
+      });
+
+      // Mock the characters module to make deleteUserCharacters throw
+      vi.doMock("../characters", () => ({
+        deleteUserCharacters: vi.fn().mockRejectedValue(new Error("disk failure")),
+      }));
+
+      await expect(deleteUser(user.id)).rejects.toThrow("disk failure");
+
+      // User file should NOT have been deleted (no orphan)
+      const stillExists = await getUserById(user.id);
+      expect(stillExists).not.toBeNull();
+    });
   });
 
   describe("atomic writes", () => {

--- a/lib/storage/users.ts
+++ b/lib/storage/users.ts
@@ -320,12 +320,9 @@ export async function deleteUser(userId: string): Promise<void> {
   }
 
   // Delete all characters owned by the user first (Requirement 4.3)
-  try {
-    const { deleteUserCharacters } = await import("./characters");
-    await deleteUserCharacters(userId);
-  } catch (error) {
-    console.error(`Error deleting characters for user ${userId}:`, error);
-  }
+  // If this fails, we abort to avoid orphaned character files
+  const { deleteUserCharacters } = await import("./characters");
+  await deleteUserCharacters(userId);
 
   const filePath = getUserFilePath(userId);
   try {


### PR DESCRIPTION
## Summary
- `deleteUser` previously wrapped character deletion in a try/catch that silently swallowed errors, reporting success even when characters couldn't be deleted
- Now propagates errors from `deleteUserCharacters`, letting callers handle failures appropriately

Closes #639

## Test plan
- [x] Tests verify errors propagate instead of being swallowed
- [x] Type-check passes
- [x] Pre-commit hooks pass