### PR TITLE
feat: add sinnerRequired to organization contacts + epic #534 verification suite (#784)

### DIFF
--- a/lib/rules/__tests__/epic-534-verification.test.ts
+++ b/lib/rules/__tests__/epic-534-verification.test.ts
@@ -274,11 +274,31 @@ describe("Verification: Organization Contacts", () => {
     expect(orgs).toHaveLength(5);
 
     const byId = Object.fromEntries(orgs.map((o) => [o.id, o]));
-    expect(byId["street-gang"]).toMatchObject({ connectionBonus: 1, karmaCost: 5 });
-    expect(byId["city-government"]).toMatchObject({ connectionBonus: 1, karmaCost: 3 });
-    expect(byId["humanis-policlub"]).toMatchObject({ connectionBonus: 2, karmaCost: 10 });
-    expect(byId["order-of-st-sylvester"]).toMatchObject({ connectionBonus: 2, karmaCost: 8 });
-    expect(byId["lone-star-god"]).toMatchObject({ connectionBonus: 3, karmaCost: 12 });
+    expect(byId["street-gang"]).toMatchObject({
+      connectionBonus: 1,
+      karmaCost: 5,
+      sinnerRequired: false,
+    });
+    expect(byId["city-government"]).toMatchObject({
+      connectionBonus: 1,
+      karmaCost: 3,
+      sinnerRequired: true,
+    });
+    expect(byId["humanis-policlub"]).toMatchObject({
+      connectionBonus: 2,
+      karmaCost: 10,
+      sinnerRequired: false,
+    });
+    expect(byId["order-of-st-sylvester"]).toMatchObject({
+      connectionBonus: 2,
+      karmaCost: 8,
+      sinnerRequired: true,
+    });
+    expect(byId["lone-star-god"]).toMatchObject({
+      connectionBonus: 3,
+      karmaCost: 12,
+      sinnerRequired: true,
+    });
   });
 });
 

--- a/lib/rules/__tests__/group-contacts.test.ts
+++ b/lib/rules/__tests__/group-contacts.test.ts
@@ -52,20 +52,34 @@ describe("getOrganizationDefinitions", () => {
     expect(orgs).toHaveLength(5);
   });
 
-  it("should include Street Gang with correct values", () => {
+  it("should include Street Gang with correct values (no SIN required)", () => {
     const orgs = getOrganizationDefinitions();
     const streetGang = orgs.find((o) => o.id === "street-gang");
     expect(streetGang).toBeDefined();
     expect(streetGang!.connectionBonus).toBe(1);
     expect(streetGang!.karmaCost).toBe(5);
+    expect(streetGang!.sinnerRequired).toBe(false);
   });
 
-  it("should include Lone Star/GOD with highest connection bonus", () => {
+  it("should include Lone Star/GOD with highest connection bonus (SIN required)", () => {
     const orgs = getOrganizationDefinitions();
     const loneStar = orgs.find((o) => o.id === "lone-star-god");
     expect(loneStar).toBeDefined();
     expect(loneStar!.connectionBonus).toBe(3);
     expect(loneStar!.karmaCost).toBe(12);
+    expect(loneStar!.sinnerRequired).toBe(true);
+  });
+
+  it("should have correct SINner requirements per Run Faster p. 177", () => {
+    const orgs = getOrganizationDefinitions();
+    const byId = Object.fromEntries(orgs.map((o) => [o.id, o]));
+
+    // N, Y, N, Y, Y per the sourcebook table
+    expect(byId["street-gang"].sinnerRequired).toBe(false);
+    expect(byId["city-government"].sinnerRequired).toBe(true);
+    expect(byId["humanis-policlub"].sinnerRequired).toBe(false);
+    expect(byId["order-of-st-sylvester"].sinnerRequired).toBe(true);
+    expect(byId["lone-star-god"].sinnerRequired).toBe(true);
   });
 });
 

--- a/lib/rules/group-contacts.ts
+++ b/lib/rules/group-contacts.ts
@@ -54,6 +54,11 @@ export interface OrganizationDefinition {
    * The wiring layer must enforce the quality budget cap.
    */
   karmaCost: number;
+  /**
+   * Whether the character must have a SIN (National or Corporate SINner
+   * quality) to use this organization as a contact (Run Faster p. 177).
+   */
+  sinnerRequired: boolean;
 }
 
 /** Validation result for an organization contact */
@@ -83,6 +88,7 @@ const ORGANIZATION_DEFINITIONS: readonly OrganizationDefinition[] = [
     description: "Local street-level criminal organization",
     connectionBonus: 1,
     karmaCost: 5,
+    sinnerRequired: false,
   },
   {
     id: "city-government",
@@ -90,6 +96,7 @@ const ORGANIZATION_DEFINITIONS: readonly OrganizationDefinition[] = [
     description: "Municipal government offices and bureaucracy",
     connectionBonus: 1,
     karmaCost: 3,
+    sinnerRequired: true,
   },
   {
     id: "humanis-policlub",
@@ -97,6 +104,7 @@ const ORGANIZATION_DEFINITIONS: readonly OrganizationDefinition[] = [
     description: "Anti-metahuman political organization",
     connectionBonus: 2,
     karmaCost: 10,
+    sinnerRequired: false,
   },
   {
     id: "order-of-st-sylvester",
@@ -104,6 +112,7 @@ const ORGANIZATION_DEFINITIONS: readonly OrganizationDefinition[] = [
     description: "Catholic religious order with magical connections",
     connectionBonus: 2,
     karmaCost: 8,
+    sinnerRequired: true,
   },
   {
     id: "lone-star-god",
@@ -111,6 +120,7 @@ const ORGANIZATION_DEFINITIONS: readonly OrganizationDefinition[] = [
     description: "Law enforcement and Grid Overwatch Division",
     connectionBonus: 3,
     karmaCost: 12,
+    sinnerRequired: true,
   },
 ];
 


### PR DESCRIPTION
## Summary

Two changes from sourcebook verification (#784):

### 1. Gap 1 Fix: SINner Quality Required

Added `sinnerRequired: boolean` field to `OrganizationDefinition` per Run Faster p. 177:

| Organization | SINner Required? |
|-------------|-----------------|
| Street Gang | N |
| City Government | **Y** |
| Humanis Policlub | N |
| Order of St. Sylvester | **Y** |
| Lone Star/GOD | **Y** |

### 2. Epic #534 Verification Suite

29 cross-reference tests validating all 7 contact modules against the sourcebook extraction. Now includes `sinnerRequired` assertions.

## Files Changed
- `lib/rules/group-contacts.ts` — Added `sinnerRequired` field + data
- `lib/rules/__tests__/group-contacts.test.ts` — SINner requirement tests (20 tests)
- `lib/rules/__tests__/epic-534-verification.test.ts` — New verification suite (29 tests)

## Test plan
- [x] 49 tests pass (20 group-contacts + 29 verification)
- [x] TypeScript type-check passes
- [x] Pre-commit and pre-push hooks pass

Addresses #784.