### PR TITLE
feat: extend SocialContact type with relationship qualities and loyalty improvement block

### DIFF
--- a/lib/rules/__tests__/contacts.test.ts
+++ b/lib/rules/__tests__/contacts.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for contact rules and validation (lib/rules/contacts.ts)
+ *
+ * Covers:
+ * - validateContact() basic validation
+ * - validateContact() organization contact integration
+ * - Loyalty improvement blocked checks
+ * - validateContactAgainstCampaign()
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateContact,
+  validateContactAgainstCampaign,
+  isLoyaltyImprovementAllowed,
+  getMaxConnection,
+  getMaxLoyalty,
+} from "../contacts";
+import type { SocialContact, SocialCapital, CreateContactRequest } from "@/lib/types/contacts";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function createMockContact(overrides: Partial<SocialContact> = {}): SocialContact {
+  return {
+    id: "contact-1",
+    name: "Mr. Johnson",
+    connection: 3,
+    loyalty: 2,
+    archetype: "Fixer",
+    status: "active",
+    favorBalance: 0,
+    group: "personal",
+    visibility: {
+      playerVisible: true,
+      showConnection: true,
+      showLoyalty: true,
+      showFavorBalance: true,
+      showSpecializations: true,
+    },
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createMockSocialCapital(overrides: Partial<SocialCapital> = {}): SocialCapital {
+  return {
+    characterId: "test-char",
+    maxContactPoints: 20,
+    usedContactPoints: 5,
+    availableContactPoints: 15,
+    totalContacts: 3,
+    activeContacts: 2,
+    burnedContacts: 0,
+    inactiveContacts: 1,
+    networkingBonus: 0,
+    socialLimitModifier: 0,
+    loyaltyBonus: 0,
+    updatedAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// BASIC VALIDATION
+// =============================================================================
+
+describe("validateContact", () => {
+  it("should validate a valid contact", () => {
+    const result = validateContact(
+      { name: "Fixer", connection: 3, loyalty: 2, archetype: "Fixer" },
+      "sr5"
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should reject missing name", () => {
+    const result = validateContact(
+      { name: "", connection: 3, loyalty: 2, archetype: "Fixer" },
+      "sr5"
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Contact name is required");
+  });
+
+  it("should reject connection above max for edition", () => {
+    const result = validateContact(
+      { name: "Test", connection: 13, loyalty: 2, archetype: "Fixer" },
+      "sr5"
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/cannot exceed 12/);
+  });
+
+  it("should reject loyalty above max for edition", () => {
+    const result = validateContact(
+      { name: "Test", connection: 3, loyalty: 7, archetype: "Fixer" },
+      "sr5"
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/cannot exceed 6/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Organization contact integration
+  // ---------------------------------------------------------------------------
+
+  describe("organization contact validation", () => {
+    it("should add organization errors when group is 'organization' and loyalty > 1", () => {
+      const result = validateContact(
+        {
+          name: "Street Gang",
+          connection: 3,
+          loyalty: 3,
+          archetype: "Organization",
+          group: "organization",
+        } as Partial<SocialContact>,
+        "sr5"
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.toLowerCase().includes("loyalty"))).toBe(true);
+    });
+
+    it("should pass organization validation when loyalty is 1", () => {
+      const result = validateContact(
+        {
+          name: "Street Gang",
+          connection: 3,
+          loyalty: 1,
+          archetype: "Organization",
+          group: "organization",
+        } as Partial<SocialContact>,
+        "sr5"
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it("should not run organization checks for personal contacts", () => {
+      const result = validateContact(
+        {
+          name: "Mr. Johnson",
+          connection: 3,
+          loyalty: 4,
+          archetype: "Fixer",
+          group: "personal",
+        } as Partial<SocialContact>,
+        "sr5"
+      );
+      expect(result.valid).toBe(true);
+    });
+  });
+});
+
+// =============================================================================
+// LOYALTY IMPROVEMENT BLOCKED
+// =============================================================================
+
+describe("isLoyaltyImprovementAllowed", () => {
+  it("should allow loyalty improvement for normal contacts", () => {
+    const contact = createMockContact({ loyaltyImprovementBlocked: false });
+    expect(isLoyaltyImprovementAllowed(contact)).toBe(true);
+  });
+
+  it("should block loyalty improvement when loyaltyImprovementBlocked is true", () => {
+    const contact = createMockContact({ loyaltyImprovementBlocked: true });
+    expect(isLoyaltyImprovementAllowed(contact)).toBe(false);
+  });
+
+  it("should allow loyalty improvement when field is undefined (default)", () => {
+    const contact = createMockContact();
+    // Field not set — should default to allowed
+    expect(isLoyaltyImprovementAllowed(contact)).toBe(true);
+  });
+});
+
+// =============================================================================
+// CAMPAIGN VALIDATION
+// =============================================================================
+
+describe("validateContactAgainstCampaign", () => {
+  it("should reject when campaign contact limit reached", () => {
+    const socialCapital = createMockSocialCapital({
+      campaignContactLimit: 5,
+      activeContacts: 5,
+    });
+    const result = validateContactAgainstCampaign(
+      { connection: 3, loyalty: 2, name: "Test", archetype: "Fixer" },
+      socialCapital
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/contact limit/);
+  });
+
+  it("should reject when connection exceeds campaign max", () => {
+    const socialCapital = createMockSocialCapital({
+      campaignMaxConnection: 6,
+    });
+    const result = validateContactAgainstCampaign(
+      { connection: 8, loyalty: 2, name: "Test", archetype: "Fixer" },
+      socialCapital
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/exceeds campaign limit/);
+  });
+});

--- a/lib/rules/contacts.ts
+++ b/lib/rules/contacts.ts
@@ -19,6 +19,7 @@ import type {
   CreateContactRequest,
   SocialCapital,
 } from "../types/contacts";
+import { validateOrganizationContact } from "./group-contacts";
 
 // =============================================================================
 // EDITION-SPECIFIC LIMITS
@@ -146,12 +147,23 @@ export function validateContact(
     }
   }
 
+  // Organization contact validation (Run Faster p. 179)
+  const contactWithGroup = contact as Partial<SocialContact>;
+  if (contactWithGroup.group === "organization") {
+    const orgResult = validateOrganizationContact(contactWithGroup as SocialContact);
+    if (!orgResult.valid) {
+      for (const err of orgResult.errors) {
+        errors.push(err.message);
+      }
+    }
+  }
+
   // Warnings for edge cases
   if (contact.connection === 1 && contact.loyalty === 1) {
     warnings.push("Very low connection and loyalty - contact may not be useful");
   }
 
-  if (contact.loyalty === 1) {
+  if (contact.loyalty === 1 && contactWithGroup.group !== "organization") {
     warnings.push("Loyalty 1 contacts may betray you for minimal gain");
   }
 
@@ -576,4 +588,21 @@ export function resolveSharedContact(
     effectiveLoyalty: 1,
     favorCostMultiplier: 2,
   };
+}
+
+// =============================================================================
+// LOYALTY IMPROVEMENT CHECKS
+// =============================================================================
+
+/**
+ * Check whether a contact's loyalty can be improved
+ *
+ * Returns false when loyaltyImprovementBlocked is set (e.g., after using
+ * Intimidation on a Blackmail relationship — Run Faster p. 177).
+ *
+ * @param contact - Contact to check
+ * @returns Whether loyalty improvement is allowed
+ */
+export function isLoyaltyImprovementAllowed(contact: SocialContact): boolean {
+  return !contact.loyaltyImprovementBlocked;
 }

--- a/lib/rules/group-contacts.ts
+++ b/lib/rules/group-contacts.ts
@@ -8,9 +8,9 @@
  * - Contractual obligations; leaves a data trail
  * - Karma cost counts against positive quality limit
  *
- * NOTE: This module is a standalone rules layer. Integration with the
- * existing contact validation pipeline (`lib/rules/contacts.ts`) and
- * favor system (`lib/rules/favors.ts`) will be done in a wiring PR.
+ * Integration: `validateContact()` in `lib/rules/contacts.ts` now calls
+ * `validateOrganizationContact()` for contacts with `group: "organization"`.
+ * The favor system integration will be done in a follow-up PR.
  *
  * @see /docs/capabilities/campaign.social-governance.md
  */

--- a/lib/rules/i-know-a-guy.ts
+++ b/lib/rules/i-know-a-guy.ts
@@ -7,10 +7,9 @@
  * (Connection + Loyalty) after the mission to become permanent.
  * Edge does not refresh until Karma is earned (next session).
  *
- * NOTE: This module is a standalone rules layer. The SocialContact type
- * does not yet have a `pendingKarmaConfirmation` field or an "edge"
- * acquisition method value. Those will be added when the integration
- * layer wires these rules to the storage/API layer.
+ * Integration: SocialContact now has `pendingKarmaConfirmation` field and
+ * `"edge"` acquisition method. Use `updateCharacterContact()` from the
+ * storage layer to set these fields when creating Edge-acquired contacts.
  *
  * @see /docs/capabilities/campaign.social-governance.md
  */

--- a/lib/rules/relationship-qualities.ts
+++ b/lib/rules/relationship-qualities.ts
@@ -10,12 +10,11 @@
  * Family (+1 Karma): +1 Loyalty for tests, −1 chip to improve loyalty,
  * but −1 Loyalty for actual job performance (they worry about you).
  *
- * NOTE: This module is a standalone rules layer. The SocialContact type does
- * not yet have `relationshipQualities` or `loyaltyImprovementBlocked` fields.
- * Those will be added when the integration layer wires these rules to the
- * storage/API layer. Callers must manage persistence of returned flags
- * (e.g., IntimidationResult.loyaltyImprovementBlocked) in their own state
- * until the type extension lands.
+ * Integration: SocialContact now has `relationshipQualities` and
+ * `loyaltyImprovementBlocked` fields. Use `updateRelationshipQualities()`
+ * and `markLoyaltyBlocked()` from the storage layer to persist state.
+ * The validation pipeline checks `loyaltyImprovementBlocked` via
+ * `isLoyaltyImprovementAllowed()` in `lib/rules/contacts.ts`.
  *
  * @see /docs/capabilities/campaign.social-governance.md
  */

--- a/lib/storage/__tests__/contacts-integration.test.ts
+++ b/lib/storage/__tests__/contacts-integration.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Integration tests for new SocialContact fields persistence
+ *
+ * Verifies that relationshipQualities, loyaltyImprovementBlocked, and
+ * pendingKarmaConfirmation fields round-trip through storage correctly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Character } from "@/lib/types";
+import type { SocialContact } from "@/lib/types/contacts";
+import type { RelationshipQuality } from "@/lib/rules/relationship-qualities";
+
+// Mock the base storage module
+vi.mock("../base", () => {
+  const storage = new Map<string, unknown>();
+  return {
+    ensureDirectory: vi.fn().mockResolvedValue(undefined),
+    readJsonFile: vi
+      .fn()
+      .mockImplementation((path: string) => Promise.resolve(storage.get(path) || null)),
+    writeJsonFile: vi.fn().mockImplementation((path: string, data: unknown) => {
+      storage.set(path, data);
+      return Promise.resolve();
+    }),
+    deleteFile: vi.fn().mockImplementation((path: string) => {
+      const existed = storage.has(path);
+      storage.delete(path);
+      return Promise.resolve(existed);
+    }),
+    readAllJsonFiles: vi.fn().mockResolvedValue([]),
+    __storage: storage,
+    __clearStorage: () => storage.clear(),
+  };
+});
+
+// Mock the characters storage module
+vi.mock("../characters", () => ({
+  getCharacter: vi.fn(),
+  updateCharacter: vi.fn(),
+}));
+
+// Import after mocking
+import {
+  updateCharacterContact,
+  updateRelationshipQualities,
+  markLoyaltyBlocked,
+  getCharacterContact,
+  getCharacterContacts,
+} from "../contacts";
+import * as charactersStorage from "../characters";
+
+// =============================================================================
+// FIXTURES
+// =============================================================================
+
+const TEST_USER_ID = "test-user";
+const TEST_CHARACTER_ID = "test-character";
+
+function createMockContact(overrides: Partial<SocialContact> = {}): SocialContact {
+  return {
+    id: "contact-1",
+    characterId: TEST_CHARACTER_ID,
+    name: "Mr. Johnson",
+    connection: 3,
+    loyalty: 2,
+    archetype: "Fixer",
+    status: "active",
+    favorBalance: 0,
+    group: "personal",
+    visibility: {
+      playerVisible: true,
+      showConnection: true,
+      showLoyalty: true,
+      showFavorBalance: true,
+      showSpecializations: true,
+    },
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createMockCharacter(contacts: SocialContact[] = []): Partial<Character> {
+  return {
+    id: TEST_CHARACTER_ID,
+    ownerId: TEST_USER_ID,
+    contacts: contacts as Character["contacts"],
+  };
+}
+
+// =============================================================================
+// RELATIONSHIP QUALITIES PERSISTENCE
+// =============================================================================
+
+describe("updateRelationshipQualities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should persist relationship qualities on a contact", async () => {
+    const contact = createMockContact();
+    const character = createMockCharacter([contact]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+    vi.mocked(charactersStorage.updateCharacter).mockResolvedValue({} as Character);
+
+    const qualities: RelationshipQuality[] = ["blackmail"];
+    const result = await updateRelationshipQualities(
+      TEST_USER_ID,
+      TEST_CHARACTER_ID,
+      "contact-1",
+      qualities
+    );
+
+    expect(result.relationshipQualities).toEqual(["blackmail"]);
+    expect(charactersStorage.updateCharacter).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      TEST_CHARACTER_ID,
+      expect.objectContaining({
+        contacts: expect.arrayContaining([
+          expect.objectContaining({
+            id: "contact-1",
+            relationshipQualities: ["blackmail"],
+          }),
+        ]),
+      })
+    );
+  });
+
+  it("should replace existing relationship qualities", async () => {
+    const contact = createMockContact({
+      relationshipQualities: ["blackmail"],
+    });
+    const character = createMockCharacter([contact]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+    vi.mocked(charactersStorage.updateCharacter).mockResolvedValue({} as Character);
+
+    const result = await updateRelationshipQualities(TEST_USER_ID, TEST_CHARACTER_ID, "contact-1", [
+      "family",
+    ]);
+
+    expect(result.relationshipQualities).toEqual(["family"]);
+  });
+
+  it("should throw when contact not found", async () => {
+    const character = createMockCharacter([]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+
+    await expect(
+      updateRelationshipQualities(TEST_USER_ID, TEST_CHARACTER_ID, "nonexistent", ["blackmail"])
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+// =============================================================================
+// LOYALTY BLOCKED PERSISTENCE
+// =============================================================================
+
+describe("markLoyaltyBlocked", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should set loyaltyImprovementBlocked to true", async () => {
+    const contact = createMockContact();
+    const character = createMockCharacter([contact]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+    vi.mocked(charactersStorage.updateCharacter).mockResolvedValue({} as Character);
+
+    const result = await markLoyaltyBlocked(TEST_USER_ID, TEST_CHARACTER_ID, "contact-1", true);
+
+    expect(result.loyaltyImprovementBlocked).toBe(true);
+  });
+
+  it("should unblock loyalty improvement", async () => {
+    const contact = createMockContact({ loyaltyImprovementBlocked: true });
+    const character = createMockCharacter([contact]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+    vi.mocked(charactersStorage.updateCharacter).mockResolvedValue({} as Character);
+
+    const result = await markLoyaltyBlocked(TEST_USER_ID, TEST_CHARACTER_ID, "contact-1", false);
+
+    expect(result.loyaltyImprovementBlocked).toBe(false);
+  });
+
+  it("should throw when contact not found", async () => {
+    const character = createMockCharacter([]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+
+    await expect(
+      markLoyaltyBlocked(TEST_USER_ID, TEST_CHARACTER_ID, "nonexistent", true)
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+// =============================================================================
+// ROUND-TRIP: NEW FIELDS PERSIST THROUGH updateCharacterContact
+// =============================================================================
+
+describe("new fields round-trip through updateCharacterContact", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should persist relationshipQualities via generic update", async () => {
+    const contact = createMockContact();
+    const character = createMockCharacter([contact]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+    vi.mocked(charactersStorage.updateCharacter).mockResolvedValue({} as Character);
+
+    const result = await updateCharacterContact(TEST_USER_ID, TEST_CHARACTER_ID, "contact-1", {
+      relationshipQualities: ["family"],
+    });
+
+    expect(result.relationshipQualities).toEqual(["family"]);
+  });
+
+  it("should persist loyaltyImprovementBlocked via generic update", async () => {
+    const contact = createMockContact();
+    const character = createMockCharacter([contact]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+    vi.mocked(charactersStorage.updateCharacter).mockResolvedValue({} as Character);
+
+    const result = await updateCharacterContact(TEST_USER_ID, TEST_CHARACTER_ID, "contact-1", {
+      loyaltyImprovementBlocked: true,
+    });
+
+    expect(result.loyaltyImprovementBlocked).toBe(true);
+  });
+
+  it("should persist pendingKarmaConfirmation via generic update", async () => {
+    const contact = createMockContact();
+    const character = createMockCharacter([contact]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+    vi.mocked(charactersStorage.updateCharacter).mockResolvedValue({} as Character);
+
+    const result = await updateCharacterContact(TEST_USER_ID, TEST_CHARACTER_ID, "contact-1", {
+      pendingKarmaConfirmation: true,
+    });
+
+    expect(result.pendingKarmaConfirmation).toBe(true);
+  });
+
+  it("should persist acquisitionMethod 'edge' via generic update", async () => {
+    const contact = createMockContact();
+    const character = createMockCharacter([contact]);
+    vi.mocked(charactersStorage.getCharacter).mockResolvedValue(character as unknown as Character);
+    vi.mocked(charactersStorage.updateCharacter).mockResolvedValue({} as Character);
+
+    const result = await updateCharacterContact(TEST_USER_ID, TEST_CHARACTER_ID, "contact-1", {
+      acquisitionMethod: "edge",
+    });
+
+    expect(result.acquisitionMethod).toBe("edge");
+  });
+});

--- a/lib/storage/contacts.ts
+++ b/lib/storage/contacts.ts
@@ -473,6 +473,53 @@ export async function updateContactFavorBalance(
 }
 
 // =============================================================================
+// RUN FASTER FIELD HELPERS
+// =============================================================================
+
+/**
+ * Update relationship qualities on a contact
+ *
+ * @param userId - Character owner ID
+ * @param characterId - Character ID
+ * @param contactId - Contact ID
+ * @param qualities - New relationship qualities array
+ * @returns Updated contact
+ */
+export async function updateRelationshipQualities(
+  userId: ID,
+  characterId: ID,
+  contactId: ID,
+  qualities: import("../rules/relationship-qualities").RelationshipQuality[]
+): Promise<SocialContact> {
+  return updateCharacterContact(userId, characterId, contactId, {
+    relationshipQualities: qualities,
+  });
+}
+
+/**
+ * Mark whether a contact's loyalty improvement is blocked
+ *
+ * Typically set after using Intimidation on a Blackmail relationship
+ * (Run Faster p. 177).
+ *
+ * @param userId - Character owner ID
+ * @param characterId - Character ID
+ * @param contactId - Contact ID
+ * @param blocked - Whether loyalty improvement is blocked
+ * @returns Updated contact
+ */
+export async function markLoyaltyBlocked(
+  userId: ID,
+  characterId: ID,
+  contactId: ID,
+  blocked: boolean
+): Promise<SocialContact> {
+  return updateCharacterContact(userId, characterId, contactId, {
+    loyaltyImprovementBlocked: blocked,
+  });
+}
+
+// =============================================================================
 // CAMPAIGN CONTACT OPERATIONS
 // =============================================================================
 

--- a/lib/types/contacts.ts
+++ b/lib/types/contacts.ts
@@ -9,6 +9,7 @@
 
 import type { ID, ISODateString, Metadata } from "./core";
 import type { EditionCode } from "./edition";
+import type { RelationshipQuality } from "../rules/relationship-qualities";
 
 // =============================================================================
 // CONTACT CORE TYPES
@@ -203,10 +204,23 @@ export interface SocialContact {
   lastContactedAt?: ISODateString;
 
   /** How the contact was acquired */
-  acquisitionMethod?: "creation" | "networking" | "introduction" | "event" | "karma";
+  acquisitionMethod?: "creation" | "networking" | "introduction" | "event" | "karma" | "edge";
 
   /** Session ID when contact was acquired (if in campaign) */
   acquisitionSessionId?: ID;
+
+  // ---------------------------------------------------------------------------
+  // Run Faster Extensions (pp. 177-178)
+  // ---------------------------------------------------------------------------
+
+  /** Relationship qualities (Run Faster pp. 177-178) */
+  relationshipQualities?: RelationshipQuality[];
+
+  /** Whether loyalty improvement is permanently blocked (via Intimidation) */
+  loyaltyImprovementBlocked?: boolean;
+
+  /** Whether this contact is pending Karma confirmation (I Know a Guy) */
+  pendingKarmaConfirmation?: boolean;
 
   createdAt: ISODateString;
   updatedAt?: ISODateString;
@@ -788,6 +802,11 @@ export interface UpdateContactRequest {
   status?: ContactStatus;
   favorBalance?: number;
   lastContactedAt?: ISODateString;
+  // Run Faster extensions (pp. 177-178)
+  relationshipQualities?: RelationshipQuality[];
+  loyaltyImprovementBlocked?: boolean;
+  pendingKarmaConfirmation?: boolean;
+  acquisitionMethod?: SocialContact["acquisitionMethod"];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `relationshipQualities`, `loyaltyImprovementBlocked`, `pendingKarmaConfirmation` fields to `SocialContact` type and `UpdateContactRequest`
- Add `"edge"` to `acquisitionMethod` union for I Know a Guy contacts
- Add `updateRelationshipQualities()` and `markLoyaltyBlocked()` storage helpers
- Integrate `validateOrganizationContact()` into `validateContact()` for organization contacts
- Add `isLoyaltyImprovementAllowed()` check to rules layer
- Update standalone module notes (relationship-qualities, i-know-a-guy, group-contacts) to reflect integration status

## Test plan
- [x] 12 new unit tests for validation (org contact integration, loyalty blocked check, basic validation)
- [x] 10 new integration tests for storage round-trip (relationship qualities, loyalty blocked, pending karma, edge acquisition method)
- [x] All 10,050 existing tests pass (zero regressions)
- [x] TypeScript type-check passes
- [x] Lint passes

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)