### PR TITLE
fix: add armor-modifier and wound-modifier to effect resolution output

### DIFF
--- a/__tests__/lib/rules/effects/resolver.test.ts
+++ b/__tests__/lib/rules/effects/resolver.test.ts
@@ -485,6 +485,40 @@ describe("Stacking", () => {
       expect(result.totalInitiativeModifier).toBe(1);
       expect(result.totalThresholdModifier).toBe(-1);
     });
+
+    it("should populate armorModifiers for armor-modifier effects", () => {
+      const effects = [
+        makeResolved({
+          effect: makeEffect({ id: "e1", type: "armor-modifier" }),
+          resolvedValue: 2,
+        }),
+        makeResolved({
+          effect: makeEffect({ id: "e2", type: "armor-modifier" }),
+          resolvedValue: 3,
+        }),
+      ];
+      const result = applyStackingRules(effects);
+      expect(result.totalArmorModifier).toBe(5);
+      expect(result.armorModifiers).toHaveLength(2);
+      expect(result.excludedByStacking).toHaveLength(0);
+    });
+
+    it("should populate woundModifiers for wound-modifier effects", () => {
+      const effects = [
+        makeResolved({
+          effect: makeEffect({ id: "e1", type: "wound-modifier" }),
+          resolvedValue: -1,
+        }),
+        makeResolved({
+          effect: makeEffect({ id: "e2", type: "wound-modifier" }),
+          resolvedValue: -2,
+        }),
+      ];
+      const result = applyStackingRules(effects);
+      expect(result.totalWoundModifier).toBe(-3);
+      expect(result.woundModifiers).toHaveLength(2);
+      expect(result.excludedByStacking).toHaveLength(0);
+    });
   });
 
   describe("NaN protection", () => {

--- a/components/character/sheet/__tests__/DerivedStatsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/DerivedStatsDisplay.test.tsx
@@ -163,11 +163,15 @@ describe("DerivedStatsDisplay", () => {
       thresholdModifiers: [],
       accuracyModifiers: [],
       initiativeModifiers: [],
+      armorModifiers: [],
+      woundModifiers: [],
       totalDicePoolModifier: 0,
       totalLimitModifier: 0,
       totalThresholdModifier: 0,
       totalAccuracyModifier: 0,
       totalInitiativeModifier: 0,
+      totalArmorModifier: 0,
+      totalWoundModifier: 0,
       excludedByStacking: [],
     };
 

--- a/components/character/sheet/__tests__/SkillsDisplay.test.tsx
+++ b/components/character/sheet/__tests__/SkillsDisplay.test.tsx
@@ -395,11 +395,15 @@ describe("SkillsDisplay", () => {
         thresholdModifiers: [],
         accuracyModifiers: [],
         initiativeModifiers: [],
+        armorModifiers: [],
+        woundModifiers: [],
         totalDicePoolModifier: 2,
         totalLimitModifier: 0,
         totalThresholdModifier: 0,
         totalAccuracyModifier: 0,
         totalInitiativeModifier: 0,
+        totalArmorModifier: 0,
+        totalWoundModifier: 0,
         excludedByStacking: [],
       } satisfies EffectResolutionResult);
     }
@@ -480,11 +484,15 @@ describe("SkillsDisplay", () => {
         thresholdModifiers: [],
         accuracyModifiers: [],
         initiativeModifiers: [],
+        armorModifiers: [],
+        woundModifiers: [],
         totalDicePoolModifier: 2,
         totalLimitModifier: 0,
         totalThresholdModifier: 0,
         totalAccuracyModifier: 0,
         totalInitiativeModifier: 0,
+        totalArmorModifier: 0,
+        totalWoundModifier: 0,
         excludedByStacking: [],
       } satisfies EffectResolutionResult);
       render(<SkillsDisplay character={character} resolveEffects={resolveEffects} />);

--- a/components/creation/hooks/useCreationEffects.ts
+++ b/components/creation/hooks/useCreationEffects.ts
@@ -41,11 +41,15 @@ const EMPTY_RESULT: EffectResolutionResult = {
   thresholdModifiers: [],
   accuracyModifiers: [],
   initiativeModifiers: [],
+  armorModifiers: [],
+  woundModifiers: [],
   totalDicePoolModifier: 0,
   totalLimitModifier: 0,
   totalThresholdModifier: 0,
   totalAccuracyModifier: 0,
   totalInitiativeModifier: 0,
+  totalArmorModifier: 0,
+  totalWoundModifier: 0,
   excludedByStacking: [],
 };
 

--- a/lib/rules/effects/stacking.ts
+++ b/lib/rules/effects/stacking.ts
@@ -52,11 +52,15 @@ function emptyResult(): EffectResolutionResult {
     thresholdModifiers: [],
     accuracyModifiers: [],
     initiativeModifiers: [],
+    armorModifiers: [],
+    woundModifiers: [],
     totalDicePoolModifier: 0,
     totalLimitModifier: 0,
     totalThresholdModifier: 0,
     totalAccuracyModifier: 0,
     totalInitiativeModifier: 0,
+    totalArmorModifier: 0,
+    totalWoundModifier: 0,
     excludedByStacking: [],
   };
 }
@@ -195,7 +199,14 @@ export function applyStackingRules(effects: UnifiedResolvedEffect[]): EffectReso
         result.initiativeModifiers.push(...included);
         result.totalInitiativeModifier = total;
         break;
-      // Other types are resolved but not surfaced in typed arrays
+      case "armor-modifier":
+        result.armorModifiers.push(...included);
+        result.totalArmorModifier = total;
+        break;
+      case "wound-modifier":
+        result.woundModifiers.push(...included);
+        result.totalWoundModifier = total;
+        break;
     }
   }
 

--- a/lib/types/effects.ts
+++ b/lib/types/effects.ts
@@ -390,6 +390,12 @@ export interface EffectResolutionResult {
   /** Initiative modifier effects */
   initiativeModifiers: UnifiedResolvedEffect[];
 
+  /** Armor modifier effects */
+  armorModifiers: UnifiedResolvedEffect[];
+
+  /** Wound modifier effects */
+  woundModifiers: UnifiedResolvedEffect[];
+
   /** Total dice pool modifier (after stacking rules) */
   totalDicePoolModifier: number;
 
@@ -404,6 +410,12 @@ export interface EffectResolutionResult {
 
   /** Total initiative modifier (after stacking rules) */
   totalInitiativeModifier: number;
+
+  /** Total armor modifier (after stacking rules) */
+  totalArmorModifier: number;
+
+  /** Total wound modifier (after stacking rules) */
+  totalWoundModifier: number;
 
   /** Effects excluded by stacking rules (for UI transparency) */
   excludedByStacking: UnifiedResolvedEffect[];


### PR DESCRIPTION
## Summary
- `armor-modifier` and `wound-modifier` effect types were missing from `applyStackingRules`, causing them to be silently dropped from resolution output
- Added `armorModifiers`, `woundModifiers`, `totalArmorModifier`, `totalWoundModifier` fields to `EffectResolutionResult`
- Added case handlers in `applyStackingRules` for both effect types

Closes #656

## Test plan
- [x] New tests verify armor-modifier and wound-modifier populate correctly
- [x] 88 resolver tests pass
- [x] Type-check passes (updated downstream object literals)