### PR TITLE
fix: surface ammo API errors to user in WeaponsDisplay

### DIFF
--- a/__tests__/components/character/sheet/WeaponsDisplay-ammo-errors.test.tsx
+++ b/__tests__/components/character/sheet/WeaponsDisplay-ammo-errors.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * Tests for WeaponsDisplay ammo error surfacing (#675)
+ *
+ * Covers: reload, unload, and swap-magazine error messages shown to user
+ */
+
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import type { Character, Weapon } from "@/lib/types";
+import {
+  setupDisplayCardMock,
+  LUCIDE_MOCK,
+  createSheetCharacter,
+} from "@/components/character/sheet/__tests__/test-helpers";
+
+// Setup mocks BEFORE imports
+setupDisplayCardMock();
+vi.mock("lucide-react", () => LUCIDE_MOCK);
+
+vi.mock("@/lib/rules", () => ({
+  useGear: () => null,
+}));
+
+vi.mock("@/lib/rules/wireless", () => ({
+  isGlobalWirelessEnabled: () => false,
+}));
+
+vi.mock("@/lib/combat", () => ({
+  useCombatReadiness: () => ({
+    canChangeReadiness: () => ({ allowed: true }),
+    performReadinessChange: vi.fn((_from, _to, fn) => fn()),
+  }),
+}));
+
+vi.mock("@/lib/rules/inventory", () => ({
+  getTransitionActionCost: () => "free",
+}));
+
+vi.mock("@/components/character/sheet/WeaponAmmoDisplay", () => ({
+  WeaponAmmoDisplay: ({
+    onReload,
+    onUnload,
+    onSwapMagazine,
+  }: {
+    onReload: (id: string) => void;
+    onUnload: () => void;
+    onSwapMagazine: (id: string) => void;
+  }) => (
+    <div data-testid="weapon-ammo-display">
+      <button data-testid="reload-btn" onClick={() => onReload("ammo-1")}>
+        Reload
+      </button>
+      <button data-testid="unload-btn" onClick={() => onUnload()}>
+        Unload
+      </button>
+      <button data-testid="swap-btn" onClick={() => onSwapMagazine("mag-1")}>
+        Swap
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/character/sheet/MoveToContainerControl", () => ({
+  MoveToContainerControl: () => null,
+}));
+
+import { WeaponsDisplay } from "@/components/character/sheet/WeaponsDisplay";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function makeWeaponWithAmmo(): Weapon {
+  return {
+    id: "pred-v",
+    name: "Ares Predator V",
+    category: "Pistols",
+    subcategory: "Heavy Pistols",
+    damage: "8P",
+    ap: -1,
+    mode: ["SA"],
+    accuracy: 5,
+    cost: 725,
+    quantity: 1,
+    equipped: true,
+    ammoState: {
+      currentRounds: 10,
+      magazineCapacity: 15,
+      loadedAmmoTypeId: "regular-ammo",
+    },
+  } as Weapon;
+}
+
+function makeCharacterWithAmmo(overrides?: Partial<Character>): Character {
+  return createSheetCharacter({
+    id: "char-1",
+    weapons: [makeWeaponWithAmmo()],
+    ammunition: [],
+    ...overrides,
+  });
+}
+
+async function expandWeaponRow() {
+  const row = screen.getByTestId("weapon-row");
+  await act(async () => {
+    fireEvent.click(row);
+  });
+}
+
+describe("WeaponsDisplay ammo error surfacing (#675)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("shows error message when reload API returns non-success response", async () => {
+    const character = makeCharacterWithAmmo();
+    const onUpdate = vi.fn();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ success: false, error: "No compatible ammo found" }),
+    });
+
+    render(<WeaponsDisplay character={character} onCharacterUpdate={onUpdate} editable />);
+
+    await expandWeaponRow();
+    const reloadBtn = screen.getByTestId("reload-btn");
+    await act(async () => {
+      fireEvent.click(reloadBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ammo-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("ammo-error")).toHaveTextContent("No compatible ammo found");
+  });
+
+  test("shows error message when reload API throws network error", async () => {
+    const character = makeCharacterWithAmmo();
+    const onUpdate = vi.fn();
+
+    mockFetch.mockRejectedValueOnce(new Error("Network failure"));
+
+    render(<WeaponsDisplay character={character} onCharacterUpdate={onUpdate} editable />);
+
+    await expandWeaponRow();
+    const reloadBtn = screen.getByTestId("reload-btn");
+    await act(async () => {
+      fireEvent.click(reloadBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ammo-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("ammo-error")).toHaveTextContent("Failed to reload weapon");
+  });
+
+  test("shows error message when unload API returns non-success response", async () => {
+    const character = makeCharacterWithAmmo();
+    const onUpdate = vi.fn();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ success: false, error: "Weapon is not loaded" }),
+    });
+
+    render(<WeaponsDisplay character={character} onCharacterUpdate={onUpdate} editable />);
+
+    await expandWeaponRow();
+    const unloadBtn = screen.getByTestId("unload-btn");
+    await act(async () => {
+      fireEvent.click(unloadBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ammo-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("ammo-error")).toHaveTextContent("Weapon is not loaded");
+  });
+
+  test("shows error message when unload API throws network error", async () => {
+    const character = makeCharacterWithAmmo();
+    const onUpdate = vi.fn();
+
+    mockFetch.mockRejectedValueOnce(new Error("Network failure"));
+
+    render(<WeaponsDisplay character={character} onCharacterUpdate={onUpdate} editable />);
+
+    await expandWeaponRow();
+    const unloadBtn = screen.getByTestId("unload-btn");
+    await act(async () => {
+      fireEvent.click(unloadBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ammo-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("ammo-error")).toHaveTextContent("Failed to unload weapon");
+  });
+
+  test("shows error message when swap magazine API returns non-success response", async () => {
+    const character = makeCharacterWithAmmo();
+    const onUpdate = vi.fn();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ success: false, error: "Magazine not found" }),
+    });
+
+    render(<WeaponsDisplay character={character} onCharacterUpdate={onUpdate} editable />);
+
+    await expandWeaponRow();
+    const swapBtn = screen.getByTestId("swap-btn");
+    await act(async () => {
+      fireEvent.click(swapBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ammo-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("ammo-error")).toHaveTextContent("Magazine not found");
+  });
+
+  test("shows error message when swap magazine API throws network error", async () => {
+    const character = makeCharacterWithAmmo();
+    const onUpdate = vi.fn();
+
+    mockFetch.mockRejectedValueOnce(new Error("Network failure"));
+
+    render(<WeaponsDisplay character={character} onCharacterUpdate={onUpdate} editable />);
+
+    await expandWeaponRow();
+    const swapBtn = screen.getByTestId("swap-btn");
+    await act(async () => {
+      fireEvent.click(swapBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ammo-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("ammo-error")).toHaveTextContent("Failed to swap magazine");
+  });
+
+  test("clears error on successful subsequent operation", async () => {
+    const character = makeCharacterWithAmmo();
+    const onUpdate = vi.fn();
+
+    // First call fails
+    mockFetch.mockRejectedValueOnce(new Error("Network failure"));
+
+    render(<WeaponsDisplay character={character} onCharacterUpdate={onUpdate} editable />);
+
+    await expandWeaponRow();
+
+    // Trigger error
+    const reloadBtn = screen.getByTestId("reload-btn");
+    await act(async () => {
+      fireEvent.click(reloadBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ammo-error")).toBeInTheDocument();
+    });
+
+    // Second call succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        weapon: {
+          ammoState: { currentRounds: 15, magazineCapacity: 15, loadedAmmoTypeId: "regular-ammo" },
+        },
+        ammunition: [],
+      }),
+    });
+
+    await act(async () => {
+      fireEvent.click(reloadBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("ammo-error")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/components/character/sheet/WeaponsDisplay.tsx
+++ b/components/character/sheet/WeaponsDisplay.tsx
@@ -182,6 +182,7 @@ function WeaponRow({
   ammunition?: AmmunitionItem[];
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [ammoError, setAmmoError] = useState<string | null>(null);
   const { pool, label } = calculateWeaponPool(weapon, character);
   const isMelee = isMeleeWeapon(weapon);
   const modeStr = weapon.mode?.join("/") || "";
@@ -210,6 +211,7 @@ function WeaponRow({
     async (ammoItemId: string) => {
       if (!character.id || !onCharacterUpdate) return;
       try {
+        setAmmoError(null);
         const response = await fetch(`/api/characters/${character.id}/weapons/${weaponId}/ammo`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -226,9 +228,11 @@ function WeaponRow({
             weapons: updatedWeapons,
             ammunition: updatedAmmunition,
           });
+        } else {
+          setAmmoError(result.error || "Failed to reload weapon");
         }
-      } catch (error) {
-        console.error("Failed to reload weapon:", error);
+      } catch {
+        setAmmoError("Failed to reload weapon");
       }
     },
     [character, weaponId, onCharacterUpdate]
@@ -237,6 +241,7 @@ function WeaponRow({
   const handleUnload = useCallback(async () => {
     if (!character.id || !onCharacterUpdate) return;
     try {
+      setAmmoError(null);
       const response = await fetch(`/api/characters/${character.id}/weapons/${weaponId}/ammo`, {
         method: "DELETE",
       });
@@ -249,9 +254,11 @@ function WeaponRow({
         );
         const updatedAmmunition = result.ammunition ?? character.ammunition;
         onCharacterUpdate({ ...character, weapons: updatedWeapons, ammunition: updatedAmmunition });
+      } else {
+        setAmmoError(result.error || "Failed to unload weapon");
       }
-    } catch (error) {
-      console.error("Failed to unload weapon:", error);
+    } catch {
+      setAmmoError("Failed to unload weapon");
     }
   }, [character, weaponId, onCharacterUpdate]);
 
@@ -259,6 +266,7 @@ function WeaponRow({
     async (magazineId: string) => {
       if (!character.id || !onCharacterUpdate) return;
       try {
+        setAmmoError(null);
         const response = await fetch(`/api/characters/${character.id}/weapons/${weaponId}/ammo`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
@@ -276,9 +284,11 @@ function WeaponRow({
               : w
           );
           onCharacterUpdate({ ...character, weapons: updatedWeapons });
+        } else {
+          setAmmoError(result.error || "Failed to swap magazine");
         }
-      } catch (error) {
-        console.error("Failed to swap magazine:", error);
+      } catch {
+        setAmmoError("Failed to swap magazine");
       }
     },
     [character, weaponId, onCharacterUpdate]
@@ -549,13 +559,23 @@ function WeaponRow({
           {weapon.ammoState && (
             <div data-testid="ammo-section">
               {editable && onCharacterUpdate ? (
-                <WeaponAmmoDisplay
-                  weapon={weapon}
-                  availableAmmo={ammunition}
-                  onReload={handleReload}
-                  onUnload={handleUnload}
-                  onSwapMagazine={handleSwapMagazine}
-                />
+                <>
+                  <WeaponAmmoDisplay
+                    weapon={weapon}
+                    availableAmmo={ammunition}
+                    onReload={handleReload}
+                    onUnload={handleUnload}
+                    onSwapMagazine={handleSwapMagazine}
+                  />
+                  {ammoError && (
+                    <p
+                      data-testid="ammo-error"
+                      className="mt-1 text-xs text-red-500 dark:text-red-400"
+                    >
+                      {ammoError}
+                    </p>
+                  )}
+                </>
               ) : (
                 <div className="flex items-baseline gap-2 text-xs text-zinc-500 dark:text-zinc-400">
                   <span className="text-[10px] font-semibold uppercase tracking-wider">Ammo</span>


### PR DESCRIPTION
## Summary
- WeaponsDisplay silently swallowed ammo API errors in catch blocks
- Now surfaces errors to the user via the existing error state mechanism

Closes #675

## Test plan
- [x] Tests verify errors are surfaced instead of silently caught
- [x] Type-check passes