### PR TITLE
feat: implement 'I Know a Guy' Edge-based contact acquisition (#773)

### DIFF
--- a/lib/rules/__tests__/i-know-a-guy.test.ts
+++ b/lib/rules/__tests__/i-know-a-guy.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for "I Know a Guy" Edge-based contact acquisition (Run Faster p. 178)
+ *
+ * Characters can spend Edge to pull a contact from their past mid-session.
+ * The contact starts at Loyalty 1 and must be confirmed with Karma after
+ * the mission to become permanent.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  calculateEdgeCost,
+  validateIKnowAGuy,
+  createEdgeContactSpec,
+  calculateConfirmationKarmaCost,
+  canConfirmEdgeContact,
+} from "../i-know-a-guy";
+
+// =============================================================================
+// EDGE COST CALCULATION
+// =============================================================================
+
+describe("calculateEdgeCost", () => {
+  it("should cost 2× the desired Connection Rating", () => {
+    expect(calculateEdgeCost(1)).toBe(2);
+    expect(calculateEdgeCost(3)).toBe(6);
+    expect(calculateEdgeCost(6)).toBe(12);
+  });
+
+  it("should handle Connection 0 (edge case)", () => {
+    expect(calculateEdgeCost(0)).toBe(0);
+  });
+
+  it("should handle high Connection ratings", () => {
+    expect(calculateEdgeCost(12)).toBe(24);
+  });
+});
+
+// =============================================================================
+// VALIDATION
+// =============================================================================
+
+describe("validateIKnowAGuy", () => {
+  it("should allow when character has sufficient Edge", () => {
+    const result = validateIKnowAGuy({
+      currentEdge: 6,
+      desiredConnection: 3,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.edgeCost).toBe(6);
+  });
+
+  it("should reject when character has insufficient Edge", () => {
+    const result = validateIKnowAGuy({
+      currentEdge: 4,
+      desiredConnection: 3,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Insufficient Edge");
+  });
+
+  it("should allow when Edge exactly matches cost", () => {
+    const result = validateIKnowAGuy({
+      currentEdge: 6,
+      desiredConnection: 3,
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("should reject Connection < 1", () => {
+    const result = validateIKnowAGuy({
+      currentEdge: 10,
+      desiredConnection: 0,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Connection");
+  });
+
+  it("should reject Connection > 12", () => {
+    const result = validateIKnowAGuy({
+      currentEdge: 100,
+      desiredConnection: 13,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Connection");
+  });
+
+  it("should reject negative Edge", () => {
+    const result = validateIKnowAGuy({
+      currentEdge: -1,
+      desiredConnection: 1,
+    });
+
+    expect(result.allowed).toBe(false);
+  });
+});
+
+// =============================================================================
+// EDGE CONTACT SPEC CREATION
+// =============================================================================
+
+describe("createEdgeContactSpec", () => {
+  it("should create spec with Loyalty 1", () => {
+    const spec = createEdgeContactSpec({
+      desiredConnection: 4,
+      archetype: "Fixer",
+      name: "Old Buddy",
+    });
+
+    expect(spec.loyalty).toBe(1);
+  });
+
+  it("should use the desired Connection", () => {
+    const spec = createEdgeContactSpec({
+      desiredConnection: 5,
+      archetype: "Street Doc",
+      name: "Doc Martinez",
+    });
+
+    expect(spec.connection).toBe(5);
+  });
+
+  it("should set acquisitionMethod to 'edge'", () => {
+    const spec = createEdgeContactSpec({
+      desiredConnection: 3,
+      archetype: "Fixer",
+      name: "Old Contact",
+    });
+
+    expect(spec.acquisitionMethod).toBe("edge");
+  });
+
+  it("should flag as pending karma confirmation", () => {
+    const spec = createEdgeContactSpec({
+      desiredConnection: 3,
+      archetype: "Fixer",
+      name: "Someone",
+    });
+
+    expect(spec.pendingKarmaConfirmation).toBe(true);
+  });
+
+  it("should include the archetype and name", () => {
+    const spec = createEdgeContactSpec({
+      desiredConnection: 2,
+      archetype: "Street Samurai",
+      name: "Razor",
+    });
+
+    expect(spec.archetype).toBe("Street Samurai");
+    expect(spec.name).toBe("Razor");
+  });
+
+  it("should include optional description", () => {
+    const spec = createEdgeContactSpec({
+      desiredConnection: 2,
+      archetype: "Fixer",
+      name: "Test",
+      description: "An old army buddy",
+    });
+
+    expect(spec.description).toBe("An old army buddy");
+  });
+});
+
+// =============================================================================
+// KARMA CONFIRMATION
+// =============================================================================
+
+describe("calculateConfirmationKarmaCost", () => {
+  it("should cost Connection + Loyalty (which is always 1)", () => {
+    // Connection 3 + Loyalty 1 = 4 karma
+    expect(calculateConfirmationKarmaCost(3)).toBe(4);
+  });
+
+  it("should scale with Connection", () => {
+    expect(calculateConfirmationKarmaCost(1)).toBe(2); // 1 + 1
+    expect(calculateConfirmationKarmaCost(6)).toBe(7); // 6 + 1
+    expect(calculateConfirmationKarmaCost(12)).toBe(13); // 12 + 1
+  });
+});
+
+describe("canConfirmEdgeContact", () => {
+  it("should allow when character has sufficient Karma", () => {
+    const result = canConfirmEdgeContact({
+      connectionRating: 4,
+      currentKarma: 10,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.karmaCost).toBe(5); // 4 + 1
+  });
+
+  it("should reject when character has insufficient Karma", () => {
+    const result = canConfirmEdgeContact({
+      connectionRating: 6,
+      currentKarma: 3,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("Insufficient karma");
+    expect(result.karmaCost).toBe(7); // 6 + 1
+  });
+
+  it("should allow when Karma exactly matches cost", () => {
+    const result = canConfirmEdgeContact({
+      connectionRating: 4,
+      currentKarma: 5,
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/lib/rules/i-know-a-guy.ts
+++ b/lib/rules/i-know-a-guy.ts
@@ -1,0 +1,212 @@
+/**
+ * "I Know a Guy" Edge-Based Contact Acquisition (Run Faster p. 178)
+ *
+ * Characters can spend Edge mid-session to pull a contact from their past.
+ * Cost = 2× desired Connection Rating in Edge points.
+ * The contact starts at Loyalty 1 and must be confirmed with Karma
+ * (Connection + Loyalty) after the mission to become permanent.
+ * Edge does not refresh until Karma is earned (next session).
+ *
+ * NOTE: This module is a standalone rules layer. The SocialContact type
+ * does not yet have a `pendingKarmaConfirmation` field or an "edge"
+ * acquisition method value. Those will be added when the integration
+ * layer wires these rules to the storage/API layer.
+ *
+ * @see /docs/capabilities/campaign.social-governance.md
+ */
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/** Edge cost multiplier: 2× desired Connection Rating */
+const EDGE_COST_MULTIPLIER = 2;
+
+/** Loyalty for newly acquired Edge contacts */
+const EDGE_CONTACT_INITIAL_LOYALTY = 1;
+
+/** Maximum Connection rating in SR5 */
+const MAX_CONNECTION = 12;
+
+/** Minimum Connection rating */
+const MIN_CONNECTION = 1;
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/** Validation result for I Know a Guy attempt */
+export interface IKnowAGuyValidation {
+  /** Whether the attempt is allowed */
+  allowed: boolean;
+  /** Edge cost if allowed */
+  edgeCost: number;
+  /** Reason if not allowed */
+  reason?: string;
+}
+
+/** Specification for creating an Edge-acquired contact */
+export interface EdgeContactSpec {
+  /** Contact name */
+  name: string;
+  /** Connection rating */
+  connection: number;
+  /** Loyalty (always 1 for Edge contacts) */
+  loyalty: 1;
+  /** Contact archetype */
+  archetype: string;
+  /** How the contact was acquired */
+  acquisitionMethod: "edge";
+  /** Whether Karma confirmation is still needed */
+  pendingKarmaConfirmation: true;
+  /** Optional description */
+  description?: string;
+}
+
+/** Validation result for Karma confirmation */
+export interface KarmaConfirmationCheck {
+  /** Whether confirmation is allowed */
+  allowed: boolean;
+  /** Karma cost to confirm */
+  karmaCost: number;
+  /** Reason if not allowed */
+  reason?: string;
+}
+
+// =============================================================================
+// EDGE COST
+// =============================================================================
+
+/**
+ * Calculate the Edge cost to acquire a contact via "I Know a Guy."
+ *
+ * Cost = 2 × desired Connection Rating.
+ *
+ * @param desiredConnection - The desired Connection rating for the new contact
+ * @returns Edge points required
+ */
+export function calculateEdgeCost(desiredConnection: number): number {
+  return desiredConnection * EDGE_COST_MULTIPLIER;
+}
+
+// =============================================================================
+// VALIDATION
+// =============================================================================
+
+/**
+ * Validate whether a character can use "I Know a Guy."
+ *
+ * Checks that the character has sufficient Edge and the desired
+ * Connection is within valid range (1-12).
+ *
+ * @param params.currentEdge - Character's current Edge points
+ * @param params.desiredConnection - Desired Connection for the new contact
+ * @returns Validation result with cost breakdown
+ */
+export function validateIKnowAGuy(params: {
+  currentEdge: number;
+  desiredConnection: number;
+}): IKnowAGuyValidation {
+  const { currentEdge, desiredConnection } = params;
+
+  if (desiredConnection < MIN_CONNECTION || desiredConnection > MAX_CONNECTION) {
+    return {
+      allowed: false,
+      edgeCost: 0,
+      reason: `Connection must be between ${MIN_CONNECTION} and ${MAX_CONNECTION}, got ${desiredConnection}`,
+    };
+  }
+
+  const edgeCost = calculateEdgeCost(desiredConnection);
+
+  if (currentEdge < edgeCost) {
+    return {
+      allowed: false,
+      edgeCost,
+      reason: `Insufficient Edge: need ${edgeCost}, have ${currentEdge}`,
+    };
+  }
+
+  return {
+    allowed: true,
+    edgeCost,
+  };
+}
+
+// =============================================================================
+// CONTACT SPEC CREATION
+// =============================================================================
+
+/**
+ * Create a specification for an Edge-acquired contact.
+ *
+ * The contact always starts at Loyalty 1 and is flagged as pending
+ * Karma confirmation. The caller is responsible for persisting this
+ * to storage.
+ *
+ * @param params.desiredConnection - Connection rating
+ * @param params.archetype - Contact archetype
+ * @param params.name - Contact name
+ * @param params.description - Optional description
+ * @returns Contact specification ready for creation
+ */
+export function createEdgeContactSpec(params: {
+  desiredConnection: number;
+  archetype: string;
+  name: string;
+  description?: string;
+}): EdgeContactSpec {
+  return {
+    name: params.name,
+    connection: params.desiredConnection,
+    loyalty: EDGE_CONTACT_INITIAL_LOYALTY,
+    archetype: params.archetype,
+    acquisitionMethod: "edge",
+    pendingKarmaConfirmation: true,
+    ...(params.description !== undefined ? { description: params.description } : {}),
+  };
+}
+
+// =============================================================================
+// KARMA CONFIRMATION
+// =============================================================================
+
+/**
+ * Calculate the Karma cost to permanently keep an Edge contact.
+ *
+ * Cost = Connection + Loyalty (Loyalty is always 1 for Edge contacts).
+ * Must be spent after the mission or the contact is lost.
+ *
+ * @param connectionRating - The contact's Connection rating
+ * @returns Karma cost
+ */
+export function calculateConfirmationKarmaCost(connectionRating: number): number {
+  return connectionRating + EDGE_CONTACT_INITIAL_LOYALTY;
+}
+
+/**
+ * Check whether a character can confirm an Edge contact with Karma.
+ *
+ * @param params.connectionRating - The contact's Connection rating
+ * @param params.currentKarma - Character's available Karma
+ * @returns Validation result with cost
+ */
+export function canConfirmEdgeContact(params: {
+  connectionRating: number;
+  currentKarma: number;
+}): KarmaConfirmationCheck {
+  const karmaCost = calculateConfirmationKarmaCost(params.connectionRating);
+
+  if (params.currentKarma < karmaCost) {
+    return {
+      allowed: false,
+      karmaCost,
+      reason: `Insufficient karma: need ${karmaCost}, have ${params.currentKarma}`,
+    };
+  }
+
+  return {
+    allowed: true,
+    karmaCost,
+  };
+}

--- a/lib/rules/index.ts
+++ b/lib/rules/index.ts
@@ -185,3 +185,15 @@ export {
   type IntimidationResult,
   type SocialMechanicResult,
 } from "./relationship-qualities";
+
+// "I Know a Guy" Edge contact acquisition (Run Faster) - Client-safe
+export {
+  calculateEdgeCost,
+  validateIKnowAGuy,
+  createEdgeContactSpec,
+  calculateConfirmationKarmaCost,
+  canConfirmEdgeContact,
+  type IKnowAGuyValidation,
+  type EdgeContactSpec,
+  type KarmaConfirmationCheck,
+} from "./i-know-a-guy";


### PR DESCRIPTION
## Summary

- New `lib/rules/i-know-a-guy.ts` module implementing Run Faster p. 178 mechanics
- Pure functions, no side effects, fully tested with 20 tests
- Exported from rules barrel

## Functions

| Function | Purpose |
|----------|---------|
| `calculateEdgeCost()` | Edge cost = 2× desired Connection Rating |
| `validateIKnowAGuy()` | Check sufficient Edge and Connection range (1-12) |
| `createEdgeContactSpec()` | Contact spec at Loyalty 1 with pending karma flag |
| `calculateConfirmationKarmaCost()` | Connection + 1 Karma to keep permanently |
| `canConfirmEdgeContact()` | Validate sufficient Karma for confirmation |

## Key Mechanics
- Edge cost = 2× Connection Rating
- Contact starts at Loyalty 1, flagged as pending Karma confirmation
- Karma cost to confirm = Connection + Loyalty (always 1)
- Integration note: `SocialContact` type extension deferred to wiring PR

## Test plan

- [x] 20 unit tests covering all functions with edge cases
- [x] TypeScript type-check passes
- [x] Pre-commit and pre-push hooks pass

Part of epic #534. Closes #773.