### PR TITLE
fix: remove redundant BookModuleEntry.replace and .append fields

### DIFF
--- a/lib/rules/merge.ts
+++ b/lib/rules/merge.ts
@@ -381,22 +381,7 @@ export function produceMergedRuleset(loadedRuleset: LoadedRuleset): MergeResult 
  * Infer the merge strategy from a BookModuleEntry
  */
 function inferMergeStrategy(entry: BookModuleEntry): MergeStrategy {
-  // Explicit strategy takes precedence
-  if (entry.mergeStrategy) {
-    return entry.mergeStrategy;
-  }
-
-  // Shorthand flags
-  if (entry.replace === true) {
-    return "replace";
-  }
-
-  if (entry.append === true) {
-    return "append";
-  }
-
-  // Default to merge
-  return "merge";
+  return entry.mergeStrategy ?? "merge";
 }
 
 // =============================================================================

--- a/lib/storage/__tests__/editions.test.ts
+++ b/lib/storage/__tests__/editions.test.ts
@@ -50,7 +50,7 @@ function createMockBookPayload(overrides: Partial<BookPayload> = {}): BookPayloa
     },
     modules: {
       metatypes: {
-        replace: true,
+        mergeStrategy: "replace",
         payload: {
           metatypes: [
             { id: "human", name: "Human" },
@@ -59,7 +59,7 @@ function createMockBookPayload(overrides: Partial<BookPayload> = {}): BookPayloa
         },
       },
       skills: {
-        replace: true,
+        mergeStrategy: "replace",
         payload: {
           activeSkills: [
             { id: "firearms", name: "Firearms" },
@@ -68,14 +68,14 @@ function createMockBookPayload(overrides: Partial<BookPayload> = {}): BookPayloa
         },
       },
       qualities: {
-        replace: true,
+        mergeStrategy: "replace",
         payload: {
           positive: [{ id: "ambidextrous", name: "Ambidextrous" }],
           negative: [{ id: "addiction", name: "Addiction" }],
         },
       },
       creationMethods: {
-        replace: true,
+        mergeStrategy: "replace",
         payload: {
           creationMethods: [
             {

--- a/lib/types/edition.ts
+++ b/lib/types/edition.ts
@@ -308,12 +308,6 @@ export interface BookModuleEntry {
   /** Merge strategy for this module's data */
   mergeStrategy?: MergeStrategy;
 
-  /** Whether to replace entirely (shorthand for mergeStrategy: "replace") */
-  replace?: boolean;
-
-  /** Whether to append (shorthand for mergeStrategy: "append") */
-  append?: boolean;
-
   /** The actual module data */
   payload: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Removed ambiguous `replace` and `append` shorthand fields from `BookModuleEntry` that duplicated `mergeStrategy`
- JSON data exclusively uses `mergeStrategy`, making these fields dead code
- Simplified `inferMergeStrategy` to a single nullish coalescing expression

Closes #663

## Test plan
- [x] Type-check passes
- [x] Related tests pass
- [x] Pre-commit hooks pass