### PR TITLE
feat: implement chip economy rules for Run Faster contact mechanics (#770)

### DIFF
--- a/lib/rules/__tests__/chips.test.ts
+++ b/lib/rules/__tests__/chips.test.ts
@@ -84,6 +84,11 @@ describe("calculateChipGain", () => {
     expect(calculateChipGain({ favorRating: 0, direction: "character-requests" })).toBe(0);
     expect(calculateChipGain({ favorRating: 0, direction: "character-provides" })).toBe(0);
   });
+
+  it("should return 0 for negative favor rating", () => {
+    expect(calculateChipGain({ favorRating: -2, direction: "character-requests" })).toBe(0);
+    expect(calculateChipGain({ favorRating: -1, direction: "character-provides" })).toBe(0);
+  });
 });
 
 // =============================================================================
@@ -117,6 +122,12 @@ describe("calculateRepaymentCost with nuyen", () => {
   it("should return nuyen amount for cash payment", () => {
     const result = calculateRepaymentCost(1, { marketValuePerChip: 1000 });
     expect(result).toBe(2000); // 1 × 1000 × 2
+  });
+
+  it("should fall back to chip-based cost when marketValuePerChip is 0", () => {
+    // Zero market value is invalid — falls back to chip multiplier
+    const result = calculateRepaymentCost(3, { marketValuePerChip: 0 });
+    expect(result).toBe(6); // 3 × 2 (chip-based, not nuyen-based)
   });
 });
 
@@ -192,6 +203,7 @@ describe("calculateLoyaltyImprovementCost", () => {
   it("should require chips equal to target loyalty level", () => {
     // Improving from Loyalty 2 → 3 costs 3 chips
     const result = calculateLoyaltyImprovementCost(2, 3);
+    expect(result.valid).toBe(true);
     expect(result.chipsRequired).toBe(3);
   });
 
@@ -200,12 +212,10 @@ describe("calculateLoyaltyImprovementCost", () => {
     expect(result.downtimeWeeks).toBe(3);
   });
 
-  it("should handle improvement by multiple levels", () => {
-    // Improving from Loyalty 1 → 4: costs 4 chips + 4 weeks
-    // (target level determines cost, not the delta)
+  it("should reject multi-level jumps (must improve one level at a time)", () => {
     const result = calculateLoyaltyImprovementCost(1, 4);
-    expect(result.chipsRequired).toBe(4);
-    expect(result.downtimeWeeks).toBe(4);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("one level at a time");
   });
 
   it("should reject invalid improvements (same level)", () => {
@@ -224,11 +234,27 @@ describe("calculateLoyaltyImprovementCost", () => {
     expect(result.valid).toBe(false);
   });
 
+  it("should reject currentLoyalty below minimum (1)", () => {
+    const result = calculateLoyaltyImprovementCost(0, 1);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("at least 1");
+  });
+
   it("should allow improvement to max loyalty (6)", () => {
     const result = calculateLoyaltyImprovementCost(5, 6);
     expect(result.valid).toBe(true);
     expect(result.chipsRequired).toBe(6);
     expect(result.downtimeWeeks).toBe(6);
+  });
+
+  it("should correctly price each single-step improvement", () => {
+    // Verify the full ladder: 1→2=2, 2→3=3, 3→4=4, 4→5=5, 5→6=6
+    for (let current = 1; current < 6; current++) {
+      const result = calculateLoyaltyImprovementCost(current, current + 1);
+      expect(result.valid).toBe(true);
+      expect(result.chipsRequired).toBe(current + 1);
+      expect(result.downtimeWeeks).toBe(current + 1);
+    }
   });
 });
 

--- a/lib/rules/chips.ts
+++ b/lib/rules/chips.ts
@@ -62,7 +62,7 @@ export function calculateChipGain(params: {
 }): number {
   const { favorRating, direction } = params;
 
-  if (favorRating === 0) {
+  if (favorRating <= 0) {
     return 0;
   }
 
@@ -89,7 +89,7 @@ export function calculateRepaymentCost(
 ): number {
   const absoluteOwed = Math.abs(chipsOwed);
 
-  if (options?.marketValuePerChip !== undefined) {
+  if (options?.marketValuePerChip !== undefined && options.marketValuePerChip > 0) {
     return absoluteOwed * options.marketValuePerChip * REPAYMENT_MULTIPLIER;
   }
 
@@ -164,25 +164,46 @@ export interface LoyaltyImprovementCost {
 }
 
 /**
- * Calculate the cost to improve a contact's Loyalty via chips.
+ * Calculate the cost to improve a contact's Loyalty by one level via chips.
  *
+ * Per Run Faster p. 177, loyalty is improved one level at a time.
  * Cost = target Loyalty level in both chips and downtime weeks.
- * For example, improving to Loyalty 4 costs 4 chips + 4 weeks of downtime.
+ * For example, improving from Loyalty 3 → 4 costs 4 chips + 4 weeks of downtime.
  *
- * @param currentLoyalty - Current loyalty rating
- * @param targetLoyalty - Desired loyalty rating
+ * To improve multiple levels, call this function once per step.
+ *
+ * @param currentLoyalty - Current loyalty rating (minimum 1)
+ * @param targetLoyalty - Desired loyalty rating (must be currentLoyalty + 1)
  * @returns Cost breakdown or validation error
  */
 export function calculateLoyaltyImprovementCost(
   currentLoyalty: number,
   targetLoyalty: number
 ): LoyaltyImprovementCost {
+  if (currentLoyalty < 1) {
+    return {
+      valid: false,
+      chipsRequired: 0,
+      downtimeWeeks: 0,
+      reason: `Current loyalty (${currentLoyalty}) must be at least 1`,
+    };
+  }
+
   if (targetLoyalty <= currentLoyalty) {
     return {
       valid: false,
       chipsRequired: 0,
       downtimeWeeks: 0,
       reason: `Target loyalty (${targetLoyalty}) must be higher than current loyalty (${currentLoyalty})`,
+    };
+  }
+
+  if (targetLoyalty !== currentLoyalty + 1) {
+    return {
+      valid: false,
+      chipsRequired: 0,
+      downtimeWeeks: 0,
+      reason: `Loyalty can only be improved one level at a time (${currentLoyalty} → ${currentLoyalty + 1})`,
     };
   }
 

--- a/lib/rules/index.ts
+++ b/lib/rules/index.ts
@@ -147,3 +147,14 @@ export {
   isCapacityBased,
   isSlotBased,
 } from "./modifications";
+
+// Chip economy (Run Faster contact mechanics) - Client-safe
+export {
+  calculateChipGain,
+  calculateRepaymentCost,
+  getDebtTimeframe,
+  calculateChipDiceBonus,
+  calculateLoyaltyImprovementCost,
+  isSecondaryServiceUse,
+  type LoyaltyImprovementCost,
+} from "./chips";


### PR DESCRIPTION
## Summary

- New `lib/rules/chips.ts` module implementing Run Faster pp. 177-178 chip economy mechanics
- Pure functions, no side effects, fully tested with 30 tests
- Foundation for #771 (maintenance), #772 (relationship qualities), and #774 (group contact restrictions)

## Functions

| Function | Purpose |
|----------|---------|
| `calculateChipGain()` | Chip balance change from favor interactions |
| `calculateRepaymentCost()` | 2× repayment multiplier (chips or cash) |
| `getDebtTimeframe()` | Weeks to repay based on amount owed |
| `calculateChipDiceBonus()` | +1 die per chip spent (max +4) |
| `calculateLoyaltyImprovementCost()` | Chips + downtime weeks to improve Loyalty |
| `isSecondaryServiceUse()` | Detects non-primary archetype service use |

## Test plan

- [x] 30 unit tests covering all functions with edge cases
- [x] TypeScript type-check passes
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass

Part of epic #534. Closes #770.