### PR TITLE
fix: make gatherActiveModifierEffects deterministic with injectable now param

### DIFF
--- a/__tests__/lib/rules/effects/gathering.test.ts
+++ b/__tests__/lib/rules/effects/gathering.test.ts
@@ -316,6 +316,74 @@ describe("Equipment readiness gating", () => {
     });
   });
 
+  describe("active modifier expiry with injectable now", () => {
+    const emptyRuleset = makeRuleset();
+
+    const MODIFIER_EFFECT: Effect = {
+      id: "mod-effect",
+      type: "dice-pool-modifier",
+      triggers: ["always"],
+      target: {},
+      value: 2,
+    };
+
+    it("should include non-expired active modifiers when now is before expiresAt", () => {
+      const char = createMockCharacter({
+        activeModifiers: [
+          {
+            id: "mod-1",
+            name: "Combat Drug",
+            source: "temporary",
+            effect: MODIFIER_EFFECT,
+            expiresAt: "2099-01-01T00:00:00.000Z",
+            appliedAt: "2020-01-01T00:00:00.000Z",
+          },
+        ],
+      });
+      const effects = gatherEffectSources(char, emptyRuleset, {
+        now: new Date("2025-06-01T00:00:00.000Z"),
+      });
+      expect(effects.some((e) => e.source.id === "mod-1")).toBe(true);
+    });
+
+    it("should exclude expired active modifiers when now is after expiresAt", () => {
+      const char = createMockCharacter({
+        activeModifiers: [
+          {
+            id: "mod-2",
+            name: "Expired Drug",
+            source: "temporary",
+            effect: MODIFIER_EFFECT,
+            expiresAt: "2020-01-01T00:00:00.000Z",
+            appliedAt: "2019-01-01T00:00:00.000Z",
+          },
+        ],
+      });
+      const effects = gatherEffectSources(char, emptyRuleset, {
+        now: new Date("2025-06-01T00:00:00.000Z"),
+      });
+      expect(effects.some((e) => e.source.id === "mod-2")).toBe(false);
+    });
+
+    it("should default now to current time when not provided", () => {
+      const char = createMockCharacter({
+        activeModifiers: [
+          {
+            id: "mod-3",
+            name: "Far Future Drug",
+            source: "temporary",
+            effect: MODIFIER_EFFECT,
+            expiresAt: "2099-12-31T23:59:59.999Z",
+            appliedAt: "2020-01-01T00:00:00.000Z",
+          },
+        ],
+      });
+      // No now parameter — should use current time, and modifier expires far in future
+      const effects = gatherEffectSources(char, emptyRuleset);
+      expect(effects.some((e) => e.source.id === "mod-3")).toBe(true);
+    });
+  });
+
   describe("stored readiness normalization", () => {
     it("should NOT gather effects from stored weapons (weapon category)", () => {
       const ruleset = makeRuleset(makeGearModule("test-weapon-catalog"));

--- a/lib/rules/effects/gathering.ts
+++ b/lib/rules/effects/gathering.ts
@@ -432,13 +432,16 @@ function gatherWeaponModEffects(character: Character, ruleset: MergedRuleset): S
  * Gather effects from active modifiers on the character.
  * Filters out expired modifiers (by timestamp or remaining uses).
  */
-function gatherActiveModifierEffects(character: Character): SourcedEffect[] {
+function gatherActiveModifierEffects(
+  character: Character,
+  now: Date = new Date()
+): SourcedEffect[] {
   const results: SourcedEffect[] = [];
-  const now = new Date().toISOString();
+  const nowISO = now.toISOString();
 
   for (const modifier of character.activeModifiers || []) {
     // Filter expired by timestamp
-    if (modifier.expiresAt && modifier.expiresAt < now) continue;
+    if (modifier.expiresAt && modifier.expiresAt < nowISO) continue;
 
     // Filter expired by remaining uses
     if (modifier.remainingUses !== undefined && modifier.remainingUses <= 0) continue;
@@ -460,7 +463,16 @@ function gatherActiveModifierEffects(character: Character): SourcedEffect[] {
  * Collects effects from qualities, gear, weapons, armor, cyberware,
  * bioware, adept powers, and active modifiers.
  */
-export function gatherEffectSources(character: Character, ruleset: MergedRuleset): SourcedEffect[] {
+export interface GatherEffectOptions {
+  /** Override the current time for deterministic expiry checks. Defaults to `new Date()`. */
+  now?: Date;
+}
+
+export function gatherEffectSources(
+  character: Character,
+  ruleset: MergedRuleset,
+  options: GatherEffectOptions = {}
+): SourcedEffect[] {
   return [
     ...gatherQualityEffects(character, ruleset),
     ...gatherGearEffects(character, ruleset),
@@ -471,6 +483,6 @@ export function gatherEffectSources(character: Character, ruleset: MergedRuleset
     ...gatherCyberwareEffects(character, ruleset),
     ...gatherBiowareEffects(character, ruleset),
     ...gatherAdeptPowerEffects(character, ruleset),
-    ...gatherActiveModifierEffects(character),
+    ...gatherActiveModifierEffects(character, options.now),
   ];
 }

--- a/lib/rules/effects/index.ts
+++ b/lib/rules/effects/index.ts
@@ -15,7 +15,7 @@ export { STACKING_RULES, getStackingRule, applyStackingRules } from "./stacking"
 
 // Gathering
 export { gatherEffectSources } from "./gathering";
-export type { SourcedEffect } from "./gathering";
+export type { SourcedEffect, GatherEffectOptions } from "./gathering";
 
 // Resolver (main pipeline)
 export { resolveEffects, resolveFromSources } from "./resolver";


### PR DESCRIPTION
## Summary
- `gatherActiveModifierEffects` used `new Date()` internally, making it non-deterministic and hard to test
- Added optional `now` parameter with default `new Date()` so callers can inject a fixed time for testing

Closes #658

## Test plan
- [x] Tests verify deterministic behavior with injected date
- [x] Type-check passes