### PR TITLE
fix: remove orphaned JSDoc block and add deprecation tracking for QualitySelection.id

### DIFF
--- a/lib/types/character.ts
+++ b/lib/types/character.ts
@@ -56,13 +56,6 @@ export type CharacterApprovalStatus =
   | "rejected" // Rejected by GM (with feedback)
   | "not-applicable"; // Not in a campaign or no approval required
 
-/**
- * Selection of a quality during character creation/advancement
- *
- * @deprecated The `id` field is deprecated. Use `qualityId` instead.
- * This field is maintained for backward compatibility during migration.
- */
-
 // =============================================================================
 // ADVANCEMENT TYPES (defined early for use in Character interface)
 // =============================================================================

--- a/lib/types/qualities.ts
+++ b/lib/types/qualities.ts
@@ -226,7 +226,7 @@ export type AcquisitionSource =
  * Selection of a quality on a character
  */
 export interface QualitySelection {
-  /** @deprecated Use qualityId instead */
+  /** @deprecated Use qualityId instead. Tracked by #661; remove in v1.9. */
   id?: string;
   qualityId: string; // References catalog Quality.id
   rating?: number; // Chosen rating for per-rating qualities


### PR DESCRIPTION
## Summary
- Removed orphaned JSDoc block at `lib/types/character.ts:59-65`
- Added `#661` tracking and v1.9 removal timeline to `@deprecated` on `QualitySelection.id`

Closes #661

## Test plan
- [x] Type-check passes
- [x] All 216 related tests pass