### PR TITLE
refactor: replace deep type imports with barrel imports in lib/rules (#738)

### DIFF
--- a/lib/rules/__tests__/ratings.test.ts
+++ b/lib/rules/__tests__/ratings.test.ts
@@ -22,7 +22,7 @@ import type {
   RatingScalingConfig,
   CatalogItemRatingSpec,
   RatingValidationContext,
-} from "@/lib/types/ratings";
+} from "@/lib/types";
 
 // =============================================================================
 // CORE CALCULATION FUNCTIONS
@@ -806,7 +806,7 @@ import {
   getRatingOptionsUnified,
   isRatingValid,
 } from "../ratings";
-import type { RatingTable } from "@/lib/types/ratings";
+import type { RatingTable } from "@/lib/types";
 
 describe("hasUnifiedRatings", () => {
   it("should return true for item with ratings table", () => {

--- a/lib/rules/action-resolution/__tests__/pool-builder.test.ts
+++ b/lib/rules/action-resolution/__tests__/pool-builder.test.ts
@@ -13,8 +13,7 @@ import type {
   PoolBuildOptions,
   EditionDiceRules,
 } from "@/lib/types";
-import type { EncumbranceState } from "@/lib/types/gear-state";
-import type { ActiveWirelessBonuses } from "@/lib/types/wireless-effects";
+import type { EncumbranceState, ActiveWirelessBonuses } from "@/lib/types";
 
 // Mock external dependencies
 vi.mock("@/lib/rules/encumbrance/calculator", () => ({

--- a/lib/rules/action-resolution/combat/ammunition-manager.ts
+++ b/lib/rules/action-resolution/combat/ammunition-manager.ts
@@ -9,13 +9,13 @@
  * @see Capability: character.inventory-management
  */
 
-import type { Weapon } from "@/lib/types";
 import type {
+  Weapon,
   WeaponAmmoState,
   MagazineItem,
   AmmunitionItem,
   AmmunitionCaliber,
-} from "@/lib/types/gear-state";
+} from "@/lib/types";
 
 // =============================================================================
 // CONSTANTS

--- a/lib/rules/action-resolution/pool-builder.ts
+++ b/lib/rules/action-resolution/pool-builder.ts
@@ -12,8 +12,7 @@ import type {
   PoolBuildOptions,
   EditionDiceRules,
 } from "@/lib/types";
-import type { EncumbranceState } from "@/lib/types/gear-state";
-import type { EffectConditionType, ActiveWirelessBonuses } from "@/lib/types/wireless-effects";
+import type { EncumbranceState, EffectConditionType, ActiveWirelessBonuses } from "@/lib/types";
 import { DEFAULT_DICE_RULES } from "./dice-engine";
 import { calculateEncumbrance } from "../encumbrance/calculator";
 import { calculateContextualWirelessBonuses } from "../wireless/bonus-calculator";

--- a/lib/rules/advancement/approval.ts
+++ b/lib/rules/advancement/approval.ts
@@ -4,8 +4,12 @@
  * Handles GM approval and rejection of character advancements in campaigns.
  */
 
-import type { Character, AdvancementRecord, Campaign } from "@/lib/types";
-import type { CampaignAdvancementSettings } from "@/lib/types/campaign";
+import type {
+  Character,
+  AdvancementRecord,
+  Campaign,
+  CampaignAdvancementSettings,
+} from "@/lib/types";
 import { applyAdvancement } from "./apply";
 
 /**

--- a/lib/rules/advancement/attributes.ts
+++ b/lib/rules/advancement/attributes.ts
@@ -12,7 +12,7 @@ import type {
   TrainingPeriod,
   CampaignEvent,
 } from "@/lib/types";
-import type { CampaignAdvancementSettings } from "@/lib/types/campaign";
+import type { CampaignAdvancementSettings } from "@/lib/types";
 import type { AdvancementRulesData } from "@/lib/rules/loader-types";
 import { getModule } from "../merge";
 import { calculateAdvancementTrainingTime } from "./training";

--- a/lib/rules/advancement/costs.ts
+++ b/lib/rules/advancement/costs.ts
@@ -5,8 +5,7 @@
  * as documented in Shadowrun 5e rules.
  */
 
-import type { AdvancementType } from "@/lib/types";
-import type { CampaignAdvancementSettings } from "@/lib/types/campaign";
+import type { AdvancementType, CampaignAdvancementSettings } from "@/lib/types";
 import type { AdvancementRulesData } from "@/lib/rules/loader-types";
 
 /**

--- a/lib/rules/advancement/edge.ts
+++ b/lib/rules/advancement/edge.ts
@@ -5,8 +5,12 @@
  * Edge advancement has no training time (no downtime required).
  */
 
-import type { Character, MergedRuleset, AdvancementRecord } from "@/lib/types";
-import type { CampaignAdvancementSettings } from "@/lib/types/campaign";
+import type {
+  Character,
+  MergedRuleset,
+  AdvancementRecord,
+  CampaignAdvancementSettings,
+} from "@/lib/types";
 import type { AdvancementRulesData } from "@/lib/rules/loader-types";
 import { getModule } from "../merge";
 import { validateAttributeAdvancement } from "./validation";

--- a/lib/rules/advancement/magic-advancement.ts
+++ b/lib/rules/advancement/magic-advancement.ts
@@ -7,8 +7,12 @@
  * - Adept power purchases
  */
 
-import type { Character, MergedRuleset, AdeptPower } from "@/lib/types";
-import type { CampaignAdvancementSettings } from "@/lib/types/campaign";
+import type {
+  Character,
+  MergedRuleset,
+  AdeptPower,
+  CampaignAdvancementSettings,
+} from "@/lib/types";
 import type { AdvancementRulesData, LoadedRuleset, SpellData } from "@/lib/rules/loader-types";
 import { extractSpellsCatalog, extractAdeptPowersCatalog } from "@/lib/rules/magic";
 

--- a/lib/rules/advancement/skills.ts
+++ b/lib/rules/advancement/skills.ts
@@ -12,7 +12,7 @@ import type {
   TrainingPeriod,
   CampaignEvent,
 } from "@/lib/types";
-import type { CampaignAdvancementSettings } from "@/lib/types/campaign";
+import type { CampaignAdvancementSettings } from "@/lib/types";
 import type { AdvancementRulesData } from "@/lib/rules/loader-types";
 import { getModule } from "../merge";
 import { calculateAdvancementTrainingTime } from "./training";

--- a/lib/rules/advancement/specializations.ts
+++ b/lib/rules/advancement/specializations.ts
@@ -13,7 +13,7 @@ import type {
   TrainingPeriod,
   CampaignEvent,
 } from "@/lib/types";
-import type { CampaignAdvancementSettings } from "@/lib/types/campaign";
+import type { CampaignAdvancementSettings } from "@/lib/types";
 import type { AdvancementRulesData } from "@/lib/rules/loader-types";
 import { getModule } from "../merge";
 import { calculateAdvancementTrainingTime } from "./training";

--- a/lib/rules/advancement/training.ts
+++ b/lib/rules/advancement/training.ts
@@ -5,8 +5,7 @@
  * as documented in Shadowrun 5e rules.
  */
 
-import type { AdvancementType } from "@/lib/types";
-import type { CampaignAdvancementSettings } from "@/lib/types/campaign";
+import type { AdvancementType, CampaignAdvancementSettings } from "@/lib/types";
 import type { AdvancementRulesData } from "@/lib/rules/loader-types";
 
 /**

--- a/lib/rules/advancement/validation.ts
+++ b/lib/rules/advancement/validation.ts
@@ -4,8 +4,13 @@
  * Validates advancement requests against character state and rules.
  */
 
-import type { Character, MergedRuleset, AdvancementType, CampaignEvent } from "@/lib/types";
-import type { CampaignAdvancementSettings } from "@/lib/types/campaign";
+import type {
+  Character,
+  MergedRuleset,
+  AdvancementType,
+  CampaignEvent,
+  CampaignAdvancementSettings,
+} from "@/lib/types";
 import type { AdvancementRulesData } from "@/lib/rules/loader-types";
 import { calculateAdvancementCost } from "./costs";
 import { validateDowntimeLimits } from "./downtime";

--- a/lib/rules/augmentations/__tests__/cyberlimb.test.ts
+++ b/lib/rules/augmentations/__tests__/cyberlimb.test.ts
@@ -53,8 +53,7 @@ import {
   type CyberlimbItem,
   type CyberlimbLocation,
 } from "../cyberlimb";
-import type { Character } from "@/lib/types/character";
-import type { CyberlimbCatalogItem, CyberwareCatalogItem } from "@/lib/types/edition";
+import type { Character, CyberlimbCatalogItem, CyberwareCatalogItem } from "@/lib/types";
 
 // =============================================================================
 // HELPER FUNCTIONS

--- a/lib/rules/augmentations/__tests__/essence-hole.test.ts
+++ b/lib/rules/augmentations/__tests__/essence-hole.test.ts
@@ -20,7 +20,7 @@ import {
   formatEssenceHole,
   getMagicLossWarning,
 } from "../essence-hole";
-import type { Character, EssenceHole } from "@/lib/types/character";
+import type { Character, EssenceHole } from "@/lib/types";
 
 // =============================================================================
 // HELPER FUNCTIONS

--- a/lib/rules/augmentations/__tests__/essence.test.ts
+++ b/lib/rules/augmentations/__tests__/essence.test.ts
@@ -21,8 +21,12 @@ import {
   MAX_ESSENCE,
   ESSENCE_MIN_VIABLE,
 } from "../essence";
-import type { CyberwareCatalogItem, BiowareCatalogItem } from "@/lib/types/edition";
-import type { CyberwareItem, BiowareItem } from "@/lib/types/character";
+import type {
+  CyberwareCatalogItem,
+  BiowareCatalogItem,
+  CyberwareItem,
+  BiowareItem,
+} from "@/lib/types";
 
 // =============================================================================
 // PRECISION TESTS

--- a/lib/rules/augmentations/__tests__/management.test.ts
+++ b/lib/rules/augmentations/__tests__/management.test.ts
@@ -16,8 +16,13 @@ import {
   aggregateActiveWirelessBonuses,
   aggregateAugmentationBonuses,
 } from "../management";
-import type { Character, CyberwareItem, BiowareItem } from "@/lib/types/character";
-import type { CyberwareCatalogItem, BiowareCatalogItem } from "@/lib/types/edition";
+import type {
+  Character,
+  CyberwareItem,
+  BiowareItem,
+  CyberwareCatalogItem,
+  BiowareCatalogItem,
+} from "@/lib/types";
 
 // =============================================================================
 // HELPER FUNCTIONS

--- a/lib/rules/augmentations/__tests__/validation.test.ts
+++ b/lib/rules/augmentations/__tests__/validation.test.ts
@@ -21,8 +21,13 @@ import {
   type ValidationContext,
   type AugmentationValidationResult,
 } from "../validation";
-import type { Character, CyberwareItem, BiowareItem } from "@/lib/types/character";
-import type { CyberwareCatalogItem, BiowareCatalogItem } from "@/lib/types/edition";
+import type {
+  Character,
+  CyberwareItem,
+  BiowareItem,
+  CyberwareCatalogItem,
+  BiowareCatalogItem,
+} from "@/lib/types";
 
 // =============================================================================
 // HELPER FUNCTIONS

--- a/lib/rules/augmentations/cyberlimb-hooks.ts
+++ b/lib/rules/augmentations/cyberlimb-hooks.ts
@@ -13,8 +13,7 @@
  */
 
 import { useState, useCallback, useEffect } from "react";
-import type { CyberwareGrade } from "@/lib/types";
-import type { CyberlimbLocation, CyberlimbEnhancementType } from "@/lib/types/cyberlimb";
+import type { CyberwareGrade, CyberlimbLocation, CyberlimbEnhancementType } from "@/lib/types";
 
 // =============================================================================
 // TYPES

--- a/lib/rules/augmentations/cyberlimb.ts
+++ b/lib/rules/augmentations/cyberlimb.ts
@@ -15,9 +15,11 @@
  * @see docs/capabilities/character.augmentation-systems.md
  */
 
-import type { Character, CyberwareGrade } from "@/lib/types/character";
-import type { CyberwareCatalogItem, CyberlimbCatalogItem } from "@/lib/types/edition";
 import type {
+  Character,
+  CyberwareGrade,
+  CyberwareCatalogItem,
+  CyberlimbCatalogItem,
   CyberlimbItem,
   CyberlimbLocation,
   CyberlimbType,
@@ -25,7 +27,7 @@ import type {
   CyberlimbEnhancement,
   CyberlimbAccessory,
   CyberlimbModificationEntry,
-} from "@/lib/types/cyberlimb";
+} from "@/lib/types";
 import {
   LIMB_HIERARCHY,
   LIMB_CM_BONUS,

--- a/lib/rules/augmentations/essence-hole.ts
+++ b/lib/rules/augmentations/essence-hole.ts
@@ -9,9 +9,7 @@
  * @satisfies Guarantee #2: Permanent link between Essence loss and Magic/Resonance reduction
  */
 
-import type { Character, EssenceHole } from "@/lib/types/character";
-import type { AugmentationRules } from "@/lib/types/edition";
-import type { MagicalPath } from "@/lib/types/core";
+import type { Character, EssenceHole, AugmentationRules, MagicalPath } from "@/lib/types";
 import { roundEssence, MAX_ESSENCE } from "./essence";
 
 // =============================================================================

--- a/lib/rules/augmentations/essence.ts
+++ b/lib/rules/augmentations/essence.ts
@@ -14,8 +14,9 @@ import type {
   BiowareItem,
   CyberwareGrade,
   BiowareGrade,
-} from "@/lib/types/character";
-import type { CyberwareCatalogItem, BiowareCatalogItem } from "@/lib/types/edition";
+  CyberwareCatalogItem,
+  BiowareCatalogItem,
+} from "@/lib/types";
 import { getCyberwareGradeMultiplier, getBiowareGradeMultiplier } from "./grades";
 
 // =============================================================================

--- a/lib/rules/augmentations/grades.ts
+++ b/lib/rules/augmentations/grades.ts
@@ -7,7 +7,7 @@
  * @satisfies Requirement: Essence expenditures MUST be calculated based on authoritative grade definitions
  */
 
-import type { CyberwareGrade, BiowareGrade } from "@/lib/types/character";
+import type { CyberwareGrade, BiowareGrade } from "@/lib/types";
 import {
   CYBERWARE_GRADE_MULTIPLIERS,
   CYBERWARE_GRADE_AVAILABILITY_MODIFIERS,

--- a/lib/rules/augmentations/management.ts
+++ b/lib/rules/augmentations/management.ts
@@ -15,12 +15,10 @@ import type {
   BiowareItem,
   CyberwareGrade,
   BiowareGrade,
-} from "@/lib/types/character";
-import type {
   CyberwareCatalogItem,
   BiowareCatalogItem,
   AugmentationRules,
-} from "@/lib/types/edition";
+} from "@/lib/types";
 import {
   calculateCyberwareEssence,
   calculateBiowareEssence,

--- a/lib/rules/augmentations/validation.ts
+++ b/lib/rules/augmentations/validation.ts
@@ -17,12 +17,10 @@ import type {
   CyberwareGrade,
   BiowareGrade,
   ItemLegality,
-} from "@/lib/types";
-import type {
   CyberwareCatalogItem,
   BiowareCatalogItem,
   AugmentationRules,
-} from "@/lib/types/edition";
+} from "@/lib/types";
 import {
   calculateCyberwareEssence,
   calculateBiowareEssence,

--- a/lib/rules/character/__tests__/state-machine.test.ts
+++ b/lib/rules/character/__tests__/state-machine.test.ts
@@ -19,7 +19,7 @@ import {
   type ValidationResult,
   type TransitionContext,
 } from "../state-machine";
-import type { Character, CharacterStatus } from "@/lib/types/character";
+import type { Character, CharacterStatus } from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/character/state-machine.ts
+++ b/lib/rules/character/state-machine.ts
@@ -14,9 +14,15 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
-import type { Character, CharacterStatus } from "@/lib/types/character";
-import type { AuditEntry, AuditActor, ActorRole, CreateAuditEntryParams } from "@/lib/types/audit";
-import type { ID } from "@/lib/types/core";
+import type {
+  Character,
+  CharacterStatus,
+  AuditEntry,
+  AuditActor,
+  ActorRole,
+  CreateAuditEntryParams,
+  ID,
+} from "@/lib/types";
 
 // =============================================================================
 // VALIDATION TYPES

--- a/lib/rules/creation/budget-totals.ts
+++ b/lib/rules/creation/budget-totals.ts
@@ -5,7 +5,7 @@
  * or creation method parameters. No React dependencies.
  */
 
-import type { GameplayLevelModifiers } from "@/lib/types/edition";
+import type { GameplayLevelModifiers } from "@/lib/types";
 import type { PriorityTableData } from "@/lib/rules/loader-types";
 import { LIFE_MODULES_KARMA_BUDGET, LIFE_MODULES_NUYEN_PER_KARMA } from "@/lib/types";
 import {

--- a/lib/rules/creation/budget-validation.ts
+++ b/lib/rules/creation/budget-validation.ts
@@ -5,7 +5,7 @@
  * against game rules. No React dependencies.
  */
 
-import type { CreationState, ValidationError } from "@/lib/types/creation";
+import type { CreationState, ValidationError } from "@/lib/types";
 import type { PriorityTableData } from "@/lib/rules/RulesetContext";
 import type { BudgetState } from "@/lib/contexts/CreationBudgetContext";
 import { LIFE_MODULES_MAX_GEAR_KARMA, LIFE_MODULES_MAX_NEGATIVE_QUALITIES } from "@/lib/types";

--- a/lib/rules/effects/character-state.ts
+++ b/lib/rules/effects/character-state.ts
@@ -8,8 +8,7 @@
  * @see Issue #485
  */
 
-import type { Character } from "@/lib/types";
-import type { CharacterStateFlags } from "@/lib/types/effects";
+import type { Character, CharacterStateFlags } from "@/lib/types";
 
 /**
  * Build character state flags from quality dynamic state.

--- a/lib/rules/effects/context.ts
+++ b/lib/rules/effects/context.ts
@@ -14,7 +14,7 @@ import type {
   EffectResolutionContext,
   SpecificAction,
   CharacterStateFlags,
-} from "@/lib/types/effects";
+} from "@/lib/types";
 
 export class EffectContextBuilder {
   private action: EffectActionContext | undefined;

--- a/lib/rules/effects/creation-adapter.ts
+++ b/lib/rules/effects/creation-adapter.ts
@@ -7,8 +7,7 @@
  * @see Issue #448
  */
 
-import type { Character } from "@/lib/types";
-import type { CreationSelections, QualitySelectionValue } from "@/lib/types/creation-selections";
+import type { Character, CreationSelections, QualitySelectionValue } from "@/lib/types";
 
 /**
  * Extract quality ID from a selection value (string or SelectedQuality object).

--- a/lib/rules/effects/format.ts
+++ b/lib/rules/effects/format.ts
@@ -7,7 +7,7 @@
  * @see Issue #448
  */
 
-import type { Effect, CharacterStateFlags } from "@/lib/types/effects";
+import type { Effect, CharacterStateFlags } from "@/lib/types";
 
 export interface EffectBadge {
   /** Compact display text, e.g., "+2 Sneaking" */

--- a/lib/rules/effects/gathering.ts
+++ b/lib/rules/effects/gathering.ts
@@ -8,11 +8,15 @@
  * @see Issue #108
  */
 
-import type { Character } from "@/lib/types";
-import type { MergedRuleset } from "@/lib/types/edition";
-import type { Quality } from "@/lib/types/qualities";
-import type { Effect, EffectSource, EffectSourceType } from "@/lib/types/effects";
-import type { EquipmentReadiness } from "@/lib/types/gear-state";
+import type {
+  Character,
+  MergedRuleset,
+  Quality,
+  Effect,
+  EffectSource,
+  EffectSourceType,
+  EquipmentReadiness,
+} from "@/lib/types";
 import { normalizeReadiness } from "@/lib/types/gear-state";
 import { resolveRatingBasedValue } from "./format";
 

--- a/lib/rules/effects/matching.ts
+++ b/lib/rules/effects/matching.ts
@@ -16,7 +16,7 @@ import type {
   EffectActionContext,
   EffectResolutionContext,
   CharacterStateFlags,
-} from "@/lib/types/effects";
+} from "@/lib/types";
 
 /**
  * Derive the set of active triggers implied by an action context.

--- a/lib/rules/effects/resolver.ts
+++ b/lib/rules/effects/resolver.ts
@@ -8,13 +8,13 @@
  * @see Issue #108
  */
 
-import type { Character } from "@/lib/types";
-import type { MergedRuleset } from "@/lib/types/edition";
 import type {
+  Character,
+  MergedRuleset,
   EffectResolutionContext,
   EffectResolutionResult,
   UnifiedResolvedEffect,
-} from "@/lib/types/effects";
+} from "@/lib/types";
 import { effectApplies } from "./matching";
 import { applyStackingRules } from "./stacking";
 import { gatherEffectSources } from "./gathering";

--- a/lib/rules/effects/stacking.ts
+++ b/lib/rules/effects/stacking.ts
@@ -12,7 +12,7 @@ import type {
   StackingRule,
   UnifiedResolvedEffect,
   EffectResolutionResult,
-} from "@/lib/types/effects";
+} from "@/lib/types";
 
 /**
  * Per-type stacking rules from the effects plan document.

--- a/lib/rules/encumbrance/__tests__/calculator.test.ts
+++ b/lib/rules/encumbrance/__tests__/calculator.test.ts
@@ -5,8 +5,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { Character, Weapon, ArmorItem, GearItem } from "@/lib/types";
-import type { EquipmentReadiness } from "@/lib/types/gear-state";
+import type { Character, Weapon, ArmorItem, GearItem, EquipmentReadiness } from "@/lib/types";
 import {
   calculateEncumbrance,
   calculateMaxCapacity,

--- a/lib/rules/encumbrance/calculator.ts
+++ b/lib/rules/encumbrance/calculator.ts
@@ -8,8 +8,14 @@
  * @see Capability: character.inventory-management
  */
 
-import type { Character, Weapon, ArmorItem, GearItem } from "@/lib/types";
-import type { EncumbranceState, EquipmentReadiness } from "@/lib/types/gear-state";
+import type {
+  Character,
+  Weapon,
+  ArmorItem,
+  GearItem,
+  EncumbranceState,
+  EquipmentReadiness,
+} from "@/lib/types";
 import { getAttributeValue } from "@/lib/rules/action-resolution/pool-builder";
 import { getContainerContentWeight, isContainer } from "@/lib/rules/inventory/container-manager";
 

--- a/lib/rules/gear/__tests__/weapon-customization.test.ts
+++ b/lib/rules/gear/__tests__/weapon-customization.test.ts
@@ -6,8 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { Weapon } from "@/lib/types/character";
-import type { WeaponModificationCatalogItem } from "@/lib/types/edition";
+import type { Weapon, WeaponModificationCatalogItem } from "@/lib/types";
 import {
   validateModInstallation,
   getAvailableMounts,

--- a/lib/rules/gear/validation.ts
+++ b/lib/rules/gear/validation.ts
@@ -24,8 +24,13 @@ import type {
   ItemLegality,
   Vehicle,
 } from "@/lib/types";
-import type { CharacterCyberdeck, CharacterCommlink } from "@/lib/types/matrix";
-import type { CharacterRCC, CharacterDrone, CharacterAutosoft } from "@/lib/types/character";
+import type {
+  CharacterCyberdeck,
+  CharacterCommlink,
+  CharacterRCC,
+  CharacterDrone,
+  CharacterAutosoft,
+} from "@/lib/types";
 
 // =============================================================================
 // CONSTANTS

--- a/lib/rules/gear/weapon-customization.ts
+++ b/lib/rules/gear/weapon-customization.ts
@@ -6,13 +6,15 @@
  * modification handling as defined in the Weapon Customization capability.
  */
 
-import type { Weapon, InstalledWeaponMod, WeaponMount } from "@/lib/types/character";
 import type {
+  Weapon,
+  InstalledWeaponMod,
+  WeaponMount,
   WeaponModificationCatalogItem,
   WeaponMountType,
   WeaponSubcategoryMountRegistry,
   WeaponSizeCategory,
-} from "@/lib/types/edition";
+} from "@/lib/types";
 
 // =============================================================================
 // TYPES

--- a/lib/rules/inventory/__tests__/state-manager.test.ts
+++ b/lib/rules/inventory/__tests__/state-manager.test.ts
@@ -5,9 +5,15 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { Weapon, ArmorItem, Character, BiowareItem, CharacterDrone } from "@/lib/types";
-import type { CyberlimbItem } from "@/lib/types/cyberlimb";
-import type { DeviceCondition } from "@/lib/types/gear-state";
+import type {
+  Weapon,
+  ArmorItem,
+  Character,
+  BiowareItem,
+  CharacterDrone,
+  CyberlimbItem,
+  DeviceCondition,
+} from "@/lib/types";
 import {
   getDefaultState,
   getValidTransitions,

--- a/lib/rules/inventory/concealment.ts
+++ b/lib/rules/inventory/concealment.ts
@@ -9,8 +9,7 @@
  * @see docs/specifications/gear-location-and-loadouts.md#concealment-integration
  */
 
-import type { Character, GearItem, Weapon, ArmorItem } from "@/lib/types";
-import type { EquipmentReadiness } from "@/lib/types/gear-state";
+import type { Character, GearItem, Weapon, ArmorItem, EquipmentReadiness } from "@/lib/types";
 import { normalizeReadiness } from "@/lib/types/gear-state";
 
 // =============================================================================

--- a/lib/rules/inventory/container-manager.ts
+++ b/lib/rules/inventory/container-manager.ts
@@ -7,12 +7,16 @@
  * @see docs/specifications/gear-location-and-loadouts.md
  */
 
-import type { Character, GearItem, Weapon, ArmorItem } from "@/lib/types";
 import type {
+  Character,
+  GearItem,
+  Weapon,
+  ArmorItem,
+  GearState,
   EquipmentReadiness,
   ContainmentRef,
   ContainerProperties,
-} from "@/lib/types/gear-state";
+} from "@/lib/types";
 
 // =============================================================================
 // CONSTANTS
@@ -411,8 +415,6 @@ export function moveItemBetweenContainers(
 // =============================================================================
 // INTERNAL HELPERS
 // =============================================================================
-
-import type { GearState } from "@/lib/types/gear-state";
 
 /**
  * Update the state of a specific item across all gear collections.

--- a/lib/rules/inventory/loadout-manager.ts
+++ b/lib/rules/inventory/loadout-manager.ts
@@ -9,14 +9,17 @@
  * @see docs/specifications/gear-location-and-loadouts.md#loadout-system
  */
 
-import type { Character, GearItem, Weapon, ArmorItem } from "@/lib/types";
 import type {
+  Character,
+  GearItem,
+  Weapon,
+  ArmorItem,
   EquipmentReadiness,
   Loadout,
   LoadoutDiff,
   StashLocationInfo,
   ContainmentRef,
-} from "@/lib/types/gear-state";
+} from "@/lib/types";
 
 // =============================================================================
 // TYPES

--- a/lib/rules/inventory/state-manager.ts
+++ b/lib/rules/inventory/state-manager.ts
@@ -8,8 +8,16 @@
  * @see Capability: character.inventory-management
  */
 
-import type { Weapon, ArmorItem, GearItem, Character, BiowareItem } from "@/lib/types";
-import type { GearState, EquipmentReadiness, DeviceCondition } from "@/lib/types/gear-state";
+import type {
+  Weapon,
+  ArmorItem,
+  GearItem,
+  Character,
+  BiowareItem,
+  GearState,
+  EquipmentReadiness,
+  DeviceCondition,
+} from "@/lib/types";
 
 // =============================================================================
 // CONSTANTS

--- a/lib/rules/life-modules/buy-off.ts
+++ b/lib/rules/life-modules/buy-off.ts
@@ -8,7 +8,7 @@
  * Pure functions — no side effects, no mutations.
  */
 
-import type { LifeModuleQualityGrant } from "@/lib/types/life-modules";
+import type { LifeModuleQualityGrant } from "@/lib/types";
 import type { QualityData } from "@/lib/rules/loader-types";
 
 // =============================================================================

--- a/lib/rules/life-modules/grant-resolver.ts
+++ b/lib/rules/life-modules/grant-resolver.ts
@@ -20,7 +20,7 @@ import type {
   LifeModuleContactGrant,
   LifeModulePhase,
   QualityReplacement,
-} from "@/lib/types/life-modules";
+} from "@/lib/types";
 import {
   LIFE_MODULES_MAX_ACTIVE_SKILL,
   LIFE_MODULES_MAX_KNOWLEDGE_SKILL,

--- a/lib/rules/life-modules/prerequisites.ts
+++ b/lib/rules/life-modules/prerequisites.ts
@@ -13,7 +13,7 @@ import type {
   LifeModulesCatalog,
   LifeModuleSelection,
   LifeModulePhase,
-} from "@/lib/types/life-modules";
+} from "@/lib/types";
 
 // =============================================================================
 // PHASE ALIASES

--- a/lib/rules/magic/__tests__/complex-form-validator.test.ts
+++ b/lib/rules/magic/__tests__/complex-form-validator.test.ts
@@ -11,9 +11,8 @@ import {
   getComplexFormDefinition,
   getAllComplexForms,
 } from "../complex-form-validator";
-import type { Character } from "@/lib/types/character";
+import type { Character, BookPayload } from "@/lib/types";
 import type { LoadedRuleset, ComplexFormData } from "../../loader-types";
-import type { BookPayload } from "@/lib/types/edition";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/magic/__tests__/drain-application.test.ts
+++ b/lib/rules/magic/__tests__/drain-application.test.ts
@@ -13,8 +13,7 @@ import {
   estimateResistanceHits,
   formatDamageCondition,
 } from "../drain-application";
-import type { Character } from "@/lib/types/character";
-import type { DrainResult } from "@/lib/types/magic";
+import type { Character, DrainResult } from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/magic/__tests__/drain-calculator.test.ts
+++ b/lib/rules/magic/__tests__/drain-calculator.test.ts
@@ -11,9 +11,8 @@ import {
   calculateDrainPreview,
   formatDrainSummary,
 } from "../drain-calculator";
-import type { Character } from "@/lib/types/character";
+import type { Character, BookPayload } from "@/lib/types";
 import type { LoadedRuleset } from "../../loader-types";
-import type { BookPayload } from "@/lib/types/edition";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/magic/__tests__/essence-magic-link.test.ts
+++ b/lib/rules/magic/__tests__/essence-magic-link.test.ts
@@ -13,7 +13,7 @@ import {
   formatEssenceMagicState,
   getMagicDegradationSummary,
 } from "../essence-magic-link";
-import type { Character } from "@/lib/types/character";
+import type { Character } from "@/lib/types";
 import type { AugmentationRulesData } from "../../loader-types";
 
 // =============================================================================

--- a/lib/rules/magic/__tests__/spell-validator.test.ts
+++ b/lib/rules/magic/__tests__/spell-validator.test.ts
@@ -15,14 +15,13 @@ import {
   getAllSpells,
   getSpellsByCategory,
 } from "../spell-validator";
-import type { Character, AdeptPower } from "@/lib/types/character";
+import type { Character, AdeptPower, BookPayload } from "@/lib/types";
 import type {
   LoadedRuleset,
   SpellData,
   SpellsCatalogData,
   AdeptPowerCatalogItem,
 } from "../../loader-types";
-import type { BookPayload } from "@/lib/types/edition";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/magic/__tests__/tradition-validator.test.ts
+++ b/lib/rules/magic/__tests__/tradition-validator.test.ts
@@ -15,9 +15,8 @@ import {
   canSummonSpirits,
   findTradition,
 } from "../tradition-validator";
-import type { Character, AdeptPower } from "@/lib/types/character";
+import type { Character, AdeptPower, BookPayload } from "@/lib/types";
 import type { LoadedRuleset, TraditionData } from "../../loader-types";
-import type { BookPayload } from "@/lib/types/edition";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/magic/complex-form-validator.ts
+++ b/lib/rules/magic/complex-form-validator.ts
@@ -5,12 +5,12 @@
  * Mirrors the spell-validator.ts pattern.
  */
 
-import type { Character } from "@/lib/types/character";
 import type {
+  Character,
   SpellValidationResult,
   MagicValidationError,
   MagicValidationWarning,
-} from "@/lib/types/magic";
+} from "@/lib/types";
 import type { LoadedRuleset, ComplexFormData } from "../loader-types";
 import { extractComplexForms } from "../loader";
 

--- a/lib/rules/magic/drain-application.ts
+++ b/lib/rules/magic/drain-application.ts
@@ -5,8 +5,7 @@
  * the resistance roll has been made.
  */
 
-import type { Character } from "@/lib/types/character";
-import type { DrainResult } from "@/lib/types/magic";
+import type { Character, DrainResult } from "@/lib/types";
 
 // =============================================================================
 // TYPES

--- a/lib/rules/magic/drain-calculator.ts
+++ b/lib/rules/magic/drain-calculator.ts
@@ -5,8 +5,13 @@
  * spellcasting, summoning, binding, and rituals.
  */
 
-import type { Character } from "@/lib/types/character";
-import type { DrainResult, DrainBreakdown, DrainModifier, DrainAction } from "@/lib/types/magic";
+import type {
+  Character,
+  DrainResult,
+  DrainBreakdown,
+  DrainModifier,
+  DrainAction,
+} from "@/lib/types";
 import type { LoadedRuleset } from "../loader-types";
 import { findTradition, getDrainAttributes } from "./tradition-validator";
 import { getSpellDefinition } from "./spell-validator";

--- a/lib/rules/magic/essence-magic-link.ts
+++ b/lib/rules/magic/essence-magic-link.ts
@@ -6,8 +6,7 @@
  * modify character state directly.
  */
 
-import type { Character } from "@/lib/types/character";
-import type { EssenceMagicState } from "@/lib/types/magic";
+import type { Character, EssenceMagicState } from "@/lib/types";
 import type { AugmentationRulesData } from "../loader-types";
 
 // =============================================================================

--- a/lib/rules/magic/spell-validator.ts
+++ b/lib/rules/magic/spell-validator.ts
@@ -5,13 +5,14 @@
  * and spell compatibility checking.
  */
 
-import type { Character, AdeptPower } from "@/lib/types/character";
 import type {
+  Character,
+  AdeptPower,
   SpellValidationResult,
   MagicValidationError,
   MagicValidationWarning,
   SpellCategory,
-} from "@/lib/types/magic";
+} from "@/lib/types";
 import type {
   LoadedRuleset,
   SpellData,

--- a/lib/rules/magic/tradition-validator.ts
+++ b/lib/rules/magic/tradition-validator.ts
@@ -5,12 +5,12 @@
  * magical path consistency checking.
  */
 
-import type { Character } from "@/lib/types/character";
 import type {
+  Character,
   TraditionValidationResult,
   MagicValidationError,
   MagicValidationWarning,
-} from "@/lib/types/magic";
+} from "@/lib/types";
 import type { LoadedRuleset, TraditionData, TraditionSpiritTypes } from "../loader-types";
 import { extractTraditions } from "../loader";
 

--- a/lib/rules/matrix/__tests__/action-mapper.test.ts
+++ b/lib/rules/matrix/__tests__/action-mapper.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { ActionDefinition } from "@/lib/types/action-definitions";
+import type { ActionDefinition } from "@/lib/types";
 import {
   actionDefinitionToMatrixAction,
   subcategoryToMatrixCategory,

--- a/lib/rules/matrix/__tests__/action-validator.test.ts
+++ b/lib/rules/matrix/__tests__/action-validator.test.ts
@@ -15,8 +15,7 @@ import {
   categorizeActions,
   getActionRequirementsSummary,
 } from "../action-validator";
-import type { MatrixAction, MatrixState, MatrixDeviceType } from "@/lib/types/matrix";
-import type { ISODateString } from "@/lib/types";
+import type { ISODateString, MatrixAction, MatrixState, MatrixDeviceType } from "@/lib/types";
 import { OVERWATCH_THRESHOLD } from "@/lib/types/matrix";
 import { createMockCharacter } from "@/__tests__/mocks/storage";
 

--- a/lib/rules/matrix/__tests__/cyberdeck-validator.test.ts
+++ b/lib/rules/matrix/__tests__/cyberdeck-validator.test.ts
@@ -9,7 +9,7 @@ import {
   getInitiativeDiceBonus,
   getBiofeedbackDamageType,
 } from "../cyberdeck-validator";
-import type { CyberdeckAttributeConfig } from "@/lib/types/matrix";
+import type { CyberdeckAttributeConfig } from "@/lib/types";
 
 describe("cyberdeck-validator", () => {
   // Standard Ares Predator cyberdeck array

--- a/lib/rules/matrix/__tests__/dice-pool-calculator.test.ts
+++ b/lib/rules/matrix/__tests__/dice-pool-calculator.test.ts
@@ -16,8 +16,7 @@ import {
   buildMatrixDefensePool,
   buildMatrixResistancePool,
 } from "../dice-pool-calculator";
-import type { MatrixAction, MatrixState, LoadedProgram } from "@/lib/types/matrix";
-import type { ISODateString } from "@/lib/types";
+import type { ISODateString, MatrixAction, MatrixState, LoadedProgram } from "@/lib/types";
 import { OVERWATCH_THRESHOLD } from "@/lib/types/matrix";
 import { createMockCharacter } from "@/__tests__/mocks/storage";
 

--- a/lib/rules/matrix/__tests__/mark-tracker.test.ts
+++ b/lib/rules/matrix/__tests__/mark-tracker.test.ts
@@ -19,8 +19,7 @@ import {
   marksNeededForLevel,
   checkActionMarks,
 } from "../mark-tracker";
-import type { MatrixState, MatrixMark } from "@/lib/types/matrix";
-import type { ISODateString } from "@/lib/types";
+import type { ISODateString, MatrixState, MatrixMark } from "@/lib/types";
 import { MAX_MARKS, OVERWATCH_THRESHOLD } from "@/lib/types/matrix";
 
 // =============================================================================

--- a/lib/rules/matrix/__tests__/overwatch-calculator.test.ts
+++ b/lib/rules/matrix/__tests__/overwatch-calculator.test.ts
@@ -11,7 +11,7 @@ import {
   shouldAutoIncreaseOS,
   getOverwatchStatusDescription,
 } from "../overwatch-calculator";
-import type { MatrixAction, MatrixState, MatrixMode } from "@/lib/types/matrix";
+import type { MatrixAction, MatrixState, MatrixMode } from "@/lib/types";
 import { OVERWATCH_THRESHOLD } from "@/lib/types/matrix";
 import { createMockCharacter } from "@/__tests__/mocks/storage";
 

--- a/lib/rules/matrix/__tests__/overwatch-tracker.test.ts
+++ b/lib/rules/matrix/__tests__/overwatch-tracker.test.ts
@@ -22,8 +22,7 @@ import {
   removeSessionFromCollection,
   getCompletedSessions,
 } from "../overwatch-tracker";
-import type { OverwatchSession } from "@/lib/types/matrix";
-import type { ISODateString } from "@/lib/types";
+import type { ISODateString, OverwatchSession } from "@/lib/types";
 import { OVERWATCH_THRESHOLD } from "@/lib/types/matrix";
 
 // =============================================================================

--- a/lib/rules/matrix/__tests__/program-validator.test.ts
+++ b/lib/rules/matrix/__tests__/program-validator.test.ts
@@ -10,8 +10,7 @@ import {
   characterOwnsProgram,
   calculateEffectiveSlotsUsed,
 } from "../program-validator";
-import type { Character } from "@/lib/types";
-import type { CharacterCyberdeck, MatrixDeviceType } from "@/lib/types/matrix";
+import type { Character, CharacterCyberdeck, MatrixDeviceType } from "@/lib/types";
 import type { LoadedRuleset, ProgramCatalogItemData } from "../../loader-types";
 import { createMockCharacter } from "@/__tests__/mocks/storage";
 

--- a/lib/rules/matrix/action-mapper.ts
+++ b/lib/rules/matrix/action-mapper.ts
@@ -7,8 +7,12 @@
  * validator expect MatrixAction objects.
  */
 
-import type { ActionDefinition, ActionSubcategory } from "@/lib/types/action-definitions";
-import type { MatrixAction, MatrixActionCategory } from "@/lib/types/matrix";
+import type {
+  ActionDefinition,
+  ActionSubcategory,
+  MatrixAction,
+  MatrixActionCategory,
+} from "@/lib/types";
 
 /**
  * Map ActionDefinition subcategory to MatrixActionCategory.

--- a/lib/rules/matrix/action-validator.ts
+++ b/lib/rules/matrix/action-validator.ts
@@ -9,15 +9,15 @@
  * - Legality classification for Overwatch
  */
 
-import type { Character } from "@/lib/types";
 import type {
+  Character,
   MatrixState,
   MatrixAction,
   MatrixMark,
   MatrixValidationError,
   MatrixValidationWarning,
   MatrixDeviceType,
-} from "@/lib/types/matrix";
+} from "@/lib/types";
 import type { LoadedRuleset } from "../loader-types";
 import { hasValidMatrixHardware, hasMatrixAccess } from "./cyberdeck-validator";
 

--- a/lib/rules/matrix/cyberdeck-validator.ts
+++ b/lib/rules/matrix/cyberdeck-validator.ts
@@ -5,13 +5,13 @@
  * Ensures ASDF assignments match the deck's attribute array.
  */
 
-import type { Character } from "@/lib/types";
 import type {
+  Character,
   CyberdeckAttributeConfig,
   CharacterCyberdeck,
   MatrixValidationError,
   MatrixValidationWarning,
-} from "@/lib/types/matrix";
+} from "@/lib/types";
 
 // =============================================================================
 // TYPES

--- a/lib/rules/matrix/dice-pool-calculator.ts
+++ b/lib/rules/matrix/dice-pool-calculator.ts
@@ -11,13 +11,15 @@
  * Integrates with the existing action resolution pool builder.
  */
 
-import type { Character, PoolModifier, ActionPool } from "@/lib/types";
 import type {
+  Character,
+  PoolModifier,
+  ActionPool,
   MatrixState,
   MatrixAction,
   CyberdeckAttributeConfig,
   LoadedProgram,
-} from "@/lib/types/matrix";
+} from "@/lib/types";
 import type { LoadedRuleset, ProgramCatalogItemData } from "../loader-types";
 import {
   buildActionPool,

--- a/lib/rules/matrix/mark-tracker.ts
+++ b/lib/rules/matrix/mark-tracker.ts
@@ -11,13 +11,14 @@
  * the target reboots.
  */
 
-import type { ID, ISODateString } from "@/lib/types";
 import type {
+  ID,
+  ISODateString,
   MatrixMark,
   MatrixState,
   MarkTargetType,
   MatrixValidationError,
-} from "@/lib/types/matrix";
+} from "@/lib/types";
 import { MAX_MARKS } from "@/lib/types/matrix";
 
 // =============================================================================

--- a/lib/rules/matrix/overwatch-calculator.ts
+++ b/lib/rules/matrix/overwatch-calculator.ts
@@ -7,14 +7,14 @@
  * attempts to crash the decker's persona.
  */
 
-import type { Character } from "@/lib/types";
 import type {
+  Character,
   MatrixState,
   MatrixAction,
   ConvergenceResult,
   ICSpawnData,
   MatrixMode,
-} from "@/lib/types/matrix";
+} from "@/lib/types";
 import { OVERWATCH_THRESHOLD } from "@/lib/types/matrix";
 
 // =============================================================================

--- a/lib/rules/matrix/overwatch-tracker.ts
+++ b/lib/rules/matrix/overwatch-tracker.ts
@@ -6,8 +6,7 @@
  * This service tracks the history of OS events for audit purposes.
  */
 
-import type { ID, ISODateString } from "@/lib/types";
-import type { OverwatchEvent, OverwatchSession } from "@/lib/types/matrix";
+import type { ID, ISODateString, OverwatchEvent, OverwatchSession } from "@/lib/types";
 import { OVERWATCH_THRESHOLD } from "@/lib/types/matrix";
 import { checkConvergence } from "./overwatch-calculator";
 

--- a/lib/rules/matrix/program-validator.ts
+++ b/lib/rules/matrix/program-validator.ts
@@ -5,13 +5,13 @@
  * Ensures programs exist in the ruleset and are compatible with devices.
  */
 
-import type { Character } from "@/lib/types";
-import type { CharacterProgram } from "@/lib/types/programs";
 import type {
+  Character,
+  CharacterProgram,
   MatrixDeviceType,
   MatrixValidationError,
   MatrixValidationWarning,
-} from "@/lib/types/matrix";
+} from "@/lib/types";
 import type { LoadedRuleset, ProgramCatalogItemData } from "../loader-types";
 import { getActiveCyberdeck } from "./cyberdeck-validator";
 

--- a/lib/rules/modifiers/__tests__/templates.test.ts
+++ b/lib/rules/modifiers/__tests__/templates.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from "vitest";
 import { MODIFIER_TEMPLATES, getModifierTemplate } from "../templates";
-import type { EffectType, EffectTrigger } from "@/lib/types/effects";
+import type { EffectType, EffectTrigger } from "@/lib/types";
 
 // =============================================================================
 // VALID VALUES

--- a/lib/rules/modifiers/templates.ts
+++ b/lib/rules/modifiers/templates.ts
@@ -7,7 +7,7 @@
  * @see Issue #114
  */
 
-import type { Effect, EffectType, EffectTrigger } from "@/lib/types/effects";
+import type { Effect, EffectType, EffectTrigger } from "@/lib/types";
 
 // =============================================================================
 // TYPES

--- a/lib/rules/modifiers/validation.ts
+++ b/lib/rules/modifiers/validation.ts
@@ -7,7 +7,7 @@
  * @see Issue #114
  */
 
-import type { EffectType, EffectTrigger } from "@/lib/types/effects";
+import type { EffectType, EffectTrigger } from "@/lib/types";
 import type { DurationPreset } from "./templates";
 import { getModifierTemplate } from "./templates";
 

--- a/lib/rules/qualities/__tests__/budget-modifiers.test.ts
+++ b/lib/rules/qualities/__tests__/budget-modifiers.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { CreationSelections } from "@/lib/types/creation-selections";
-import type { SelectedQuality } from "@/lib/types/creation-selections";
+import type { CreationSelections, SelectedQuality } from "@/lib/types";
 import {
   getQualityBudgetModifiers,
   applyJackOfAllTradesModifier,

--- a/lib/rules/qualities/__tests__/effects.test.ts
+++ b/lib/rules/qualities/__tests__/effects.test.ts
@@ -14,7 +14,7 @@ import type {
   EffectTarget,
   EffectCondition,
 } from "@/lib/types";
-import type { TestContext, CombatContext, MagicContext, MatrixContext } from "@/lib/types/gameplay";
+import type { TestContext, CombatContext, MagicContext, MatrixContext } from "@/lib/types";
 import {
   resolveTemplateVariable,
   resolveEffectValue,

--- a/lib/rules/qualities/budget-modifiers.ts
+++ b/lib/rules/qualities/budget-modifiers.ts
@@ -8,13 +8,12 @@
  * Importable from both client and server code (no React dependencies).
  */
 
-import type { CreationSelections } from "@/lib/types/creation-selections";
+import type { CreationSelections, QualitySelectionValue } from "@/lib/types";
 import {
   getPositiveQualityIds,
   getPositiveQualities,
   getQualityId,
 } from "@/lib/types/creation-selections";
-import type { QualitySelectionValue } from "@/lib/types/creation-selections";
 
 // =============================================================================
 // TYPES

--- a/lib/rules/qualities/effects.ts
+++ b/lib/rules/qualities/effects.ts
@@ -12,9 +12,7 @@ import type {
   EffectTrigger,
   EffectTarget,
   EffectCondition,
-} from "@/lib/types";
-import type { Character } from "@/lib/types";
-import type {
+  Character,
   GameplayContext,
   TestContext,
   CombatContext,
@@ -24,7 +22,7 @@ import type {
   DamageContext,
   CostContext,
   ResolvedEffect,
-} from "@/lib/types/gameplay";
+} from "@/lib/types";
 
 /**
  * Resolve template variables in effect values and targets

--- a/lib/rules/qualities/effects/handlers.ts
+++ b/lib/rules/qualities/effects/handlers.ts
@@ -5,8 +5,7 @@
  * Each handler knows how to process its effect type and return appropriate values.
  */
 
-import type { QualityEffect, EffectType } from "@/lib/types";
-import type { ResolvedEffect } from "@/lib/types/gameplay";
+import type { QualityEffect, EffectType, ResolvedEffect } from "@/lib/types";
 
 /**
  * Handler function for a specific effect type

--- a/lib/rules/qualities/effects/integration.ts
+++ b/lib/rules/qualities/effects/integration.ts
@@ -5,9 +5,9 @@
  * These provide convenient entry points for dice pools, limits, wound modifiers, etc.
  */
 
-import type { Character } from "@/lib/types";
-import type { MergedRuleset } from "@/lib/types";
 import type {
+  Character,
+  MergedRuleset,
   TestContext,
   CombatContext,
   MagicContext,
@@ -16,7 +16,7 @@ import type {
   DamageContext,
   CostContext,
   ResolvedEffect,
-} from "@/lib/types/gameplay";
+} from "@/lib/types";
 import { getQualityDefinition } from "../utils";
 import { getActiveEffects, filterEffectsByTrigger } from "../effects";
 import { processEffect } from "./handlers";

--- a/lib/rules/rigging/__tests__/action-validator.test.ts
+++ b/lib/rules/rigging/__tests__/action-validator.test.ts
@@ -13,8 +13,8 @@ import {
   getControlModeDescription,
   getActionTypeDescription,
 } from "../action-validator";
-import type { Character } from "@/lib/types/character";
 import type {
+  Character,
   RiggingState,
   SlavedDrone,
   SharedAutosoft,
@@ -22,7 +22,7 @@ import type {
   DroneNetwork,
   RCCConfiguration,
   JumpedInState,
-} from "@/lib/types/rigging";
+} from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/rigging/__tests__/biofeedback-handler.test.ts
+++ b/lib/rules/rigging/__tests__/biofeedback-handler.test.ts
@@ -24,7 +24,7 @@ import {
   createTestSlavedDrone,
   createTestJumpedInState,
 } from "./fixtures";
-import type { Character } from "@/lib/types/character";
+import type { Character } from "@/lib/types";
 
 // =============================================================================
 // DAMAGE TYPE TESTS

--- a/lib/rules/rigging/__tests__/dice-pool-calculator.test.ts
+++ b/lib/rules/rigging/__tests__/dice-pool-calculator.test.ts
@@ -10,15 +10,16 @@ import {
   getEffectivePool,
   estimateSuccessChance,
 } from "../dice-pool-calculator";
-import type { Character } from "@/lib/types/character";
 import type {
+  Character,
+  VehicleCatalogItem,
+  DroneCatalogItem,
   RiggingState,
   SlavedDrone,
   SharedAutosoft,
   VehicleControlRig,
   JumpedInState,
-} from "@/lib/types/rigging";
-import type { VehicleCatalogItem, DroneCatalogItem } from "@/lib/types/vehicles";
+} from "@/lib/types";
 import type { VehicleActionValidation, ActionBonus } from "../action-validator";
 
 // =============================================================================

--- a/lib/rules/rigging/__tests__/fixtures.ts
+++ b/lib/rules/rigging/__tests__/fixtures.ts
@@ -10,8 +10,7 @@ import type {
   CharacterDrone,
   CharacterAutosoft,
   CyberwareItem,
-} from "@/lib/types/character";
-import type {
+  AutosoftCategory,
   RiggingState,
   DroneNetwork,
   SlavedDrone,
@@ -22,8 +21,7 @@ import type {
   RCCConfiguration,
   RiggerVRMode,
   RunningAutosoft,
-} from "@/lib/types/rigging";
-import type { AutosoftCategory } from "@/lib/types/vehicles";
+} from "@/lib/types";
 
 // =============================================================================
 // CHARACTER FIXTURES

--- a/lib/rules/rigging/__tests__/noise-calculator.test.ts
+++ b/lib/rules/rigging/__tests__/noise-calculator.test.ts
@@ -17,7 +17,7 @@ import {
   type SpamZoneLevel,
   type StaticZoneLevel,
 } from "../noise-calculator";
-import type { TerrainModifier, DistanceBand } from "@/lib/types/rigging";
+import type { TerrainModifier, DistanceBand } from "@/lib/types";
 
 // =============================================================================
 // DISTANCE BAND TESTS

--- a/lib/rules/rigging/__tests__/rcc-validator.test.ts
+++ b/lib/rules/rigging/__tests__/rcc-validator.test.ts
@@ -23,7 +23,7 @@ import {
   createTestCharacterDrone,
   createTestCharacterAutosoft,
 } from "./fixtures";
-import type { CharacterRCC, CharacterAutosoft } from "@/lib/types/character";
+import type { CharacterRCC, CharacterAutosoft } from "@/lib/types";
 
 // =============================================================================
 // RCC CALCULATION TESTS

--- a/lib/rules/rigging/__tests__/vcr-validator.test.ts
+++ b/lib/rules/rigging/__tests__/vcr-validator.test.ts
@@ -15,7 +15,7 @@ import {
   createTestCharacterRCC,
   createTestCharacterDrone,
 } from "./fixtures";
-import type { CyberwareItem } from "@/lib/types/character";
+import type { CyberwareItem } from "@/lib/types";
 
 // =============================================================================
 // VCR DETECTION TESTS

--- a/lib/rules/rigging/action-validator.ts
+++ b/lib/rules/rigging/action-validator.ts
@@ -7,8 +7,9 @@
  * Based on SR5 Core Rulebook Chapter 11: Riggers
  */
 
-import type { Character } from "@/lib/types/character";
 import type {
+  Character,
+  AutosoftCategory,
   RiggingState,
   ControlMode,
   VehicleActionType,
@@ -17,8 +18,7 @@ import type {
   RiggingValidationWarning,
   SlavedDrone,
   SharedAutosoft,
-} from "@/lib/types/rigging";
-import type { AutosoftCategory } from "@/lib/types/vehicles";
+} from "@/lib/types";
 import { hasVehicleControlRig } from "./vcr-validator";
 import { hasRCC } from "./rcc-validator";
 

--- a/lib/rules/rigging/biofeedback-handler.ts
+++ b/lib/rules/rigging/biofeedback-handler.ts
@@ -7,13 +7,13 @@
  * SR5 Core Rulebook p. 229 (Biofeedback), p. 265-266 (Rigger rules)
  */
 
-import type { Character } from "@/lib/types/character";
 import type {
+  Character,
   RiggingState,
   RiggerVRMode,
   BiofeedbackResult,
   DumpshockResult,
-} from "@/lib/types/rigging";
+} from "@/lib/types";
 import { DUMPSHOCK_DAMAGE } from "@/lib/types/rigging";
 
 // =============================================================================

--- a/lib/rules/rigging/dice-pool-calculator.ts
+++ b/lib/rules/rigging/dice-pool-calculator.ts
@@ -7,23 +7,25 @@
  * Based on SR5 Core Rulebook Chapter 11: Riggers
  */
 
-import type { Character } from "@/lib/types/character";
 import type {
+  Character,
+  VehicleCatalogItem,
+  DroneCatalogItem,
+  HandlingRating,
+  VehicleActionType,
   RiggingState,
   ControlMode,
   VehicleTestType,
   SlavedDrone,
   SharedAutosoft,
   ActiveVehicleState,
-} from "@/lib/types/rigging";
-import type { VehicleCatalogItem, DroneCatalogItem, HandlingRating } from "@/lib/types/vehicles";
+} from "@/lib/types";
 import {
   getApplicableAutosofts,
   getControlModeBonus,
   getLimitTypeForTest,
   type VehicleActionValidation,
 } from "./action-validator";
-import type { VehicleActionType } from "@/lib/types/rigging";
 
 // =============================================================================
 // RESULT TYPES

--- a/lib/rules/rigging/drone-condition.ts
+++ b/lib/rules/rigging/drone-condition.ts
@@ -7,7 +7,7 @@
  * SR5 Core Rulebook p. 199 (Condition Monitors)
  */
 
-import type { SlavedDrone, DroneNetwork } from "@/lib/types/rigging";
+import type { SlavedDrone, DroneNetwork } from "@/lib/types";
 import { VEHICLE_CONDITION_BASE } from "@/lib/types/rigging";
 
 // =============================================================================

--- a/lib/rules/rigging/drone-network.ts
+++ b/lib/rules/rigging/drone-network.ts
@@ -7,8 +7,9 @@
  * SR5 Core Rulebook p. 265-269
  */
 
-import type { CharacterDrone, CharacterAutosoft } from "@/lib/types/character";
 import type {
+  CharacterDrone,
+  CharacterAutosoft,
   DroneNetwork,
   SlavedDrone,
   SharedAutosoft,
@@ -16,7 +17,7 @@ import type {
   RCCConfiguration,
   DroneCommandType,
   RiggingValidationError,
-} from "@/lib/types/rigging";
+} from "@/lib/types";
 import { VEHICLE_CONDITION_BASE } from "@/lib/types/rigging";
 import { calculateMaxSlavedDrones } from "./rcc-validator";
 import { calculateDroneNoise, type SpamZoneLevel, type StaticZoneLevel } from "./noise-calculator";

--- a/lib/rules/rigging/jumped-in-manager.ts
+++ b/lib/rules/rigging/jumped-in-manager.ts
@@ -7,8 +7,8 @@
  * SR5 Core Rulebook p. 265-266
  */
 
-import type { Character } from "@/lib/types/character";
 import type {
+  Character,
   JumpedInState,
   RiggingState,
   RiggerVRMode,
@@ -16,7 +16,7 @@ import type {
   VehicleControlRig,
   RiggingValidationError,
   RiggingValidationWarning,
-} from "@/lib/types/rigging";
+} from "@/lib/types";
 import { JUMPED_IN_INITIATIVE_BONUS, JUMPED_IN_HOTSIM_INITIATIVE_BONUS } from "@/lib/types/rigging";
 import { getVehicleControlRig, hasVehicleControlRig } from "./vcr-validator";
 import { getDroneFromNetwork } from "./drone-network";

--- a/lib/rules/rigging/noise-calculator.ts
+++ b/lib/rules/rigging/noise-calculator.ts
@@ -7,7 +7,7 @@
  * SR5 Core Rulebook p. 231
  */
 
-import type { DistanceBand, TerrainModifier, NoiseCalculation } from "@/lib/types/rigging";
+import type { DistanceBand, TerrainModifier, NoiseCalculation } from "@/lib/types";
 
 // =============================================================================
 // CONSTANTS - DISTANCE NOISE (SR5 p. 231)

--- a/lib/rules/rigging/rcc-validator.ts
+++ b/lib/rules/rigging/rcc-validator.ts
@@ -12,13 +12,11 @@ import type {
   CharacterRCC,
   CharacterDrone,
   CharacterAutosoft,
-} from "@/lib/types/character";
-import type {
   RCCConfiguration,
   RiggingValidationError,
   RiggingValidationWarning,
   RunningAutosoft,
-} from "@/lib/types/rigging";
+} from "@/lib/types";
 import { DRONE_SLAVE_LIMIT_MULTIPLIER } from "@/lib/types/rigging";
 
 // =============================================================================

--- a/lib/rules/rigging/vcr-validator.ts
+++ b/lib/rules/rigging/vcr-validator.ts
@@ -7,13 +7,14 @@
  * SR5 Core Rulebook p. 452
  */
 
-import type { Character, CyberwareItem } from "@/lib/types/character";
 import type {
+  Character,
+  CyberwareItem,
   VehicleControlRig,
   RiggerVRMode,
   RiggingValidationError,
   RiggingValidationWarning,
-} from "@/lib/types/rigging";
+} from "@/lib/types";
 import { JUMPED_IN_INITIATIVE_BONUS, JUMPED_IN_HOTSIM_INITIATIVE_BONUS } from "@/lib/types/rigging";
 
 // =============================================================================

--- a/lib/rules/skills/__tests__/group-utils.test.ts
+++ b/lib/rules/skills/__tests__/group-utils.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { SkillGroupValue } from "@/lib/types/creation-selections";
+import type { SkillGroupValue } from "@/lib/types";
 import {
   normalizeGroupValue,
   getGroupRating,

--- a/lib/rules/skills/group-utils.ts
+++ b/lib/rules/skills/group-utils.ts
@@ -13,7 +13,7 @@
  *   group level using skill points. That must be done using karma.
  */
 
-import type { SkillGroupValue } from "@/lib/types/creation-selections";
+import type { SkillGroupValue } from "@/lib/types";
 
 // =============================================================================
 // TYPE HELPERS

--- a/lib/rules/validation/__tests__/augmentation-validator.test.ts
+++ b/lib/rules/validation/__tests__/augmentation-validator.test.ts
@@ -8,10 +8,14 @@
 import { describe, it, expect } from "vitest";
 import { validateCharacter } from "../character-validator";
 import type { CharacterValidationContext } from "../types";
-import type { Character, CyberwareItem, BiowareItem } from "@/lib/types/character";
-import type { MergedRuleset } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
-import type { CyberlimbItem } from "@/lib/types/cyberlimb";
+import type {
+  MergedRuleset,
+  Character,
+  CyberwareItem,
+  BiowareItem,
+  CreationState,
+  CyberlimbItem,
+} from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/validation/__tests__/budget-calculator.test.ts
+++ b/lib/rules/validation/__tests__/budget-calculator.test.ts
@@ -12,7 +12,7 @@ import {
   KARMA_TO_NUYEN_LIMIT,
   SR5_KARMA_BUDGET,
 } from "../budget-calculator";
-import type { CreationSelections } from "@/lib/types/creation-selections";
+import type { CreationSelections } from "@/lib/types";
 
 // =============================================================================
 // TEST HELPERS

--- a/lib/rules/validation/__tests__/character-validator.test.ts
+++ b/lib/rules/validation/__tests__/character-validator.test.ts
@@ -6,8 +6,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Character, CharacterDraft } from "@/lib/types/character";
-import type { MergedRuleset, CreationMethod, Campaign, CreationState } from "@/lib/types";
+import type {
+  MergedRuleset,
+  CreationMethod,
+  Campaign,
+  CreationState,
+  Character,
+  CharacterDraft,
+} from "@/lib/types";
 import { FocusType } from "@/lib/types/edition";
 import {
   validateCharacter,

--- a/lib/rules/validation/__tests__/contact-budget.test.ts
+++ b/lib/rules/validation/__tests__/contact-budget.test.ts
@@ -7,9 +7,7 @@
 import { describe, it, expect } from "vitest";
 import { validateCharacter } from "../character-validator";
 import type { CharacterValidationContext } from "../types";
-import type { Character } from "@/lib/types/character";
-import type { MergedRuleset } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
+import type { MergedRuleset, Character, CreationState } from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/validation/__tests__/karma-budget.test.ts
+++ b/lib/rules/validation/__tests__/karma-budget.test.ts
@@ -7,9 +7,7 @@
 import { describe, it, expect } from "vitest";
 import { validateCharacter } from "../character-validator";
 import type { CharacterValidationContext } from "../types";
-import type { Character } from "@/lib/types/character";
-import type { MergedRuleset } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
+import type { MergedRuleset, Character, CreationState } from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/validation/__tests__/knowledge-budget.test.ts
+++ b/lib/rules/validation/__tests__/knowledge-budget.test.ts
@@ -7,9 +7,7 @@
 import { describe, it, expect } from "vitest";
 import { validateCharacter } from "../character-validator";
 import type { CharacterValidationContext } from "../types";
-import type { Character } from "@/lib/types/character";
-import type { MergedRuleset } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
+import type { MergedRuleset, Character, CreationState } from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/validation/__tests__/materialize.test.ts
+++ b/lib/rules/validation/__tests__/materialize.test.ts
@@ -7,8 +7,7 @@
 
 import { describe, it, expect } from "vitest";
 import { materializeFromCreationState } from "../materialize";
-import type { Character } from "@/lib/types/character";
-import type { CreationState } from "@/lib/types/creation";
+import type { Character, CreationState } from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/validation/__tests__/nuyen-budget.test.ts
+++ b/lib/rules/validation/__tests__/nuyen-budget.test.ts
@@ -7,9 +7,7 @@
 import { describe, it, expect } from "vitest";
 import { validateCharacter } from "../character-validator";
 import type { CharacterValidationContext } from "../types";
-import type { Character } from "@/lib/types/character";
-import type { MergedRuleset } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
+import type { MergedRuleset, Character, CreationState } from "@/lib/types";
 import type { PriorityTableData } from "@/lib/rules/loader-types";
 
 // =============================================================================

--- a/lib/rules/validation/__tests__/priority-consistency.test.ts
+++ b/lib/rules/validation/__tests__/priority-consistency.test.ts
@@ -8,9 +8,7 @@
 import { describe, it, expect } from "vitest";
 import { validateCharacter } from "../character-validator";
 import type { CharacterValidationContext } from "../types";
-import type { Character } from "@/lib/types/character";
-import type { MergedRuleset } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
+import type { MergedRuleset, Character, CreationState } from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/validation/__tests__/shapeshifter-validator.test.ts
+++ b/lib/rules/validation/__tests__/shapeshifter-validator.test.ts
@@ -8,9 +8,7 @@
 import { describe, it, expect } from "vitest";
 import { shapeshifterValidator, SHAPESHIFTER_ERROR_CODES } from "../shapeshifter-validator";
 import type { CharacterValidationContext, ValidationIssue } from "../types";
-import type { Character } from "@/lib/types/character";
-import type { MergedRuleset } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
+import type { MergedRuleset, Character, CreationState } from "@/lib/types";
 
 // =============================================================================
 // TEST FIXTURES

--- a/lib/rules/validation/__tests__/skill-group-constraints.test.ts
+++ b/lib/rules/validation/__tests__/skill-group-constraints.test.ts
@@ -8,9 +8,7 @@
 import { describe, it, expect } from "vitest";
 import { validateCharacter } from "../character-validator";
 import type { CharacterValidationContext } from "../types";
-import type { Character } from "@/lib/types/character";
-import type { MergedRuleset } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
+import type { MergedRuleset, Character, CreationState } from "@/lib/types";
 import type { SkillGroupData } from "../../loader-types";
 
 // =============================================================================

--- a/lib/rules/validation/budget-calculator.ts
+++ b/lib/rules/validation/budget-calculator.ts
@@ -10,12 +10,11 @@
  * - Guarantee: Server validates all budget calculations independently
  */
 
-import type { CreationSelections } from "@/lib/types/creation-selections";
 import {
   getQualityBudgetModifiers,
   FRIENDS_IN_HIGH_PLACES_CONTACT_MULTIPLIER,
 } from "@/lib/rules/qualities/budget-modifiers";
-import type { Contact } from "@/lib/types";
+import type { Contact, CreationSelections } from "@/lib/types";
 
 // =============================================================================
 // NUYEN CALCULATION

--- a/lib/rules/validation/character-validator.ts
+++ b/lib/rules/validation/character-validator.ts
@@ -17,9 +17,10 @@ import type {
   FocusItem,
   CyberwareItem,
   BiowareItem,
-} from "@/lib/types/character";
-import type { MergedRuleset, Campaign, CreationMethod } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
+  MergedRuleset,
+  Campaign,
+  CreationMethod,
+} from "@/lib/types";
 import {
   type CharacterValidationContext,
   type CharacterValidationResult,
@@ -39,8 +40,6 @@ import {
 import { validateAllQualities, validateKarmaLimits } from "../qualities";
 import { getModule } from "../merge";
 import { getGroupRating, isGroupBroken } from "../skills/group-utils";
-import type { CreationSelections } from "@/lib/types/creation-selections";
-import type { LanguageSkill, KnowledgeSkill, CharacterSpell } from "@/lib/types/character";
 import type {
   ComplexFormData,
   SkillGroupData,
@@ -67,7 +66,14 @@ import {
 import { isGradeAvailableAtCreation, applyGradeToAvailability } from "../augmentations/grades";
 import { isCyberlimb } from "@/lib/types/cyberlimb";
 import { CREATION_CONSTRAINTS } from "../gear/validation";
-import type { ArmorItem } from "@/lib/types";
+import type {
+  ArmorItem,
+  CreationState,
+  CreationSelections,
+  LanguageSkill,
+  KnowledgeSkill,
+  CharacterSpell,
+} from "@/lib/types";
 import { shapeshifterValidator } from "./shapeshifter-validator";
 
 // =============================================================================

--- a/lib/rules/validation/materialize.ts
+++ b/lib/rules/validation/materialize.ts
@@ -13,13 +13,17 @@
  *    for post-creation use (advancement, combat, etc.)
  */
 
-import type { Character, CharacterDraft } from "@/lib/types/character";
-import type { CreationState } from "@/lib/types/creation";
-import type { CreationSelections, QualitySelectionValue } from "@/lib/types/creation-selections";
-import type { QualitySelection } from "@/lib/types/qualities";
-import type { MagicalPath } from "@/lib/types/core";
-import type { CharacterProgram } from "@/lib/types/programs";
-import type { CharacterDataSoftware } from "@/lib/types/character";
+import type {
+  Character,
+  CharacterDraft,
+  CreationState,
+  CreationSelections,
+  QualitySelectionValue,
+  QualitySelection,
+  MagicalPath,
+  CharacterProgram,
+  CharacterDataSoftware,
+} from "@/lib/types";
 
 // Map creation "magical-path" values to Character.magicalPath values
 const MAGICAL_PATH_MAP: Record<string, MagicalPath> = {

--- a/lib/rules/validation/types.ts
+++ b/lib/rules/validation/types.ts
@@ -4,9 +4,14 @@
  * Types for comprehensive character validation during creation and finalization.
  */
 
-import type { Character, CharacterDraft } from "@/lib/types/character";
-import type { MergedRuleset, CreationMethod, Campaign } from "@/lib/types";
-import type { CreationState } from "@/lib/types/creation";
+import type {
+  MergedRuleset,
+  CreationMethod,
+  Campaign,
+  Character,
+  CharacterDraft,
+  CreationState,
+} from "@/lib/types";
 
 // =============================================================================
 // VALIDATION MODES

--- a/lib/rules/wireless/__tests__/bonus-calculator.test.ts
+++ b/lib/rules/wireless/__tests__/bonus-calculator.test.ts
@@ -6,8 +6,14 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { Character, CyberwareItem, Weapon, BiowareItem, ArmorItem } from "@/lib/types";
-import type { WirelessEffect } from "@/lib/types/wireless-effects";
+import type {
+  Character,
+  CyberwareItem,
+  Weapon,
+  BiowareItem,
+  ArmorItem,
+  WirelessEffect,
+} from "@/lib/types";
 import {
   isGlobalWirelessEnabled,
   isItemWirelessActive,

--- a/lib/rules/wireless/bonus-calculator.ts
+++ b/lib/rules/wireless/bonus-calculator.ts
@@ -9,14 +9,15 @@
  * @see Capability: character.inventory-management
  */
 
-import type { Character, CyberwareItem } from "@/lib/types";
 import type {
+  Character,
+  CyberwareItem,
   WirelessEffect,
   ActiveWirelessBonuses,
   AttributeKey,
   LimitKey,
   EffectConditionType,
-} from "@/lib/types/wireless-effects";
+} from "@/lib/types";
 import {
   EMPTY_WIRELESS_BONUSES,
   applyWirelessEffect,

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -128,6 +128,9 @@ export type {
   CyberlimbEnhancementCatalogItem,
   CyberlimbAccessoryCatalogItem,
   CyberImplantWeaponCatalogItem,
+  // Weapon customization types
+  WeaponSubcategoryMountRegistry,
+  WeaponSizeCategory,
 } from "./edition";
 
 // Character types
@@ -214,6 +217,7 @@ export type {
   EffectResolutionResult,
   ActiveModifier,
   StackingRule,
+  CharacterStateFlags,
 } from "./effects";
 
 // Cyberware/Bioware grade multipliers and modifiers
@@ -285,6 +289,7 @@ export type {
   VehicleSelections,
   CreationSelections,
   FreeSkillDesignations,
+  SkillGroupValue,
 } from "./creation-selections";
 
 // Creation selection type guards and accessors


### PR DESCRIPTION
## Summary
- Replace all 222 deep `import type` statements from `@/lib/types/[module]` with barrel imports from `@/lib/types` across 123 files in `lib/rules/`
- Enforces the documented convention: "Always import from `@/lib/types`" (CLAUDE.md)
- Add 4 missing type re-exports to `lib/types/index.ts`: `SkillGroupValue`, `CharacterStateFlags`, `WeaponSubcategoryMountRegistry`, `WeaponSizeCategory`
- Value imports (enums, functions, constants) remain as deep imports — these need specific module paths for tree-shaking

**Breakdown by sub-module replaced:**
- `character` (56), `matrix` (24), `rigging` (21), `edition` (19), `gear-state` (14), `creation` (13), `creation-selections` (13), `effects` (10), `campaign` (10), `magic` (7), `cyberlimb` (6), `wireless-effects` (5), `vehicles` (4), `life-modules` (4), `gameplay` (4), and 12 others

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (9,807 tests)
- [x] Pre-commit hooks pass (lint, format)
- [x] Pre-push hooks pass (knip, CLAUDE.md validation)
- [x] Zero deep `import type` from `@/lib/types/[module]` remain in `lib/rules/`

Closes #738