### PR TITLE
fix: eliminate duplicate skill-categories map construction

### DIFF
--- a/components/creation/SkillsCard.tsx
+++ b/components/creation/SkillsCard.tsx
@@ -17,6 +17,7 @@
 import { useMemo, useState } from "react";
 import { useSkills } from "@/lib/rules";
 import { getGroupRating, isGroupBroken } from "@/lib/rules/skills/group-utils";
+import { buildSkillCategoriesMap } from "@/lib/rules/skills/utils";
 import type { CreationState } from "@/lib/types";
 import type { SkillGroupValue } from "@/lib/types/creation-selections";
 import { useCreationBudgets } from "@/lib/contexts";
@@ -102,13 +103,7 @@ export function SkillsCard({ state, updateState }: SkillsCardProps) {
   }, [state.selections.positiveQualities]);
 
   // Build skill categories map for designation hooks
-  const skillCategories = useMemo(() => {
-    const categories: Record<string, string | undefined> = {};
-    for (const skill of activeSkills) {
-      categories[skill.id] = skill.category;
-    }
-    return categories;
-  }, [activeSkills]);
+  const skillCategories = useMemo(() => buildSkillCategoriesMap(activeSkills), [activeSkills]);
 
   // Map of skill ID to name for display
   const skillNameMap = useMemo(() => {

--- a/lib/contexts/CreationBudgetContext.tsx
+++ b/lib/contexts/CreationBudgetContext.tsx
@@ -34,6 +34,7 @@ import {
 } from "../rules/skills/free-skills";
 import { FREE_SKILL_TYPE_LABELS } from "@/components/creation/magic-path/constants";
 import { calculateBrokenGroupSkillPointOffset } from "../rules/skills/group-utils";
+import { buildSkillCategoriesMap } from "../rules/skills/utils";
 import {
   getQualityBudgetModifiers,
   getDefaultModifiers,
@@ -59,22 +60,6 @@ import {
   POINT_BUY_KARMA_BUDGET,
   POINT_BUY_NUYEN_PER_KARMA,
 } from "../rules/point-buy-validation";
-
-// =============================================================================
-// SKILL CATEGORY HELPERS
-// =============================================================================
-
-/**
- * Build a map of skill ID to category from skill data.
- * Used for determining which skills qualify for free skill allocations.
- */
-function buildSkillCategoriesMap(activeSkills: SkillData[]): Record<string, string | undefined> {
-  const categories: Record<string, string | undefined> = {};
-  for (const skill of activeSkills) {
-    categories[skill.id] = skill.category;
-  }
-  return categories;
-}
 
 // =============================================================================
 // TYPES

--- a/lib/rules/skills/__tests__/utils.test.ts
+++ b/lib/rules/skills/__tests__/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { buildSkillCategoriesMap } from "../utils";
+
+describe("buildSkillCategoriesMap", () => {
+  it("builds a map of skill ID to category", () => {
+    const skills = [
+      { id: "firearms", category: "combat" },
+      { id: "perception", category: "technical" },
+      { id: "athletics", category: "physical" },
+    ];
+
+    const result = buildSkillCategoriesMap(skills);
+
+    expect(result).toEqual({
+      firearms: "combat",
+      perception: "technical",
+      athletics: "physical",
+    });
+  });
+
+  it("returns undefined for skills without a category", () => {
+    const skills = [{ id: "firearms", category: "combat" }, { id: "perception" }];
+
+    const result = buildSkillCategoriesMap(skills);
+
+    expect(result).toEqual({
+      firearms: "combat",
+      perception: undefined,
+    });
+  });
+
+  it("converts null category to undefined", () => {
+    const skills = [{ id: "firearms", category: null }];
+
+    const result = buildSkillCategoriesMap(skills);
+
+    expect(result).toEqual({ firearms: undefined });
+  });
+
+  it("returns an empty object for an empty array", () => {
+    const result = buildSkillCategoriesMap([]);
+
+    expect(result).toEqual({});
+  });
+});

--- a/lib/rules/skills/index.ts
+++ b/lib/rules/skills/index.ts
@@ -36,3 +36,5 @@ export {
   calculateFreeSkillGroupPointsUsed,
   getSkillsWithFreeAllocation,
 } from "./free-skills";
+
+export { buildSkillCategoriesMap } from "./utils";

--- a/lib/rules/skills/utils.ts
+++ b/lib/rules/skills/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Skill Utilities
+ *
+ * Shared helper functions for skill-related operations.
+ */
+
+/**
+ * Build a map of skill ID to category from skill data.
+ * Used for determining which skills qualify for free skill allocations.
+ */
+export function buildSkillCategoriesMap(
+  activeSkills: ReadonlyArray<{ id: string; category?: string | null }>
+): Record<string, string | undefined> {
+  const categories: Record<string, string | undefined> = {};
+  for (const skill of activeSkills) {
+    categories[skill.id] = skill.category ?? undefined;
+  }
+  return categories;
+}


### PR DESCRIPTION
## Summary
- Removed duplicate skill-categories map construction by reusing a single shared map

Closes #671

## Test plan
- [x] Type-check passes
- [x] Related tests pass