### PR TITLE
docs: update CLAUDE.md counts and fix validation script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,12 @@ pnpm docker:dev       # Build and start Docker containers
 ## Key Directories
 
 ```
-/app                    # Next.js App Router pages + API routes (~146 route files)
-/lib                    # Business logic (types, storage ~21 modules, rules, auth, combat, security)
-/components/creation    # Character creation cards (~117 components in 19 subfolders)
+/app                    # Next.js App Router pages + API routes (~162 route files)
+/lib                    # Business logic (types, storage ~22 modules, rules, auth, combat, security)
+/components/creation    # Character creation cards (~142 components in 21 subfolders)
 /data/editions/{code}/  # Edition data (edition.json, core-rulebook.json, grunt-templates/)
 /docs/pdfs/             # Sourcebook PDFs for rule reference (Core Rulebook, Run Faster, Run & Gun, Errata)
-/__tests__              # ~353 test files (Vitest)
+/__tests__              # ~493 test files (Vitest)
 /e2e                    # E2E tests (Playwright)
 ```
 

--- a/scripts/validate-claude-md.ts
+++ b/scripts/validate-claude-md.ts
@@ -103,7 +103,7 @@ results.push({
 // Check 3: Test file count (includes .test.ts and .test.tsx)
 const testFiles = parseInt(
   execSync(
-    `find ${ROOT} -type f \\( -name "*.test.ts" -o -name "*.test.tsx" \\) -not -path "*/node_modules/*" | wc -l`,
+    `find ${ROOT} -type f \\( -name "*.test.ts" -o -name "*.test.tsx" \\) -not -path "*/node_modules/*" -not -path "*/.claude/*" -not -path "*/.next/*" | wc -l`,
     { encoding: "utf-8" }
   ).trim(),
   10


### PR DESCRIPTION
## Summary
- Update all CLAUDE.md counts to match current codebase (components: 142, routes: 162, tests: 493, storage: 22, subfolders: 21)
- Fix `validate-claude-md.ts` to exclude `.claude/` and `.next/` directories from test file count — worktree directories were inflating the count from 493 to 9450

## Test plan
- [x] `pnpm validate-docs` passes with all checks green