### PR TITLE
fix: remove debug console.log from action-executor.ts applyStateChanges

### DIFF
--- a/lib/rules/action-resolution/__tests__/action-executor.test.ts
+++ b/lib/rules/action-resolution/__tests__/action-executor.test.ts
@@ -1079,7 +1079,7 @@ describe("executeOpposedTest", () => {
 // =============================================================================
 
 describe("applyStateChanges", () => {
-  it("should group changes by entity", async () => {
+  it("should accept changes without producing console output", async () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     const changes: StateChange[] = [
@@ -1111,19 +1111,14 @@ describe("applyStateChanges", () => {
 
     await applyStateChanges(changes);
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("2 changes to character char-1")
-    );
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("1 changes to character char-2")
-    );
+    expect(consoleSpy).not.toHaveBeenCalled();
 
     consoleSpy.mockRestore();
   });
 });
 
 describe("rollbackStateChanges", () => {
-  it("should reverse changes and swap values", async () => {
+  it("should reverse changes and swap values without console output", async () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     const changes: StateChange[] = [
@@ -1147,10 +1142,7 @@ describe("rollbackStateChanges", () => {
 
     await rollbackStateChanges(changes);
 
-    // Should be called with rollback prefix
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("2 changes to character char-1")
-    );
+    expect(consoleSpy).not.toHaveBeenCalled();
 
     consoleSpy.mockRestore();
   });

--- a/lib/rules/action-resolution/action-executor.ts
+++ b/lib/rules/action-resolution/action-executor.ts
@@ -533,12 +533,8 @@ export async function applyStateChanges(changes: StateChange[]): Promise<void> {
 
   // Apply changes to each entity
   // This is a simplified implementation - would need actual storage updates
-  for (const [key, entityChanges] of byEntity) {
-    const [entityType, entityId] = key.split(":");
-
-    // Would apply changes based on entity type
-    // For now, just log that changes would be applied
-    console.log(`Would apply ${entityChanges.length} changes to ${entityType} ${entityId}`);
+  for (const [_key, _entityChanges] of byEntity) {
+    // TODO: implement actual state mutation (see migration-engine)
   }
 }
 


### PR DESCRIPTION
Removes debug console.log from applyStateChanges (#664). Updates tests to verify no console output.