### PR TITLE
fix: throw explicit error when calculateRemainingBudget lacks creationState

### DIFF
--- a/__tests__/lib/rules/calculateRemainingBudget.test.ts
+++ b/__tests__/lib/rules/calculateRemainingBudget.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for calculateRemainingBudget — ensures the function throws
+ * when creationState is absent instead of silently returning 0.
+ *
+ * Covers issue #654.
+ */
+
+import { describe, it, expect } from "vitest";
+import { calculateRemainingBudget } from "@/lib/rules/constraint-validation";
+import type { Character, CreationState } from "@/lib/types";
+
+// Minimal character stub — only the fields the function signature requires
+const stubCharacter = { id: "char-1" } as Character;
+
+describe("calculateRemainingBudget", () => {
+  it("returns the tracked budget value when creationState is present", () => {
+    const creationState = {
+      budgets: { karma: 25, resources: 50000 },
+    } as unknown as CreationState;
+
+    expect(calculateRemainingBudget("karma", stubCharacter, creationState)).toBe(25);
+    expect(calculateRemainingBudget("resources", stubCharacter, creationState)).toBe(50000);
+  });
+
+  it("returns 0 for a known budget that has been fully spent", () => {
+    const creationState = {
+      budgets: { karma: 0 },
+    } as unknown as CreationState;
+
+    expect(calculateRemainingBudget("karma", stubCharacter, creationState)).toBe(0);
+  });
+
+  it("throws when creationState is undefined", () => {
+    expect(() =>
+      calculateRemainingBudget("karma", stubCharacter, undefined)
+    ).toThrow();
+  });
+
+  it("throws when creationState is explicitly omitted (no second arg)", () => {
+    expect(() =>
+      calculateRemainingBudget("karma", stubCharacter)
+    ).toThrow();
+  });
+
+  it("throws when creationState has no entry for the requested budgetId", () => {
+    const creationState = {
+      budgets: { resources: 100 },
+    } as unknown as CreationState;
+
+    expect(() =>
+      calculateRemainingBudget("karma", stubCharacter, creationState)
+    ).toThrow();
+  });
+});

--- a/lib/rules/constraint-validation.ts
+++ b/lib/rules/constraint-validation.ts
@@ -992,14 +992,21 @@ export function calculateRemainingBudget(
   _character: Character | CharacterDraft,
   creationState?: CreationState
 ): number {
-  // If we have creation state with tracked budgets, use that
-  if (creationState?.budgets?.[budgetId] !== undefined) {
-    return creationState.budgets[budgetId];
+  if (!creationState) {
+    throw new Error(
+      `calculateRemainingBudget: creationState is required but was ${String(creationState)}. ` +
+        `Cannot determine budget "${budgetId}" without creation state.`
+    );
   }
 
-  // Otherwise, calculate from character data
-  // This is a simplified calculation - real implementation would be more complex
-  return 0;
+  if (creationState.budgets[budgetId] === undefined) {
+    throw new Error(
+      `calculateRemainingBudget: budget "${budgetId}" not found in creationState. ` +
+        `Available budgets: ${Object.keys(creationState.budgets).join(", ") || "(none)"}`
+    );
+  }
+
+  return creationState.budgets[budgetId];
 }
 
 /**


### PR DESCRIPTION
## Summary
- `calculateRemainingBudget` silently returned 0 when `creationState` was absent, hiding bugs in callers
- Now throws an explicit error so callers know the state is missing

Closes #654

## Test plan
- [x] Test verifies error is thrown when creationState is absent
- [x] Existing tests pass
- [x] Type-check passes