### PR TITLE
fix: pass character.nuyen instead of Infinity in AugmentationsDisplay

### DIFF
--- a/components/character/sheet/AugmentationsDisplay.tsx
+++ b/components/character/sheet/AugmentationsDisplay.tsx
@@ -964,7 +964,7 @@ export function AugmentationsDisplay({
           }}
           onAdd={handleAddEnhancement}
           limb={selectedCyberlimb}
-          availableNuyen={Infinity}
+          availableNuyen={character.nuyen}
         />
       )}
 
@@ -978,7 +978,7 @@ export function AugmentationsDisplay({
           }}
           onAdd={handleAddAccessory}
           limb={selectedCyberlimb}
-          availableNuyen={Infinity}
+          availableNuyen={character.nuyen}
         />
       )}
 
@@ -990,7 +990,7 @@ export function AugmentationsDisplay({
         augmentationType="cyberware"
         mode="management"
         remainingEssence={remainingEssence}
-        remainingNuyen={Infinity}
+        remainingNuyen={character.nuyen}
         isAwakened={isAwakened}
         isTechnomancer={isTechnomancer}
         currentMagic={character.specialAttributes?.magic ?? 0}


### PR DESCRIPTION
## Summary
- Replace `availableNuyen={Infinity}` with `character.nuyen` in three modal props in AugmentationsDisplay
- CyberlimbEnhancementModal, CyberlimbAccessoryModal, and AugmentationModal now enforce actual nuyen validation

## Test plan
- [x] Type-check passes
- [x] Pre-commit hooks pass (lint, type-check, coverage)

Closes #676