### PR TITLE
refactor: remove explicit generics from getModule/extractModule calls (#655)

### DIFF
--- a/lib/rules/advancement/attributes.ts
+++ b/lib/rules/advancement/attributes.ts
@@ -91,7 +91,7 @@ export function advanceAttribute(
   options: AdvanceAttributeOptions = {}
 ): AdvanceAttributeResult {
   // Extract advancement rules from ruleset
-  const advancementRules = getModule<AdvancementRulesData>(ruleset, "advancement");
+  const advancementRules = getModule(ruleset, "advancement");
 
   // Validate advancement (including downtime limits if applicable)
   const validation = validateAttributeAdvancement(character, attributeId, newRating, ruleset, {

--- a/lib/rules/advancement/edge.ts
+++ b/lib/rules/advancement/edge.ts
@@ -52,7 +52,7 @@ export function advanceEdge(
   options: AdvanceEdgeOptions = {}
 ): AdvanceEdgeResult {
   // Extract advancement rules
-  const advancementRules = getModule<AdvancementRulesData>(ruleset, "advancement");
+  const advancementRules = getModule(ruleset, "advancement");
 
   // Validate advancement
   const validation = validateAttributeAdvancement(character, "edge", newRating, ruleset, {

--- a/lib/rules/advancement/skills.ts
+++ b/lib/rules/advancement/skills.ts
@@ -92,7 +92,7 @@ export function advanceSkill(
   options: AdvanceSkillOptions = {}
 ): AdvanceSkillResult {
   // Extract advancement rules
-  const advancementRules = getModule<AdvancementRulesData>(ruleset, "advancement");
+  const advancementRules = getModule(ruleset, "advancement");
 
   // Validate advancement (including downtime limits if applicable)
   const validation = validateSkillAdvancement(character, skillId, newRating, ruleset, {

--- a/lib/rules/advancement/specializations.ts
+++ b/lib/rules/advancement/specializations.ts
@@ -89,7 +89,7 @@ export function advanceSpecialization(
   options: AdvanceSpecializationOptions = {}
 ): AdvanceSpecializationResult {
   // Extract advancement rules
-  const advancementRules = getModule<AdvancementRulesData>(ruleset, "advancement");
+  const advancementRules = getModule(ruleset, "advancement");
 
   // Validate advancement
   const validation = validateSpecializationAdvancement(character, skillId, ruleset, {

--- a/lib/rules/constraint-validation.ts
+++ b/lib/rules/constraint-validation.ts
@@ -330,12 +330,7 @@ export function getMetatypeAttributeLimits(
   metatypeId: string,
   ruleset: MergedRuleset
 ): Record<string, { min: number; max: number }> | null {
-  const metatypesModule = getModule<{
-    metatypes: Array<{
-      id: string;
-      attributes: Record<string, { min: number; max: number } | { base: number }>;
-    }>;
-  }>(ruleset, "metatypes");
+  const metatypesModule = getModule(ruleset, "metatypes");
 
   if (!metatypesModule) return null;
 

--- a/lib/rules/loader-types.ts
+++ b/lib/rules/loader-types.ts
@@ -229,7 +229,44 @@ export interface QualityData {
 export interface PriorityTableData {
   levels: string[];
   categories: Array<{ id: string; name: string; description?: string }>;
-  table: Record<string, Record<string, unknown>>;
+  table: Record<string, PriorityLevelEntry>;
+}
+
+/**
+ * A single priority level entry (e.g., "A", "B", "C", "D", "E").
+ * Each level defines what the character gets for metatype, attributes,
+ * magic/resonance, skills, and resources at that priority.
+ */
+export interface PriorityLevelEntry {
+  metatype?: {
+    available: string[];
+    specialAttributePoints: Record<string, number>;
+  };
+  attributes?: number;
+  magic?: {
+    options: PriorityMagicOption[];
+  };
+  skills?: {
+    skillPoints: number;
+    skillGroupPoints: number;
+  };
+  resources?: number;
+}
+
+/**
+ * A magic/resonance option within a priority level.
+ */
+export interface PriorityMagicOption {
+  path: string;
+  magicRating?: number;
+  resonanceRating?: number;
+  spells?: number;
+  complexForms?: number;
+  freeSkills?: Array<{
+    type: string;
+    rating: number;
+    count: number;
+  }>;
 }
 
 // =============================================================================

--- a/lib/rules/loader.ts
+++ b/lib/rules/loader.ts
@@ -279,7 +279,7 @@ import type { MetatypeData } from "./loader-types";
  * Load metatypes from a ruleset
  */
 export function extractMetatypes(ruleset: LoadedRuleset): MetatypeData[] {
-  const ruleModule = extractModule<{ metatypes: MetatypeData[] }>(ruleset, "metatypes");
+  const ruleModule = extractModule(ruleset, "metatypes");
   return ruleModule?.metatypes || [];
 }
 
@@ -303,14 +303,7 @@ export function extractSkills(ruleset: LoadedRuleset): {
   exampleKnowledgeSkills: ExampleKnowledgeSkillData[];
   exampleLanguages: ExampleLanguageData[];
 } {
-  const ruleModule = extractModule<{
-    activeSkills: SkillData[];
-    skillGroups: SkillGroupData[];
-    knowledgeCategories: KnowledgeCategoryData[];
-    creationLimits: SkillCreationLimitsData;
-    exampleKnowledgeSkills: ExampleKnowledgeSkillData[];
-    exampleLanguages: ExampleLanguageData[];
-  }>(ruleset, "skills");
+  const ruleModule = extractModule(ruleset, "skills");
 
   return {
     activeSkills: ruleModule?.activeSkills || [],
@@ -336,10 +329,7 @@ export function extractQualities(ruleset: LoadedRuleset): {
   positive: QualityData[];
   negative: QualityData[];
 } {
-  const ruleModule = extractModule<{
-    positive: QualityData[];
-    negative: QualityData[];
-  }>(ruleset, "qualities");
+  const ruleModule = extractModule(ruleset, "qualities");
 
   return {
     positive: ruleModule?.positive || [],
@@ -353,7 +343,7 @@ import type { PriorityTableData } from "./loader-types";
  * Load priority table from a ruleset
  */
 export function extractPriorityTable(ruleset: LoadedRuleset): PriorityTableData | null {
-  return extractModule<PriorityTableData>(ruleset, "priorities");
+  return extractModule(ruleset, "priorities");
 }
 
 import type { MagicPathData } from "./loader-types";
@@ -362,7 +352,7 @@ import type { MagicPathData } from "./loader-types";
  * Load magic paths from a ruleset
  */
 export function extractMagicPaths(ruleset: LoadedRuleset): MagicPathData[] {
-  const ruleModule = extractModule<{ paths: MagicPathData[] }>(ruleset, "magic");
+  const ruleModule = extractModule(ruleset, "magic");
   return ruleModule?.paths || [];
 }
 
@@ -376,7 +366,7 @@ import type {
  * Load lifestyles from a ruleset
  */
 export function extractLifestyles(ruleset: LoadedRuleset): LifestyleData[] {
-  const ruleModule = extractModule<{ lifestyles: LifestyleData[] }>(ruleset, "lifestyle");
+  const ruleModule = extractModule(ruleset, "lifestyle");
   return ruleModule?.lifestyles || [];
 }
 
@@ -384,10 +374,7 @@ export function extractLifestyles(ruleset: LoadedRuleset): LifestyleData[] {
  * Load lifestyle metatype modifiers from a ruleset
  */
 export function extractLifestyleModifiers(ruleset: LoadedRuleset): Record<string, number> {
-  const ruleModule = extractModule<{ metatypeModifiers: Record<string, number> }>(
-    ruleset,
-    "lifestyle"
-  );
+  const ruleModule = extractModule(ruleset, "lifestyle");
   return ruleModule?.metatypeModifiers || {};
 }
 
@@ -397,7 +384,7 @@ export function extractLifestyleModifiers(ruleset: LoadedRuleset): Record<string
 export function extractLifestyleSubscriptions(
   ruleset: LoadedRuleset
 ): LifestyleSubscriptionCatalogItem[] {
-  const ruleModule = extractModule<LifestyleSubscriptionsCatalogData>(ruleset, "lifestyle");
+  const ruleModule = extractModule(ruleset, "lifestyle");
   return ruleModule?.subscriptions || [];
 }
 
@@ -411,7 +398,7 @@ import type { GearCatalogData } from "./loader-types";
  * Load gear catalog from a ruleset
  */
 export function extractGear(ruleset: LoadedRuleset): GearCatalogData | null {
-  const ruleModule = extractModule<GearCatalogData>(ruleset, "gear");
+  const ruleModule = extractModule(ruleset, "gear");
   return ruleModule;
 }
 
@@ -430,7 +417,7 @@ import type {
  * Load spells from a ruleset
  */
 export function extractSpells(ruleset: LoadedRuleset): SpellsCatalogData | null {
-  const ruleModule = extractModule<{ spells: SpellsCatalogData }>(ruleset, "magic");
+  const ruleModule = extractModule(ruleset, "magic");
   return ruleModule?.spells || null;
 }
 
@@ -438,7 +425,7 @@ export function extractSpells(ruleset: LoadedRuleset): SpellsCatalogData | null 
  * Load complex forms from a ruleset
  */
 export function extractComplexForms(ruleset: LoadedRuleset): ComplexFormData[] {
-  const ruleModule = extractModule<{ complexForms: ComplexFormData[] }>(ruleset, "magic");
+  const ruleModule = extractModule(ruleset, "magic");
   return ruleModule?.complexForms || [];
 }
 
@@ -446,7 +433,7 @@ export function extractComplexForms(ruleset: LoadedRuleset): ComplexFormData[] {
  * Load sprite types from a ruleset
  */
 export function extractSpriteTypes(ruleset: LoadedRuleset): SpriteTypeData[] {
-  const ruleModule = extractModule<{ spriteTypes: SpriteTypeData[] }>(ruleset, "magic");
+  const ruleModule = extractModule(ruleset, "magic");
   return ruleModule?.spriteTypes || [];
 }
 
@@ -454,7 +441,7 @@ export function extractSpriteTypes(ruleset: LoadedRuleset): SpriteTypeData[] {
  * Load sprite powers from a ruleset
  */
 export function extractSpritePowers(ruleset: LoadedRuleset): SpritePowerData[] {
-  const ruleModule = extractModule<{ spritePowers: SpritePowerData[] }>(ruleset, "magic");
+  const ruleModule = extractModule(ruleset, "magic");
   return ruleModule?.spritePowers || [];
 }
 
@@ -472,7 +459,7 @@ import type {
  * Load cyberware catalog from a ruleset
  */
 export function extractCyberware(ruleset: LoadedRuleset): CyberwareCatalogData | null {
-  const ruleModule = extractModule<CyberwareCatalogData>(ruleset, "cyberware");
+  const ruleModule = extractModule(ruleset, "cyberware");
   if (!ruleModule) return null;
 
   return {
@@ -492,7 +479,7 @@ export function extractCyberware(ruleset: LoadedRuleset): CyberwareCatalogData |
  * Load bioware catalog from a ruleset
  */
 export function extractBioware(ruleset: LoadedRuleset): BiowareCatalogData | null {
-  const ruleModule = extractModule<BiowareCatalogData>(ruleset, "bioware");
+  const ruleModule = extractModule(ruleset, "bioware");
   if (!ruleModule) return null;
 
   return {
@@ -527,10 +514,7 @@ import type { ContactTemplateData } from "../types";
  * Load contact templates from a ruleset
  */
 export function extractContactTemplates(ruleset: LoadedRuleset): ContactTemplateData[] {
-  const ruleModule = extractModule<{ templates: ContactTemplateData[] }>(
-    ruleset,
-    "contactTemplates"
-  );
+  const ruleModule = extractModule(ruleset, "contactTemplates");
   return ruleModule?.templates || [];
 }
 
@@ -544,7 +528,7 @@ import type { AdeptPowerCatalogItem } from "./loader-types";
  * Load adept powers from a ruleset
  */
 export function extractAdeptPowers(ruleset: LoadedRuleset): AdeptPowerCatalogItem[] {
-  const ruleModule = extractModule<{ powers: AdeptPowerCatalogItem[] }>(ruleset, "adeptPowers");
+  const ruleModule = extractModule(ruleset, "adeptPowers");
   return ruleModule?.powers || [];
 }
 
@@ -558,7 +542,7 @@ import type { LifeModulesCatalog } from "../types";
  * Load life modules catalog from a ruleset
  */
 export function extractLifeModules(ruleset: LoadedRuleset): LifeModulesCatalog | null {
-  const ruleModule = extractModule<LifeModulesCatalog>(ruleset, "lifeModules");
+  const ruleModule = extractModule(ruleset, "lifeModules");
   return ruleModule || null;
 }
 
@@ -572,7 +556,7 @@ import type { TraditionData } from "./loader-types";
  * Load traditions from a ruleset
  */
 export function extractTraditions(ruleset: LoadedRuleset): TraditionData[] {
-  const ruleModule = extractModule<{ traditions: TraditionData[] }>(ruleset, "magic");
+  const ruleModule = extractModule(ruleset, "magic");
   return ruleModule?.traditions || [];
 }
 
@@ -586,7 +570,7 @@ import type { MentorSpiritData } from "./loader-types";
  * Load mentor spirits from a ruleset
  */
 export function extractMentorSpirits(ruleset: LoadedRuleset): MentorSpiritData[] {
-  const ruleModule = extractModule<{ mentorSpirits: MentorSpiritData[] }>(ruleset, "magic");
+  const ruleModule = extractModule(ruleset, "magic");
   return ruleModule?.mentorSpirits || [];
 }
 
@@ -600,7 +584,7 @@ import type { RitualData, RitualKeywordData } from "./loader-types";
  * Load rituals from a ruleset
  */
 export function extractRituals(ruleset: LoadedRuleset): RitualData[] {
-  const ruleModule = extractModule<{ rituals: RitualData[] }>(ruleset, "magic");
+  const ruleModule = extractModule(ruleset, "magic");
   return ruleModule?.rituals || [];
 }
 
@@ -608,7 +592,7 @@ export function extractRituals(ruleset: LoadedRuleset): RitualData[] {
  * Load ritual keywords from a ruleset
  */
 export function extractRitualKeywords(ruleset: LoadedRuleset): RitualKeywordData[] {
-  const ruleModule = extractModule<{ ritualKeywords: RitualKeywordData[] }>(ruleset, "magic");
+  const ruleModule = extractModule(ruleset, "magic");
   return ruleModule?.ritualKeywords || [];
 }
 
@@ -630,7 +614,7 @@ import type {
  * Load vehicles catalog from a ruleset
  */
 export function extractVehicles(ruleset: LoadedRuleset): VehicleCatalogItemData[] {
-  const ruleModule = extractModule<VehiclesCatalogData>(ruleset, "vehicles");
+  const ruleModule = extractModule(ruleset, "vehicles");
   if (!ruleModule) return [];
 
   // Combine all vehicle types
@@ -649,7 +633,7 @@ export function extractVehiclesByCategory(ruleset: LoadedRuleset): {
   watercraft: VehicleCatalogItemData[];
   aircraft: VehicleCatalogItemData[];
 } {
-  const ruleModule = extractModule<VehiclesCatalogData>(ruleset, "vehicles");
+  const ruleModule = extractModule(ruleset, "vehicles");
   return {
     groundcraft: ruleModule?.groundcraft || [],
     watercraft: ruleModule?.watercraft || [],
@@ -661,7 +645,7 @@ export function extractVehiclesByCategory(ruleset: LoadedRuleset): {
  * Load vehicle categories metadata from a ruleset
  */
 export function extractVehicleCategories(ruleset: LoadedRuleset): VehicleCategoryData[] {
-  const ruleModule = extractModule<VehiclesCatalogData>(ruleset, "vehicles");
+  const ruleModule = extractModule(ruleset, "vehicles");
   return ruleModule?.categories || [];
 }
 
@@ -669,7 +653,7 @@ export function extractVehicleCategories(ruleset: LoadedRuleset): VehicleCategor
  * Load drones from a ruleset
  */
 export function extractDrones(ruleset: LoadedRuleset): DroneCatalogItemData[] {
-  const ruleModule = extractModule<VehiclesCatalogData>(ruleset, "vehicles");
+  const ruleModule = extractModule(ruleset, "vehicles");
   return ruleModule?.drones || [];
 }
 
@@ -677,7 +661,7 @@ export function extractDrones(ruleset: LoadedRuleset): DroneCatalogItemData[] {
  * Load drone size categories from a ruleset
  */
 export function extractDroneSizes(ruleset: LoadedRuleset): DroneSizeData[] {
-  const ruleModule = extractModule<VehiclesCatalogData>(ruleset, "vehicles");
+  const ruleModule = extractModule(ruleset, "vehicles");
   return ruleModule?.droneSizes || [];
 }
 
@@ -685,7 +669,7 @@ export function extractDroneSizes(ruleset: LoadedRuleset): DroneSizeData[] {
  * Load RCCs (Rigger Command Consoles) from a ruleset
  */
 export function extractRCCs(ruleset: LoadedRuleset): RCCCatalogItemData[] {
-  const ruleModule = extractModule<VehiclesCatalogData>(ruleset, "vehicles");
+  const ruleModule = extractModule(ruleset, "vehicles");
   return ruleModule?.rccs || [];
 }
 
@@ -693,7 +677,7 @@ export function extractRCCs(ruleset: LoadedRuleset): RCCCatalogItemData[] {
  * Load autosofts from a ruleset
  */
 export function extractAutosofts(ruleset: LoadedRuleset): AutosoftCatalogItemData[] {
-  const ruleModule = extractModule<VehiclesCatalogData>(ruleset, "vehicles");
+  const ruleModule = extractModule(ruleset, "vehicles");
   return ruleModule?.autosofts || [];
 }
 
@@ -701,7 +685,7 @@ export function extractAutosofts(ruleset: LoadedRuleset): AutosoftCatalogItemDat
  * Load complete vehicles module data from a ruleset
  */
 export function extractVehiclesCatalog(ruleset: LoadedRuleset): VehiclesCatalogData | null {
-  return extractModule<VehiclesCatalogData>(ruleset, "vehicles");
+  return extractModule(ruleset, "vehicles");
 }
 
 // =============================================================================
@@ -714,7 +698,7 @@ import type { ProgramCatalogItemData, ProgramsCatalogData } from "./loader-types
  * Load all programs from a ruleset
  */
 export function extractPrograms(ruleset: LoadedRuleset): ProgramCatalogItemData[] {
-  const ruleModule = extractModule<ProgramsCatalogData>(ruleset, "programs");
+  const ruleModule = extractModule(ruleset, "programs");
   if (!ruleModule) return [];
 
   return [
@@ -732,7 +716,7 @@ export function extractProgramsByCategory(ruleset: LoadedRuleset): {
   hacking: ProgramCatalogItemData[];
   agents: ProgramCatalogItemData[];
 } {
-  const ruleModule = extractModule<ProgramsCatalogData>(ruleset, "programs");
+  const ruleModule = extractModule(ruleset, "programs");
   return {
     common: ruleModule?.common || [],
     hacking: ruleModule?.hacking || [],
@@ -744,7 +728,7 @@ export function extractProgramsByCategory(ruleset: LoadedRuleset): {
  * Load common programs from a ruleset
  */
 export function extractCommonPrograms(ruleset: LoadedRuleset): ProgramCatalogItemData[] {
-  const ruleModule = extractModule<ProgramsCatalogData>(ruleset, "programs");
+  const ruleModule = extractModule(ruleset, "programs");
   return ruleModule?.common || [];
 }
 
@@ -752,7 +736,7 @@ export function extractCommonPrograms(ruleset: LoadedRuleset): ProgramCatalogIte
  * Load hacking programs from a ruleset
  */
 export function extractHackingPrograms(ruleset: LoadedRuleset): ProgramCatalogItemData[] {
-  const ruleModule = extractModule<ProgramsCatalogData>(ruleset, "programs");
+  const ruleModule = extractModule(ruleset, "programs");
   return ruleModule?.hacking || [];
 }
 
@@ -760,7 +744,7 @@ export function extractHackingPrograms(ruleset: LoadedRuleset): ProgramCatalogIt
  * Load agent programs from a ruleset
  */
 export function extractAgentPrograms(ruleset: LoadedRuleset): ProgramCatalogItemData[] {
-  const ruleModule = extractModule<ProgramsCatalogData>(ruleset, "programs");
+  const ruleModule = extractModule(ruleset, "programs");
   return ruleModule?.agents || [];
 }
 
@@ -768,7 +752,7 @@ export function extractAgentPrograms(ruleset: LoadedRuleset): ProgramCatalogItem
  * Load complete programs module data from a ruleset
  */
 export function extractProgramsCatalog(ruleset: LoadedRuleset): ProgramsCatalogData | null {
-  return extractModule<ProgramsCatalogData>(ruleset, "programs");
+  return extractModule(ruleset, "programs");
 }
 
 import type { DataSoftwareCatalogData, DataSoftwareCatalogItemData } from "./loader-types";
@@ -778,12 +762,7 @@ import type { DataSoftwareCatalogData, DataSoftwareCatalogItemData } from "./loa
  * Data software is stored in the programs module alongside regular programs.
  */
 export function extractDataSoftwareCatalog(ruleset: LoadedRuleset): DataSoftwareCatalogData | null {
-  const programsModule = extractModule<{
-    datasofts?: DataSoftwareCatalogItemData[];
-    mapsofts?: DataSoftwareCatalogItemData[];
-    shopsofts?: DataSoftwareCatalogItemData[];
-    tutorsofts?: DataSoftwareCatalogItemData[];
-  }>(ruleset, "programs");
+  const programsModule = extractModule(ruleset, "programs");
 
   if (!programsModule) return null;
 
@@ -815,7 +794,7 @@ import type { FocusCatalogItemData } from "./loader-types";
  * Load foci from a ruleset
  */
 export function extractFoci(ruleset: LoadedRuleset): FocusCatalogItemData[] {
-  const ruleModule = extractModule<{ foci: FocusCatalogItemData[] }>(ruleset, "foci");
+  const ruleModule = extractModule(ruleset, "foci");
   return ruleModule?.foci || [];
 }
 
@@ -829,7 +808,7 @@ import type { SpiritsCatalogData } from "./loader-types";
  * Load spirits from a ruleset
  */
 export function extractSpirits(ruleset: LoadedRuleset): SpiritsCatalogData | null {
-  const ruleModule = extractModule<SpiritsCatalogData>(ruleset, "spirits");
+  const ruleModule = extractModule(ruleset, "spirits");
   return ruleModule || null;
 }
 
@@ -851,7 +830,7 @@ import type {
 export function extractWeaponModifications(
   ruleset: LoadedRuleset
 ): WeaponModificationCatalogItemData[] {
-  const ruleModule = extractModule<ModificationsCatalogData>(ruleset, "modifications");
+  const ruleModule = extractModule(ruleset, "modifications");
   return ruleModule?.weaponMods || [];
 }
 
@@ -861,7 +840,7 @@ export function extractWeaponModifications(
 export function extractArmorModifications(
   ruleset: LoadedRuleset
 ): ArmorModificationCatalogItemData[] {
-  const ruleModule = extractModule<ModificationsCatalogData>(ruleset, "modifications");
+  const ruleModule = extractModule(ruleset, "modifications");
   return ruleModule?.armorMods || [];
 }
 
@@ -871,7 +850,7 @@ export function extractArmorModifications(
 export function extractCyberwareModifications(
   ruleset: LoadedRuleset
 ): CyberwareModificationCatalogItemData[] {
-  const ruleModule = extractModule<ModificationsCatalogData>(ruleset, "modifications");
+  const ruleModule = extractModule(ruleset, "modifications");
   return ruleModule?.cyberwareMods || [];
 }
 
@@ -881,7 +860,7 @@ export function extractCyberwareModifications(
 export function extractGearModifications(
   ruleset: LoadedRuleset
 ): GearModificationCatalogItemData[] {
-  const ruleModule = extractModule<ModificationsCatalogData>(ruleset, "modifications");
+  const ruleModule = extractModule(ruleset, "modifications");
   return ruleModule?.gearMods || [];
 }
 
@@ -889,7 +868,7 @@ export function extractGearModifications(
  * Load complete modifications catalog from a ruleset
  */
 export function extractModifications(ruleset: LoadedRuleset): ModificationsCatalogData | null {
-  return extractModule<ModificationsCatalogData>(ruleset, "modifications");
+  return extractModule(ruleset, "modifications");
 }
 
 // =============================================================================
@@ -902,7 +881,7 @@ import type { AdvancementRulesData } from "./loader-types";
  * Load advancement rules from a ruleset
  */
 export function extractAdvancement(ruleset: LoadedRuleset): AdvancementRulesData {
-  const ruleModule = extractModule<AdvancementRulesData>(ruleset, "advancement");
+  const ruleModule = extractModule(ruleset, "advancement");
 
   return (
     ruleModule || {
@@ -929,7 +908,7 @@ import type { InfectedCatalogData } from "./infected/types";
  * Load infected catalog from a ruleset
  */
 export function extractInfected(ruleset: LoadedRuleset): InfectedCatalogData | null {
-  const ruleModule = extractModule<InfectedCatalogData>(ruleset, "infected");
+  const ruleModule = extractModule(ruleset, "infected");
   if (!ruleModule) return null;
 
   return {
@@ -957,7 +936,7 @@ export interface ActionsCatalogData {
  * Extract actions from a ruleset
  */
 export function extractActions(ruleset: LoadedRuleset): ActionsCatalogData | null {
-  const ruleModule = extractModule<ActionsCatalogData>(ruleset, "actions");
+  const ruleModule = extractModule(ruleset, "actions");
 
   if (!ruleModule) return null;
 

--- a/lib/rules/validation/character-validator.ts
+++ b/lib/rules/validation/character-validator.ts
@@ -164,15 +164,7 @@ const priorityConsistencyValidator: ValidatorDefinition = {
     }
 
     // Load priority table from ruleset
-    const prioritiesModule = getModule<{
-      table: Record<
-        string,
-        {
-          metatype: { available: string[] };
-          magic: { options: Array<{ path: string }> };
-        }
-      >;
-    }>(ruleset, "priorities");
+    const prioritiesModule = getModule(ruleset, "priorities");
 
     if (!prioritiesModule?.table) {
       return issues;
@@ -184,7 +176,7 @@ const priorityConsistencyValidator: ValidatorDefinition = {
 
     const metatypeLevel = priorities.metatype;
     if (metatypeLevel && character.metatype && table[metatypeLevel]) {
-      const availableMetatypes = table[metatypeLevel].metatype.available;
+      const availableMetatypes = table[metatypeLevel].metatype?.available ?? [];
       if (!availableMetatypes.includes(character.metatype)) {
         issues.push({
           code: "PRIORITY_METATYPE_INVALID",
@@ -208,7 +200,7 @@ const priorityConsistencyValidator: ValidatorDefinition = {
       if (rawMagicalPath && rawMagicalPath !== "mundane") {
         // Map character field values back to priority table values (e.g. "full-mage" → "magician")
         const priorityPath = CHARACTER_TO_PRIORITY_PATH[rawMagicalPath] ?? rawMagicalPath;
-        const availablePaths = table[magicLevel].magic.options.map((o) => o.path);
+        const availablePaths = (table[magicLevel].magic?.options ?? []).map((o) => o.path);
 
         if (!availablePaths.includes(priorityPath)) {
           issues.push({
@@ -220,7 +212,7 @@ const priorityConsistencyValidator: ValidatorDefinition = {
         }
       } else {
         // Mundane with non-E magic priority is a waste
-        const magicOptions = table[magicLevel].magic.options;
+        const magicOptions = table[magicLevel].magic?.options ?? [];
         if (magicOptions.length > 0) {
           issues.push({
             code: "PRIORITY_MAGIC_WASTED",
@@ -1526,7 +1518,7 @@ const complexFormValidator: ValidatorDefinition = {
     }
 
     // Get complex forms catalog from merged ruleset
-    const magicModule = getModule<{ complexForms?: ComplexFormData[] }>(ruleset, "magic");
+    const magicModule = getModule(ruleset, "magic");
     const formsCatalog = magicModule?.complexForms || [];
 
     const invalidForms: string[] = [];
@@ -1641,16 +1633,7 @@ const spellValidator: ValidatorDefinition = {
     // Spell limit check from priority table
     if (creationState?.priorities?.magic) {
       const magicLevel = creationState.priorities.magic;
-      const prioritiesModule = getModule<{
-        table: Record<
-          string,
-          {
-            magic: {
-              options: Array<{ path: string; spells?: number }>;
-            };
-          }
-        >;
-      }>(ruleset, "priorities");
+      const prioritiesModule = getModule(ruleset, "priorities");
 
       if (prioritiesModule?.table) {
         const levelData = prioritiesModule.table[magicLevel];
@@ -1671,7 +1654,7 @@ const spellValidator: ValidatorDefinition = {
     }
 
     // Get spells catalog from merged ruleset
-    const magicModule = getModule<{ spells?: SpellsCatalogData }>(ruleset, "magic");
+    const magicModule = getModule(ruleset, "magic");
     const spellsCatalog = magicModule?.spells;
 
     // Flatten all spell categories into a single lookup set
@@ -1778,7 +1761,7 @@ const adeptPowerValidator: ValidatorDefinition = {
     }
 
     // Get adept powers catalog from merged ruleset
-    const adeptModule = getModule<{ powers: AdeptPowerCatalogItem[] }>(ruleset, "adeptPowers");
+    const adeptModule = getModule(ruleset, "adeptPowers");
     const powersCatalog = adeptModule?.powers || [];
     const catalogMap = new Map(powersCatalog.map((p) => [p.id, p]));
 
@@ -1946,7 +1929,7 @@ const fociValidator: ValidatorDefinition = {
     }
 
     // Get foci catalog from merged ruleset
-    const fociModule = getModule<{ foci: FocusCatalogItemData[] }>(ruleset, "foci");
+    const fociModule = getModule(ruleset, "foci");
     const fociCatalog = fociModule?.foci || [];
     const catalogMap = new Map(fociCatalog.map((f) => [f.id, f]));
 
@@ -2058,7 +2041,7 @@ const skillGroupConstraintValidator: ValidatorDefinition = {
     const skillKarmaSpent = selections.skillKarmaSpent;
 
     // Get skill group definitions from merged ruleset to map group -> member skills
-    const skillsModule = getModule<{ skillGroups?: SkillGroupData[] }>(ruleset, "skills");
+    const skillsModule = getModule(ruleset, "skills");
     const skillGroupDefs = skillsModule?.skillGroups || [];
 
     for (const [groupId, groupValue] of Object.entries(skillGroups)) {
@@ -2280,7 +2263,7 @@ const nuyenBudgetValidator: ValidatorDefinition = {
     const priorities = creationState.priorities || {};
 
     // Get priority table from ruleset
-    const priorityTable = getModule<PriorityTableData>(ruleset, "priorities");
+    const priorityTable = getModule(ruleset, "priorities");
     if (!priorityTable) {
       // No priority table = can't validate nuyen budget
       return issues;

--- a/lib/rules/validation/constraint-attribute-limit.ts
+++ b/lib/rules/validation/constraint-attribute-limit.ts
@@ -26,12 +26,7 @@ export function validateAttributeLimit(
   };
 
   // Get metatype limits from ruleset
-  const metatypesModule = getModule<{
-    metatypes: Array<{
-      id: string;
-      attributes: Record<string, { min: number; max: number }>;
-    }>;
-  }>(ruleset, "metatypes");
+  const metatypesModule = getModule(ruleset, "metatypes");
 
   if (!metatypesModule) return null;
 

--- a/lib/rules/validation/constraint-equipment-rating.ts
+++ b/lib/rules/validation/constraint-equipment-rating.ts
@@ -31,7 +31,7 @@ import type { ValidationContext } from "../constraint-validation";
  * Find a gear catalog item by ID or name
  */
 function findGearCatalogItem(ruleset: MergedRuleset, identifier: string): GearItemData | null {
-  const gearCatalog = getModule<GearCatalogData>(ruleset, "gear");
+  const gearCatalog = getModule(ruleset, "gear");
   if (!gearCatalog) return null;
 
   // Search GearItemData sub-arrays (browsable + hidden)
@@ -71,7 +71,7 @@ function findCyberwareCatalogItem(
   ruleset: MergedRuleset,
   identifier: string
 ): CyberwareCatalogItemData | null {
-  const cyberwareCatalog = getModule<CyberwareCatalogData>(ruleset, "cyberware");
+  const cyberwareCatalog = getModule(ruleset, "cyberware");
   if (!cyberwareCatalog) return null;
 
   const catalog = cyberwareCatalog.catalog || [];

--- a/lib/rules/validation/constraint-special-attribute-init.ts
+++ b/lib/rules/validation/constraint-special-attribute-init.ts
@@ -31,12 +31,7 @@ export function validateSpecialAttributeInit(
   const errors: string[] = [];
 
   // Get metatype data for edge limits
-  const metatypesModule = getModule<{
-    metatypes: Array<{
-      id: string;
-      attributes: Record<string, { min: number; max: number }>;
-    }>;
-  }>(ruleset, "metatypes");
+  const metatypesModule = getModule(ruleset, "metatypes");
 
   const metatype = metatypesModule?.metatypes.find(
     (m) => m.id === character.metatype?.toLowerCase()
@@ -68,20 +63,7 @@ export function validateSpecialAttributeInit(
       // Get the base magic from priority table
       const magicPriority = creationState?.priorities?.magic;
       if (magicPriority && ruleset) {
-        const prioritiesModule = getModule<{
-          table: Record<
-            string,
-            {
-              magic?: {
-                options?: Array<{
-                  path: string;
-                  magicRating?: number;
-                  resonanceRating?: number;
-                }>;
-              };
-            }
-          >;
-        }>(ruleset, "priorities");
+        const prioritiesModule = getModule(ruleset, "priorities");
 
         if (prioritiesModule?.table?.[magicPriority]?.magic?.options) {
           const option = prioritiesModule.table[magicPriority].magic.options.find(
@@ -115,19 +97,7 @@ export function validateSpecialAttributeInit(
       // Technomancers should have resonance from priority
       const magicPriority = creationState?.priorities?.magic;
       if (magicPriority && ruleset) {
-        const prioritiesModule = getModule<{
-          table: Record<
-            string,
-            {
-              magic?: {
-                options?: Array<{
-                  path: string;
-                  resonanceRating?: number;
-                }>;
-              };
-            }
-          >;
-        }>(ruleset, "priorities");
+        const prioritiesModule = getModule(ruleset, "priorities");
 
         if (prioritiesModule?.table?.[magicPriority]?.magic?.options) {
           const option = prioritiesModule.table[magicPriority].magic.options.find(


### PR DESCRIPTION
## Summary
- Remove all 67 explicit type generics from production `getModule<T>()` and `extractModule<T>()` call sites across 11 files
- Return types are now inferred from the module key via `RuleModulePayloadMap`
- Type `PriorityTableData.table` with proper `PriorityLevelEntry` and `PriorityMagicOption` interfaces (was `Record<string, Record<string, unknown>>`)
- Add null-safety guards for optional priority table fields
- Net result: -41 lines (107 added, 148 removed)

**Files changed:**
- `loader.ts` — 47 extractModule generics removed
- `character-validator.ts` — 7 getModule generics removed + null-safety guards
- `constraint-special-attribute-init.ts` — 3 getModule generics removed
- `constraint-validation.ts` — 1 getModule generic removed
- `constraint-attribute-limit.ts` — 1 getModule generic removed
- `constraint-equipment-rating.ts` — 2 getModule generics removed
- `advancement/*.ts` — 4 getModule generics removed (1 per file)
- `loader-types.ts` — `PriorityLevelEntry` + `PriorityMagicOption` interfaces added

This is **Phase 4+5** of the [MergedRuleset type safety plan](https://github.com/Jasrags/ShadowMaster/issues/655#issuecomment-4071629389).

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (9,807 tests)
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass
- [x] Zero `extractModule<` or `getModule<` explicit generics remain in production code

Part of #655