### PR TITLE
refactor: replace console.error with structured logger in lib/auth services

### DIFF
--- a/lib/auth/email-verification.ts
+++ b/lib/auth/email-verification.ts
@@ -22,6 +22,7 @@ import {
 import { sendEmail, renderTemplate } from "@/lib/email";
 import { VerificationEmailTemplate } from "@/lib/email/templates/verification-email";
 import { AuditLogger } from "@/lib/security/audit-logger";
+import { authLogger } from "@/lib/logging";
 
 /** Token size in bytes (32 bytes = 256 bits of entropy) */
 const TOKEN_BYTES = 32;
@@ -140,11 +141,11 @@ export async function sendVerificationEmail(
 
       return { success: true };
     } else {
-      console.error("Failed to send verification email:", result.error);
+      authLogger.error({ error: result.error }, "Failed to send verification email");
       return { success: false, error: result.error || "Failed to send email" };
     }
   } catch (error) {
-    console.error("Error in sendVerificationEmail:", error);
+    authLogger.error({ error }, "Error in sendVerificationEmail");
     return {
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",
@@ -204,7 +205,7 @@ export async function verifyEmailToken(token: string): Promise<VerificationResul
 
     return { success: true, userId: user.id };
   } catch (error) {
-    console.error("Error in verifyEmailToken:", error);
+    authLogger.error({ error }, "Error in verifyEmailToken");
     await AuditLogger.log({
       event: "verification.failed",
       metadata: {

--- a/lib/auth/magic-link.ts
+++ b/lib/auth/magic-link.ts
@@ -25,6 +25,7 @@ import {
 import { sendEmail, renderTemplate } from "@/lib/email";
 import { MagicLinkEmailTemplate } from "@/lib/email/templates/magic-link-email";
 import { AuditLogger } from "@/lib/security/audit-logger";
+import { authLogger } from "@/lib/logging";
 
 /** Token size in bytes (32 bytes = 256 bits of entropy) */
 const TOKEN_BYTES = 32;
@@ -192,11 +193,11 @@ export async function sendMagicLinkEmail(
 
       return { success: true };
     } else {
-      console.error("Failed to send magic link email:", result.error);
+      authLogger.error({ error: result.error }, "Failed to send magic link email");
       return { success: false, error: result.error || "Failed to send email" };
     }
   } catch (error) {
-    console.error("Error in sendMagicLinkEmail:", error);
+    authLogger.error({ error }, "Error in sendMagicLinkEmail");
     return {
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",
@@ -334,7 +335,7 @@ export async function verifyMagicLink(token: string): Promise<VerifyMagicLinkRes
       sessionVersion: user.sessionVersion,
     };
   } catch (error) {
-    console.error("Error in verifyMagicLink:", error);
+    authLogger.error({ error }, "Error in verifyMagicLink");
     await AuditLogger.log({
       event: "magic_link.failed",
       metadata: {

--- a/lib/auth/password-reset.ts
+++ b/lib/auth/password-reset.ts
@@ -24,6 +24,7 @@ import {
 import { sendEmail, renderTemplate } from "@/lib/email";
 import { PasswordResetEmailTemplate } from "@/lib/email/templates/password-reset-email";
 import { AuditLogger } from "@/lib/security/audit-logger";
+import { authLogger } from "@/lib/logging";
 import { sendPasswordChangedEmail } from "@/lib/email/security-alerts";
 import { sendAdminPasswordResetNotification } from "@/lib/email/admin-notifications";
 import { isStrongPassword } from "./validation";
@@ -158,11 +159,11 @@ export async function sendPasswordResetEmail(
 
       return { success: true };
     } else {
-      console.error("Failed to send password reset email:", result.error);
+      authLogger.error({ error: result.error }, "Failed to send password reset email");
       return { success: false, error: result.error || "Failed to send email" };
     }
   } catch (error) {
-    console.error("Error in sendPasswordResetEmail:", error);
+    authLogger.error({ error }, "Error in sendPasswordResetEmail");
     return {
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",
@@ -202,7 +203,7 @@ export async function requestPasswordReset(
 
     // Send admin notification (fire-and-forget)
     sendAdminPasswordResetNotification(user.id, user.email, user.username, new Date(), ip).catch(
-      (err) => console.error("Admin notification failed:", err)
+      (err) => authLogger.error({ error: err }, "Admin notification failed")
     );
   }
 
@@ -237,7 +238,7 @@ export async function validateResetToken(token: string): Promise<ValidateTokenRe
 
     return { valid: true, userId: user.id };
   } catch (error) {
-    console.error("Error in validateResetToken:", error);
+    authLogger.error({ error }, "Error in validateResetToken");
     return { valid: false, reason: "invalid" };
   }
 }
@@ -308,12 +309,12 @@ export async function resetPassword(
     // Send password changed notification email (fire-and-forget)
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
     sendPasswordChangedEmail(user.id, user.email, user.username, new Date(), baseUrl).catch((err) =>
-      console.error("Failed to send password changed email:", err)
+      authLogger.error({ error: err }, "Failed to send password changed email")
     );
 
     return { success: true, userId: user.id };
   } catch (error) {
-    console.error("Error in resetPassword:", error);
+    authLogger.error({ error }, "Error in resetPassword");
     await AuditLogger.log({
       event: "password_reset.failed",
       metadata: {


### PR DESCRIPTION
## Summary
- Replace all 12 `console.error` calls with `authLogger.error()` across 3 auth service files
- `lib/auth/email-verification.ts` — 3 replacements
- `lib/auth/magic-link.ts` — 3 replacements
- `lib/auth/password-reset.ts` — 6 replacements

## Test plan
- [x] Type-check passes
- [x] No `console.error` calls remain in the 3 modified files

Closes #644