### PR TITLE
feat: add Johnson betrayal risk assessment to GM campaign view (#835)

### DIFF
--- a/app/api/campaigns/[id]/contacts/[contactId]/betrayal/__tests__/route.test.ts
+++ b/app/api/campaigns/[id]/contacts/[contactId]/betrayal/__tests__/route.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Tests for /api/campaigns/[id]/contacts/[contactId]/betrayal endpoint
+ *
+ * Tests GM-only betrayal planning state management including:
+ * - Authentication and authorization (GM-only)
+ * - Setting betrayal planning with betrayal type
+ * - Clearing betrayal planning
+ * - Revealing and hiding warning signals
+ * - Contact not found handling
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET, PATCH } from "../route";
+import { NextRequest } from "next/server";
+import * as sessionModule from "@/lib/auth/session";
+import * as campaignAuthModule from "@/lib/auth/campaign";
+import * as contactStorage from "@/lib/storage/contacts";
+import type { SocialContact, BetrayalPlanningState } from "@/lib/types";
+
+vi.mock("@/lib/auth/session");
+vi.mock("@/lib/auth/campaign", () => ({
+  authorizeGM: vi.fn(),
+}));
+vi.mock("@/lib/storage/contacts");
+
+function createMockRequest(url: string, body?: unknown, method = "GET"): NextRequest {
+  const headers = new Headers();
+  if (body) headers.set("Content-Type", "application/json");
+  const urlObj = new URL(url);
+  const request = new NextRequest(urlObj, {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers,
+  });
+  Object.defineProperty(request, "nextUrl", { value: urlObj, writable: false });
+  if (body) (request as { json: () => Promise<unknown> }).json = async () => body;
+  return request;
+}
+
+function createMockContact(overrides?: Partial<SocialContact>): SocialContact {
+  return {
+    id: "test-contact-id",
+    campaignId: "test-campaign-id",
+    name: "Mr. Johnson",
+    archetype: "Mr. Johnson",
+    connection: 5,
+    loyalty: 2,
+    favorBalance: 0,
+    status: "active",
+    factionId: "aztechnology",
+    group: "campaign",
+    visibility: {
+      playerVisible: true,
+      showConnection: true,
+      showLoyalty: true,
+      showFavorBalance: true,
+      showSpecializations: true,
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as SocialContact;
+}
+
+const BASE_URL =
+  "http://localhost:3000/api/campaigns/test-campaign-id/contacts/test-contact-id/betrayal";
+const ROUTE_PARAMS = {
+  params: Promise.resolve({ id: "test-campaign-id", contactId: "test-contact-id" }),
+};
+
+describe("GET /api/campaigns/[id]/contacts/[contactId]/betrayal", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should return 401 when not authenticated", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue(null);
+    const request = createMockRequest(BASE_URL);
+    const response = await GET(request, ROUTE_PARAMS);
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 403 when not GM", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue("player-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: false,
+      campaign: null,
+      role: null,
+      error: "Not authorized",
+      status: 403,
+    });
+    const request = createMockRequest(BASE_URL);
+    const response = await GET(request, ROUTE_PARAMS);
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 404 when contact not found", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(null);
+    const request = createMockRequest(BASE_URL);
+    const response = await GET(request, ROUTE_PARAMS);
+    expect(response.status).toBe(404);
+  });
+
+  it("should return null betrayal planning when none set", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(createMockContact());
+    const request = createMockRequest(BASE_URL);
+    const response = await GET(request, ROUTE_PARAMS);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.betrayalPlanning).toBeNull();
+  });
+
+  it("should return active betrayal planning", async () => {
+    const planning: BetrayalPlanningState = {
+      betrayalTypeId: "non-payment",
+      revealedSignals: ["Payment terms are unusually complex"],
+      markedAt: new Date().toISOString(),
+    };
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(
+      createMockContact({ betrayalPlanning: planning })
+    );
+    const request = createMockRequest(BASE_URL);
+    const response = await GET(request, ROUTE_PARAMS);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.betrayalPlanning).toEqual(planning);
+  });
+});
+
+describe("PATCH /api/campaigns/[id]/contacts/[contactId]/betrayal", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should return 401 when not authenticated", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue(null);
+    const request = createMockRequest(BASE_URL, { action: "set" }, "PATCH");
+    const response = await PATCH(request, ROUTE_PARAMS);
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 403 when not GM", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue("player-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: false,
+      campaign: null,
+      role: null,
+      error: "Not authorized",
+      status: 403,
+    });
+    const request = createMockRequest(BASE_URL, { action: "set" }, "PATCH");
+    const response = await PATCH(request, ROUTE_PARAMS);
+    expect(response.status).toBe(403);
+  });
+
+  it("should set betrayal planning with valid betrayal type", async () => {
+    const contact = createMockContact();
+    const updatedContact = createMockContact({
+      betrayalPlanning: {
+        betrayalTypeId: "liquidation",
+        revealedSignals: [],
+        markedAt: new Date().toISOString(),
+      },
+    });
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+    vi.mocked(contactStorage.updateCampaignContactBetrayalPlanning).mockResolvedValue(
+      updatedContact
+    );
+
+    const request = createMockRequest(
+      BASE_URL,
+      { action: "set", betrayalTypeId: "liquidation" },
+      "PATCH"
+    );
+    const response = await PATCH(request, ROUTE_PARAMS);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(contactStorage.updateCampaignContactBetrayalPlanning).toHaveBeenCalledWith(
+      "test-campaign-id",
+      "test-contact-id",
+      expect.objectContaining({
+        betrayalTypeId: "liquidation",
+        revealedSignals: [],
+      })
+    );
+  });
+
+  it("should reject set without betrayalTypeId", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(createMockContact());
+
+    const request = createMockRequest(BASE_URL, { action: "set" }, "PATCH");
+    const response = await PATCH(request, ROUTE_PARAMS);
+    expect(response.status).toBe(400);
+  });
+
+  it("should clear betrayal planning", async () => {
+    const contact = createMockContact({
+      betrayalPlanning: {
+        betrayalTypeId: "non-payment",
+        revealedSignals: [],
+        markedAt: new Date().toISOString(),
+      },
+    });
+    const clearedContact = createMockContact({ betrayalPlanning: undefined });
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+    vi.mocked(contactStorage.updateCampaignContactBetrayalPlanning).mockResolvedValue(
+      clearedContact
+    );
+
+    const request = createMockRequest(BASE_URL, { action: "clear" }, "PATCH");
+    const response = await PATCH(request, ROUTE_PARAMS);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(contactStorage.updateCampaignContactBetrayalPlanning).toHaveBeenCalledWith(
+      "test-campaign-id",
+      "test-contact-id",
+      null
+    );
+  });
+
+  it("should reveal a warning signal", async () => {
+    const planning: BetrayalPlanningState = {
+      betrayalTypeId: "non-payment",
+      revealedSignals: [],
+      markedAt: new Date().toISOString(),
+    };
+    const contact = createMockContact({ betrayalPlanning: planning });
+    const updatedContact = createMockContact({
+      betrayalPlanning: {
+        ...planning,
+        revealedSignals: ["Johnson is evasive about payment details"],
+      },
+    });
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+    vi.mocked(contactStorage.updateCampaignContactBetrayalPlanning).mockResolvedValue(
+      updatedContact
+    );
+
+    const request = createMockRequest(
+      BASE_URL,
+      {
+        action: "reveal-signal",
+        signal: "Johnson is evasive about payment details",
+      },
+      "PATCH"
+    );
+    const response = await PATCH(request, ROUTE_PARAMS);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(contactStorage.updateCampaignContactBetrayalPlanning).toHaveBeenCalledWith(
+      "test-campaign-id",
+      "test-contact-id",
+      expect.objectContaining({
+        revealedSignals: ["Johnson is evasive about payment details"],
+      })
+    );
+  });
+
+  it("should hide a previously revealed signal", async () => {
+    const planning: BetrayalPlanningState = {
+      betrayalTypeId: "non-payment",
+      revealedSignals: ["signal-a", "signal-b"],
+      markedAt: new Date().toISOString(),
+    };
+    const contact = createMockContact({ betrayalPlanning: planning });
+    const updatedContact = createMockContact({
+      betrayalPlanning: { ...planning, revealedSignals: ["signal-b"] },
+    });
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+    vi.mocked(contactStorage.updateCampaignContactBetrayalPlanning).mockResolvedValue(
+      updatedContact
+    );
+
+    const request = createMockRequest(
+      BASE_URL,
+      { action: "hide-signal", signal: "signal-a" },
+      "PATCH"
+    );
+    const response = await PATCH(request, ROUTE_PARAMS);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(contactStorage.updateCampaignContactBetrayalPlanning).toHaveBeenCalledWith(
+      "test-campaign-id",
+      "test-contact-id",
+      expect.objectContaining({
+        revealedSignals: ["signal-b"],
+      })
+    );
+  });
+
+  it("should reject reveal-signal when no active planning", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(
+      createMockContact({ betrayalPlanning: undefined })
+    );
+
+    const request = createMockRequest(
+      BASE_URL,
+      { action: "reveal-signal", signal: "test" },
+      "PATCH"
+    );
+    const response = await PATCH(request, ROUTE_PARAMS);
+    expect(response.status).toBe(400);
+  });
+
+  it("should reject invalid action", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(createMockContact());
+
+    const request = createMockRequest(BASE_URL, { action: "invalid" }, "PATCH");
+    const response = await PATCH(request, ROUTE_PARAMS);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("Invalid action");
+  });
+
+  it("should not duplicate already-revealed signals", async () => {
+    const planning: BetrayalPlanningState = {
+      betrayalTypeId: "non-payment",
+      revealedSignals: ["already-revealed"],
+      markedAt: new Date().toISOString(),
+    };
+    const contact = createMockContact({ betrayalPlanning: planning });
+    const updatedContact = createMockContact({ betrayalPlanning: planning });
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      role: "gm",
+      campaign: {} as never,
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+    vi.mocked(contactStorage.updateCampaignContactBetrayalPlanning).mockResolvedValue(
+      updatedContact
+    );
+
+    const request = createMockRequest(
+      BASE_URL,
+      { action: "reveal-signal", signal: "already-revealed" },
+      "PATCH"
+    );
+    const response = await PATCH(request, ROUTE_PARAMS);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    // Should pass the same signals array (no duplicate)
+    expect(contactStorage.updateCampaignContactBetrayalPlanning).toHaveBeenCalledWith(
+      "test-campaign-id",
+      "test-contact-id",
+      expect.objectContaining({
+        revealedSignals: ["already-revealed"],
+      })
+    );
+  });
+});

--- a/app/api/campaigns/[id]/contacts/[contactId]/betrayal/route.ts
+++ b/app/api/campaigns/[id]/contacts/[contactId]/betrayal/route.ts
@@ -1,0 +1,178 @@
+/**
+ * API Route: /api/campaigns/[id]/contacts/[contactId]/betrayal
+ *
+ * PATCH - Set or clear betrayal planning state (GM only)
+ * GET   - Get betrayal planning state (GM only)
+ *
+ * This endpoint manages the GM-only betrayal planning state for Johnson contacts.
+ * All operations require GM authorization. Betrayal planning data is never
+ * exposed to non-GM users (filtered at the contacts list endpoint level).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { authorizeGM } from "@/lib/auth/campaign";
+import { getCampaignContact, updateCampaignContactBetrayalPlanning } from "@/lib/storage/contacts";
+import type { BetrayalPlanningState } from "@/lib/types";
+
+interface RouteParams {
+  params: Promise<{ id: string; contactId: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const userId = await getSession();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: campaignId, contactId } = await params;
+
+    const auth = await authorizeGM(campaignId, userId);
+    if (!auth.authorized) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: auth.status });
+    }
+
+    const contact = await getCampaignContact(campaignId, contactId);
+    if (!contact) {
+      return NextResponse.json({ success: false, error: "Contact not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      betrayalPlanning: contact.betrayalPlanning ?? null,
+      contactId: contact.id,
+      contactName: contact.name,
+    });
+  } catch (error) {
+    console.error("Failed to get betrayal planning:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to get betrayal planning" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const userId = await getSession();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: campaignId, contactId } = await params;
+
+    const auth = await authorizeGM(campaignId, userId);
+    if (!auth.authorized) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: auth.status });
+    }
+
+    const contact = await getCampaignContact(campaignId, contactId);
+    if (!contact) {
+      return NextResponse.json({ success: false, error: "Contact not found" }, { status: 404 });
+    }
+
+    const body = await request.json();
+
+    // Clear betrayal planning
+    if (body.action === "clear") {
+      const updatedContact = await updateCampaignContactBetrayalPlanning(
+        campaignId,
+        contactId,
+        null
+      );
+      return NextResponse.json({ success: true, contact: updatedContact });
+    }
+
+    // Set betrayal planning
+    if (body.action === "set") {
+      if (!body.betrayalTypeId || typeof body.betrayalTypeId !== "string") {
+        return NextResponse.json(
+          { success: false, error: "betrayalTypeId is required" },
+          { status: 400 }
+        );
+      }
+
+      const planning: BetrayalPlanningState = {
+        betrayalTypeId: body.betrayalTypeId,
+        revealedSignals: Array.isArray(body.revealedSignals) ? body.revealedSignals : [],
+        gmNotes: typeof body.gmNotes === "string" ? body.gmNotes : undefined,
+        markedAt: new Date().toISOString(),
+      };
+
+      const updatedContact = await updateCampaignContactBetrayalPlanning(
+        campaignId,
+        contactId,
+        planning
+      );
+      return NextResponse.json({ success: true, contact: updatedContact });
+    }
+
+    // Update revealed signals on existing planning
+    if (body.action === "reveal-signal") {
+      if (!contact.betrayalPlanning) {
+        return NextResponse.json(
+          { success: false, error: "No active betrayal planning to update" },
+          { status: 400 }
+        );
+      }
+
+      if (typeof body.signal !== "string") {
+        return NextResponse.json({ success: false, error: "signal is required" }, { status: 400 });
+      }
+
+      const revealed = contact.betrayalPlanning.revealedSignals.includes(body.signal)
+        ? contact.betrayalPlanning.revealedSignals
+        : [...contact.betrayalPlanning.revealedSignals, body.signal];
+
+      const planning: BetrayalPlanningState = {
+        ...contact.betrayalPlanning,
+        revealedSignals: revealed,
+      };
+
+      const updatedContact = await updateCampaignContactBetrayalPlanning(
+        campaignId,
+        contactId,
+        planning
+      );
+      return NextResponse.json({ success: true, contact: updatedContact });
+    }
+
+    // Hide a previously revealed signal
+    if (body.action === "hide-signal") {
+      if (!contact.betrayalPlanning) {
+        return NextResponse.json(
+          { success: false, error: "No active betrayal planning to update" },
+          { status: 400 }
+        );
+      }
+
+      if (typeof body.signal !== "string") {
+        return NextResponse.json({ success: false, error: "signal is required" }, { status: 400 });
+      }
+
+      const planning: BetrayalPlanningState = {
+        ...contact.betrayalPlanning,
+        revealedSignals: contact.betrayalPlanning.revealedSignals.filter((s) => s !== body.signal),
+      };
+
+      const updatedContact = await updateCampaignContactBetrayalPlanning(
+        campaignId,
+        contactId,
+        planning
+      );
+      return NextResponse.json({ success: true, contact: updatedContact });
+    }
+
+    return NextResponse.json(
+      { success: false, error: "Invalid action. Use: set, clear, reveal-signal, hide-signal" },
+      { status: 400 }
+    );
+  } catch (error) {
+    console.error("Failed to update betrayal planning:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to update betrayal planning" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/campaigns/[id]/contacts/[contactId]/betrayal/route.ts
+++ b/app/api/campaigns/[id]/contacts/[contactId]/betrayal/route.ts
@@ -19,6 +19,10 @@ interface RouteParams {
   params: Promise<{ id: string; contactId: string }>;
 }
 
+const MAX_BETRAYAL_TYPE_ID_LEN = 100;
+const MAX_GM_NOTES_LEN = 2000;
+const MAX_SIGNAL_LEN = 500;
+
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const userId = await getSession();
@@ -93,10 +97,24 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         );
       }
 
+      if (body.betrayalTypeId.length > MAX_BETRAYAL_TYPE_ID_LEN) {
+        return NextResponse.json(
+          { success: false, error: "betrayalTypeId exceeds maximum length" },
+          { status: 400 }
+        );
+      }
+
+      const gmNotes =
+        typeof body.gmNotes === "string" ? body.gmNotes.slice(0, MAX_GM_NOTES_LEN) : undefined;
+
+      const revealedSignals: string[] = Array.isArray(body.revealedSignals)
+        ? (body.revealedSignals as unknown[]).filter((s): s is string => typeof s === "string")
+        : [];
+
       const planning: BetrayalPlanningState = {
         betrayalTypeId: body.betrayalTypeId,
-        revealedSignals: Array.isArray(body.revealedSignals) ? body.revealedSignals : [],
-        gmNotes: typeof body.gmNotes === "string" ? body.gmNotes : undefined,
+        revealedSignals,
+        gmNotes,
         markedAt: new Date().toISOString(),
       };
 
@@ -117,8 +135,11 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         );
       }
 
-      if (typeof body.signal !== "string") {
-        return NextResponse.json({ success: false, error: "signal is required" }, { status: 400 });
+      if (typeof body.signal !== "string" || body.signal.length > MAX_SIGNAL_LEN) {
+        return NextResponse.json(
+          { success: false, error: "signal is required and must be under 500 characters" },
+          { status: 400 }
+        );
       }
 
       const revealed = contact.betrayalPlanning.revealedSignals.includes(body.signal)
@@ -147,8 +168,11 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         );
       }
 
-      if (typeof body.signal !== "string") {
-        return NextResponse.json({ success: false, error: "signal is required" }, { status: 400 });
+      if (typeof body.signal !== "string" || body.signal.length > MAX_SIGNAL_LEN) {
+        return NextResponse.json(
+          { success: false, error: "signal is required and must be under 500 characters" },
+          { status: 400 }
+        );
       }
 
       const planning: BetrayalPlanningState = {

--- a/app/api/campaigns/[id]/contacts/__tests__/route.test.ts
+++ b/app/api/campaigns/[id]/contacts/__tests__/route.test.ts
@@ -185,6 +185,60 @@ describe("GET /api/campaigns/[id]/contacts", () => {
     expect(data.isGm).toBe(false);
   });
 
+  it("should strip betrayalPlanning from contacts for non-GM players", async () => {
+    const contacts = [
+      createMockContact({
+        betrayalPlanning: {
+          betrayalTypeId: "liquidation",
+          revealedSignals: ["Job involves extremely sensitive secrets"],
+          markedAt: new Date().toISOString(),
+        },
+      }),
+    ];
+    const mockCampaign = createMockCampaign();
+    vi.mocked(sessionModule.getSession).mockResolvedValue("player-1");
+    vi.mocked(campaignAuthModule.authorizeMember).mockResolvedValue({
+      authorized: true,
+      campaign: mockCampaign,
+      role: "player",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContacts).mockResolvedValue(contacts);
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts"
+    );
+    const response = await GET(request, { params: Promise.resolve({ id: "test-campaign-id" }) });
+    const data = await response.json();
+    expect(response.status).toBe(200);
+    expect(data.contacts[0].betrayalPlanning).toBeUndefined();
+    expect(data.contacts[0].gmNotes).toBeUndefined();
+  });
+
+  it("should preserve betrayalPlanning for GM", async () => {
+    const planning = {
+      betrayalTypeId: "liquidation",
+      revealedSignals: ["Job involves extremely sensitive secrets"],
+      markedAt: new Date().toISOString(),
+    };
+    const contacts = [createMockContact({ betrayalPlanning: planning })];
+    const mockCampaign = createMockCampaign();
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeMember).mockResolvedValue({
+      authorized: true,
+      campaign: mockCampaign,
+      role: "gm",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContacts).mockResolvedValue(contacts);
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts"
+    );
+    const response = await GET(request, { params: Promise.resolve({ id: "test-campaign-id" }) });
+    const data = await response.json();
+    expect(response.status).toBe(200);
+    expect(data.contacts[0].betrayalPlanning).toEqual(planning);
+  });
+
   it("should filter by archetype", async () => {
     const contacts = [createMockContact({ archetype: "fixer" })];
     const mockCampaign = createMockCampaign();

--- a/app/api/campaigns/[id]/contacts/route.ts
+++ b/app/api/campaigns/[id]/contacts/route.ts
@@ -71,6 +71,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
           favorBalance: c.visibility.showFavorBalance ? c.favorBalance : undefined,
           // Never show GM notes to players
           gmNotes: undefined,
+          // Never show betrayal planning to players
+          betrayalPlanning: undefined,
         };
         return visibleContact;
       });

--- a/app/campaigns/[id]/components/BetrayalAssessmentPanel.tsx
+++ b/app/campaigns/[id]/components/BetrayalAssessmentPanel.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  AlertTriangle,
+  Eye,
+  EyeOff,
+  Shield,
+  ShieldAlert,
+  Skull,
+  X,
+  Loader2,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import type { SocialContact } from "@/lib/types";
+import type { BetrayalTypeData, JohnsonFactionData } from "@/lib/rules/module-payloads";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+interface BetrayalAssessmentPanelProps {
+  contact: SocialContact;
+  campaignId: string;
+  betrayalTypes: BetrayalTypeData[];
+  factions: JohnsonFactionData[];
+  onContactUpdated: (contact: SocialContact) => void;
+}
+
+// =============================================================================
+// SEVERITY DISPLAY
+// =============================================================================
+
+const SEVERITY_CONFIG = {
+  moderate: {
+    label: "Moderate",
+    color: "text-amber-400",
+    bg: "bg-amber-500/10 border-amber-500/30",
+    icon: Shield,
+  },
+  severe: {
+    label: "Severe",
+    color: "text-orange-400",
+    bg: "bg-orange-500/10 border-orange-500/30",
+    icon: ShieldAlert,
+  },
+  lethal: {
+    label: "Lethal",
+    color: "text-red-400",
+    bg: "bg-red-500/10 border-red-500/30",
+    icon: Skull,
+  },
+} as const;
+
+const RISK_COLORS: Record<string, string> = {
+  "very-low": "text-green-400 bg-green-500/10",
+  low: "text-green-300 bg-green-500/10",
+  moderate: "text-amber-400 bg-amber-500/10",
+  high: "text-orange-400 bg-orange-500/10",
+  "very-high": "text-red-400 bg-red-500/10",
+  uncertain: "text-zinc-400 bg-zinc-500/10",
+};
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+export function BetrayalAssessmentPanel({
+  contact,
+  campaignId,
+  betrayalTypes,
+  factions,
+  onContactUpdated,
+}: BetrayalAssessmentPanelProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(!!contact.betrayalPlanning);
+  const [selectedTypeId, setSelectedTypeId] = useState<string>(
+    contact.betrayalPlanning?.betrayalTypeId ?? ""
+  );
+
+  const faction = contact.factionId ? factions.find((f) => f.id === contact.factionId) : null;
+
+  const activePlanning = contact.betrayalPlanning;
+  const activeType = activePlanning
+    ? betrayalTypes.find((t) => t.id === activePlanning.betrayalTypeId)
+    : null;
+
+  const handleSetBetrayal = useCallback(async () => {
+    if (!selectedTypeId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/campaigns/${campaignId}/contacts/${contact.id}/betrayal`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "set", betrayalTypeId: selectedTypeId }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        onContactUpdated(data.contact);
+      } else {
+        setError(data.error || "Failed to set betrayal planning");
+      }
+    } catch {
+      setError("Failed to set betrayal planning");
+    } finally {
+      setLoading(false);
+    }
+  }, [campaignId, contact.id, selectedTypeId, onContactUpdated]);
+
+  const handleClearBetrayal = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/campaigns/${campaignId}/contacts/${contact.id}/betrayal`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "clear" }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        onContactUpdated(data.contact);
+        setSelectedTypeId("");
+      } else {
+        setError(data.error || "Failed to clear betrayal planning");
+      }
+    } catch {
+      setError("Failed to clear betrayal planning");
+    } finally {
+      setLoading(false);
+    }
+  }, [campaignId, contact.id, onContactUpdated]);
+
+  const handleToggleSignal = useCallback(
+    async (signal: string, revealed: boolean) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/campaigns/${campaignId}/contacts/${contact.id}/betrayal`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: revealed ? "hide-signal" : "reveal-signal",
+            signal,
+          }),
+        });
+        const data = await res.json();
+        if (data.success) {
+          onContactUpdated(data.contact);
+        } else {
+          setError(data.error || "Failed to update signal");
+        }
+      } catch {
+        setError("Failed to update signal");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [campaignId, contact.id, onContactUpdated]
+  );
+
+  return (
+    <div className="rounded-lg border border-zinc-700 bg-zinc-800/50">
+      {/* Header */}
+      <button
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex w-full items-center justify-between px-4 py-3 text-left"
+      >
+        <div className="flex items-center gap-2">
+          <AlertTriangle
+            className={`h-4 w-4 ${activePlanning ? "text-red-400" : "text-zinc-500"}`}
+          />
+          <span className="text-sm font-medium text-zinc-200">Betrayal Assessment</span>
+          {activePlanning && (
+            <span className="rounded-full bg-red-500/20 px-2 py-0.5 text-[10px] font-bold uppercase text-red-400">
+              Planning Active
+            </span>
+          )}
+        </div>
+        {expanded ? (
+          <ChevronUp className="h-4 w-4 text-zinc-500" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-zinc-500" />
+        )}
+      </button>
+
+      {!expanded && null}
+
+      {expanded && (
+        <div className="space-y-4 border-t border-zinc-700 px-4 py-4">
+          {error && (
+            <div className="rounded bg-red-900/30 p-2 text-xs text-red-400">
+              {error}
+              <button onClick={() => setError(null)} className="ml-2 underline hover:no-underline">
+                Dismiss
+              </button>
+            </div>
+          )}
+
+          {/* Faction Risk Hint */}
+          {faction && faction.betrayalRisk && (
+            <div className="rounded border border-zinc-600 bg-zinc-900/50 p-3 text-xs">
+              <div className="mb-1 flex items-center gap-2">
+                <span className="font-mono text-[10px] uppercase text-zinc-500">Faction Risk</span>
+                <span
+                  className={`rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${RISK_COLORS[faction.betrayalRisk] ?? "text-zinc-400 bg-zinc-500/10"}`}
+                >
+                  {faction.betrayalRisk}
+                </span>
+              </div>
+              {faction.betrayalNotes && <p className="text-zinc-400">{faction.betrayalNotes}</p>}
+            </div>
+          )}
+
+          {/* Loyalty-Based Risk Hint */}
+          <div className="rounded border border-zinc-600 bg-zinc-900/50 p-3 text-xs">
+            <div className="mb-1 flex items-center gap-2">
+              <span className="font-mono text-[10px] uppercase text-zinc-500">
+                Loyalty Assessment
+              </span>
+              <span
+                className={`rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${
+                  contact.loyalty <= 2
+                    ? "text-red-400 bg-red-500/10"
+                    : contact.loyalty <= 4
+                      ? "text-amber-400 bg-amber-500/10"
+                      : "text-green-400 bg-green-500/10"
+                }`}
+              >
+                Loyalty {contact.loyalty}
+              </span>
+            </div>
+            <p className="text-zinc-400">
+              {contact.loyalty <= 1
+                ? "Minimal loyalty — contact would betray for almost any reason."
+                : contact.loyalty <= 2
+                  ? "Low loyalty — contact is unreliable and easily swayed."
+                  : contact.loyalty <= 3
+                    ? "Average loyalty — contact is professional but not personally invested."
+                    : contact.loyalty <= 4
+                      ? "Good loyalty — contact values the relationship and is generally reliable."
+                      : "High loyalty — contact is a trusted ally unlikely to betray willingly."}
+            </p>
+          </div>
+
+          {/* Betrayal Types Reference */}
+          <div>
+            <h4 className="mb-2 text-xs font-medium uppercase tracking-wider text-zinc-500">
+              Betrayal Types
+            </h4>
+            <div className="space-y-2">
+              {betrayalTypes.map((bt) => {
+                const config = SEVERITY_CONFIG[bt.severity] ?? SEVERITY_CONFIG.moderate;
+                const Icon = config.icon;
+                return (
+                  <div key={bt.id} className={`rounded border p-3 text-xs ${config.bg}`}>
+                    <div className="mb-1 flex items-center gap-2">
+                      <Icon className={`h-3.5 w-3.5 ${config.color}`} />
+                      <span className={`font-medium ${config.color}`}>{bt.name}</span>
+                      <span
+                        className={`rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${config.color}`}
+                      >
+                        {config.label}
+                      </span>
+                    </div>
+                    <p className="text-zinc-400">{bt.description}</p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Active Betrayal Planning */}
+          {activePlanning && activeType ? (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h4 className="text-xs font-medium uppercase tracking-wider text-red-400">
+                  Active Betrayal Plan
+                </h4>
+                <button
+                  onClick={handleClearBetrayal}
+                  disabled={loading}
+                  className="inline-flex items-center gap-1 rounded border border-zinc-600 px-2 py-1 text-[10px] text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200 disabled:opacity-50"
+                >
+                  <X className="h-3 w-3" />
+                  Clear
+                </button>
+              </div>
+
+              <div className="rounded border border-red-500/30 bg-red-500/5 p-3 text-xs">
+                <div className="mb-2 flex items-center gap-2">
+                  <Skull className="h-4 w-4 text-red-400" />
+                  <span className="font-medium text-red-300">{activeType.name}</span>
+                </div>
+                <p className="text-zinc-400">{activeType.description}</p>
+              </div>
+
+              {/* Warning Signals Checklist */}
+              {activeType.warningSignals && activeType.warningSignals.length > 0 && (
+                <div>
+                  <h5 className="mb-2 text-xs font-medium text-zinc-400">
+                    Warning Signals — click to reveal/hide for players
+                  </h5>
+                  <div className="space-y-1">
+                    {activeType.warningSignals.map((signal) => {
+                      const isRevealed = activePlanning.revealedSignals.includes(signal);
+                      return (
+                        <button
+                          key={signal}
+                          onClick={() => handleToggleSignal(signal, isRevealed)}
+                          disabled={loading}
+                          className={`flex w-full items-start gap-2 rounded border px-3 py-2 text-left text-xs transition-colors disabled:opacity-50 ${
+                            isRevealed
+                              ? "border-amber-500/30 bg-amber-500/10 text-amber-300"
+                              : "border-zinc-700 bg-zinc-800 text-zinc-500 hover:border-zinc-600 hover:text-zinc-400"
+                          }`}
+                        >
+                          {isRevealed ? (
+                            <Eye className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-400" />
+                          ) : (
+                            <EyeOff className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                          )}
+                          <span>{signal}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            /* Set Betrayal Planning */
+            <div className="space-y-3">
+              <h4 className="text-xs font-medium uppercase tracking-wider text-zinc-500">
+                Mark as Planning Betrayal
+              </h4>
+              <div className="flex gap-2">
+                <select
+                  value={selectedTypeId}
+                  onChange={(e) => setSelectedTypeId(e.target.value)}
+                  className="flex-1 rounded border border-zinc-600 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+                >
+                  <option value="">Select betrayal type...</option>
+                  {betrayalTypes.map((bt) => (
+                    <option key={bt.id} value={bt.id}>
+                      {bt.name} ({bt.severity})
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={handleSetBetrayal}
+                  disabled={loading || !selectedTypeId}
+                  className="rounded bg-red-600 px-3 py-2 text-xs font-medium text-white hover:bg-red-500 disabled:opacity-50"
+                >
+                  {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Mark"}
+                </button>
+              </div>
+              <p className="text-[10px] text-zinc-600">
+                This is hidden from players. Only the GM can see betrayal planning state.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/campaigns/[id]/components/BetrayalAssessmentPanel.tsx
+++ b/app/campaigns/[id]/components/BetrayalAssessmentPanel.tsx
@@ -166,6 +166,8 @@ export function BetrayalAssessmentPanel({
       {/* Header */}
       <button
         onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-label={`${expanded ? "Collapse" : "Expand"} betrayal assessment for ${contact.name}`}
         className="flex w-full items-center justify-between px-4 py-3 text-left"
       >
         <div className="flex items-center gap-2">
@@ -185,8 +187,6 @@ export function BetrayalAssessmentPanel({
           <ChevronDown className="h-4 w-4 text-zinc-500" />
         )}
       </button>
-
-      {!expanded && null}
 
       {expanded && (
         <div className="space-y-4 border-t border-zinc-700 px-4 py-4">
@@ -340,6 +340,7 @@ export function BetrayalAssessmentPanel({
                 <select
                   value={selectedTypeId}
                   onChange={(e) => setSelectedTypeId(e.target.value)}
+                  aria-label="Select betrayal type"
                   className="flex-1 rounded border border-zinc-600 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
                 >
                   <option value="">Select betrayal type...</option>

--- a/app/campaigns/[id]/components/CampaignContactsTab.tsx
+++ b/app/campaigns/[id]/components/CampaignContactsTab.tsx
@@ -67,13 +67,9 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
     setContacts((prev) => prev.map((c) => (c.id === updatedContact.id ? updatedContact : c)));
   }, []);
 
-  // Filter to only Johnson contacts (those with factionId or archetype "Mr. Johnson")
-  const johnsonContacts = contacts.filter(
-    (c) => c.factionId || c.archetype.toLowerCase().includes("johnson")
-  );
-  const otherContacts = contacts.filter(
-    (c) => !c.factionId && !c.archetype.toLowerCase().includes("johnson")
-  );
+  // Johnson contacts are those with a faction tag (Run Faster pp. 196-211)
+  const johnsonContacts = contacts.filter((c) => !!c.factionId);
+  const otherContacts = contacts.filter((c) => !c.factionId);
 
   if (loading) {
     return (
@@ -142,6 +138,8 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
                 {/* Contact Header */}
                 <button
                   onClick={() => setExpandedContactId(isExpanded ? null : contact.id)}
+                  aria-expanded={isExpanded}
+                  aria-label={`${isExpanded ? "Collapse" : "Expand"} betrayal assessment for ${contact.name}`}
                   className="flex w-full items-center justify-between px-4 py-3 text-left"
                 >
                   <div className="flex items-center gap-3">

--- a/app/campaigns/[id]/components/CampaignContactsTab.tsx
+++ b/app/campaigns/[id]/components/CampaignContactsTab.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Loader2, Info, Users, AlertTriangle } from "lucide-react";
+import type { Campaign, SocialContact } from "@/lib/types";
+import type {
+  BetrayalTypeData,
+  JohnsonFactionData,
+  JohnsonProfilesModulePayload,
+} from "@/lib/rules/module-payloads";
+import { BetrayalAssessmentPanel } from "./BetrayalAssessmentPanel";
+
+interface CampaignContactsTabProps {
+  campaign: Campaign;
+}
+
+export default function CampaignContactsTab({ campaign }: CampaignContactsTabProps) {
+  const [contacts, setContacts] = useState<SocialContact[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Ruleset data
+  const [betrayalTypes, setBetrayalTypes] = useState<BetrayalTypeData[]>([]);
+  const [factions, setFactions] = useState<JohnsonFactionData[]>([]);
+
+  // Expanded contact for betrayal panel
+  const [expandedContactId, setExpandedContactId] = useState<string | null>(null);
+
+  const fetchContacts = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/campaigns/${campaign.id}/contacts`);
+      const data = await res.json();
+      if (data.success) {
+        setContacts(data.contacts || []);
+      } else {
+        setError(data.error || "Failed to load contacts");
+      }
+    } catch {
+      setError("Failed to load contacts");
+    } finally {
+      setLoading(false);
+    }
+  }, [campaign.id]);
+
+  const fetchRulesetData = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/rulesets/${campaign.editionCode}`);
+      const data = await res.json();
+      if (data.success && data.extractedData) {
+        const jp = data.extractedData.johnsonProfiles as JohnsonProfilesModulePayload | null;
+        if (jp) {
+          setBetrayalTypes(jp.betrayalTypes || []);
+          setFactions(jp.factions || []);
+        }
+      }
+    } catch {
+      // Non-critical — betrayal assessment will show without faction data
+    }
+  }, [campaign.editionCode]);
+
+  useEffect(() => {
+    fetchContacts();
+    fetchRulesetData();
+  }, [fetchContacts, fetchRulesetData]);
+
+  const handleContactUpdated = useCallback((updatedContact: SocialContact) => {
+    setContacts((prev) => prev.map((c) => (c.id === updatedContact.id ? updatedContact : c)));
+  }, []);
+
+  // Filter to only Johnson contacts (those with factionId or archetype "Mr. Johnson")
+  const johnsonContacts = contacts.filter(
+    (c) => c.factionId || c.archetype.toLowerCase().includes("johnson")
+  );
+  const otherContacts = contacts.filter(
+    (c) => !c.factionId && !c.archetype.toLowerCase().includes("johnson")
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
+      </div>
+    );
+  }
+
+  if (contacts.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-zinc-300 py-12 text-center dark:border-zinc-700">
+        <Users className="mx-auto h-12 w-12 text-zinc-400 opacity-50" />
+        <h3 className="mt-2 text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+          No campaign contacts yet
+        </h3>
+        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+          Create contacts from the campaign to manage Johnson relationships and betrayal scenarios.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-medium text-zinc-900 dark:text-zinc-50">
+          Campaign Contacts — Betrayal Assessment
+        </h3>
+        {betrayalTypes.length === 0 && (
+          <span className="flex items-center gap-1 text-xs text-amber-400">
+            <Info className="h-3.5 w-3.5" />
+            Enable Run Faster for betrayal types
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-400">
+          {error}
+          <button onClick={() => setError(null)} className="ml-2 underline hover:no-underline">
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Johnson Contacts */}
+      {johnsonContacts.length > 0 && (
+        <div className="space-y-4">
+          <h4 className="flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            <AlertTriangle className="h-4 w-4" />
+            Johnson Contacts ({johnsonContacts.length})
+          </h4>
+          {johnsonContacts.map((contact) => {
+            const faction = contact.factionId
+              ? factions.find((f) => f.id === contact.factionId)
+              : null;
+            const isExpanded = expandedContactId === contact.id;
+
+            return (
+              <div
+                key={contact.id}
+                className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900"
+              >
+                {/* Contact Header */}
+                <button
+                  onClick={() => setExpandedContactId(isExpanded ? null : contact.id)}
+                  className="flex w-full items-center justify-between px-4 py-3 text-left"
+                >
+                  <div className="flex items-center gap-3">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
+                          {contact.name}
+                        </span>
+                        {contact.betrayalPlanning && (
+                          <span className="rounded-full bg-red-500/20 px-2 py-0.5 text-[10px] font-bold uppercase text-red-400">
+                            Betrayal Planned
+                          </span>
+                        )}
+                        <span
+                          className={`rounded px-1.5 py-0.5 text-[10px] font-mono ${
+                            contact.status === "active"
+                              ? "bg-green-500/10 text-green-400"
+                              : "bg-zinc-500/10 text-zinc-400"
+                          }`}
+                        >
+                          {contact.status}
+                        </span>
+                      </div>
+                      <div className="mt-0.5 flex items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
+                        <span>{contact.archetype}</span>
+                        {faction && (
+                          <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-amber-400">
+                            {faction.name}
+                          </span>
+                        )}
+                        <span>
+                          C:{contact.connection} / L:{contact.loyalty}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {faction?.betrayalRisk && (
+                      <span
+                        className={`rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${
+                          {
+                            "very-low": "text-green-400 bg-green-500/10",
+                            low: "text-green-300 bg-green-500/10",
+                            moderate: "text-amber-400 bg-amber-500/10",
+                            high: "text-orange-400 bg-orange-500/10",
+                            "very-high": "text-red-400 bg-red-500/10",
+                            uncertain: "text-zinc-400 bg-zinc-500/10",
+                          }[faction.betrayalRisk] ?? "text-zinc-400 bg-zinc-500/10"
+                        }`}
+                      >
+                        Risk: {faction.betrayalRisk}
+                      </span>
+                    )}
+                  </div>
+                </button>
+
+                {/* Betrayal Assessment Panel */}
+                {isExpanded && betrayalTypes.length > 0 && (
+                  <div className="border-t border-zinc-200 px-4 py-4 dark:border-zinc-700">
+                    <BetrayalAssessmentPanel
+                      contact={contact}
+                      campaignId={campaign.id}
+                      betrayalTypes={betrayalTypes}
+                      factions={factions}
+                      onContactUpdated={handleContactUpdated}
+                    />
+                  </div>
+                )}
+
+                {isExpanded && betrayalTypes.length === 0 && (
+                  <div className="border-t border-zinc-200 px-4 py-4 dark:border-zinc-700">
+                    <div className="rounded border border-dashed border-zinc-600 p-4 text-center text-xs text-zinc-500">
+                      <Info className="mx-auto mb-1 h-5 w-5" />
+                      Betrayal type data not available. Enable the Run Faster sourcebook in campaign
+                      settings.
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Other Contacts */}
+      {otherContacts.length > 0 && (
+        <div className="space-y-3">
+          <h4 className="text-sm font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            Other Contacts ({otherContacts.length})
+          </h4>
+          {otherContacts.map((contact) => (
+            <div
+              key={contact.id}
+              className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-700 dark:bg-zinc-900"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
+                  {contact.name}
+                </span>
+                <span
+                  className={`rounded px-1.5 py-0.5 text-[10px] font-mono ${
+                    contact.status === "active"
+                      ? "bg-green-500/10 text-green-400"
+                      : "bg-zinc-500/10 text-zinc-400"
+                  }`}
+                >
+                  {contact.status}
+                </span>
+              </div>
+              <div className="mt-0.5 flex items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
+                <span>{contact.archetype}</span>
+                <span>
+                  C:{contact.connection} / L:{contact.loyalty}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/campaigns/[id]/components/CampaignRunSessionCard.tsx
+++ b/app/campaigns/[id]/components/CampaignRunSessionCard.tsx
@@ -25,26 +25,35 @@ const PHASE_ICONS: Record<string, typeof Target> = {
 
 const PHASE_COLORS: Record<string, { active: string; completed: string; pending: string }> = {
   "the-meet": {
-    active: "border-amber-500 bg-amber-500/10 text-amber-400",
-    completed: "border-green-600 bg-green-600/20 text-green-400",
-    pending: "border-zinc-600 bg-zinc-800 text-zinc-500",
+    active: "border-amber-500 bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-400",
+    completed:
+      "border-green-500 bg-green-50 text-green-700 dark:border-green-600 dark:bg-green-600/20 dark:text-green-400",
+    pending:
+      "border-zinc-300 bg-zinc-100 text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-500",
   },
   "the-run": {
-    active: "border-red-500 bg-red-500/10 text-red-400",
-    completed: "border-green-600 bg-green-600/20 text-green-400",
-    pending: "border-zinc-600 bg-zinc-800 text-zinc-500",
+    active: "border-red-500 bg-red-50 text-red-700 dark:bg-red-500/10 dark:text-red-400",
+    completed:
+      "border-green-500 bg-green-50 text-green-700 dark:border-green-600 dark:bg-green-600/20 dark:text-green-400",
+    pending:
+      "border-zinc-300 bg-zinc-100 text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-500",
   },
   "the-handoff": {
-    active: "border-indigo-500 bg-indigo-500/10 text-indigo-400",
-    completed: "border-green-600 bg-green-600/20 text-green-400",
-    pending: "border-zinc-600 bg-zinc-800 text-zinc-500",
+    active:
+      "border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-400",
+    completed:
+      "border-green-500 bg-green-50 text-green-700 dark:border-green-600 dark:bg-green-600/20 dark:text-green-400",
+    pending:
+      "border-zinc-300 bg-zinc-100 text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-500",
   },
 };
 
 const DEFAULT_PHASE_COLORS = {
-  active: "border-zinc-400 bg-zinc-400/10 text-zinc-300",
-  completed: "border-green-600 bg-green-600/20 text-green-400",
-  pending: "border-zinc-600 bg-zinc-800 text-zinc-500",
+  active: "border-zinc-400 bg-zinc-100 text-zinc-600 dark:bg-zinc-400/10 dark:text-zinc-300",
+  completed:
+    "border-green-500 bg-green-50 text-green-700 dark:border-green-600 dark:bg-green-600/20 dark:text-green-400",
+  pending:
+    "border-zinc-300 bg-zinc-100 text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-500",
 };
 
 function getPhaseStatus(

--- a/app/campaigns/[id]/components/CampaignTabs.tsx
+++ b/app/campaigns/[id]/components/CampaignTabs.tsx
@@ -7,6 +7,7 @@ export type CampaignTabId =
   | "roster"
   | "grunt-teams"
   | "run-tracker"
+  | "contacts"
   | "locations"
   | "posts"
   | "calendar"
@@ -38,6 +39,7 @@ export default function CampaignTabs({
     ...(isGM ? [{ id: "roster" as const, label: "Roster", public: false }] : []),
     ...(isGM ? [{ id: "grunt-teams" as const, label: "Grunt Teams", public: false }] : []),
     ...(isGM ? [{ id: "run-tracker" as const, label: "Run Tracker", public: false }] : []),
+    ...(isGM ? [{ id: "contacts" as const, label: "Contacts", public: false }] : []),
     ...(isGM
       ? [
           {

--- a/app/campaigns/[id]/components/CampaignTabs.tsx
+++ b/app/campaigns/[id]/components/CampaignTabs.tsx
@@ -55,8 +55,8 @@ export default function CampaignTabs({
   const tabs = allTabs.filter((tab) => tab.public || isMember);
 
   return (
-    <div className="border-b border-zinc-200 dark:border-zinc-800">
-      <nav className="-mb-px flex space-x-8" aria-label="Campaign tabs">
+    <div className="border-b border-zinc-200 dark:border-zinc-800 overflow-x-auto">
+      <nav className="-mb-px flex space-x-4 sm:space-x-6" aria-label="Campaign tabs">
         {tabs.map((tab) => (
           <button
             key={tab.id}

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -28,6 +28,7 @@ import CampaignAdvancementsTab from "./components/CampaignAdvancementsTab";
 import CampaignCharacterApprovalsTab from "./components/CampaignCharacterApprovalsTab";
 import CampaignGruntTeamsTab from "./components/CampaignGruntTeamsTab";
 import CampaignRunTrackerTab from "./components/CampaignRunTrackerTab";
+import CampaignContactsTab from "./components/CampaignContactsTab";
 
 interface CampaignDetailProps {
   params: Promise<{ id: string }>;
@@ -349,6 +350,9 @@ export default function CampaignDetailPage({ params }: CampaignDetailProps) {
         )}
         {activeTab === "run-tracker" && userRole === "gm" && campaign && (
           <CampaignRunTrackerTab campaign={campaign} />
+        )}
+        {activeTab === "contacts" && userRole === "gm" && campaign && (
+          <CampaignContactsTab campaign={campaign} />
         )}
         {activeTab === "approvals" && userRole === "gm" && (
           <div className="space-y-8">

--- a/data/editions/sr5/run-faster.json
+++ b/data/editions/sr5/run-faster.json
@@ -16846,6 +16846,8 @@
               "asset recovery",
               "security testing"
             ],
+            "betrayalRisk": "moderate",
+            "betrayalNotes": "Know they have good rep; will use betrayal fully if situation requires it",
             "source": "run-faster",
             "page": 198
           },
@@ -16861,6 +16863,8 @@
               "wetwork",
               "smuggling"
             ],
+            "betrayalRisk": "high",
+            "betrayalNotes": "Overall corporate plan to dominate/destroy the world colors all dealings",
             "source": "run-faster",
             "page": 199
           },
@@ -16876,6 +16880,8 @@
               "research protection",
               "space-related ops"
             ],
+            "betrayalRisk": "moderate",
+            "betrayalNotes": "Top security at every meet regardless of job size",
             "source": "run-faster",
             "page": 200
           },
@@ -16891,6 +16897,8 @@
               "social engineering",
               "data retrieval"
             ],
+            "betrayalRisk": "moderate",
+            "betrayalNotes": "Dawkins Group association — can destroy anyone with minimal effort",
             "source": "run-faster",
             "page": 200
           },
@@ -16906,6 +16914,8 @@
               "wetwork",
               "corporate espionage"
             ],
+            "betrayalRisk": "very-high",
+            "betrayalNotes": "May send kill squad if you fail and accepted money",
             "source": "run-faster",
             "page": 201
           },
@@ -16915,6 +16925,8 @@
             "category": "megacorporate",
             "description": "A major Matrix infrastructure provider struggling with internal instability. NeoNET Johnsons may be working competing internal agendas, making them unpredictable employers.",
             "typicalJobs": ["matrix ops", "data theft", "asset recovery", "sabotage", "extraction"],
+            "betrayalRisk": "very-low",
+            "betrayalNotes": "Building reliable teams is their priority",
             "source": "run-faster",
             "page": 202
           },
@@ -16930,6 +16942,8 @@
               "counter-intelligence",
               "security testing"
             ],
+            "betrayalRisk": "moderate",
+            "betrayalNotes": "Internal politics mean Johnson's enemies become your enemies",
             "source": "run-faster",
             "page": 202
           },
@@ -16945,6 +16959,8 @@
               "sabotage",
               "investigation"
             ],
+            "betrayalRisk": "uncertain",
+            "betrayalNotes": "S-K Johnsons are left alone a lot and quickly learn not to question missions",
             "source": "run-faster",
             "page": 203
           },
@@ -16960,6 +16976,8 @@
               "extraction",
               "corporate espionage"
             ],
+            "betrayalRisk": "low",
+            "betrayalNotes": "Low if honor is maintained",
             "source": "run-faster",
             "page": 203
           },
@@ -16975,6 +16993,8 @@
               "astral ops",
               "smuggling"
             ],
+            "betrayalRisk": "moderate",
+            "betrayalNotes": "Magical member is always watching",
             "source": "run-faster",
             "page": 204
           },
@@ -16990,6 +17010,8 @@
               "territory defense",
               "debt collection"
             ],
+            "betrayalRisk": "low",
+            "betrayalNotes": "Low risk of non-payment; high risk of violence if you show disrespect",
             "source": "run-faster",
             "page": 205
           },
@@ -17005,6 +17027,8 @@
               "protection rackets",
               "corporate infiltration"
             ],
+            "betrayalRisk": "high",
+            "betrayalNotes": "Biggest hypocrites in the shadows — break all rules they insist you follow",
             "source": "run-faster",
             "page": 206
           },
@@ -17020,6 +17044,8 @@
               "BTL distribution",
               "enforcement"
             ],
+            "betrayalRisk": "high",
+            "betrayalNotes": "Payback will come using magic — find a warded place and plan to stay there",
             "source": "run-faster",
             "page": 206
           },
@@ -17029,6 +17055,8 @@
             "category": "syndicate",
             "description": "Russian organized crime known for extreme violence and no formal code of honor. Vory Johnsons are unpredictable and dangerous employers who may betray runners on a whim.",
             "typicalJobs": ["wetwork", "intimidation", "smuggling", "matrix crime", "arms dealing"],
+            "betrayalRisk": "moderate",
+            "betrayalNotes": "Good people to work for if you aren't looking to make friends; violence is their only problem-solving method",
             "source": "run-faster",
             "page": 207
           },
@@ -17044,6 +17072,8 @@
               "anti-metahuman ops",
               "arson"
             ],
+            "betrayalRisk": "moderate",
+            "betrayalNotes": "Will promise anything and lie about everything; highest post-run kill risk among extremists",
             "source": "run-faster",
             "page": 208
           },
@@ -17059,6 +17089,8 @@
               "propaganda",
               "investigation"
             ],
+            "betrayalRisk": "low",
+            "betrayalNotes": "Mission-driven and passionate; less likely to betray but plans may be idealistic",
             "source": "run-faster",
             "page": 208
           },
@@ -17068,6 +17100,8 @@
             "category": "extremist",
             "description": "A violent anti-metahuman terrorist organization that targets metahumans and their allies. Alamos Johnsons are dangerous fanatics willing to sacrifice runners for their cause.",
             "typicalJobs": ["terrorism", "wetwork", "sabotage", "bombing", "anti-metahuman ops"],
+            "betrayalRisk": "very-high",
+            "betrayalNotes": "Dangerous fanatics willing to sacrifice runners; highest post-run kill risk",
             "source": "run-faster",
             "page": 209
           },
@@ -17083,6 +17117,8 @@
               "protection",
               "investigation"
             ],
+            "betrayalRisk": "low",
+            "betrayalNotes": "Low intentional betrayal risk; high accidental risk from incompetence and bad intel",
             "source": "run-faster",
             "page": 210
           }

--- a/lib/rules/module-payloads.ts
+++ b/lib/rules/module-payloads.ts
@@ -242,6 +242,10 @@ export interface JohnsonFactionData {
   category: JohnsonFactionCategory;
   description: string;
   typicalJobs?: string[];
+  /** Betrayal risk level for this faction (Run Faster pp. 202-211) */
+  betrayalRisk?: import("../types/contacts").BetrayalRiskLevel;
+  /** GM-facing notes about betrayal tendencies */
+  betrayalNotes?: string;
   source: string;
   page: number;
 }

--- a/lib/storage/contacts.ts
+++ b/lib/storage/contacts.ts
@@ -26,6 +26,7 @@ import type {
   CreateContactRequest,
   UpdateContactRequest,
   ContactVisibility,
+  BetrayalPlanningState,
 } from "../types/contacts";
 import { ensureDirectory, readJsonFile, writeJsonFile, deleteFile, readAllJsonFiles } from "./base";
 import { getCharacter, updateCharacter } from "./characters";
@@ -637,6 +638,36 @@ export async function updateCampaignContact(
     id: contact.id, // Prevent ID change
     campaignId: contact.campaignId, // Prevent campaign change
     visibility: mergedVisibility,
+    updatedAt: new Date().toISOString(),
+  };
+
+  const filePath = getCampaignContactPath(campaignId, contactId);
+  await writeJsonFile(filePath, updatedContact);
+
+  return updatedContact;
+}
+
+/**
+ * Set or clear betrayal planning state on a campaign contact (GM-only)
+ *
+ * @param campaignId - Campaign ID
+ * @param contactId - Contact ID
+ * @param planning - Betrayal planning state, or null to clear
+ * @returns Updated contact
+ */
+export async function updateCampaignContactBetrayalPlanning(
+  campaignId: ID,
+  contactId: ID,
+  planning: BetrayalPlanningState | null
+): Promise<SocialContact> {
+  const contact = await getCampaignContact(campaignId, contactId);
+  if (!contact) {
+    throw new Error(`Campaign contact ${contactId} not found`);
+  }
+
+  const updatedContact: SocialContact = {
+    ...contact,
+    betrayalPlanning: planning ?? undefined,
     updatedAt: new Date().toISOString(),
   };
 

--- a/lib/types/contacts.ts
+++ b/lib/types/contacts.ts
@@ -10,6 +10,37 @@
 import type { ID, ISODateString, Metadata } from "./core";
 import type { EditionCode } from "./edition";
 import type { RelationshipQuality, ChipCostAdjustment } from "../rules/relationship-qualities";
+import type { BetrayalSeverity } from "../rules/module-payloads";
+
+// =============================================================================
+// BETRAYAL PLANNING TYPES (GM-only)
+// =============================================================================
+
+/**
+ * GM-only betrayal planning state for a Johnson contact.
+ * Hidden from players via ContactVisibility filtering.
+ */
+export interface BetrayalPlanningState {
+  /** Which betrayal type the Johnson is planning */
+  betrayalTypeId: string;
+  /** Warning signals the GM has chosen to reveal to players */
+  revealedSignals: string[];
+  /** GM notes about the betrayal scenario */
+  gmNotes?: string;
+  /** When the GM marked this contact as planning betrayal */
+  markedAt: ISODateString;
+}
+
+/**
+ * Faction-level betrayal risk assessment hint
+ */
+export type BetrayalRiskLevel =
+  | "very-low"
+  | "low"
+  | "moderate"
+  | "high"
+  | "very-high"
+  | "uncertain";
 
 // =============================================================================
 // CONTACT CORE TYPES
@@ -227,6 +258,13 @@ export interface SocialContact {
 
   createdAt: ISODateString;
   updatedAt?: ISODateString;
+
+  // ---------------------------------------------------------------------------
+  // Betrayal Planning (GM-only, Run Faster pp. 210-211)
+  // ---------------------------------------------------------------------------
+
+  /** GM-only betrayal planning state (hidden from players) */
+  betrayalPlanning?: BetrayalPlanningState;
 
   /** Extensible metadata */
   metadata?: Metadata;

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -571,6 +571,9 @@ export type {
   ContactArchetype,
   ContactServiceType,
   ContactPreferredPayment,
+  // Betrayal planning types
+  BetrayalPlanningState,
+  BetrayalRiskLevel,
   // Favor ledger types
   FavorTransactionType,
   FavorRiskLevel,


### PR DESCRIPTION
## Summary

- Add betrayal risk assessment tool to campaign GM contacts tab for planning narrative tension
- Add `BetrayalPlanningState` type and `betrayalRisk`/`betrayalNotes` to all 18 Johnson factions
- Add GM-only PATCH endpoint for betrayal planning CRUD (set, clear, reveal/hide warning signals)
- Add `BetrayalAssessmentPanel` with faction risk hints, loyalty assessment, and signal checklist
- Add "Contacts" tab to campaign page (GM-only) with inline betrayal assessment per Johnson

## Test plan

- [x] 15 API route tests for betrayal endpoint (auth, set, clear, reveal, hide, validation)
- [x] 2 visibility tests confirming `betrayalPlanning` stripped from non-GM responses
- [x] TypeScript strict mode passes
- [x] All 457 contact-related tests pass
- [x] Data validation passes (`pnpm verify-data`)

Closes #835

🤖 Generated with [Claude Code](https://claude.ai/code)