### PR TITLE
feat: support non-human metatype attribute distribution in contact NPC builder (#790)

### DIFF
--- a/lib/rules/__tests__/contact-npc.test.ts
+++ b/lib/rules/__tests__/contact-npc.test.ts
@@ -10,8 +10,10 @@ import {
   getNpcBuildTable,
   getNpcBuildEntry,
   generateContactStatBlock,
+  getMetatypeBaseAttributes,
   type NpcBuildEntry,
   type ContactStatBlock,
+  type NpcMetatype,
 } from "../contact-npc";
 
 // =============================================================================
@@ -125,5 +127,135 @@ describe("generateContactStatBlock", () => {
   it("should throw for non-integer Connection rating", () => {
     expect(() => generateContactStatBlock(2.5)).toThrow("Connection rating");
     expect(() => generateContactStatBlock(NaN)).toThrow("Connection rating");
+  });
+
+  it("should default to human metatype", () => {
+    const block = generateContactStatBlock(4);
+    expect(block.metatype).toBe("human");
+  });
+
+  it("should include metatype in stat block", () => {
+    const block = generateContactStatBlock(4, "ork");
+    expect(block.metatype).toBe("ork");
+  });
+});
+
+// =============================================================================
+// METATYPE BASE ATTRIBUTES
+// =============================================================================
+
+describe("getMetatypeBaseAttributes", () => {
+  it("returns human average attributes (all 3s)", () => {
+    const attrs = getMetatypeBaseAttributes("human");
+    expect(attrs.body).toBe(3);
+    expect(attrs.agility).toBe(3);
+    expect(attrs.reaction).toBe(3);
+    expect(attrs.strength).toBe(3);
+    expect(attrs.charisma).toBe(3);
+    expect(attrs.intuition).toBe(3);
+    expect(attrs.logic).toBe(3);
+    expect(attrs.willpower).toBe(3);
+  });
+
+  it("returns elf racial minimums (AGI 2, CHA 3, rest 1)", () => {
+    const attrs = getMetatypeBaseAttributes("elf");
+    expect(attrs.agility).toBe(2);
+    expect(attrs.charisma).toBe(3);
+    expect(attrs.body).toBe(1);
+    expect(attrs.strength).toBe(1);
+  });
+
+  it("returns dwarf racial minimums (BOD 3, STR 3, WIL 2)", () => {
+    const attrs = getMetatypeBaseAttributes("dwarf");
+    expect(attrs.body).toBe(3);
+    expect(attrs.strength).toBe(3);
+    expect(attrs.willpower).toBe(2);
+    expect(attrs.agility).toBe(1);
+  });
+
+  it("returns ork racial minimums (BOD 4, STR 3)", () => {
+    const attrs = getMetatypeBaseAttributes("ork");
+    expect(attrs.body).toBe(4);
+    expect(attrs.strength).toBe(3);
+    expect(attrs.agility).toBe(1);
+    expect(attrs.charisma).toBe(1);
+  });
+
+  it("returns troll racial minimums (BOD 5, STR 5)", () => {
+    const attrs = getMetatypeBaseAttributes("troll");
+    expect(attrs.body).toBe(5);
+    expect(attrs.strength).toBe(5);
+    expect(attrs.agility).toBe(1);
+    expect(attrs.charisma).toBe(1);
+  });
+
+  it("returns a copy (not a reference)", () => {
+    const attrs1 = getMetatypeBaseAttributes("human");
+    const attrs2 = getMetatypeBaseAttributes("human");
+    attrs1.body = 99;
+    expect(attrs2.body).toBe(3);
+  });
+
+  it("throws for unknown metatype", () => {
+    expect(() => getMetatypeBaseAttributes("gnome" as NpcMetatype)).toThrow("Unknown metatype");
+  });
+});
+
+// =============================================================================
+// METATYPE STAT BLOCK GENERATION
+// =============================================================================
+
+describe("generateContactStatBlock — metatype support", () => {
+  it("generates ork stat block with correct base attributes and derived stats", () => {
+    const block = generateContactStatBlock(4, "ork");
+
+    expect(block.baseAttributes.body).toBe(4);
+    expect(block.baseAttributes.strength).toBe(3);
+    expect(block.baseAttributes.agility).toBe(1);
+
+    // Derived: initiative = REA(1) + INT(1) = 2
+    expect(block.derived.initiative).toBe(2);
+    // Physical CM: ceil(4/2) + 8 = 10
+    expect(block.derived.physicalConditionMonitor).toBe(10);
+    // Stun CM: ceil(1/2) + 8 = 9
+    expect(block.derived.stunConditionMonitor).toBe(9);
+  });
+
+  it("generates troll stat block with higher body-based derived stats", () => {
+    const block = generateContactStatBlock(6, "troll");
+
+    expect(block.baseAttributes.body).toBe(5);
+    expect(block.baseAttributes.strength).toBe(5);
+    // Physical CM: ceil(5/2) + 8 = 11
+    expect(block.derived.physicalConditionMonitor).toBe(11);
+  });
+
+  it("generates elf stat block with higher charisma-based derived stats", () => {
+    const block = generateContactStatBlock(3, "elf");
+
+    expect(block.baseAttributes.charisma).toBe(3);
+    expect(block.baseAttributes.agility).toBe(2);
+    // Composure: CHA(3) + WIL(1) = 4
+    expect(block.derived.composure).toBe(4);
+    // Judge Intentions: CHA(3) + INT(1) = 4
+    expect(block.derived.judgeIntentions).toBe(4);
+  });
+
+  it("generates dwarf stat block with willpower-based derived stats", () => {
+    const block = generateContactStatBlock(3, "dwarf");
+
+    expect(block.baseAttributes.willpower).toBe(2);
+    // Stun CM: ceil(2/2) + 8 = 9
+    expect(block.derived.stunConditionMonitor).toBe(9);
+  });
+
+  it("preserves build points regardless of metatype", () => {
+    const human = generateContactStatBlock(6, "human");
+    const troll = generateContactStatBlock(6, "troll");
+
+    expect(human.bonusAttributePoints).toBe(troll.bonusAttributePoints);
+    expect(human.totalSkillPoints).toBe(troll.totalSkillPoints);
+    expect(human.specialAttributePoints).toBe(troll.specialAttributePoints);
+    expect(human.nuyen).toBe(troll.nuyen);
   });
 });

--- a/lib/rules/contact-npc.ts
+++ b/lib/rules/contact-npc.ts
@@ -57,27 +57,113 @@ export interface NpcDerivedStats {
   stunConditionMonitor: number;
 }
 
+/** Supported metatypes for NPC generation */
+export type NpcMetatype = "human" | "elf" | "dwarf" | "ork" | "troll";
+
 /** Generated stat block for a contact NPC */
 export interface ContactStatBlock {
   /** Connection rating used to generate this block */
   connectionRating: number;
+  /** Metatype used for base attributes */
+  metatype: NpcMetatype;
   /** Build points from the table */
   bonusAttributePoints: number;
   totalSkillPoints: number;
   specialAttributePoints: number;
   nuyen: number;
-  /** Base metatype attributes (human average) */
+  /** Base metatype attributes */
   baseAttributes: NpcBaseAttributes;
   /** Derived combat/social stats */
   derived: NpcDerivedStats;
 }
 
 // =============================================================================
-// CONSTANTS
+// METATYPE BASE ATTRIBUTES (SR5 CRB attribute minimums)
 // =============================================================================
 
-/** Human average attribute value (SR5 base for all physical/mental attributes) */
-const HUMAN_BASE_ATTRIBUTE = 3;
+/**
+ * Racial attribute minimums by metatype (SR5 Core Rulebook Table).
+ *
+ * Run Faster p. 180: "Distribute 18 points among the attributes,
+ * starting with the minimum for the contact's metatype."
+ *
+ * For human contacts, we use 3 (average) rather than the racial min of 1,
+ * since the Run Faster quickstats sidebar treats human NPCs as having
+ * balanced attributes. Non-human metatypes use their racial minimums.
+ */
+const METATYPE_BASE_ATTRIBUTES: Readonly<Record<NpcMetatype, NpcBaseAttributes>> = {
+  human: {
+    body: 3,
+    agility: 3,
+    reaction: 3,
+    strength: 3,
+    charisma: 3,
+    intuition: 3,
+    logic: 3,
+    willpower: 3,
+  },
+  elf: {
+    body: 1,
+    agility: 2,
+    reaction: 1,
+    strength: 1,
+    charisma: 3,
+    intuition: 1,
+    logic: 1,
+    willpower: 1,
+  },
+  dwarf: {
+    body: 3,
+    agility: 1,
+    reaction: 1,
+    strength: 3,
+    charisma: 1,
+    intuition: 1,
+    logic: 1,
+    willpower: 2,
+  },
+  ork: {
+    body: 4,
+    agility: 1,
+    reaction: 1,
+    strength: 3,
+    charisma: 1,
+    intuition: 1,
+    logic: 1,
+    willpower: 1,
+  },
+  troll: {
+    body: 5,
+    agility: 1,
+    reaction: 1,
+    strength: 5,
+    charisma: 1,
+    intuition: 1,
+    logic: 1,
+    willpower: 1,
+  },
+};
+
+/**
+ * Get base attributes for NPC stat block generation.
+ *
+ * For human contacts, returns the "average" value of 3 (per Run Faster
+ * quickstats sidebar), not the racial minimum of 1. Non-human metatypes
+ * return their SR5 CRB racial attribute minimums.
+ *
+ * Do NOT use this for character validation — use edition metatype data instead.
+ *
+ * @param metatype - Metatype identifier
+ * @returns Base attributes for NPC generation
+ * @throws Error if metatype is not recognized
+ */
+export function getMetatypeBaseAttributes(metatype: NpcMetatype): NpcBaseAttributes {
+  const attrs = METATYPE_BASE_ATTRIBUTES[metatype];
+  if (!attrs) {
+    throw new Error(`Unknown metatype: ${metatype}`);
+  }
+  return { ...attrs };
+}
 
 // =============================================================================
 // NPC BUILD TABLE DATA (Run Faster p. 180)
@@ -201,16 +287,19 @@ export function getNpcBuildEntry(connectionRating: number): NpcBuildEntry | unde
 /**
  * Generate a base stat block for a contact NPC from their Connection rating.
  *
- * Uses human average attributes (3 for all physical/mental) as the base,
- * with bonus attribute points and derived stats calculated from the table.
- * The caller is responsible for distributing bonus attribute points and
- * skill points based on the contact's archetype.
+ * Uses metatype-specific base attributes (racial minimums for non-humans,
+ * average of 3 for humans). The caller is responsible for distributing
+ * bonus attribute points and skill points based on the contact's archetype.
  *
  * @param connectionRating - Connection rating (integer 1-12)
+ * @param metatype - Contact metatype (defaults to "human")
  * @returns Generated stat block
  * @throws Error if connectionRating is invalid
  */
-export function generateContactStatBlock(connectionRating: number): ContactStatBlock {
+export function generateContactStatBlock(
+  connectionRating: number,
+  metatype: NpcMetatype = "human"
+): ContactStatBlock {
   const entry = getNpcBuildEntry(connectionRating);
 
   if (!entry) {
@@ -219,32 +308,37 @@ export function generateContactStatBlock(connectionRating: number): ContactStatB
     );
   }
 
-  const baseAttributes: NpcBaseAttributes = {
-    body: HUMAN_BASE_ATTRIBUTE,
-    agility: HUMAN_BASE_ATTRIBUTE,
-    reaction: HUMAN_BASE_ATTRIBUTE,
-    strength: HUMAN_BASE_ATTRIBUTE,
-    charisma: HUMAN_BASE_ATTRIBUTE,
-    intuition: HUMAN_BASE_ATTRIBUTE,
-    logic: HUMAN_BASE_ATTRIBUTE,
-    willpower: HUMAN_BASE_ATTRIBUTE,
-  };
+  const baseAttributes = getMetatypeBaseAttributes(metatype);
 
-  const derived: NpcDerivedStats = {
-    initiative: baseAttributes.reaction + baseAttributes.intuition,
-    composure: baseAttributes.charisma + baseAttributes.willpower,
-    judgeIntentions: baseAttributes.charisma + baseAttributes.intuition,
-    physicalConditionMonitor: Math.ceil(baseAttributes.body / 2) + 8,
-    stunConditionMonitor: Math.ceil(baseAttributes.willpower / 2) + 8,
-  };
+  const derived = calculateDerivedStats(baseAttributes);
 
   return {
     connectionRating: entry.connectionRating,
+    metatype,
     bonusAttributePoints: entry.bonusAttributePoints,
     totalSkillPoints: entry.totalSkillPoints,
     specialAttributePoints: entry.specialAttributePoints,
     nuyen: entry.nuyen,
     baseAttributes,
     derived,
+  };
+}
+
+/**
+ * Calculate derived combat/social stats from base attributes.
+ *
+ * Exported so callers who distribute bonus attribute points can
+ * recalculate derived stats after modification.
+ *
+ * @param attrs - Base physical/mental attributes
+ * @returns Derived combat/social stats
+ */
+export function calculateDerivedStats(attrs: NpcBaseAttributes): NpcDerivedStats {
+  return {
+    initiative: attrs.reaction + attrs.intuition,
+    composure: attrs.charisma + attrs.willpower,
+    judgeIntentions: attrs.charisma + attrs.intuition,
+    physicalConditionMonitor: Math.ceil(attrs.body / 2) + 8,
+    stunConditionMonitor: Math.ceil(attrs.willpower / 2) + 8,
   };
 }


### PR DESCRIPTION
## Summary

- `generateContactStatBlock()` now accepts optional `metatype` parameter (defaults to `"human"`)
- Non-human metatypes (elf, dwarf, ork, troll) use SR5 CRB racial attribute minimums as base
- Derived stats (initiative, composure, condition monitors) recalculated from metatype-adjusted attributes
- New `getMetatypeBaseAttributes()` export for standalone metatype lookup
- `ContactStatBlock` now includes `metatype` field
- Backward compatible — existing callers without metatype param get identical human behavior

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 483 files, 10,172 tests pass
- [x] All 14 existing contact-npc tests still pass (no regressions)
- [x] 6 new tests for `getMetatypeBaseAttributes` (human, elf, dwarf, ork, troll + copy safety)
- [x] 5 new tests for metatype stat generation (ork, troll, elf, dwarf derived stats + build point parity)
- [x] 2 new tests for metatype field in stat block (default + explicit)

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)