### PR TITLE
fix: match catalog items by catalogId instead of name in GearDisplay

### DIFF
--- a/components/character/sheet/GearDisplay.tsx
+++ b/components/character/sheet/GearDisplay.tsx
@@ -47,8 +47,17 @@ function formatCategoryLabel(category: string, catalog: GearCatalogData | null):
     .join(" ");
 }
 
-/** Search all GearItemData sub-arrays in the catalog to find an item by name. */
-function findCatalogItem(catalog: GearCatalogData | null, name: string): GearItemData | undefined {
+/** Search all GearItemData sub-arrays in the catalog to find an item by catalogId, falling back to name for legacy data. */
+function findCatalogItemByIdOrName(
+  catalog: GearCatalogData | null,
+  catalogId: string | undefined,
+  name: string
+): GearItemData | undefined {
+  if (catalogId) {
+    const byId = findGearItemInCatalog(catalog, (item) => item.id === catalogId);
+    if (byId) return byId;
+  }
+  // Fallback to name matching for legacy characters without catalogId
   return findGearItemInCatalog(catalog, (item) => item.name === name);
 }
 
@@ -546,7 +555,7 @@ export function GearDisplay({ character, gear, onCharacterUpdate, editable }: Ge
             </div>
             <div className="overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950">
               {grouped[cat].map(({ item, originalIndex }, idx) => {
-                const catalogItem = findCatalogItem(catalog, item.name);
+                const catalogItem = findCatalogItemByIdOrName(catalog, item.catalogId, item.name);
                 return (
                   <GearRow
                     key={`${item.name}-${idx}`}

--- a/components/creation/gear/GearPanel.tsx
+++ b/components/creation/gear/GearPanel.tsx
@@ -246,6 +246,7 @@ export function GearPanel({ state, updateState }: GearPanelProps) {
 
       const newGear: GearItem = {
         id: `${gearData.id}-${Date.now()}`,
+        catalogId: gearData.id,
         name: displayName,
         category: gearData.category,
         cost: unitCost,

--- a/lib/types/character.ts
+++ b/lib/types/character.ts
@@ -745,6 +745,8 @@ export interface InstalledGearMod {
 
 export interface GearItem {
   id?: ID;
+  /** Reference to the catalog item ID for reliable lookup */
+  catalogId?: string;
   name: string;
   category: string;
   /** Subcategory for more specific classification (e.g., "clothing" for armor) */


### PR DESCRIPTION
## Summary
- Add `catalogId?: string` field to `GearItem` type
- Set `catalogId` when creating gear items in GearPanel
- Replace name-based catalog matching with catalogId-first matching (name fallback for legacy data)

## Test plan
- [x] All 50 GearDisplay tests pass
- [x] Type-check passes
- [x] Pre-commit hooks pass

Closes #678