### PR TITLE
refactor: remove unnecessary unsafe casts in tests and budget-totals (#655)

### DIFF
--- a/lib/rules/creation/budget-totals.ts
+++ b/lib/rules/creation/budget-totals.ts
@@ -6,7 +6,7 @@
  */
 
 import type { GameplayLevelModifiers } from "@/lib/types/edition";
-import type { PriorityTableData } from "@/lib/rules/RulesetContext";
+import type { PriorityTableData } from "@/lib/rules/loader-types";
 import { LIFE_MODULES_KARMA_BUDGET, LIFE_MODULES_NUYEN_PER_KARMA } from "@/lib/types";
 import {
   POINT_BUY_KARMA_BUDGET,
@@ -63,7 +63,7 @@ export function calculateBudgetTotals(
   // Attribute points from priority
   const attrPriority = priorities.attributes;
   if (attrPriority && priorityTable.table[attrPriority]) {
-    const attrPoints = priorityTable.table[attrPriority].attributes as number;
+    const attrPoints = priorityTable.table[attrPriority].attributes;
     totals["attribute-points"] = {
       total: attrPoints || 0,
       label: "Attribute Points",
@@ -74,10 +74,7 @@ export function calculateBudgetTotals(
   // Skill points from priority
   const skillPriority = priorities.skills;
   if (skillPriority && priorityTable.table[skillPriority]) {
-    const skillData = priorityTable.table[skillPriority].skills as {
-      skillPoints: number;
-      skillGroupPoints: number;
-    };
+    const skillData = priorityTable.table[skillPriority].skills;
     totals["skill-points"] = {
       total: skillData?.skillPoints || 0,
       label: "Skill Points",
@@ -93,7 +90,7 @@ export function calculateBudgetTotals(
   // Resources (nuyen) from priority, with gameplay level multiplier
   const resourcePriority = priorities.resources;
   if (resourcePriority && priorityTable.table[resourcePriority]) {
-    const baseNuyen = priorityTable.table[resourcePriority].resources as number;
+    const baseNuyen = priorityTable.table[resourcePriority].resources;
     const multiplier = gameplayModifiers?.resourcesMultiplier ?? 1;
     totals["nuyen"] = {
       total: Math.round((baseNuyen || 0) * multiplier),
@@ -106,9 +103,7 @@ export function calculateBudgetTotals(
   const metatypePriority = priorities.metatype;
   const selectedMetatype = selections.metatype as string;
   if (metatypePriority && selectedMetatype && priorityTable.table[metatypePriority]) {
-    const metatypeData = priorityTable.table[metatypePriority].metatype as {
-      specialAttributePoints: Record<string, number>;
-    };
+    const metatypeData = priorityTable.table[metatypePriority].metatype;
     const specialPoints = metatypeData?.specialAttributePoints?.[selectedMetatype] || 0;
     totals["special-attribute-points"] = {
       total: specialPoints,
@@ -144,15 +139,7 @@ export function calculateBudgetTotals(
   const magicPriority = priorities.magic;
   const magicPath = selections["magical-path"] as string;
   if (magicPriority && priorityTable.table[magicPriority] && magicPath) {
-    const magicData = priorityTable.table[magicPriority].magic as {
-      options?: Array<{
-        path: string;
-        spells?: number;
-        complexForms?: number;
-        magicRating?: number;
-        resonanceRating?: number;
-      }>;
-    };
+    const magicData = priorityTable.table[magicPriority].magic;
     // Find the selected path's option to get spells/forms count
     const selectedOption = magicData?.options?.find((opt) => opt.path === magicPath);
 

--- a/lib/rules/magic/__tests__/complex-form-validator.test.ts
+++ b/lib/rules/magic/__tests__/complex-form-validator.test.ts
@@ -33,7 +33,7 @@ function createMockComplexForm(overrides: Partial<ComplexFormData> = {}): Comple
 
 function createMockRuleset(complexForms?: ComplexFormData[]): LoadedRuleset {
   return {
-    edition: {} as LoadedRuleset["edition"],
+    edition: {} as unknown as LoadedRuleset["edition"],
     books: [
       {
         id: "core-rulebook",

--- a/lib/rules/validation/__tests__/augmentation-validator.test.ts
+++ b/lib/rules/validation/__tests__/augmentation-validator.test.ts
@@ -25,7 +25,7 @@ function createMockRuleset(): MergedRuleset {
     bookIds: ["core-rulebook"],
     modules: {},
     createdAt: new Date().toISOString(),
-  } as unknown as MergedRuleset;
+  } as MergedRuleset;
 }
 
 function createContext(

--- a/lib/rules/validation/__tests__/contact-budget.test.ts
+++ b/lib/rules/validation/__tests__/contact-budget.test.ts
@@ -23,7 +23,7 @@ function createMockRuleset(): MergedRuleset {
     bookIds: ["core-rulebook"],
     modules: {},
     createdAt: new Date().toISOString(),
-  } as unknown as MergedRuleset;
+  } as MergedRuleset;
 }
 
 function createContext(

--- a/lib/rules/validation/__tests__/karma-budget.test.ts
+++ b/lib/rules/validation/__tests__/karma-budget.test.ts
@@ -23,7 +23,7 @@ function createMockRuleset(): MergedRuleset {
     bookIds: ["core-rulebook"],
     modules: {},
     createdAt: new Date().toISOString(),
-  } as unknown as MergedRuleset;
+  } as MergedRuleset;
 }
 
 function createContext(

--- a/lib/rules/validation/__tests__/knowledge-budget.test.ts
+++ b/lib/rules/validation/__tests__/knowledge-budget.test.ts
@@ -23,7 +23,7 @@ function createMockRuleset(): MergedRuleset {
     bookIds: ["core-rulebook"],
     modules: {},
     createdAt: new Date().toISOString(),
-  } as unknown as MergedRuleset;
+  } as MergedRuleset;
 }
 
 function createContext(

--- a/lib/rules/validation/__tests__/priority-consistency.test.ts
+++ b/lib/rules/validation/__tests__/priority-consistency.test.ts
@@ -77,7 +77,7 @@ function createMockRuleset(): MergedRuleset {
       },
     },
     createdAt: new Date().toISOString(),
-  } as unknown as MergedRuleset;
+  } as MergedRuleset;
 }
 
 function createContext(

--- a/lib/rules/validation/__tests__/shapeshifter-validator.test.ts
+++ b/lib/rules/validation/__tests__/shapeshifter-validator.test.ts
@@ -24,7 +24,7 @@ function createMockRuleset(): MergedRuleset {
     bookIds: ["core-rulebook", "run-faster"],
     modules: {},
     createdAt: new Date().toISOString(),
-  } as unknown as MergedRuleset;
+  } as MergedRuleset;
 }
 
 function createContext(

--- a/lib/rules/validation/__tests__/skill-group-constraints.test.ts
+++ b/lib/rules/validation/__tests__/skill-group-constraints.test.ts
@@ -29,7 +29,7 @@ function createMockRuleset(skillGroups: SkillGroupData[] = []): MergedRuleset {
       },
     },
     createdAt: new Date().toISOString(),
-  } as unknown as MergedRuleset;
+  } as MergedRuleset;
 }
 
 function createContext(


### PR DESCRIPTION
## Summary
- Remove `as unknown as MergedRuleset` double-casts from 7 test files — `as MergedRuleset` suffices since `modules: {}` is assignable to the optional mapped type
- Remove 5 stale type assertion casts from `budget-totals.ts` now that `PriorityLevelEntry` is properly typed
- Update `budget-totals.ts` import to use `loader-types.ts` (typed) instead of `RulesetContext` (untyped)
- 4 test files retain `as unknown as` because their mocks are missing other required properties (not related to module typing)

This is **Phase 6+7** (final phase) of the [MergedRuleset type safety plan](https://github.com/Jasrags/ShadowMaster/issues/655#issuecomment-4071629389).

## Issue #655 completion summary

| Phase | PR | What |
|-------|-----|------|
| 1 | #753 | `RuleModulePayloadMap` + composite payload interfaces |
| 2+3 | #754 | Type-safe `getModule`/`extractModule` signatures |
| 4+5 | #755 | Remove 67 explicit generics + type `PriorityTableData` |
| 6+7 | This PR | Remove 7 test double-casts + 5 stale production casts |

**Net result across all 4 PRs:** 20 typed module payloads, 67 explicit generics eliminated, 12 unsafe casts removed, `PriorityTableData` fully typed. Type safety enforced through accessor functions.

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (9,807 tests)
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass

Closes #655