### PR TITLE
refactor: make getModule and extractModule type-safe (#655)

### DIFF
--- a/lib/rules/loader.ts
+++ b/lib/rules/loader.ts
@@ -23,6 +23,7 @@ import type {
   CreationMethod,
 } from "../types";
 import type { LoadedRuleset, LoadedBook, LoadResult, RulesetLoadConfig } from "./loader-types";
+import type { RuleModulePayloadMap } from "./module-payloads";
 import {
   getEdition,
   getAllEditions,
@@ -168,12 +169,16 @@ export async function loadAllCreationMethods(editionCode: EditionCode): Promise<
 // =============================================================================
 
 /**
- * Extract a specific module type from a loaded ruleset
+ * Extract a specific module type from a loaded ruleset.
+ *
+ * Return type is inferred from the module key via RuleModulePayloadMap.
+ * No explicit generic needed: `extractModule(ruleset, "gear")` returns
+ * `GearCatalogData | null`.
  */
-export function extractModule<T = Record<string, unknown>>(
+export function extractModule<T = never, K extends RuleModuleType = RuleModuleType>(
   ruleset: LoadedRuleset,
-  moduleType: RuleModuleType
-): T | null {
+  moduleType: K
+): [T] extends [never] ? RuleModulePayloadMap[K] | null : T | null {
   // Merge payloads from all books (core + sourcebooks) so that
   // sourcebook data with "append" merge strategy is included.
   // Arrays of objects with `id` fields are deduplicated; other values
@@ -221,7 +226,7 @@ export function extractModule<T = Record<string, unknown>>(
     }
   }
 
-  return merged as T | null;
+  return merged as [T] extends [never] ? RuleModulePayloadMap[K] | null : T | null;
 }
 
 /**

--- a/lib/rules/merge.ts
+++ b/lib/rules/merge.ts
@@ -14,6 +14,7 @@
 import { v4 as uuidv4 } from "uuid";
 import type { ID, MergeStrategy, RuleModuleType, MergedRuleset, BookModuleEntry } from "../types";
 import type { LoadedRuleset } from "./loader-types";
+import type { RuleModulePayloadMap } from "./module-payloads";
 
 // =============================================================================
 // TYPES
@@ -414,13 +415,21 @@ export async function loadAndMergeRuleset(
 }
 
 /**
- * Get a module from a merged ruleset with type safety
+ * Get a module from a merged ruleset with type safety.
+ *
+ * Preferred: let the return type be inferred from the module key:
+ *   `getModule(ruleset, "gear")` → `GearCatalogData | undefined`
+ *
+ * Legacy: explicit generic override still supported for migration:
+ *   `getModule<{ metatypes: MetatypeData[] }>(ruleset, "metatypes")`
  */
-export function getModule<T = ModulePayload>(
+export function getModule<T = never, K extends RuleModuleType = RuleModuleType>(
   ruleset: MergedRuleset,
-  moduleType: RuleModuleType
-): T | undefined {
-  return ruleset.modules[moduleType] as T | undefined;
+  moduleType: K
+): [T] extends [never] ? RuleModulePayloadMap[K] | undefined : T | undefined {
+  return ruleset.modules[moduleType] as [T] extends [never]
+    ? RuleModulePayloadMap[K] | undefined
+    : T | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Update `getModule()` and `extractModule()` to infer return types from the module key via `RuleModulePayloadMap`
- Uses `[T] extends [never]` conditional type pattern for dual-mode generics:
  - **New (preferred):** `getModule(ruleset, "gear")` → `GearCatalogData | undefined`
  - **Legacy:** `getModule<SomeType>(ruleset, "gear")` → `SomeType | undefined` (still works)
- Zero call sites modified — full backward compatibility with existing explicit generics
- Legacy generics will be removed in Phase 4+5

This is **Phase 2+3** of the [MergedRuleset type safety plan](https://github.com/Jasrags/ShadowMaster/issues/655#issuecomment-4071629389).

Note: `MergedRuleset.modules` retains its `Record<string, unknown>` type in `edition.ts` to avoid a circular dependency (`edition.ts` → `loader-types.ts` → `edition.ts`). Type safety is enforced through the accessor functions instead.

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (9,807 tests)
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass
- [x] All existing callers with explicit generics still compile

Part of #655