### PR TITLE
feat: add campaign contacts management with GM creation, merged view, and visibility controls (#843)

### DIFF
--- a/app/api/campaigns/[id]/contacts/[contactId]/__tests__/route.test.ts
+++ b/app/api/campaigns/[id]/contacts/[contactId]/__tests__/route.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for /api/campaigns/[id]/contacts/[contactId] endpoint
+ *
+ * Tests campaign contact PATCH (update) functionality including
+ * visibility toggle and loyalty overrides.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PATCH } from "../route";
+import { NextRequest } from "next/server";
+import * as sessionModule from "@/lib/auth/session";
+import * as campaignAuthModule from "@/lib/auth/campaign";
+import * as contactStorage from "@/lib/storage/contacts";
+import type { SocialContact } from "@/lib/types";
+
+vi.mock("@/lib/auth/session");
+vi.mock("@/lib/auth/campaign", () => ({
+  authorizeGM: vi.fn(),
+}));
+vi.mock("@/lib/storage/contacts");
+
+function createMockRequest(url: string, body: unknown): NextRequest {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  const urlObj = new URL(url);
+  const request = new NextRequest(urlObj, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers,
+  });
+  (request as { json: () => Promise<unknown> }).json = async () => body;
+  return request;
+}
+
+function createMockContact(overrides?: Partial<SocialContact>): SocialContact {
+  return {
+    id: "test-contact-id",
+    campaignId: "test-campaign-id",
+    name: "Test Contact",
+    archetype: "fixer",
+    connection: 3,
+    loyalty: 2,
+    favorBalance: 0,
+    status: "active",
+    group: "campaign",
+    visibility: {
+      playerVisible: false,
+      showConnection: false,
+      showLoyalty: false,
+      showFavorBalance: false,
+      showSpecializations: false,
+    },
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  } as SocialContact;
+}
+
+const makeParams = (id = "test-campaign-id", contactId = "test-contact-id") =>
+  Promise.resolve({ id, contactId });
+
+describe("PATCH /api/campaigns/[id]/contacts/[contactId]", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should return 401 when not authenticated", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue(null);
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts/test-contact-id",
+      { visibility: { playerVisible: true } }
+    );
+    const response = await PATCH(request, { params: makeParams() });
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 403 when not GM", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue("player-1");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: false,
+      campaign: null,
+      role: "player",
+      error: "Only the GM can perform this action",
+      status: 403,
+    });
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts/test-contact-id",
+      { visibility: { playerVisible: true } }
+    );
+    const response = await PATCH(request, { params: makeParams() });
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 404 when contact not found", async () => {
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      campaign: {} as never,
+      role: "gm",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(null);
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts/nonexistent",
+      { visibility: { playerVisible: true } }
+    );
+    const response = await PATCH(request, {
+      params: makeParams("test-campaign-id", "nonexistent"),
+    });
+    expect(response.status).toBe(404);
+  });
+
+  it("should toggle visibility successfully", async () => {
+    const contact = createMockContact();
+    const updatedContact = createMockContact({
+      visibility: {
+        playerVisible: true,
+        showConnection: true,
+        showLoyalty: true,
+        showFavorBalance: false,
+        showSpecializations: true,
+      },
+    });
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      campaign: {} as never,
+      role: "gm",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+    vi.mocked(contactStorage.updateCampaignContact).mockResolvedValue(updatedContact);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts/test-contact-id",
+      {
+        visibility: {
+          playerVisible: true,
+          showConnection: true,
+          showLoyalty: true,
+          showSpecializations: true,
+        },
+      }
+    );
+    const response = await PATCH(request, { params: makeParams() });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.contact.visibility.playerVisible).toBe(true);
+  });
+
+  it("should update loyalty overrides", async () => {
+    const contact = createMockContact();
+    const updatedContact = createMockContact({
+      loyaltyOverrides: { "char-1": 5, "char-2": 1 },
+    });
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      campaign: {} as never,
+      role: "gm",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+    vi.mocked(contactStorage.updateCampaignContact).mockResolvedValue(updatedContact);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts/test-contact-id",
+      { loyaltyOverrides: { "char-1": 5, "char-2": 1 } }
+    );
+    const response = await PATCH(request, { params: makeParams() });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.contact.loyaltyOverrides).toEqual({ "char-1": 5, "char-2": 1 });
+  });
+
+  it("should reject loyalty override out of range", async () => {
+    const contact = createMockContact();
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      campaign: {} as never,
+      role: "gm",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts/test-contact-id",
+      { loyaltyOverrides: { "char-1": 10 } }
+    );
+    const response = await PATCH(request, { params: makeParams() });
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("between 1 and 6");
+  });
+
+  it("should reject name exceeding max length", async () => {
+    const contact = createMockContact();
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      campaign: {} as never,
+      role: "gm",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts/test-contact-id",
+      { name: "x".repeat(201) }
+    );
+    const response = await PATCH(request, { params: makeParams() });
+    expect(response.status).toBe(400);
+  });
+
+  it("should reject connection out of range", async () => {
+    const contact = createMockContact();
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockResolvedValue({
+      authorized: true,
+      campaign: {} as never,
+      role: "gm",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContact).mockResolvedValue(contact);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts/test-contact-id",
+      { connection: 15 }
+    );
+    const response = await PATCH(request, { params: makeParams() });
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("between 1 and 12");
+  });
+
+  it("should return 500 on internal error", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeGM).mockRejectedValue(new Error("DB error"));
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts/test-contact-id",
+      { loyalty: 3 }
+    );
+    const response = await PATCH(request, { params: makeParams() });
+    expect(response.status).toBe(500);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/app/api/campaigns/[id]/contacts/[contactId]/route.ts
+++ b/app/api/campaigns/[id]/contacts/[contactId]/route.ts
@@ -1,0 +1,132 @@
+/**
+ * API Route: /api/campaigns/[id]/contacts/[contactId]
+ *
+ * PATCH - Update a campaign contact (GM only)
+ *   Supports visibility toggle, loyalty overrides, and general field updates.
+ *
+ * @see /docs/capabilities/campaign.social-governance.md
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { authorizeGM } from "@/lib/auth/campaign";
+import { getCampaignContact, updateCampaignContact } from "@/lib/storage/contacts";
+import type { ContactStatus, UpdateContactRequest } from "@/lib/types";
+
+interface RouteParams {
+  params: Promise<{ id: string; contactId: string }>;
+}
+
+const MAX_NAME_LEN = 200;
+const MAX_DESCRIPTION_LEN = 2000;
+const MAX_GM_NOTES_LEN = 2000;
+const MAX_LOYALTY = 6;
+const MAX_CONNECTION = 12;
+const VALID_STATUSES: readonly ContactStatus[] = [
+  "active",
+  "burned",
+  "inactive",
+  "missing",
+  "deceased",
+];
+
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const userId = await getSession();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: campaignId, contactId } = await params;
+
+    const auth = await authorizeGM(campaignId, userId);
+    if (!auth.authorized) {
+      return NextResponse.json({ success: false, error: auth.error }, { status: auth.status });
+    }
+
+    const contact = await getCampaignContact(campaignId, contactId);
+    if (!contact) {
+      return NextResponse.json({ success: false, error: "Contact not found" }, { status: 404 });
+    }
+
+    const body = (await request.json()) as UpdateContactRequest;
+
+    // Validate string lengths
+    if (body.name !== undefined && body.name.length > MAX_NAME_LEN) {
+      return NextResponse.json(
+        { success: false, error: `Name must be ${MAX_NAME_LEN} characters or less` },
+        { status: 400 }
+      );
+    }
+    if (body.description !== undefined && body.description.length > MAX_DESCRIPTION_LEN) {
+      return NextResponse.json(
+        { success: false, error: `Description must be ${MAX_DESCRIPTION_LEN} characters or less` },
+        { status: 400 }
+      );
+    }
+    if (body.gmNotes !== undefined && body.gmNotes.length > MAX_GM_NOTES_LEN) {
+      return NextResponse.json(
+        { success: false, error: `GM notes must be ${MAX_GM_NOTES_LEN} characters or less` },
+        { status: 400 }
+      );
+    }
+
+    // Validate numeric ranges
+    if (body.loyalty !== undefined && (body.loyalty < 1 || body.loyalty > MAX_LOYALTY)) {
+      return NextResponse.json(
+        { success: false, error: `Loyalty must be between 1 and ${MAX_LOYALTY}` },
+        { status: 400 }
+      );
+    }
+    if (
+      body.connection !== undefined &&
+      (body.connection < 1 || body.connection > MAX_CONNECTION)
+    ) {
+      return NextResponse.json(
+        { success: false, error: `Connection must be between 1 and ${MAX_CONNECTION}` },
+        { status: 400 }
+      );
+    }
+
+    // Validate status enum
+    if (body.status !== undefined && !(VALID_STATUSES as readonly string[]).includes(body.status)) {
+      return NextResponse.json({ success: false, error: "Invalid status value" }, { status: 400 });
+    }
+
+    // Validate favor balance
+    if (body.favorBalance !== undefined && !Number.isFinite(body.favorBalance)) {
+      return NextResponse.json({ success: false, error: "Invalid favor balance" }, { status: 400 });
+    }
+
+    // Validate loyalty overrides
+    if (body.loyaltyOverrides !== undefined) {
+      for (const [charId, value] of Object.entries(body.loyaltyOverrides)) {
+        if (typeof charId !== "string" || charId.length === 0) {
+          return NextResponse.json(
+            { success: false, error: "Invalid character ID in loyalty overrides" },
+            { status: 400 }
+          );
+        }
+        if (typeof value !== "number" || value < 1 || value > MAX_LOYALTY) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: `Loyalty override for ${charId} must be between 1 and ${MAX_LOYALTY}`,
+            },
+            { status: 400 }
+          );
+        }
+      }
+    }
+
+    const updatedContact = await updateCampaignContact(campaignId, contactId, body);
+
+    return NextResponse.json({ success: true, contact: updatedContact });
+  } catch (error) {
+    console.error("Failed to update campaign contact:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to update campaign contact" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/campaigns/[id]/contacts/[contactId]/route.ts
+++ b/app/api/campaigns/[id]/contacts/[contactId]/route.ts
@@ -88,6 +88,21 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       );
     }
 
+    // Validate imageUrl if provided
+    if (body.imageUrl !== undefined && body.imageUrl !== "") {
+      try {
+        const u = new URL(body.imageUrl);
+        if (u.protocol !== "https:") {
+          return NextResponse.json(
+            { success: false, error: "imageUrl must use HTTPS" },
+            { status: 400 }
+          );
+        }
+      } catch {
+        return NextResponse.json({ success: false, error: "Invalid imageUrl" }, { status: 400 });
+      }
+    }
+
     // Validate status enum
     if (body.status !== undefined && !(VALID_STATUSES as readonly string[]).includes(body.status)) {
       return NextResponse.json({ success: false, error: "Invalid status value" }, { status: 400 });
@@ -100,6 +115,13 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     // Validate loyalty overrides
     if (body.loyaltyOverrides !== undefined) {
+      const MAX_OVERRIDES = 200;
+      if (Object.keys(body.loyaltyOverrides).length > MAX_OVERRIDES) {
+        return NextResponse.json(
+          { success: false, error: "Too many loyalty overrides" },
+          { status: 400 }
+        );
+      }
       for (const [charId, value] of Object.entries(body.loyaltyOverrides)) {
         if (typeof charId !== "string" || charId.length === 0) {
           return NextResponse.json(

--- a/app/api/campaigns/[id]/contacts/__tests__/route.test.ts
+++ b/app/api/campaigns/[id]/contacts/__tests__/route.test.ts
@@ -19,7 +19,10 @@ vi.mock("@/lib/auth/campaign", () => ({
   authorizeMember: vi.fn(),
 }));
 vi.mock("@/lib/storage/contacts");
+vi.mock("@/lib/storage/characters");
 vi.mock("@/lib/rules/contacts");
+
+import * as characterStorage from "@/lib/storage/characters";
 
 function createMockRequest(url: string, body?: unknown, method = "GET"): NextRequest {
   const headers = new Headers();
@@ -45,6 +48,7 @@ function createMockContact(overrides?: Partial<SocialContact>): SocialContact {
     loyalty: 2,
     favorBalance: 0,
     status: "active",
+    group: "campaign",
     visibility: {
       playerVisible: true,
       showConnection: true,
@@ -297,6 +301,72 @@ describe("GET /api/campaigns/[id]/contacts", () => {
     const response = await GET(request, { params: Promise.resolve({ id: "test-campaign-id" }) });
     expect(response.status).toBe(500);
     consoleErrorSpy.mockRestore();
+  });
+
+  it("should return merged view with character contacts when include=all", async () => {
+    const campaignContact = createMockContact({ id: "camp-1", name: "Campaign Contact" });
+    const charContact = createMockContact({
+      id: "char-1",
+      name: "Character Contact",
+      characterId: "char-id-1",
+    });
+    const mockCampaign = createMockCampaign({ gmId: "test-gm-id", playerIds: ["player-1"] });
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeMember).mockResolvedValue({
+      authorized: true,
+      campaign: mockCampaign,
+      role: "gm",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContacts).mockResolvedValue([campaignContact]);
+    vi.mocked(characterStorage.getUserCharacters).mockImplementation(async (userId) => {
+      if (userId === "test-gm-id") return [];
+      return [
+        {
+          id: "char-id-1",
+          ownerId: "player-1",
+          name: "Street Sam",
+          campaignId: "test-campaign-id",
+          contacts: [],
+        } as unknown as import("@/lib/types").Character,
+      ];
+    });
+    vi.mocked(contactStorage.getCharacterContacts).mockResolvedValue([charContact]);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts?include=all"
+    );
+    const response = await GET(request, { params: Promise.resolve({ id: "test-campaign-id" }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.contacts).toHaveLength(2);
+    expect(data.characterNames).toEqual({ "char-id-1": "Street Sam" });
+  });
+
+  it("should not include character contacts without include=all", async () => {
+    const campaignContact = createMockContact({ id: "camp-1" });
+    const mockCampaign = createMockCampaign();
+
+    vi.mocked(sessionModule.getSession).mockResolvedValue("test-gm-id");
+    vi.mocked(campaignAuthModule.authorizeMember).mockResolvedValue({
+      authorized: true,
+      campaign: mockCampaign,
+      role: "gm",
+      status: 200,
+    });
+    vi.mocked(contactStorage.getCampaignContacts).mockResolvedValue([campaignContact]);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/campaigns/test-campaign-id/contacts"
+    );
+    const response = await GET(request, { params: Promise.resolve({ id: "test-campaign-id" }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.contacts).toHaveLength(1);
+    expect(characterStorage.getUserCharacters).not.toHaveBeenCalled();
   });
 });
 

--- a/app/api/campaigns/[id]/contacts/route.ts
+++ b/app/api/campaigns/[id]/contacts/route.ts
@@ -10,9 +10,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { authorizeGM, authorizeMember } from "@/lib/auth/campaign";
-import { getCampaignContacts, createCampaignContact } from "@/lib/storage/contacts";
+import {
+  getCampaignContacts,
+  createCampaignContact,
+  getCharacterContacts,
+} from "@/lib/storage/contacts";
+import { getUserCharacters } from "@/lib/storage/characters";
 import { validateContact } from "@/lib/rules/contacts";
 import type { CreateContactRequest, ContactStatus, SocialContact } from "@/lib/types";
+
+const VALID_STATUSES: readonly ContactStatus[] = [
+  "active",
+  "burned",
+  "inactive",
+  "missing",
+  "deceased",
+];
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -36,10 +49,36 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const searchParams = request.nextUrl.searchParams;
     const archetype = searchParams.get("archetype");
     const location = searchParams.get("location");
-    const status = searchParams.get("status") as ContactStatus | null;
+    const statusParam = searchParams.get("status");
+    const status: ContactStatus | null =
+      statusParam && (VALID_STATUSES as readonly string[]).includes(statusParam)
+        ? (statusParam as ContactStatus)
+        : null;
+    const include = searchParams.get("include"); // "all" = merged view with character contacts
 
     // Get campaign contacts
     let contacts = await getCampaignContacts(campaignId);
+
+    // Build character name map for owner labels (GM merged view)
+    const characterNames: Record<string, string> = {};
+
+    // If GM requests merged view, include character contacts from all campaign members
+    if (isGm && include === "all") {
+      const allMemberIds = [campaign.gmId, ...campaign.playerIds];
+      const characterArrays = await Promise.all(
+        allMemberIds.map((memberId) => getUserCharacters(memberId))
+      );
+      const campaignCharacters = characterArrays
+        .flat()
+        .filter((char) => char.campaignId === campaignId);
+
+      // Build name map and collect character contacts
+      for (const char of campaignCharacters) {
+        characterNames[char.id] = char.name;
+        const charContacts = await getCharacterContacts(char.ownerId, char.id);
+        contacts = [...contacts, ...charContacts];
+      }
+    }
 
     // Filter by visibility (non-GMs only see player-visible contacts)
     if (!isGm) {
@@ -83,6 +122,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       contacts: displayContacts,
       count: displayContacts.length,
       isGm,
+      characterNames: isGm ? characterNames : undefined,
     });
   } catch (error) {
     console.error("Failed to get campaign contacts:", error);

--- a/app/api/campaigns/[id]/contacts/route.ts
+++ b/app/api/campaigns/[id]/contacts/route.ts
@@ -72,12 +72,18 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         .flat()
         .filter((char) => char.campaignId === campaignId);
 
-      // Build name map and collect character contacts
+      // Build name map and collect character contacts (parallelized)
       for (const char of campaignCharacters) {
         characterNames[char.id] = char.name;
-        const charContacts = await getCharacterContacts(char.ownerId, char.id);
-        contacts = [...contacts, ...charContacts];
       }
+      const charContactArrays = await Promise.all(
+        campaignCharacters.map((char) => getCharacterContacts(char.ownerId, char.id))
+      );
+      // Only include contacts scoped to this campaign (exclude contacts from other campaigns)
+      const scopedCharContacts = charContactArrays
+        .flat()
+        .filter((c) => !c.campaignId || c.campaignId === campaignId);
+      contacts = [...contacts, ...scopedCharContacts];
     }
 
     // Filter by visibility (non-GMs only see player-visible contacts)

--- a/app/campaigns/[id]/components/CampaignContactCard.tsx
+++ b/app/campaigns/[id]/components/CampaignContactCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "react-aria-components";
 import { Info, Eye, EyeOff, ChevronDown, ChevronUp, X } from "lucide-react";
 import type { SocialContact } from "@/lib/types";
@@ -244,6 +244,11 @@ function LoyaltyOverrideRow({
   onRemoveOverride,
 }: LoyaltyOverrideRowProps) {
   const [localValue, setLocalValue] = useState<number>(override ?? defaultLoyalty);
+
+  // Sync local value when the prop changes (e.g. after a refetch)
+  useEffect(() => {
+    setLocalValue(override ?? defaultLoyalty);
+  }, [override, defaultLoyalty]);
 
   const handleBlur = () => {
     const clamped = Math.max(1, Math.min(6, localValue));

--- a/app/campaigns/[id]/components/CampaignContactCard.tsx
+++ b/app/campaigns/[id]/components/CampaignContactCard.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "react-aria-components";
+import { Info, Eye, EyeOff, ChevronDown, ChevronUp, X } from "lucide-react";
+import type { SocialContact } from "@/lib/types";
+import type { BetrayalTypeData, JohnsonFactionData } from "@/lib/rules/module-payloads";
+import { BetrayalAssessmentPanel } from "./BetrayalAssessmentPanel";
+
+const RISK_COLORS: Record<string, string> = {
+  "very-low": "text-green-400 bg-green-500/10",
+  low: "text-green-300 bg-green-500/10",
+  moderate: "text-amber-400 bg-amber-500/10",
+  high: "text-orange-400 bg-orange-500/10",
+  "very-high": "text-red-400 bg-red-500/10",
+  uncertain: "text-zinc-400 bg-zinc-500/10",
+};
+
+export interface CampaignContactCardProps {
+  contact: SocialContact;
+  faction: JohnsonFactionData | null;
+  ownerLabel: string;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onToggleVisibility: () => void;
+  betrayalTypes: BetrayalTypeData[];
+  factions: JohnsonFactionData[];
+  campaignId: string;
+  onContactUpdated: (c: SocialContact) => void;
+  isLoyaltyExpanded: boolean;
+  onToggleLoyalty: () => void;
+  characterNames: Record<string, string>;
+  onSetLoyaltyOverride: (characterId: string, value: number) => void;
+  onRemoveLoyaltyOverride: (characterId: string) => void;
+}
+
+export function CampaignContactCard({
+  contact,
+  faction,
+  ownerLabel,
+  isExpanded,
+  onToggleExpand,
+  onToggleVisibility,
+  betrayalTypes,
+  factions,
+  campaignId,
+  onContactUpdated,
+  isLoyaltyExpanded,
+  onToggleLoyalty,
+  characterNames,
+  onSetLoyaltyOverride,
+  onRemoveLoyaltyOverride,
+}: CampaignContactCardProps) {
+  const isCampaignContact = !contact.characterId;
+
+  return (
+    <div className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900">
+      {/* Contact Header */}
+      <div className="flex items-center justify-between px-4 py-3">
+        <Button
+          onPress={onToggleExpand}
+          aria-expanded={isExpanded}
+          aria-label={`${isExpanded ? "Collapse" : "Expand"} details for ${contact.name}`}
+          className="flex flex-1 items-center gap-3 text-left outline-none"
+        >
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
+                {contact.name}
+              </span>
+              {/* Owner Badge */}
+              <span
+                className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                  isCampaignContact
+                    ? "bg-indigo-500/10 text-indigo-400"
+                    : "bg-cyan-500/10 text-cyan-400"
+                }`}
+              >
+                {ownerLabel}
+              </span>
+              {/* Betrayal Planned */}
+              {contact.betrayalPlanning && (
+                <span className="rounded-full bg-red-500/20 px-2 py-0.5 text-[10px] font-bold uppercase text-red-400">
+                  Betrayal Planned
+                </span>
+              )}
+              {/* Status */}
+              <span
+                className={`rounded px-1.5 py-0.5 text-[10px] font-mono ${
+                  contact.status === "active"
+                    ? "bg-green-500/10 text-green-400"
+                    : "bg-zinc-500/10 text-zinc-400"
+                }`}
+              >
+                {contact.status}
+              </span>
+            </div>
+            <div className="mt-0.5 flex flex-wrap items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
+              <span>{contact.archetype}</span>
+              {faction && (
+                <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-amber-400">
+                  {faction.name}
+                </span>
+              )}
+              <span>
+                C:{contact.connection} / L:{contact.loyalty}
+              </span>
+            </div>
+          </div>
+        </Button>
+
+        <div className="flex items-center gap-2">
+          {/* Visibility Toggle (campaign contacts only) */}
+          {isCampaignContact && (
+            <Button
+              onPress={onToggleVisibility}
+              aria-label={
+                contact.visibility.playerVisible ? "Hide from players" : "Show to players"
+              }
+              className={`rounded p-1 outline-none ${
+                contact.visibility.playerVisible
+                  ? "text-green-400 hover:bg-green-500/10"
+                  : "text-zinc-400 hover:bg-zinc-500/10"
+              }`}
+            >
+              {contact.visibility.playerVisible ? (
+                <Eye className="h-4 w-4" />
+              ) : (
+                <EyeOff className="h-4 w-4" />
+              )}
+            </Button>
+          )}
+          {/* Visibility badge for character contacts */}
+          {!isCampaignContact && (
+            <span className="text-[10px] text-zinc-400">
+              {contact.visibility.playerVisible ? "visible" : "private"}
+            </span>
+          )}
+          {/* Risk Badge */}
+          {faction?.betrayalRisk && (
+            <span
+              className={`rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${
+                RISK_COLORS[faction.betrayalRisk] ?? "text-zinc-400 bg-zinc-500/10"
+              }`}
+            >
+              Risk: {faction.betrayalRisk}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Per-Character Loyalty Section (campaign contacts only) */}
+      {isCampaignContact && isExpanded && (
+        <div className="border-t border-zinc-200 px-4 py-3 dark:border-zinc-700">
+          <Button
+            onPress={onToggleLoyalty}
+            className="flex items-center gap-1 text-xs font-medium text-zinc-500 outline-none hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+          >
+            {isLoyaltyExpanded ? (
+              <ChevronUp className="h-3 w-3" />
+            ) : (
+              <ChevronDown className="h-3 w-3" />
+            )}
+            Per-Character Loyalty
+          </Button>
+
+          {isLoyaltyExpanded && (
+            <div className="mt-2 space-y-2">
+              <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+                <span>Campaign default: L:{contact.loyalty}</span>
+              </div>
+              {Object.entries(characterNames).map(([charId, charName]) => (
+                <LoyaltyOverrideRow
+                  key={charId}
+                  characterId={charId}
+                  characterName={charName}
+                  override={contact.loyaltyOverrides?.[charId]}
+                  defaultLoyalty={contact.loyalty}
+                  onSetOverride={onSetLoyaltyOverride}
+                  onRemoveOverride={onRemoveLoyaltyOverride}
+                />
+              ))}
+              {Object.keys(characterNames).length === 0 && (
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                  No campaign characters found.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Betrayal Assessment Panel (Johnson contacts) */}
+      {isExpanded && contact.factionId && betrayalTypes.length > 0 && (
+        <div className="border-t border-zinc-200 px-4 py-4 dark:border-zinc-700">
+          <BetrayalAssessmentPanel
+            contact={contact}
+            campaignId={campaignId}
+            betrayalTypes={betrayalTypes}
+            factions={factions}
+            onContactUpdated={onContactUpdated}
+          />
+        </div>
+      )}
+
+      {isExpanded && contact.factionId && betrayalTypes.length === 0 && (
+        <div className="border-t border-zinc-200 px-4 py-4 dark:border-zinc-700">
+          <div className="rounded border border-dashed border-zinc-600 p-4 text-center text-xs text-zinc-500">
+            <Info className="mx-auto mb-1 h-5 w-5" />
+            Betrayal type data not available. Enable the Run Faster sourcebook in campaign settings.
+          </div>
+        </div>
+      )}
+
+      {/* Description (non-Johnson contacts expanded) */}
+      {isExpanded && !contact.factionId && contact.description && (
+        <div className="border-t border-zinc-200 px-4 py-3 dark:border-zinc-700">
+          <p className="text-xs text-zinc-600 dark:text-zinc-400">{contact.description}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// =============================================================================
+// Loyalty Override Row — uses onBlur to avoid API calls on every keystroke
+// =============================================================================
+
+interface LoyaltyOverrideRowProps {
+  characterId: string;
+  characterName: string;
+  override: number | undefined;
+  defaultLoyalty: number;
+  onSetOverride: (characterId: string, value: number) => void;
+  onRemoveOverride: (characterId: string) => void;
+}
+
+function LoyaltyOverrideRow({
+  characterId,
+  characterName,
+  override,
+  defaultLoyalty,
+  onSetOverride,
+  onRemoveOverride,
+}: LoyaltyOverrideRowProps) {
+  const [localValue, setLocalValue] = useState<number>(override ?? defaultLoyalty);
+
+  const handleBlur = () => {
+    const clamped = Math.max(1, Math.min(6, localValue));
+    if (clamped !== (override ?? defaultLoyalty)) {
+      onSetOverride(characterId, clamped);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="min-w-[100px] text-xs text-zinc-600 dark:text-zinc-300">
+        {characterName}
+      </span>
+      <input
+        type="number"
+        min={1}
+        max={6}
+        value={localValue}
+        onChange={(e) => setLocalValue(Math.max(1, Math.min(6, Number(e.target.value))))}
+        onBlur={handleBlur}
+        className="w-16 rounded border border-zinc-300 bg-white px-2 py-0.5 text-xs text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+      />
+      {override !== undefined && (
+        <Button
+          onPress={() => onRemoveOverride(characterId)}
+          aria-label={`Reset loyalty for ${characterName} to campaign default`}
+          className="text-xs text-zinc-400 outline-none hover:text-zinc-600 dark:hover:text-zinc-200"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      )}
+      {override !== undefined && <span className="text-[10px] text-amber-400">override</span>}
+    </div>
+  );
+}

--- a/app/campaigns/[id]/components/CampaignContactsTab.tsx
+++ b/app/campaigns/[id]/components/CampaignContactsTab.tsx
@@ -1,21 +1,29 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
-import { Loader2, Info, Users, AlertTriangle } from "lucide-react";
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { Button } from "react-aria-components";
+import { Loader2, Info, Users, AlertTriangle, Plus, Eye, EyeOff, Search, X } from "lucide-react";
 import type { Campaign, SocialContact } from "@/lib/types";
 import type {
   BetrayalTypeData,
   JohnsonFactionData,
   JohnsonProfilesModulePayload,
 } from "@/lib/rules/module-payloads";
-import { BetrayalAssessmentPanel } from "./BetrayalAssessmentPanel";
+import { CampaignContactCard } from "./CampaignContactCard";
 
 interface CampaignContactsTabProps {
   campaign: Campaign;
 }
 
+/** Owner filter option */
+type OwnerFilter = "all" | "campaign" | string; // string = characterId
+
+/** Visibility filter option */
+type VisibilityFilter = "all" | "visible" | "gm-only";
+
 export default function CampaignContactsTab({ campaign }: CampaignContactsTabProps) {
   const [contacts, setContacts] = useState<SocialContact[]>([]);
+  const [characterNames, setCharacterNames] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -26,12 +34,34 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
   // Expanded contact for betrayal panel
   const [expandedContactId, setExpandedContactId] = useState<string | null>(null);
 
+  // Creation form
+  const [showNewForm, setShowNewForm] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [formData, setFormData] = useState({
+    name: "",
+    archetype: "",
+    connection: 3,
+    loyalty: 3,
+    description: "",
+    factionId: "",
+    playerVisible: false,
+  });
+
+  // Filters
+  const [ownerFilter, setOwnerFilter] = useState<OwnerFilter>("all");
+  const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilter>("all");
+  const [searchText, setSearchText] = useState("");
+
+  // Per-character loyalty expand
+  const [loyaltyExpandedId, setLoyaltyExpandedId] = useState<string | null>(null);
+
   const fetchContacts = useCallback(async () => {
     try {
-      const res = await fetch(`/api/campaigns/${campaign.id}/contacts`);
+      const res = await fetch(`/api/campaigns/${campaign.id}/contacts?include=all`);
       const data = await res.json();
       if (data.success) {
         setContacts(data.contacts || []);
+        setCharacterNames(data.characterNames || {});
       } else {
         setError(data.error || "Failed to load contacts");
       }
@@ -45,6 +75,7 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
   const fetchRulesetData = useCallback(async () => {
     try {
       const res = await fetch(`/api/rulesets/${campaign.editionCode}`);
+      if (!res.ok) return;
       const data = await res.json();
       if (data.success && data.extractedData) {
         const jp = data.extractedData.johnsonProfiles as JohnsonProfilesModulePayload | null;
@@ -67,9 +98,185 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
     setContacts((prev) => prev.map((c) => (c.id === updatedContact.id ? updatedContact : c)));
   }, []);
 
-  // Johnson contacts are those with a faction tag (Run Faster pp. 196-211)
-  const johnsonContacts = contacts.filter((c) => !!c.factionId);
-  const otherContacts = contacts.filter((c) => !c.factionId);
+  // ---------------------------------------------------------------------------
+  // Contact Creation
+  // ---------------------------------------------------------------------------
+
+  const resetForm = () => {
+    setFormData({
+      name: "",
+      archetype: "",
+      connection: 3,
+      loyalty: 3,
+      description: "",
+      factionId: "",
+      playerVisible: false,
+    });
+  };
+
+  const handleCreateContact = async () => {
+    if (!formData.name.trim() || !formData.archetype.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/campaigns/${campaign.id}/contacts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: formData.name.trim(),
+          archetype: formData.archetype.trim(),
+          connection: formData.connection,
+          loyalty: formData.loyalty,
+          description: formData.description.trim() || undefined,
+          factionId: formData.factionId || undefined,
+          visibility: {
+            playerVisible: formData.playerVisible,
+            showConnection: formData.playerVisible,
+            showLoyalty: formData.playerVisible,
+            showFavorBalance: false,
+            showSpecializations: formData.playerVisible,
+          },
+        }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setContacts((prev) => [...prev, data.contact]);
+        resetForm();
+        setShowNewForm(false);
+      } else {
+        setError(data.error || "Failed to create contact");
+      }
+    } catch {
+      setError("Failed to create contact");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Visibility Toggle
+  // ---------------------------------------------------------------------------
+
+  const handleToggleVisibility = async (contact: SocialContact) => {
+    if (contact.characterId) return;
+    const newVisible = !contact.visibility.playerVisible;
+    try {
+      const res = await fetch(`/api/campaigns/${campaign.id}/contacts/${contact.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          visibility: {
+            playerVisible: newVisible,
+            showConnection: newVisible,
+            showLoyalty: newVisible,
+            showSpecializations: newVisible,
+          },
+        }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        handleContactUpdated(data.contact);
+      }
+    } catch {
+      setError("Failed to update visibility");
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Per-Character Loyalty
+  // ---------------------------------------------------------------------------
+
+  const handleSetLoyaltyOverride = async (
+    contact: SocialContact,
+    characterId: string,
+    value: number
+  ) => {
+    if (contact.characterId) return;
+    const updated = { ...(contact.loyaltyOverrides ?? {}), [characterId]: value };
+    try {
+      const res = await fetch(`/api/campaigns/${campaign.id}/contacts/${contact.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ loyaltyOverrides: updated }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        handleContactUpdated(data.contact);
+      }
+    } catch {
+      setError("Failed to update loyalty override");
+    }
+  };
+
+  const handleRemoveLoyaltyOverride = async (contact: SocialContact, characterId: string) => {
+    if (contact.characterId) return;
+    // Use destructuring to remove key immutably
+    const { [characterId]: _removed, ...remaining } = contact.loyaltyOverrides ?? {};
+    try {
+      const res = await fetch(`/api/campaigns/${campaign.id}/contacts/${contact.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ loyaltyOverrides: remaining }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        handleContactUpdated(data.contact);
+      }
+    } catch {
+      setError("Failed to remove loyalty override");
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Filtering
+  // ---------------------------------------------------------------------------
+
+  const filteredContacts = useMemo(() => {
+    let result = contacts;
+
+    if (ownerFilter === "campaign") {
+      result = result.filter((c) => !c.characterId);
+    } else if (ownerFilter !== "all") {
+      result = result.filter((c) => c.characterId === ownerFilter);
+    }
+
+    if (visibilityFilter === "visible") {
+      result = result.filter((c) => c.visibility.playerVisible);
+    } else if (visibilityFilter === "gm-only") {
+      result = result.filter((c) => !c.visibility.playerVisible);
+    }
+
+    if (searchText.trim()) {
+      const query = searchText.toLowerCase();
+      result = result.filter(
+        (c) =>
+          c.name.toLowerCase().includes(query) ||
+          c.archetype.toLowerCase().includes(query) ||
+          c.organization?.toLowerCase().includes(query) ||
+          c.description?.toLowerCase().includes(query)
+      );
+    }
+
+    return result;
+  }, [contacts, ownerFilter, visibilityFilter, searchText]);
+
+  const characterOwners = useMemo(() => {
+    const owners = new Map<string, string>();
+    for (const c of contacts) {
+      if (c.characterId && characterNames[c.characterId]) {
+        owners.set(c.characterId, characterNames[c.characterId]);
+      }
+    }
+    return Array.from(owners.entries());
+  }, [contacts, characterNames]);
+
+  const johnsonContacts = filteredContacts.filter((c) => !!c.factionId);
+  const otherContacts = filteredContacts.filter((c) => !c.factionId);
+
+  const getOwnerLabel = (contact: SocialContact): string => {
+    if (!contact.characterId) return "Campaign";
+    return characterNames[contact.characterId] || "Character";
+  };
 
   if (loading) {
     return (
@@ -79,41 +286,269 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
     );
   }
 
-  if (contacts.length === 0) {
-    return (
-      <div className="rounded-lg border border-dashed border-zinc-300 py-12 text-center dark:border-zinc-700">
-        <Users className="mx-auto h-12 w-12 text-zinc-400 opacity-50" />
-        <h3 className="mt-2 text-sm font-semibold text-zinc-900 dark:text-zinc-50">
-          No campaign contacts yet
-        </h3>
-        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-          Create contacts from the campaign to manage Johnson relationships and betrayal scenarios.
-        </p>
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-medium text-zinc-900 dark:text-zinc-50">
-          Campaign Contacts — Betrayal Assessment
-        </h3>
-        {betrayalTypes.length === 0 && (
-          <span className="flex items-center gap-1 text-xs text-amber-400">
-            <Info className="h-3.5 w-3.5" />
-            Enable Run Faster for betrayal types
-          </span>
-        )}
+        <h3 className="text-lg font-medium text-zinc-900 dark:text-zinc-50">Campaign Contacts</h3>
+        <div className="flex items-center gap-2">
+          {betrayalTypes.length === 0 && (
+            <span className="flex items-center gap-1 text-xs text-amber-400">
+              <Info className="h-3.5 w-3.5" />
+              Enable Run Faster for betrayal types
+            </span>
+          )}
+          {!showNewForm && (
+            <Button
+              onPress={() => setShowNewForm(true)}
+              className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white outline-none hover:bg-indigo-700 pressed:bg-indigo-800"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              New Contact
+            </Button>
+          )}
+        </div>
       </div>
 
       {error && (
         <div className="rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-400">
           {error}
-          <button onClick={() => setError(null)} className="ml-2 underline hover:no-underline">
+          <Button
+            onPress={() => setError(null)}
+            className="ml-2 underline outline-none hover:no-underline"
+          >
             Dismiss
-          </button>
+          </Button>
+        </div>
+      )}
+
+      {/* Creation Form */}
+      {showNewForm && (
+        <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+          <h4 className="mb-3 text-sm font-medium text-zinc-900 dark:text-zinc-50">
+            Create Campaign Contact
+          </h4>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                Name *
+              </label>
+              <input
+                type="text"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                placeholder="e.g. Mr. Johnson"
+                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                Archetype *
+              </label>
+              <input
+                type="text"
+                value={formData.archetype}
+                onChange={(e) => setFormData({ ...formData, archetype: e.target.value })}
+                placeholder="e.g. Mr. Johnson, Fixer, Street Doc"
+                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                Connection (1-12)
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={12}
+                value={formData.connection}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    connection: Math.max(1, Math.min(12, Number(e.target.value))),
+                  })
+                }
+                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                Loyalty (1-6)
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={6}
+                value={formData.loyalty}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    loyalty: Math.max(1, Math.min(6, Number(e.target.value))),
+                  })
+                }
+                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              />
+            </div>
+            {factions.length > 0 && (
+              <div className="sm:col-span-2">
+                <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                  Johnson Faction (optional)
+                </label>
+                <select
+                  value={formData.factionId}
+                  onChange={(e) => setFormData({ ...formData, factionId: e.target.value })}
+                  className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                >
+                  <option value="">None</option>
+                  {factions.map((f) => (
+                    <option key={f.id} value={f.id}>
+                      {f.name} ({f.category})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+            <div className="sm:col-span-2">
+              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
+                Description (optional)
+              </label>
+              <textarea
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                rows={2}
+                placeholder="Brief description of the contact..."
+                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+              />
+            </div>
+            <div className="flex items-center gap-2 sm:col-span-2">
+              <Button
+                onPress={() => setFormData({ ...formData, playerVisible: !formData.playerVisible })}
+                className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium outline-none ${
+                  formData.playerVisible
+                    ? "bg-green-500/10 text-green-400 hover:bg-green-500/20"
+                    : "bg-zinc-500/10 text-zinc-400 hover:bg-zinc-500/20"
+                }`}
+              >
+                {formData.playerVisible ? (
+                  <Eye className="h-3.5 w-3.5" />
+                ) : (
+                  <EyeOff className="h-3.5 w-3.5" />
+                )}
+                {formData.playerVisible ? "Campaign-wide" : "GM Only"}
+              </Button>
+              <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                {formData.playerVisible ? "Players can see this contact" : "Only visible to the GM"}
+              </span>
+            </div>
+          </div>
+          <div className="mt-4 flex gap-2">
+            <Button
+              onPress={handleCreateContact}
+              isDisabled={creating || !formData.name.trim() || !formData.archetype.trim()}
+              className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-4 py-1.5 text-xs font-medium text-white outline-none hover:bg-indigo-700 pressed:bg-indigo-800 disabled:opacity-50"
+            >
+              {creating ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Plus className="h-3.5 w-3.5" />
+              )}
+              Create
+            </Button>
+            <Button
+              onPress={() => {
+                setShowNewForm(false);
+                resetForm();
+              }}
+              className="rounded-md px-4 py-1.5 text-xs font-medium text-zinc-500 outline-none hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Filter Bar */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Search */}
+        <div className="relative flex-1 min-w-[180px]">
+          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-400" />
+          <input
+            type="text"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            placeholder="Search contacts..."
+            className="w-full rounded-md border border-zinc-300 bg-white py-1.5 pl-8 pr-8 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+          />
+          {searchText && (
+            <Button
+              onPress={() => setSearchText("")}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-400 outline-none hover:text-zinc-600 dark:hover:text-zinc-200"
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+
+        {/* Owner Filter */}
+        <select
+          value={ownerFilter}
+          onChange={(e) => setOwnerFilter(e.target.value as OwnerFilter)}
+          className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+        >
+          <option value="all">All Owners</option>
+          <option value="campaign">Campaign (GM)</option>
+          {characterOwners.map(([id, name]) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+        </select>
+
+        {/* Visibility Filter */}
+        <select
+          value={visibilityFilter}
+          onChange={(e) => setVisibilityFilter(e.target.value as VisibilityFilter)}
+          className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs text-zinc-700 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+        >
+          <option value="all">All Visibility</option>
+          <option value="visible">Visible to Players</option>
+          <option value="gm-only">GM Only</option>
+        </select>
+
+        <span className="text-xs text-zinc-500 dark:text-zinc-400">
+          {filteredContacts.length} of {contacts.length} contacts
+        </span>
+      </div>
+
+      {/* Empty State */}
+      {contacts.length === 0 && !showNewForm && (
+        <div className="rounded-lg border border-dashed border-zinc-300 py-12 text-center dark:border-zinc-700">
+          <Users className="mx-auto h-12 w-12 text-zinc-400 opacity-50" />
+          <h3 className="mt-2 text-sm font-semibold text-zinc-900 dark:text-zinc-50">
+            No campaign contacts yet
+          </h3>
+          <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+            Create contacts from the campaign to manage Johnson relationships and betrayal
+            scenarios.
+          </p>
+          <Button
+            onPress={() => setShowNewForm(true)}
+            className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white outline-none hover:bg-indigo-700 pressed:bg-indigo-800"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New Contact
+          </Button>
+        </div>
+      )}
+
+      {/* No Results */}
+      {contacts.length > 0 && filteredContacts.length === 0 && (
+        <div className="rounded-lg border border-dashed border-zinc-300 py-8 text-center dark:border-zinc-700">
+          <Search className="mx-auto h-8 w-8 text-zinc-400 opacity-50" />
+          <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+            No contacts match the current filters.
+          </p>
         </div>
       )}
 
@@ -124,103 +559,34 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
             <AlertTriangle className="h-4 w-4" />
             Johnson Contacts ({johnsonContacts.length})
           </h4>
-          {johnsonContacts.map((contact) => {
-            const faction = contact.factionId
-              ? factions.find((f) => f.id === contact.factionId)
-              : null;
-            const isExpanded = expandedContactId === contact.id;
-
-            return (
-              <div
-                key={contact.id}
-                className="rounded-lg border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900"
-              >
-                {/* Contact Header */}
-                <button
-                  onClick={() => setExpandedContactId(isExpanded ? null : contact.id)}
-                  aria-expanded={isExpanded}
-                  aria-label={`${isExpanded ? "Collapse" : "Expand"} betrayal assessment for ${contact.name}`}
-                  className="flex w-full items-center justify-between px-4 py-3 text-left"
-                >
-                  <div className="flex items-center gap-3">
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
-                          {contact.name}
-                        </span>
-                        {contact.betrayalPlanning && (
-                          <span className="rounded-full bg-red-500/20 px-2 py-0.5 text-[10px] font-bold uppercase text-red-400">
-                            Betrayal Planned
-                          </span>
-                        )}
-                        <span
-                          className={`rounded px-1.5 py-0.5 text-[10px] font-mono ${
-                            contact.status === "active"
-                              ? "bg-green-500/10 text-green-400"
-                              : "bg-zinc-500/10 text-zinc-400"
-                          }`}
-                        >
-                          {contact.status}
-                        </span>
-                      </div>
-                      <div className="mt-0.5 flex items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
-                        <span>{contact.archetype}</span>
-                        {faction && (
-                          <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-amber-400">
-                            {faction.name}
-                          </span>
-                        )}
-                        <span>
-                          C:{contact.connection} / L:{contact.loyalty}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {faction?.betrayalRisk && (
-                      <span
-                        className={`rounded px-1.5 py-0.5 text-[10px] font-bold uppercase ${
-                          {
-                            "very-low": "text-green-400 bg-green-500/10",
-                            low: "text-green-300 bg-green-500/10",
-                            moderate: "text-amber-400 bg-amber-500/10",
-                            high: "text-orange-400 bg-orange-500/10",
-                            "very-high": "text-red-400 bg-red-500/10",
-                            uncertain: "text-zinc-400 bg-zinc-500/10",
-                          }[faction.betrayalRisk] ?? "text-zinc-400 bg-zinc-500/10"
-                        }`}
-                      >
-                        Risk: {faction.betrayalRisk}
-                      </span>
-                    )}
-                  </div>
-                </button>
-
-                {/* Betrayal Assessment Panel */}
-                {isExpanded && betrayalTypes.length > 0 && (
-                  <div className="border-t border-zinc-200 px-4 py-4 dark:border-zinc-700">
-                    <BetrayalAssessmentPanel
-                      contact={contact}
-                      campaignId={campaign.id}
-                      betrayalTypes={betrayalTypes}
-                      factions={factions}
-                      onContactUpdated={handleContactUpdated}
-                    />
-                  </div>
-                )}
-
-                {isExpanded && betrayalTypes.length === 0 && (
-                  <div className="border-t border-zinc-200 px-4 py-4 dark:border-zinc-700">
-                    <div className="rounded border border-dashed border-zinc-600 p-4 text-center text-xs text-zinc-500">
-                      <Info className="mx-auto mb-1 h-5 w-5" />
-                      Betrayal type data not available. Enable the Run Faster sourcebook in campaign
-                      settings.
-                    </div>
-                  </div>
-                )}
-              </div>
-            );
-          })}
+          {johnsonContacts.map((contact) => (
+            <CampaignContactCard
+              key={contact.id}
+              contact={contact}
+              faction={
+                contact.factionId
+                  ? (factions.find((f) => f.id === contact.factionId) ?? null)
+                  : null
+              }
+              ownerLabel={getOwnerLabel(contact)}
+              isExpanded={expandedContactId === contact.id}
+              onToggleExpand={() =>
+                setExpandedContactId(expandedContactId === contact.id ? null : contact.id)
+              }
+              onToggleVisibility={() => handleToggleVisibility(contact)}
+              betrayalTypes={betrayalTypes}
+              factions={factions}
+              campaignId={campaign.id}
+              onContactUpdated={handleContactUpdated}
+              isLoyaltyExpanded={loyaltyExpandedId === contact.id}
+              onToggleLoyalty={() =>
+                setLoyaltyExpandedId(loyaltyExpandedId === contact.id ? null : contact.id)
+              }
+              characterNames={characterNames}
+              onSetLoyaltyOverride={(charId, val) => handleSetLoyaltyOverride(contact, charId, val)}
+              onRemoveLoyaltyOverride={(charId) => handleRemoveLoyaltyOverride(contact, charId)}
+            />
+          ))}
         </div>
       )}
 
@@ -231,31 +597,28 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
             Other Contacts ({otherContacts.length})
           </h4>
           {otherContacts.map((contact) => (
-            <div
+            <CampaignContactCard
               key={contact.id}
-              className="rounded-lg border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-700 dark:bg-zinc-900"
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
-                  {contact.name}
-                </span>
-                <span
-                  className={`rounded px-1.5 py-0.5 text-[10px] font-mono ${
-                    contact.status === "active"
-                      ? "bg-green-500/10 text-green-400"
-                      : "bg-zinc-500/10 text-zinc-400"
-                  }`}
-                >
-                  {contact.status}
-                </span>
-              </div>
-              <div className="mt-0.5 flex items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
-                <span>{contact.archetype}</span>
-                <span>
-                  C:{contact.connection} / L:{contact.loyalty}
-                </span>
-              </div>
-            </div>
+              contact={contact}
+              faction={null}
+              ownerLabel={getOwnerLabel(contact)}
+              isExpanded={expandedContactId === contact.id}
+              onToggleExpand={() =>
+                setExpandedContactId(expandedContactId === contact.id ? null : contact.id)
+              }
+              onToggleVisibility={() => handleToggleVisibility(contact)}
+              betrayalTypes={betrayalTypes}
+              factions={factions}
+              campaignId={campaign.id}
+              onContactUpdated={handleContactUpdated}
+              isLoyaltyExpanded={loyaltyExpandedId === contact.id}
+              onToggleLoyalty={() =>
+                setLoyaltyExpandedId(loyaltyExpandedId === contact.id ? null : contact.id)
+              }
+              characterNames={characterNames}
+              onSetLoyaltyOverride={(charId, val) => handleSetLoyaltyOverride(contact, charId, val)}
+              onRemoveLoyaltyOverride={(charId) => handleRemoveLoyaltyOverride(contact, charId)}
+            />
           ))}
         </div>
       )}

--- a/app/campaigns/[id]/components/CampaignContactsTab.tsx
+++ b/app/campaigns/[id]/components/CampaignContactsTab.tsx
@@ -130,6 +130,8 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
       const data = await res.json();
       if (data.success) {
         handleContactUpdated(data.contact);
+      } else {
+        setError(data.error || "Failed to update visibility");
       }
     } catch {
       setError("Failed to update visibility");
@@ -156,6 +158,8 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
       const data = await res.json();
       if (data.success) {
         handleContactUpdated(data.contact);
+      } else {
+        setError(data.error || "Failed to update loyalty override");
       }
     } catch {
       setError("Failed to update loyalty override");
@@ -175,6 +179,8 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
       const data = await res.json();
       if (data.success) {
         handleContactUpdated(data.contact);
+      } else {
+        setError(data.error || "Failed to remove loyalty override");
       }
     } catch {
       setError("Failed to remove loyalty override");

--- a/app/campaigns/[id]/components/CampaignContactsTab.tsx
+++ b/app/campaigns/[id]/components/CampaignContactsTab.tsx
@@ -2,14 +2,15 @@
 
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { Button } from "react-aria-components";
-import { Loader2, Info, Users, AlertTriangle, Plus, Eye, EyeOff, Search, X } from "lucide-react";
-import type { Campaign, SocialContact } from "@/lib/types";
+import { Loader2, Info, Users, AlertTriangle, Plus, Search, X } from "lucide-react";
+import type { Campaign, SocialContact, CreateContactRequest } from "@/lib/types";
 import type {
   BetrayalTypeData,
   JohnsonFactionData,
   JohnsonProfilesModulePayload,
 } from "@/lib/rules/module-payloads";
 import { CampaignContactCard } from "./CampaignContactCard";
+import { ContactFormModal } from "@/app/characters/[id]/contacts/components/ContactFormModal";
 
 interface CampaignContactsTabProps {
   campaign: Campaign;
@@ -34,18 +35,8 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
   // Expanded contact for betrayal panel
   const [expandedContactId, setExpandedContactId] = useState<string | null>(null);
 
-  // Creation form
-  const [showNewForm, setShowNewForm] = useState(false);
-  const [creating, setCreating] = useState(false);
-  const [formData, setFormData] = useState({
-    name: "",
-    archetype: "",
-    connection: 3,
-    loyalty: 3,
-    description: "",
-    factionId: "",
-    playerVisible: false,
-  });
+  // Creation modal
+  const [showCreateModal, setShowCreateModal] = useState(false);
 
   // Filters
   const [ownerFilter, setOwnerFilter] = useState<OwnerFilter>("all");
@@ -99,57 +90,20 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
   }, []);
 
   // ---------------------------------------------------------------------------
-  // Contact Creation
+  // Contact Creation (via modal)
   // ---------------------------------------------------------------------------
 
-  const resetForm = () => {
-    setFormData({
-      name: "",
-      archetype: "",
-      connection: 3,
-      loyalty: 3,
-      description: "",
-      factionId: "",
-      playerVisible: false,
+  const handleCreateContact = async (data: CreateContactRequest) => {
+    const res = await fetch(`/api/campaigns/${campaign.id}/contacts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
     });
-  };
-
-  const handleCreateContact = async () => {
-    if (!formData.name.trim() || !formData.archetype.trim()) return;
-    setCreating(true);
-    setError(null);
-    try {
-      const res = await fetch(`/api/campaigns/${campaign.id}/contacts`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: formData.name.trim(),
-          archetype: formData.archetype.trim(),
-          connection: formData.connection,
-          loyalty: formData.loyalty,
-          description: formData.description.trim() || undefined,
-          factionId: formData.factionId || undefined,
-          visibility: {
-            playerVisible: formData.playerVisible,
-            showConnection: formData.playerVisible,
-            showLoyalty: formData.playerVisible,
-            showFavorBalance: false,
-            showSpecializations: formData.playerVisible,
-          },
-        }),
-      });
-      const data = await res.json();
-      if (data.success) {
-        setContacts((prev) => [...prev, data.contact]);
-        resetForm();
-        setShowNewForm(false);
-      } else {
-        setError(data.error || "Failed to create contact");
-      }
-    } catch {
-      setError("Failed to create contact");
-    } finally {
-      setCreating(false);
+    const result = await res.json();
+    if (result.success) {
+      setContacts((prev) => [...prev, result.contact]);
+    } else {
+      throw new Error(result.error || "Failed to create contact");
     }
   };
 
@@ -298,15 +252,13 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
               Enable Run Faster for betrayal types
             </span>
           )}
-          {!showNewForm && (
-            <Button
-              onPress={() => setShowNewForm(true)}
-              className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white outline-none hover:bg-indigo-700 pressed:bg-indigo-800"
-            >
-              <Plus className="h-3.5 w-3.5" />
-              New Contact
-            </Button>
-          )}
+          <Button
+            onPress={() => setShowCreateModal(true)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white outline-none hover:bg-indigo-700 pressed:bg-indigo-800"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New Contact
+          </Button>
         </div>
       </div>
 
@@ -322,150 +274,14 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
         </div>
       )}
 
-      {/* Creation Form */}
-      {showNewForm && (
-        <div className="rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
-          <h4 className="mb-3 text-sm font-medium text-zinc-900 dark:text-zinc-50">
-            Create Campaign Contact
-          </h4>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <div>
-              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                Name *
-              </label>
-              <input
-                type="text"
-                value={formData.name}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                placeholder="e.g. Mr. Johnson"
-                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                Archetype *
-              </label>
-              <input
-                type="text"
-                value={formData.archetype}
-                onChange={(e) => setFormData({ ...formData, archetype: e.target.value })}
-                placeholder="e.g. Mr. Johnson, Fixer, Street Doc"
-                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                Connection (1-12)
-              </label>
-              <input
-                type="number"
-                min={1}
-                max={12}
-                value={formData.connection}
-                onChange={(e) =>
-                  setFormData({
-                    ...formData,
-                    connection: Math.max(1, Math.min(12, Number(e.target.value))),
-                  })
-                }
-                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                Loyalty (1-6)
-              </label>
-              <input
-                type="number"
-                min={1}
-                max={6}
-                value={formData.loyalty}
-                onChange={(e) =>
-                  setFormData({
-                    ...formData,
-                    loyalty: Math.max(1, Math.min(6, Number(e.target.value))),
-                  })
-                }
-                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
-              />
-            </div>
-            {factions.length > 0 && (
-              <div className="sm:col-span-2">
-                <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                  Johnson Faction (optional)
-                </label>
-                <select
-                  value={formData.factionId}
-                  onChange={(e) => setFormData({ ...formData, factionId: e.target.value })}
-                  className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
-                >
-                  <option value="">None</option>
-                  {factions.map((f) => (
-                    <option key={f.id} value={f.id}>
-                      {f.name} ({f.category})
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-            <div className="sm:col-span-2">
-              <label className="mb-1 block text-xs font-medium text-zinc-500 dark:text-zinc-400">
-                Description (optional)
-              </label>
-              <textarea
-                value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                rows={2}
-                placeholder="Brief description of the contact..."
-                className="w-full rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:placeholder:text-zinc-500"
-              />
-            </div>
-            <div className="flex items-center gap-2 sm:col-span-2">
-              <Button
-                onPress={() => setFormData({ ...formData, playerVisible: !formData.playerVisible })}
-                className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium outline-none ${
-                  formData.playerVisible
-                    ? "bg-green-500/10 text-green-400 hover:bg-green-500/20"
-                    : "bg-zinc-500/10 text-zinc-400 hover:bg-zinc-500/20"
-                }`}
-              >
-                {formData.playerVisible ? (
-                  <Eye className="h-3.5 w-3.5" />
-                ) : (
-                  <EyeOff className="h-3.5 w-3.5" />
-                )}
-                {formData.playerVisible ? "Campaign-wide" : "GM Only"}
-              </Button>
-              <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                {formData.playerVisible ? "Players can see this contact" : "Only visible to the GM"}
-              </span>
-            </div>
-          </div>
-          <div className="mt-4 flex gap-2">
-            <Button
-              onPress={handleCreateContact}
-              isDisabled={creating || !formData.name.trim() || !formData.archetype.trim()}
-              className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-4 py-1.5 text-xs font-medium text-white outline-none hover:bg-indigo-700 pressed:bg-indigo-800 disabled:opacity-50"
-            >
-              {creating ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Plus className="h-3.5 w-3.5" />
-              )}
-              Create
-            </Button>
-            <Button
-              onPress={() => {
-                setShowNewForm(false);
-                resetForm();
-              }}
-              className="rounded-md px-4 py-1.5 text-xs font-medium text-zinc-500 outline-none hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
-            >
-              Cancel
-            </Button>
-          </div>
-        </div>
-      )}
+      {/* Contact Creation Modal (reuses character contact form in campaign mode) */}
+      <ContactFormModal
+        isOpen={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        onSubmit={handleCreateContact}
+        johnsonFactions={factions}
+        mode="campaign"
+      />
 
       {/* Filter Bar */}
       <div className="flex flex-wrap items-center gap-3">
@@ -522,7 +338,7 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
       </div>
 
       {/* Empty State */}
-      {contacts.length === 0 && !showNewForm && (
+      {contacts.length === 0 && (
         <div className="rounded-lg border border-dashed border-zinc-300 py-12 text-center dark:border-zinc-700">
           <Users className="mx-auto h-12 w-12 text-zinc-400 opacity-50" />
           <h3 className="mt-2 text-sm font-semibold text-zinc-900 dark:text-zinc-50">
@@ -533,7 +349,7 @@ export default function CampaignContactsTab({ campaign }: CampaignContactsTabPro
             scenarios.
           </p>
           <Button
-            onPress={() => setShowNewForm(true)}
+            onPress={() => setShowCreateModal(true)}
             className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white outline-none hover:bg-indigo-700 pressed:bg-indigo-800"
           >
             <Plus className="h-3.5 w-3.5" />

--- a/app/characters/[id]/contacts/components/ContactFormModal.tsx
+++ b/app/characters/[id]/contacts/components/ContactFormModal.tsx
@@ -12,7 +12,7 @@ import {
   TextField,
   TextArea,
 } from "react-aria-components";
-import { X } from "lucide-react";
+import { X, Eye, EyeOff } from "lucide-react";
 import type { SocialContact, CreateContactRequest, ContactArchetype } from "@/lib/types";
 import type { JohnsonFactionData } from "@/lib/rules/loader-types";
 import type { Theme } from "@/lib/themes";
@@ -34,6 +34,8 @@ interface ContactFormModalProps {
   usedContactPoints?: number;
   johnsonFactions?: JohnsonFactionData[];
   theme?: Theme;
+  /** "character" (default) = player contact with karma budget; "campaign" = GM contact with visibility toggle */
+  mode?: "character" | "campaign";
 }
 
 const DEFAULT_ARCHETYPES = [
@@ -65,9 +67,11 @@ export function ContactFormModal({
   usedContactPoints = 0,
   johnsonFactions = [],
   theme,
+  mode = "character",
 }: ContactFormModalProps) {
   const t = theme || THEMES[DEFAULT_THEME];
   const isEditing = !!contact;
+  const isCampaignMode = mode === "campaign";
 
   const [formData, setFormData] = useState<CreateContactRequest>({
     name: "",
@@ -86,6 +90,7 @@ export function ContactFormModal({
   const [specializationInput, setSpecializationInput] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [playerVisible, setPlayerVisible] = useState(false);
 
   const orgDefinitions = getOrganizationDefinitions();
 
@@ -124,6 +129,7 @@ export function ContactFormModal({
       setError(null);
       setIsOrganizationContact(source?.group === "organization" || false);
       setSelectedOrg(null);
+      setPlayerVisible(false);
     }
   }, [isOpen, contact, prefillContact]);
 
@@ -174,14 +180,28 @@ export function ContactFormModal({
       return;
     }
 
-    if (isOverBudget) {
+    if (!isCampaignMode && isOverBudget) {
       setError("Not enough contact points available");
       return;
     }
 
     setIsSubmitting(true);
     try {
-      await onSubmit(formData);
+      const submitData: CreateContactRequest = {
+        ...formData,
+        ...(isCampaignMode
+          ? {
+              visibility: {
+                playerVisible,
+                showConnection: playerVisible,
+                showLoyalty: playerVisible,
+                showFavorBalance: false,
+                showSpecializations: playerVisible,
+              },
+            }
+          : {}),
+      };
+      await onSubmit(submitData);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save contact");
@@ -214,7 +234,11 @@ export function ContactFormModal({
               {/* Header */}
               <div className={`flex items-center justify-between p-4 border-b ${t.colors.border}`}>
                 <Heading slot="title" className={`text-lg font-bold ${t.colors.heading}`}>
-                  {isEditing ? "Edit Contact" : "Add New Contact"}
+                  {isEditing
+                    ? "Edit Contact"
+                    : isCampaignMode
+                      ? "Create Campaign Contact"
+                      : "Add New Contact"}
                 </Heading>
                 <Button
                   onPress={close}
@@ -226,8 +250,8 @@ export function ContactFormModal({
 
               {/* Body */}
               <div className="p-6 max-h-[70vh] overflow-y-auto space-y-4">
-                {/* Budget indicator */}
-                {maxContactPoints > 0 && (
+                {/* Budget indicator (character mode only) */}
+                {!isCampaignMode && maxContactPoints > 0 && (
                   <div
                     className={`p-3 rounded border ${
                       isOverBudget
@@ -292,33 +316,34 @@ export function ContactFormModal({
                   </select>
                 </div>
 
-                {/* Johnson Faction Selector */}
-                {formData.archetype === "Mr. Johnson" && johnsonFactions.length > 0 && (
-                  <div className="space-y-2">
-                    <Label className="text-xs font-mono text-muted-foreground uppercase">
-                      Faction Profile
-                    </Label>
-                    <select
-                      value={formData.factionId || ""}
-                      onChange={(e) =>
-                        setFormData({
-                          ...formData,
-                          factionId: e.target.value || undefined,
-                        })
-                      }
-                      className={`w-full px-3 py-2 rounded border ${t.colors.border} bg-background text-foreground`}
-                    >
-                      <option value="">No faction (generic Johnson)</option>
-                      {johnsonFactions.map((faction) => (
-                        <option key={faction.id} value={faction.id}>
-                          {faction.name} ({faction.category})
-                        </option>
-                      ))}
-                    </select>
+                {/* Johnson Faction Selector — always visible in campaign mode, archetype-gated in character mode */}
+                {(isCampaignMode || formData.archetype === "Mr. Johnson") &&
+                  johnsonFactions.length > 0 && (
+                    <div className="space-y-2">
+                      <Label className="text-xs font-mono text-muted-foreground uppercase">
+                        Faction Profile
+                      </Label>
+                      <select
+                        value={formData.factionId || ""}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            factionId: e.target.value || undefined,
+                          })
+                        }
+                        className={`w-full px-3 py-2 rounded border ${t.colors.border} bg-background text-foreground`}
+                      >
+                        <option value="">No faction (generic Johnson)</option>
+                        {johnsonFactions.map((faction) => (
+                          <option key={faction.id} value={faction.id}>
+                            {faction.name} ({faction.category})
+                          </option>
+                        ))}
+                      </select>
 
-                    {selectedFaction && <FactionInfoCard faction={selectedFaction} />}
-                  </div>
-                )}
+                      {selectedFaction && <FactionInfoCard faction={selectedFaction} />}
+                    </div>
+                  )}
 
                 {/* Organization Toggle */}
                 <div className="space-y-2">
@@ -526,6 +551,31 @@ export function ContactFormModal({
                   />
                 </TextField>
 
+                {/* Visibility Toggle (campaign mode only) */}
+                {isCampaignMode && (
+                  <div className="flex items-center gap-3">
+                    <Button
+                      type="button"
+                      onPress={() => setPlayerVisible(!playerVisible)}
+                      className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium outline-none ${
+                        playerVisible
+                          ? "bg-green-500/10 text-green-400 hover:bg-green-500/20"
+                          : "bg-muted text-muted-foreground hover:bg-muted/80"
+                      }`}
+                    >
+                      {playerVisible ? (
+                        <Eye className="h-3.5 w-3.5" />
+                      ) : (
+                        <EyeOff className="h-3.5 w-3.5" />
+                      )}
+                      {playerVisible ? "Campaign-wide" : "GM Only"}
+                    </Button>
+                    <span className="text-xs text-muted-foreground">
+                      {playerVisible ? "Players can see this contact" : "Only visible to the GM"}
+                    </span>
+                  </div>
+                )}
+
                 {/* Notes */}
                 <TextField className="space-y-1">
                   <Label className="text-xs font-mono text-muted-foreground uppercase">Notes</Label>
@@ -551,10 +601,16 @@ export function ContactFormModal({
                 </Button>
                 <Button
                   type="submit"
-                  isDisabled={isSubmitting || isOverBudget}
+                  isDisabled={isSubmitting || (!isCampaignMode && isOverBudget)}
                   className={`px-4 py-2 rounded ${t.colors.accentBg} text-white disabled:opacity-50`}
                 >
-                  {isSubmitting ? "Saving..." : isEditing ? "Save Changes" : "Add Contact"}
+                  {isSubmitting
+                    ? "Saving..."
+                    : isEditing
+                      ? "Save Changes"
+                      : isCampaignMode
+                        ? "Create Contact"
+                        : "Add Contact"}
                 </Button>
               </div>
             </form>

--- a/lib/types/contacts.ts
+++ b/lib/types/contacts.ts
@@ -266,6 +266,13 @@ export interface SocialContact {
   /** GM-only betrayal planning state (hidden from players) */
   betrayalPlanning?: BetrayalPlanningState;
 
+  /**
+   * Per-character loyalty overrides for campaign contacts.
+   * Keyed by characterId. Characters without an override use the base `loyalty` value.
+   * Only applies when `group === "campaign"`.
+   */
+  loyaltyOverrides?: Record<string, number>;
+
   /** Extensible metadata */
   metadata?: Metadata;
 }
@@ -854,6 +861,8 @@ export interface UpdateContactRequest {
   acquisitionMethod?: SocialContact["acquisitionMethod"];
   /** Johnson faction profile ID (Run Faster pp. 196-211) */
   factionId?: string;
+  /** Per-character loyalty overrides (campaign contacts only) */
+  loyaltyOverrides?: Record<string, number>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **GM Contact Creation Form** — inline expandable form with name, archetype, connection, loyalty, description, Johnson faction selection, and visibility toggle (defaults to GM-only)
- **Merged Contact View** — single list combining campaign + character contacts with owner badges (indigo for Campaign, cyan for character names) and visibility indicators
- **Filter Bar** — search text, owner dropdown (All/Campaign/individual characters), visibility filter (All/Visible to Players/GM Only)
- **PATCH Route** — `/api/campaigns/[id]/contacts/[contactId]` for visibility toggle, loyalty overrides, and general contact updates with full input validation
- **Per-Character Loyalty** — expandable section on campaign contacts showing all characters with editable loyalty overrides and reset-to-default capability
- **Visibility Toggle** — eye icon on campaign contacts for quick playerVisible toggling
- Extracted `CampaignContactCard` component for maintainability

## Files Changed

- `lib/types/contacts.ts` — added `loyaltyOverrides` to `SocialContact` and `UpdateContactRequest`
- `app/api/campaigns/[id]/contacts/route.ts` — merged view via `?include=all`, status param validation
- `app/api/campaigns/[id]/contacts/[contactId]/route.ts` — new PATCH route with validation
- `app/campaigns/[id]/components/CampaignContactsTab.tsx` — rewritten with creation form, filters, merged view
- `app/campaigns/[id]/components/CampaignContactCard.tsx` — extracted card component with React Aria Buttons
- Tests for PATCH route (9 tests) and merged view GET (2 tests)

## Test plan

- [x] Type-check passes
- [x] All 468 contact-related tests pass
- [ ] Verify GM can create campaign contacts from Contacts tab UI
- [ ] Verify default visibility is GM-only, configurable to campaign-wide
- [ ] Verify merged view shows campaign + character contacts with owner labels
- [ ] Verify filters work: by owner, by visibility, by search text
- [ ] Verify GM can toggle contact visibility from the contact card
- [ ] Verify per-character loyalty overrides work with onBlur save

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)