### PR TITLE
docs: add codemaps, contributing guide, env reference, and runbook

### DIFF
--- a/.reports/codemap-diff.txt
+++ b/.reports/codemap-diff.txt
@@ -1,0 +1,38 @@
+Documentation Update Report — 2026-04-13
+==========================================
+
+Codemaps (INITIAL GENERATION)
+─────────────────────────────
+Created:  docs/CODEMAPS/architecture.md  — 55 lines, ~600 tokens
+Created:  docs/CODEMAPS/backend.md       — 106 lines, ~950 tokens
+Created:  docs/CODEMAPS/frontend.md      — 80 lines, ~700 tokens
+Created:  docs/CODEMAPS/data.md          — 79 lines, ~600 tokens
+Created:  docs/CODEMAPS/dependencies.md  — 43 lines, ~400 tokens
+Total codemaps: 363 lines, ~3250 tokens
+
+Documentation
+─────────────
+Created:  docs/CONTRIBUTING.md  — Scripts table, git workflow, code style, PR checklist
+Created:  docs/ENV.md           — All env vars from .env.example (6 categories, 30+ vars)
+Created:  docs/RUNBOOK.md       — Deploy procedures, health checks, common issues, rollback
+
+Project Stats
+─────────────
+  API route files: 217
+  Page routes: 31
+  Components: ~240
+  Storage modules: 22
+  Rules engine modules: 55
+  Type definition files: 34
+  Test files: ~493
+
+Staleness Warnings (90+ days without update)
+─────────────────────────────────────────────
+  STALE (129 days): docs/rules/README.md
+  STALE (119 days): docs/data_tables/magic/spirits_man_water.md
+  STALE (119 days): docs/data_tables/magic/spirits_air_earth_beasts_fire.md
+  STALE (109 days): docs/prompts/operational/ (7 files)
+  STALE (109 days): docs/prompts/governance/ai_project_manager.md
+  STALE (109 days): docs/decisions/003-005 (3 ADR files)
+
+  Note: docs/references/ and docs/archive/ excluded from staleness check.

--- a/docs/CODEMAPS/architecture.md
+++ b/docs/CODEMAPS/architecture.md
@@ -1,0 +1,56 @@
+<!-- Generated: 2026-04-13 | Files scanned: ~650 | Token estimate: ~600 -->
+
+# Architecture Overview
+
+## System Type
+
+Single Next.js 16 application (App Router), file-based JSON storage, no database.
+
+## High-Level Data Flow
+
+```
+Browser → Next.js App Router → API Routes → Storage Layer → JSON Files (/data/)
+                                    ↓
+                              Rules Engine (/lib/rules/)
+                                    ↓
+                              Edition Data (/data/editions/sr5/)
+```
+
+## Service Boundaries
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Frontend (React 19 + React Aria)                        │
+│  Pages: 31 routes │ Components: ~240 │ Contexts: 6      │
+├─────────────────────────────────────────────────────────┤
+│ API Layer (Next.js Route Handlers)                      │
+│  217 route files │ 9 domains │ Auth + Rate Limiting      │
+├─────────────────────────────────────────────────────────┤
+│ Business Logic                                          │
+│  Rules Engine: 55 modules │ Storage: 22 modules          │
+│  Auth: session + magic-link │ Email: SMTP/Resend/mock    │
+├─────────────────────────────────────────────────────────┤
+│ Persistence (JSON files)                                │
+│  Characters: ~1268 │ Campaigns: ~493 │ Users: ~119       │
+│  Edition data: SR5 (core-rulebook, run-faster, errata)   │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Key Domains
+
+| Domain         | Pages | API Routes | Components              |
+| -------------- | ----- | ---------- | ----------------------- |
+| Characters     | 8     | 80+        | ~170 (creation + sheet) |
+| Campaigns      | 8+    | 25+        | ~20                     |
+| Combat         | 0     | 14         | ~8                      |
+| Auth/Account   | 5     | 13         | ~5                      |
+| Editions/Rules | 1     | 9          | ~7                      |
+| Locations      | 5     | 14         | ~10                     |
+| Grunt Teams    | 4     | 10         | ~10                     |
+
+## Cross-Cutting Concerns
+
+- **Auth**: Cookie-based sessions (httpOnly, 7-day), bcryptjs passwords, magic links
+- **Observability**: Sentry error tracking, Pino structured logging
+- **Security**: Rate limiting, audit logging, input validation, RBAC (owner/GM/admin)
+- **Email**: Pluggable transport (SMTP, Resend, file, mock)

--- a/docs/CODEMAPS/backend.md
+++ b/docs/CODEMAPS/backend.md
@@ -1,0 +1,114 @@
+<!-- Generated: 2026-04-13 | Files scanned: 217 | Token estimate: ~950 -->
+
+# Backend Architecture
+
+## API Route Domains (217 route files)
+
+### Auth (9 routes)
+
+```
+POST /api/auth/signin        → verifyCredentials → createSession → RateLimiter
+POST /api/auth/signup        → createUser → hashPassword → sendVerificationEmail
+POST /api/auth/signout       → clearSession → AuditLogger
+GET  /api/auth/me            → getSession → getUserById
+POST /api/auth/magic-link    → requestMagicLink → RateLimiter
+POST /api/auth/forgot-password → requestPasswordReset → RateLimiter
+POST /api/auth/reset-password → resetPassword → isStrongPassword
+```
+
+### Characters — Core (80+ routes)
+
+```
+GET    /api/characters                → searchCharacters (multi-criteria)
+POST   /api/characters                → createCharacterDraft → logActivity
+GET    /api/characters/[id]           → resolveCharacterForGameplay
+PATCH  /api/characters/[id]           → updateCharacter → authorizeOwnerAccess → createAuditEntry
+DELETE /api/characters/[id]           → deleteCharacter → authorizeOwnerAccess
+POST   /api/characters/[id]/finalize  → finalizeCharacter
+POST   /api/characters/[id]/clone     → cloneCharacter
+POST   /api/characters/[id]/validate  → validateCharacter
+```
+
+### Characters — Advancement
+
+```
+POST /api/characters/[id]/advancement/skills           → advanceSkill → loadAndMergeRuleset
+POST /api/characters/[id]/advancement/attributes       → advanceAttribute
+POST /api/characters/[id]/advancement/edge             → advanceEdge
+POST /api/characters/[id]/advancement/specializations  → advanceSpecialization
+POST /api/characters/[id]/advancement/[recordId]/approve → authorizeGM
+```
+
+### Characters — Subsystems
+
+```
+augmentations/          → CRUD + cyberlimbs + enhancements + accessories (13 routes)
+contacts/               → CRUD + call-favor + spend-chips + edge (8 routes)
+loadouts/               → CRUD + apply (5 routes)
+inventory/              → items + containers (4 routes)
+weapons/[id]/ammo|mods  → ammo management + weapon mods (6 routes)
+magic/                  → spells + drain (4 routes)
+matrix/                 → programs + overwatch (4 routes)
+rigging/                → drones + validation (3 routes)
+qualities/              → CRUD + state toggle (5 routes)
+modifiers/              → CRUD (4 routes)
+training/               → CRUD (4 routes)
+```
+
+### Campaigns (25+ routes)
+
+```
+GET/POST /api/campaigns              → list/create
+GET/PUT/DELETE /api/campaigns/[id]   → CRUD (GM-only write)
+POST /api/campaigns/[id]/join|leave  → player management
+sessions/                            → CRUD + complete + edge-refresh + awards
+advancements/                        → list + approve/reject (GM)
+contacts/                            → campaign-level contacts
+locations/                           → import/export support
+```
+
+### Combat (14 routes)
+
+```
+GET/POST   /api/combat                           → list/create sessions
+GET/PATCH/DELETE /api/combat/[sessionId]          → session CRUD
+POST /api/combat/[sessionId]/turn                → advance turn
+POST /api/combat/[sessionId]/spend-action        → action economy
+participants/                                    → CRUD combatants
+```
+
+### Other Domains
+
+```
+grunt-teams/     → team CRUD + bulk damage + initiative + edge (10 routes)
+editions/        → edition metadata + content + archetypes + grunt-templates (9 routes)
+locations/       → CRUD + connections + templates (14 routes)
+account/         → preferences + export/import + delete + password (5 routes)
+settings/        → account + communications + password (6 routes)
+users/           → admin CRUD + suspend/lockout (7 routes)
+notifications/   → list + mark-read (3 routes)
+health           → health check (1 route)
+```
+
+## Authorization Model
+
+```
+getSession()              → All authenticated routes
+authorizeOwnerAccess()    → Character owner only
+authorizeCampaign()       → Campaign member access
+authorizeGM()             → GM-only operations
+requireAdmin()            → Admin panel operations
+resolveCharacterForGameplay() → GM cross-user character access
+```
+
+## Key Storage Functions
+
+```
+readJsonFile() / writeJsonFile()  → All data persistence
+getCharacter() / updateCharacter() → Character CRUD
+getCampaignById() / updateCampaign() → Campaign CRUD
+loadAndMergeRuleset()             → Ruleset composition (edition + errata)
+createAuditEntry()                → Character change audit trail
+logActivity()                     → Campaign activity feed
+createNotification()              → User notifications
+```

--- a/docs/CODEMAPS/data.md
+++ b/docs/CODEMAPS/data.md
@@ -1,0 +1,80 @@
+<!-- Generated: 2026-04-13 | Files scanned: ~22 storage modules | Token estimate: ~600 -->
+
+# Data Architecture
+
+## Storage Model
+
+File-based JSON storage in `/data/` — no database. All access via `readJsonFile()` / `writeJsonFile()`.
+
+## Data Directories
+
+```
+/data/
+├── editions/sr5/
+│   ├── edition.json              Edition metadata
+│   ├── core-rulebook.json        ~850KB core ruleset (mechanics, attributes, skills, qualities)
+│   ├── run-faster.json           ~570KB sourcebook supplement
+│   ├── core-errata-2014-02-09.json  Errata patches
+│   ├── rule-reference.json       ~43KB indexed reference
+│   ├── archetypes/               Archetype templates by role
+│   ├── example-characters/       Sample character sheets
+│   ├── grunt-templates/          NPC stat templates
+│   └── sample-contacts/          56 pre-made contact files
+├── characters/                   ~1268 character JSON files
+├── campaigns/                    ~493 campaign files
+├── users/                        ~119 user records
+├── combat/                       18 combat encounter dirs
+├── contacts/                     Contact/NPC profiles
+├── notifications/                35 notification type dirs
+├── emails/                       ~1984 email logs
+├── activity/                     22+ campaign activity logs
+├── audit/                        Audit trail records
+├── migration/                    Schema migration snapshots
+├── violations/                   Constraint violation records
+├── matrix/                       Matrix session data
+├── ruleset-snapshots/            Cached rule state
+├── drift-reports/                Sync drift detection
+├── campaign_templates/           Campaign setup templates
+├── templates/                    Email/form templates
+└── security/                     Security audit data
+```
+
+## Storage Modules (/lib/storage/)
+
+| Module                 | Entity        | Key Operations                      |
+| ---------------------- | ------------- | ----------------------------------- |
+| `characters.ts`        | Characters    | CRUD, advancement, skill updates    |
+| `campaigns.ts`         | Campaigns     | Create, state management, archives  |
+| `users.ts`             | Users         | Account, permissions, preferences   |
+| `contacts.ts`          | Contacts      | Relationship states, NPC management |
+| `combat.ts`            | Combat        | Encounter state, initiative, turns  |
+| `editions.ts`          | Editions      | Rulebook loading, errata merging    |
+| `grunts.ts`            | Grunts        | NPC instances                       |
+| `grunt-templates.ts`   | Templates     | NPC stat templates                  |
+| `locations.ts`         | Locations     | Security ratings, metadata          |
+| `archetypes.ts`        | Archetypes    | Archetype lookup                    |
+| `notifications.ts`     | Notifications | System alerts                       |
+| `activity.ts`          | Activity      | Campaign activity feed              |
+| `favor-ledger.ts`      | Favors        | Favor/obligation tracking           |
+| `social-capital.ts`    | Social        | Karma and street cred               |
+| `action-history.ts`    | Actions       | Timestamped action records          |
+| `user-audit.ts`        | Audit         | User action audit log               |
+| `ruleset-snapshots.ts` | Snapshots     | Cached rule snapshots               |
+| `snapshot-cache.ts`    | Cache         | In-memory rule cache                |
+| `base.ts`              | —             | Abstract CRUD base class            |
+| `validation.ts`        | —             | Data validation rules               |
+
+## Data Flow
+
+```
+API Route → Storage Module → readJsonFile(path) → JSON.parse → Return
+         → Storage Module → writeJsonFile(path, data) → JSON.stringify → fs.writeFile
+         → loadAndMergeRuleset() → edition.json + core-rulebook + errata → merged ruleset
+```
+
+## Edition Data Schema
+
+```
+edition.json:        { id, name, version, rulebooks[] }
+core-rulebook.json:  { id, name, page, section, entries[] } (nested catalog)
+```

--- a/docs/CODEMAPS/dependencies.md
+++ b/docs/CODEMAPS/dependencies.md
@@ -1,0 +1,51 @@
+<!-- Generated: 2026-04-13 | Files scanned: package.json | Token estimate: ~400 -->
+
+# Dependencies
+
+## Framework
+
+- `next@16.1.6` — App Router, React Server Components
+- `react@19.2.4` / `react-dom@19.2.4` — React 19
+- `server-only@0.0.1` — Server-side execution enforcement
+
+## UI
+
+- `react-aria-components@1.14.0` — Accessible UI components (buttons, inputs, selects, modals)
+- `lucide-react@0.563.0` — Icon library
+- `tw-animate-css@1.4.0` — Tailwind CSS animations
+- Tailwind CSS 4 — Utility-first styling (dark mode)
+
+## Auth & Security
+
+- `bcryptjs@3.0.3` — Password hashing
+- Cookie-based sessions (httpOnly, 7-day, built-in)
+
+## Email
+
+- `nodemailer@7.0.13` — SMTP email transport
+- `resend@6.9.1` — Managed email service (alternative transport)
+- `@react-email/components@1.0.6` — Email template components
+
+## Observability
+
+- `@sentry/nextjs@10.38.0` — Error tracking, performance monitoring
+- `pino@10.3.0` — Structured JSON logging
+
+## Utilities
+
+- `uuid@13.0.0` — UUID generation
+- `@tanstack/react-virtual@3.13.18` — Virtual scrolling for large lists
+
+## External Services
+
+- **Sentry** — Error tracking (cloud)
+- **Resend** — Email delivery (optional, cloud)
+- **SMTP** — Email delivery (configurable)
+
+## No External Dependencies For
+
+- Database (JSON file storage)
+- State management (React Context)
+- Routing (Next.js App Router)
+- Validation (custom, no Zod/Yup)
+- ORM (no database)

--- a/docs/CODEMAPS/frontend.md
+++ b/docs/CODEMAPS/frontend.md
@@ -1,0 +1,84 @@
+<!-- Generated: 2026-04-13 | Files scanned: ~240 components | Token estimate: ~700 -->
+
+# Frontend Architecture
+
+## Page Tree (31 routes)
+
+```
+/                                          Landing/Dashboard
+├── /signin, /signup, /forgot-password     Auth flows
+├── /reset-password/[token]                Password reset
+├── /characters
+│   ├── /create                            Wizard-based creation
+│   ├── /create/sheet                      Sheet-driven creation (ADR-011)
+│   ├── /[id]                              Character sheet view
+│   ├── /[id]/edit                         Resume draft editing
+│   ├── /[id]/advancement                  XP/advancement
+│   └── /[id]/contacts(/[contactId])       Contact management
+├── /campaigns
+│   ├── /create, /discover                 Campaign setup/browse
+│   ├── /[id]                              Campaign dashboard
+│   ├── /[id]/settings                     Config (GM only)
+│   ├── /[id]/advancement                  Group advancement
+│   ├── /[id]/grunt-teams(/create/[id])    NPC team management
+│   └── /[id]/locations(/create/[id])      Location database
+├── /rulesets                              Edition selector
+├── /settings                              User preferences
+└── /users                                 Admin user management
+```
+
+## Component Hierarchy (~240 components)
+
+| Directory            | Count | Purpose                                                                                                                                                                                                                                                                      |
+| -------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `creation/`          | 118   | Character creation cards (21 subfolders: archetype, priority, attributes, skills, augmentations, spells, qualities, gear, vehicles, contacts, adept-powers, matrix, foci, armor, weapons, identities, knowledge-languages, drugs-toxins, life-modules, magic-path, metatype) |
+| `character/sheet/`   | 49    | Sheet display (attributes, armor, augmentations, combat, conditions, contacts, drones, equipment, skills, spells, vehicles, weapons)                                                                                                                                         |
+| `rule-reference/`    | 7     | Rules lookup: category tabs, search, palette, table                                                                                                                                                                                                                          |
+| `cyberlimbs/`        | 6     | Cyberlimb management: cards, detail, install/enhance modals                                                                                                                                                                                                                  |
+| `action-resolution/` | 4     | Action pool builder, edge selector, history                                                                                                                                                                                                                                  |
+| `combat/`            | 4     | Combat tracker, condition monitor, opposed tests                                                                                                                                                                                                                             |
+| `ui/`                | 4     | Base primitives: modal, tooltip, dice roller, faction card                                                                                                                                                                                                                   |
+| `sync/`              | 2     | Migration wizard, stability shield                                                                                                                                                                                                                                           |
+| Root-level           | ~51   | AugmentationCard, DiceRoller, EssenceDisplay, NotificationBell, ThemeProvider, etc.                                                                                                                                                                                          |
+
+## State Management
+
+### Context Providers (app/providers.tsx)
+
+```
+ThemeProvider → I18nProvider → AuthProvider → SidebarProvider
+```
+
+### Domain Contexts
+
+```
+RulesetContext      (lib/rules/)        → Edition, priorities, metatypes, creation methods
+CreationBudgetContext (lib/contexts/)   → Karma, nuyen, attribute/skill points, spells, powers
+SidebarContext      (lib/contexts/)     → Mobile drawer + desktop collapse (localStorage)
+RuleReferenceContext (lib/contexts/)    → Rules panel open/close + category
+MatrixSessionContext (lib/matrix/)      → Hacking session state
+RiggingSessionContext (lib/rigging/)    → Drone piloting state
+CombatSessionProvider (lib/combat/)    → Combat encounter state
+```
+
+### Provider Tree
+
+```
+RulesetProvider → CombatSessionProvider → MatrixSessionProvider → RiggingSessionProvider
+```
+
+## Creation Flow (Dual Path)
+
+```
+Wizard Path:  Edition → Archetype → Priority → Attributes → Skills → Gear → Finalize
+Sheet Path:   Edition → Sheet view with inline editing (ADR-011)
+
+Both constrained by: CreationBudgetContext (karma, nuyen, points)
+```
+
+## UI Patterns
+
+- **React Aria Components** for accessibility (no raw HTML interactive elements)
+- **Card-based UI** for creation steps and sheet sections
+- **Dark/light theme** with localStorage persistence
+- **Modals** for complex interactions (cyberlimb install, enhancement, accessories)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,140 @@
+# Contributing to Shadow Master
+
+## Prerequisites
+
+- **Node.js** 18+
+- **pnpm** (package manager)
+- **Docker** (optional, for containerized dev)
+
+## Setup
+
+```bash
+git clone <repo-url>
+cd ShadowMaster
+pnpm install
+cp .env.example .env.local   # Configure environment
+pnpm dev                      # http://localhost:3000
+```
+
+## Git Workflow
+
+1. Create a feature branch: `git checkout -b feature/<issue-number>-<short-description>`
+2. Never commit directly to `main`
+3. Use conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+
+## Pre-commit Hooks
+
+Hooks run automatically via Husky:
+
+- **Pre-commit**: lint-staged, type-check
+- **Pre-push**: knip (dead code), CLAUDE.md validation
+
+<!-- AUTO-GENERATED:SCRIPTS:START -->
+
+## Available Scripts
+
+### Development
+
+| Command         | Description                                        |
+| --------------- | -------------------------------------------------- |
+| `pnpm dev`      | Start dev server (Next.js)                         |
+| `pnpm dev:all`  | Dev server + type-check + lint (concurrent)        |
+| `pnpm dev:full` | Dev server + type-check + lint + knip (concurrent) |
+| `pnpm build`    | Production build                                   |
+| `pnpm start`    | Start production server                            |
+
+### Quality Checks
+
+| Command             | Description                                              |
+| ------------------- | -------------------------------------------------------- |
+| `pnpm lint`         | ESLint with cache                                        |
+| `pnpm type-check`   | TypeScript strict check                                  |
+| `pnpm check`        | Combined lint + type-check + knip                        |
+| `pnpm check:ci`     | Full CI check (format + lint + type-check + test + knip) |
+| `pnpm format`       | Prettier formatting                                      |
+| `pnpm format:check` | Check formatting without writing                         |
+| `pnpm knip`         | Dead code detection                                      |
+
+### Testing
+
+| Command              | Description                |
+| -------------------- | -------------------------- |
+| `pnpm test`          | Run unit tests (Vitest)    |
+| `pnpm test:watch`    | Tests in watch mode        |
+| `pnpm test:ci`       | Tests for CI (single run)  |
+| `pnpm test:coverage` | Tests with coverage report |
+| `pnpm test:e2e`      | Playwright E2E tests       |
+| `pnpm test:e2e:ui`   | Playwright with UI mode    |
+
+### Data Validation
+
+| Command                       | Description                                        |
+| ----------------------------- | -------------------------------------------------- |
+| `pnpm verify-data`            | Validate JSON data files                           |
+| `pnpm verify-naming`          | Check kebab-case naming conventions                |
+| `pnpm verify-reference`       | Compare reference extractions against edition data |
+| `pnpm validate-characters`    | Validate example character files                   |
+| `pnpm validate-docs`          | Validate CLAUDE.md counts                          |
+| `pnpm validate-creation-docs` | Check creation component doc drift                 |
+
+### Utilities
+
+| Command                  | Description                           |
+| ------------------------ | ------------------------------------- |
+| `pnpm backup`            | Backup data files                     |
+| `pnpm health-check`      | Run health check script               |
+| `pnpm seed-data`         | Seed development data                 |
+| `pnpm user-admin`        | User administration CLI               |
+| `pnpm check-tests`       | Check test coverage gaps              |
+| `pnpm generate-diagrams` | Generate component hierarchy diagrams |
+
+### Docker
+
+| Command                   | Description                       |
+| ------------------------- | --------------------------------- |
+| `pnpm docker:dev`         | Build and start Docker containers |
+| `pnpm docker:build`       | Build Docker image                |
+| `pnpm docker:build:fresh` | Build without cache               |
+| `pnpm docker:up`          | Start containers                  |
+| `pnpm docker:down`        | Stop containers                   |
+| `pnpm docker:logs`        | Tail container logs               |
+
+### Auditing
+
+| Command                       | Description                      |
+| ----------------------------- | -------------------------------- |
+| `pnpm audit:creation`         | Creation UX audit                |
+| `pnpm audit:creation:strict`  | Strict creation audit            |
+| `pnpm audit:creation:verbose` | Verbose creation audit           |
+| `pnpm audit:creation:report`  | Creation audit (markdown output) |
+
+<!-- AUTO-GENERATED:SCRIPTS:END -->
+
+## Testing
+
+- Test files live in `__tests__/` directories mirroring source: `lib/rules/foo.ts` -> `lib/rules/__tests__/foo.test.ts`
+- Component tests adjacent: `components/creation/Foo.tsx` -> `components/creation/__tests__/Foo.test.tsx`
+- Naming: `describe('FunctionName')` -> `it('does X when Y')`
+- Prefer `userEvent` over `fireEvent` in component tests
+- No test file should import from another test file
+
+## Code Style
+
+- **TypeScript strict mode** — no `any`, no `@ts-ignore`
+- **React Aria Components** — no raw `<button>`, `<input>`, `<select>`
+- **Tailwind CSS** — no inline styles
+- **Named exports** from non-page files
+- **Immutable updates** — never mutate state directly
+- **Data identifiers** in JSON: `kebab-case`
+- **TypeScript keys**: `camelCase`
+- Always import types from `@/lib/types`
+
+## PR Checklist
+
+- [ ] `pnpm type-check` passes
+- [ ] `pnpm test` passes
+- [ ] `pnpm lint` passes
+- [ ] No `any` types introduced
+- [ ] No `@ts-ignore` / `@ts-expect-error`
+- [ ] Authentication checked on protected routes
+- [ ] No hardcoded secrets

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,73 @@
+<!-- Generated: 2026-04-13 | Source: .env.example -->
+
+# Environment Variables
+
+## Application Settings
+
+| Variable              | Required | Description                                                             | Default                 |
+| --------------------- | -------- | ----------------------------------------------------------------------- | ----------------------- |
+| `NODE_ENV`            | No       | Node environment                                                        | `development`           |
+| `NEXT_PUBLIC_APP_ENV` | No       | UI environment badge (`local`, `docker`, `staging`, `production`)       | `local`                 |
+| `NEXT_PUBLIC_APP_URL` | No       | Canonical app URL                                                       | `http://localhost:3000` |
+| `NEXT_PUBLIC_GIT_SHA` | No       | Git SHA for UI display (set by CI)                                      | —                       |
+| `LOG_LEVEL`           | No       | Override log level (`fatal`, `error`, `warn`, `info`, `debug`, `trace`) | env-based               |
+| `PORT`                | No       | Application port                                                        | `3000`                  |
+
+## Email Configuration
+
+| Variable                   | Required    | Description                                      | Default             |
+| -------------------------- | ----------- | ------------------------------------------------ | ------------------- |
+| `EMAIL_TRANSPORT`          | Yes\*       | Transport type: `smtp`, `resend`, `file`, `mock` | `file`              |
+| `EMAIL_FROM`               | Yes\*       | Sender email address                             | `noreply@localhost` |
+| `EMAIL_FROM_NAME`          | Yes\*       | Sender display name                              | `Shadow Master`     |
+| `SMTP_HOST`                | When smtp   | SMTP server hostname                             | `localhost`         |
+| `SMTP_PORT`                | When smtp   | SMTP server port                                 | `1025`              |
+| `SMTP_SECURE`              | When smtp   | Use TLS                                          | `false`             |
+| `SMTP_USER`                | When smtp   | SMTP username                                    | —                   |
+| `SMTP_PASS`                | When smtp   | SMTP password                                    | —                   |
+| `RESEND_API_KEY`           | When resend | Resend API key (`re_xxx`)                        | —                   |
+| `ADMIN_NOTIFICATION_EMAIL` | No          | Admin notification recipient(s), comma-separated | —                   |
+
+\*Required for email features; defaults work for local development.
+
+## Docker & Deployment
+
+| Variable                  | Required    | Description               | Default         |
+| ------------------------- | ----------- | ------------------------- | --------------- |
+| `HOSTNAME`                | Docker      | Bind address              | `0.0.0.0`       |
+| `NEXT_TELEMETRY_DISABLED` | No          | Disable Next.js telemetry | `1`             |
+| `REPO`                    | Docker push | Image repository name     | `shadow-master` |
+| `IMAGE_TAG`               | Docker push | Image tag                 | `latest`        |
+
+## Container Registry
+
+| Variable             | Required       | Description                               |
+| -------------------- | -------------- | ----------------------------------------- |
+| `GHCR_REGISTRY`      | GHCR push      | GitHub Container Registry URL (`ghcr.io`) |
+| `GHCR_OWNER`         | GHCR push      | GitHub username/org                       |
+| `GITHUB_TOKEN`       | GHCR push      | PAT with `write:packages` scope           |
+| `DOCKERHUB_REGISTRY` | DockerHub push | Registry URL (`docker.io`)                |
+| `DOCKERHUB_OWNER`    | DockerHub push | DockerHub username/org                    |
+| `DOCKERHUB_TOKEN`    | DockerHub push | DockerHub access token                    |
+
+## Portainer Deployment (Optional)
+
+| Variable              | Required | Description                        |
+| --------------------- | -------- | ---------------------------------- |
+| `PORTAINER_WEBHOOK`   | No       | Webhook URL for stack redeployment |
+| `PORTAINER_URL`       | No       | Direct API access URL              |
+| `PORTAINER_API_TOKEN` | No       | Portainer API token                |
+
+## HTTPS (Caddy Reverse Proxy)
+
+| Variable       | Required | Description                             |
+| -------------- | -------- | --------------------------------------- |
+| `CF_API_TOKEN` | HTTPS    | Cloudflare API token (DNS-01 challenge) |
+| `DOMAIN`       | HTTPS    | Domain for TLS certificate              |
+| `HTTPS_PORT`   | HTTPS    | HTTPS port (default: `2075`)            |
+
+## Testing
+
+| Variable            | Required | Description                                              |
+| ------------------- | -------- | -------------------------------------------------------- |
+| `E2E_BYPASS_SECRET` | No       | Bypasses signup restrictions in non-production E2E tests |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,109 @@
+# Runbook
+
+## Deployment
+
+### Local Development
+
+```bash
+pnpm install
+cp .env.example .env.local
+pnpm dev                    # http://localhost:3000
+```
+
+### Docker (Local)
+
+```bash
+cp .env.example .env.local
+pnpm docker:dev             # Builds and starts containers
+pnpm docker:logs            # Tail logs
+pnpm docker:down            # Stop
+```
+
+### Staging (Portainer)
+
+1. Push image to GHCR: `make docker-push-ghcr`
+2. Portainer webhook triggers stack redeploy
+3. Verify via amber environment badge in UI
+
+### Production
+
+1. Push tagged image to registry
+2. Deploy via Portainer or manual `docker compose up -d`
+3. Verify: no environment badge visible in UI
+
+## Health Check
+
+```bash
+# Local
+curl http://localhost:3000/api/health
+
+# Script-based
+pnpm health-check
+```
+
+## Common Issues
+
+### Build Failures
+
+```bash
+pnpm type-check      # Check for TypeScript errors first
+pnpm lint             # Then lint errors
+pnpm knip             # Dead code / unused exports
+```
+
+### Data Validation Errors
+
+```bash
+pnpm verify-data      # JSON structure validation
+pnpm verify-naming    # kebab-case convention check
+pnpm verify-reference # Reference data consistency
+```
+
+### Test Failures
+
+```bash
+pnpm test             # Run all unit tests
+pnpm test:e2e         # Run E2E tests
+pnpm check-tests      # Find coverage gaps
+```
+
+### Email Not Working
+
+1. Check `EMAIL_TRANSPORT` in `.env.local`
+2. For local dev: use `file` transport (emails saved to `data/emails/`)
+3. For SMTP: verify `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`
+4. For Resend: verify `RESEND_API_KEY`
+
+### Docker Issues
+
+```bash
+pnpm docker:build:fresh   # Rebuild without cache
+pnpm docker:logs          # Check container logs
+pnpm docker:down          # Clean restart
+```
+
+## Rollback
+
+### Code Rollback
+
+```bash
+git log --oneline -10          # Find target commit
+git revert <commit-sha>        # Create revert commit
+# Or for Docker deployment:
+docker compose down
+IMAGE_TAG=<previous-tag> docker compose up -d
+```
+
+### Data Rollback
+
+```bash
+pnpm backup                    # Create backup first
+# Restore from backup in data/ directory
+```
+
+## Monitoring
+
+- **Sentry**: Error tracking and performance monitoring (`@sentry/nextjs`)
+- **Pino logs**: Structured JSON logging (check `LOG_LEVEL` setting)
+- **Environment badge**: Visual indicator in UI header
+  - Purple = local, Blue = docker, Amber = staging, Hidden = production

--- a/docs/gm-feature-toggle-candidates.md
+++ b/docs/gm-feature-toggle-candidates.md
@@ -1,0 +1,488 @@
+# GM Feature Toggle Candidates
+
+Audit of the ShadowMaster codebase identifying every implemented system that could be surfaced as a GM-configurable feature toggle in campaign settings.
+
+**Audit date:** 2026-03-26
+**Codebase:** ShadowMaster (Next.js / TypeScript)
+**Edition:** SR5 (3 books loaded: Core Rulebook, Core Errata 2014-02-09, Run Faster)
+
+---
+
+## SR5 Core Rulebook (SR5)
+
+### 1. Dice Rolling (App vs. Physical Dice)
+
+- **What it controls:** Whether the app rolls dice for combat, spellcasting, and skill tests, or defers to the GM and players rolling physical dice and entering results manually.
+- **Current behavior:** The dice engine (`lib/rules/action-resolution/dice-engine.ts`) is fully implemented with `rollDice()`, `rollDiceExploding()`, `executeRoll()`, and `executeReroll()`. Rolls are always app-generated using cryptographically secure random. There is no "manual entry" mode.
+- **Toggle idea:** "Dice Mode" — `app-roll` (default) vs. `manual-entry` (players enter hit counts from physical dice). In manual mode, the app skips auto-rolling and presents input fields for hits, ones, and glitch status.
+- **Implementation location:**
+  - `lib/rules/action-resolution/dice-engine.ts` — `executeRoll()`, `rollDice()`, `rollD6()`
+  - `lib/rules/action-resolution/edge-actions.ts` — Edge action definitions (Push the Limit, Second Chance, etc.)
+- **Toggle exists today:** No
+
+### 2. Hit Threshold and Glitch Rules
+
+- **What it controls:** What number counts as a hit (default: 5+), the glitch threshold (default: more than 50% ones), and whether critical glitches require zero hits.
+- **Current behavior:** Hardcoded in `DEFAULT_DICE_RULES` — `hitThreshold: 5`, `glitchThreshold: 0.5`, `criticalGlitchRequiresZeroHits: true`. The `EditionDiceRules` type supports overrides, but no campaign UI exposes them.
+- **Toggle idea:** Allow GMs to tweak for house rules — e.g., hits on 4+ (easier), critical glitches even with hits (harsher). Rare use case but the plumbing exists.
+- **Implementation location:**
+  - `lib/rules/action-resolution/dice-engine.ts:17-76` — `DEFAULT_DICE_RULES` constant
+  - `lib/types/` — `EditionDiceRules` type (already supports overrides)
+- **Toggle exists today:** Partial (type supports it, no UI)
+
+### 3. Wound Modifier Calculation
+
+- **What it controls:** How many damage boxes trigger a -1 dice pool penalty, and the maximum wound penalty.
+- **Current behavior:** Hardcoded in `DEFAULT_DICE_RULES.woundModifiers` — `boxesPerPenalty: 3`, `maxPenalty: -4`. The type supports different values.
+- **Toggle idea:** GMs running grittier games might set `boxesPerPenalty: 2` (harsher wounds). GMs running cinematic games might set `maxPenalty: -2` (less punishing).
+- **Implementation location:**
+  - `lib/rules/action-resolution/dice-engine.ts:72-75` — `woundModifiers` config
+  - `lib/rules/action-resolution/pool-builder.ts` — wound modifier applied to dice pools
+- **Toggle exists today:** Partial (type supports it, no UI)
+
+### 4. Gameplay Level Presets (Street / Standard / Prime Runner)
+
+- **What it controls:** Starting karma, maximum gear availability at creation, contact point multiplier, and resource multiplier.
+- **Current behavior:** Three presets defined in `core-rulebook.json` module `gameplayLevels`. Selected at campaign creation and enforced throughout character creation. Values: Street (13 karma, avail 6, CHA×2), Experienced (25 karma, avail 12, CHA×3), Prime Runner (35 karma, avail 18, CHA×5, 1.5× resources).
+- **Toggle idea:** Already configurable as a campaign setting. Could be extended with "Custom" option letting GMs set arbitrary values for each field.
+- **Implementation location:**
+  - `data/editions/sr5/core-rulebook.json` — `gameplayLevels` module
+  - `app/campaigns/create/page.tsx:343-362` — gameplay level selector
+  - `app/campaigns/[id]/settings/page.tsx:558-578` — editable in settings
+  - `lib/types/edition.ts` — `GameplayLevelModifiers` interface
+- **Toggle exists today:** Yes (preset selection), but not fully custom
+
+### 5. Character Creation Method Restrictions
+
+- **What it controls:** Which creation methods players can use (Priority, Sum-to-Ten, Point Buy, Life Modules).
+- **Current behavior:** GMs select enabled creation methods at campaign creation (`enabledCreationMethodIds`). Characters are blocked from using disabled methods via `getAvailableCreationMethods()` and `validateCreationMethodForCampaign()`.
+- **Toggle idea:** Already implemented. GMs can enable/disable each method per campaign.
+- **Implementation location:**
+  - `lib/types/campaign.ts:87` — `enabledCreationMethodIds`
+  - `lib/rules/creation-method-filter.ts` — filtering and validation
+  - `app/campaigns/[id]/settings/page.tsx:539-556` — creation method checkboxes
+- **Toggle exists today:** Yes
+
+### 6. Attribute Rating Cap (One at Max Rule)
+
+- **What it controls:** During creation, only one Physical or Mental attribute can be at the metatype maximum. Exceptional Attribute quality allows one more.
+- **Current behavior:** Hardcoded in `lib/rules/validation/constraint-attribute-limit.ts`. The constraint checks `maxAtMax` parameter (default 1) and grants +1 for Exceptional Attribute quality. Campaign `advancementSettings.attributeRatingCap` applies a separate absolute cap during advancement.
+- **Toggle idea:** "Attribute Max Enforcement" — strict (only 1 at max, default), relaxed (2 at max), or off (no limit). Some GMs find the one-at-max rule too restrictive for experienced runners.
+- **Implementation location:**
+  - `lib/rules/validation/constraint-attribute-limit.ts` — `maxAtMax` parameter
+  - `app/campaigns/[id]/settings/components/AdvancementSettingsForm.tsx:150-196` — attribute rating cap input
+- **Toggle exists today:** Partial (advancement cap exists, creation "one at max" is hardcoded)
+
+### 7. Skill Rating Cap at Creation
+
+- **What it controls:** Maximum skill rating during character creation (default: 6, or 7 with Aptitude quality).
+- **Current behavior:** Hardcoded in `lib/rules/validation/constraint-skill-limit.ts` — base max 6, Aptitude allows 7 for one skill. Campaign `advancementSettings.skillRatingCap` applies during advancement.
+- **Toggle idea:** GMs who want more powerful starting characters could raise the creation cap to 7 or 8. Configurable as `creationSkillCap` separate from advancement cap.
+- **Implementation location:**
+  - `lib/rules/validation/constraint-skill-limit.ts` — `max` and `maxWithAptitude` params
+  - `app/campaigns/[id]/settings/components/AdvancementSettingsForm.tsx:184-193` — skill rating cap input (advancement only)
+- **Toggle exists today:** Partial (advancement cap exists, creation cap hardcoded)
+
+### 8. Gear Availability at Creation
+
+- **What it controls:** Maximum availability rating for gear purchasable during character creation (default: 12), and whether Restricted/Forbidden items are allowed.
+- **Current behavior:** Hardcoded in `CREATION_CONSTRAINTS` — `maxAvailabilityAtCreation: 12`, `allowRestrictedAtCreation: false`, `allowForbiddenAtCreation: false`. Gameplay level modifiers override `maxAvailability` (Street: 6, Experienced: 12, Prime: 18).
+- **Toggle idea:** "Gear Restriction Level" — strict (no R/F items, default), relaxed (R items with GM approval), or open (all items). Some GMs allow Restricted gear at creation for Prime Runner games.
+- **Implementation location:**
+  - `lib/rules/gear/validation.ts:42-54` — `CREATION_CONSTRAINTS`
+  - `lib/rules/validation/constraint-equipment-rating.ts:117-122` — availability enforcement
+  - `components/creation/matrix-gear/matrixGearHelpers.ts:16` — UI constraint reference
+- **Toggle exists today:** No (hardcoded, gameplay level partially overrides availability number)
+
+### 9. Quality Karma Caps (25/25 Rule)
+
+- **What it controls:** Maximum karma spent on positive qualities (25) and maximum karma gained from negative qualities (25) during creation.
+- **Current behavior:** Hardcoded in `lib/rules/creation/budget-validation.ts:90-109`. Exceeding either cap produces a blocking error.
+- **Toggle idea:** "Quality Karma Limits" — standard (25/25), expanded (35/35 for experienced campaigns), or unlimited (honor system). Many GMs house-rule higher caps.
+- **Implementation location:**
+  - `lib/rules/creation/budget-validation.ts:90-109` — hardcoded 25 karma checks
+  - `lib/types/index.ts` — `LIFE_MODULES_MAX_NEGATIVE_QUALITIES` constant (also 25)
+- **Toggle exists today:** No
+
+### 10. Karma-to-Nuyen Conversion Cap
+
+- **What it controls:** How much karma can be converted to nuyen during creation (default: 10 karma = 20,000¥). Born Rich quality raises this to 40 karma.
+- **Current behavior:** Default cap from `lib/rules/qualities/budget-modifiers.ts`. Life Modules uses a separate constant (`LIFE_MODULES_MAX_GEAR_KARMA = 200`). Enforced as an error in `budget-validation.ts:112-124`.
+- **Toggle idea:** "Karma-to-Nuyen Cap" — standard (10), generous (20), or per creation method default. Lets GMs control how gear-heavy starting characters can be.
+- **Implementation location:**
+  - `lib/rules/creation/budget-validation.ts:112-124` — cap enforcement
+  - `lib/rules/qualities/budget-modifiers.ts` — `getDefaultModifiers()` returns default cap
+- **Toggle exists today:** No (quality-driven override exists, no GM override)
+
+### 11. Nuyen and Karma Carryover Limits
+
+- **What it controls:** How much unspent nuyen (default: 5,000¥) and karma (default: 7) a character can carry from creation into gameplay.
+- **Current behavior:** Warnings (not errors) in `budget-validation.ts:51-68`. Excess is flagged but not blocked — the player is told "X will be lost."
+- **Toggle idea:** "Carryover Policy" — standard (warn about loss), strict (hard error, must spend), or generous (raise caps to 10,000¥ / 15 karma).
+- **Implementation location:**
+  - `lib/rules/creation/budget-validation.ts:51-68` — warning-level checks
+- **Toggle exists today:** No
+
+### 12. Contact Rating Limits
+
+- **What it controls:** Maximum Connection rating (SR5: 12) and Loyalty rating (all editions: 6) for contacts.
+- **Current behavior:** Hardcoded in `lib/rules/contacts.ts` — `getMaxConnection('sr5')` returns 12, `getMaxLoyalty()` returns 6. Validated in `validateContact()`.
+- **Toggle idea:** GMs could cap Connection lower (e.g., max 6 for street-level campaigns) or raise Loyalty cap for relationship-heavy games.
+- **Implementation location:**
+  - `lib/rules/contacts.ts:32-61` — max connection/loyalty by edition
+  - `components/creation/contacts/ContactsCard.tsx:68-99` — UI enforcement
+- **Toggle exists today:** No
+
+### 13. Contact Karma Budget (CHA × Multiplier)
+
+- **What it controls:** Free contact karma during creation, calculated as Charisma × gameplay level multiplier (Street: ×2, Experienced: ×3, Prime: ×5).
+- **Current behavior:** Driven by gameplay level modifiers from `gameplayLevels` data module. "Friends in High Places" quality adds bonus via `FRIENDS_IN_HIGH_PLACES_CONTACT_MULTIPLIER`.
+- **Toggle idea:** Already partially configurable via gameplay level. Could expose a direct "Contact Karma Multiplier" override independent of gameplay level.
+- **Implementation location:**
+  - `components/creation/contacts/ContactsCard.tsx:69-72` — budget calculation
+  - `data/editions/sr5/core-rulebook.json` — `gameplayLevels` module `contactMultiplier`
+- **Toggle exists today:** Partial (tied to gameplay level, no independent override)
+
+### 14. Essence and Magic/Resonance Reduction Formula
+
+- **What it controls:** How essence loss from augmentations reduces Magic (or Resonance) — round up (default, most punishing), round down (lenient), or exact (house rule).
+- **Current behavior:** Configurable via `AugmentationRulesData.magicReductionFormula` in edition rules. Default is `"roundUp"`. The `calculateEffectiveMagic()` function supports all three modes.
+- **Toggle idea:** "Magic Loss Formula" — `roundUp` (RAW), `roundDown` (lenient house rule), `exact` (fractional tracking). This is one of the most common house rules in SR5.
+- **Implementation location:**
+  - `lib/rules/magic/essence-magic-link.ts:20,37-63` — formula selection and calculation
+  - `lib/rules/augmentations/validation.ts:127` — `magicReductionFormula` in default rules
+- **Toggle exists today:** Partial (type and logic support it, no campaign UI to set it)
+
+### 15. Essence Hole Tracking
+
+- **What it controls:** Whether removing augmentations creates "essence holes" (permanently lost essence that can't be reclaimed), or whether essence fully returns.
+- **Current behavior:** `trackEssenceHoles: true` in `DEFAULT_AUGMENTATION_RULES`. Logic exists in `lib/rules/augmentations/essence-hole.ts`. Currently tracks but essence hole value is always 0 in `getEssenceMagicState()`.
+- **Toggle idea:** "Essence Holes" — on (RAW, essence is permanently lost when chrome is removed) vs. off (essence fully recovers, more forgiving).
+- **Implementation location:**
+  - `lib/rules/augmentations/essence-hole.ts` — essence hole calculations
+  - `lib/rules/augmentations/validation.ts:125` — `trackEssenceHoles` flag
+  - `lib/rules/magic/essence-magic-link.ts:139` — always 0 (not yet fully wired)
+- **Toggle exists today:** Partial (flag exists in rules data, not exposed to GM)
+
+### 16. Cyberware/Bioware Grade Availability
+
+- **What it controls:** Which augmentation grades are available (Used, Standard, Alpha, Beta, Delta) and their essence multipliers.
+- **Current behavior:** All grades defined with fixed multipliers — Used (1.5×), Standard (1.0×), Alpha (0.8×), Beta (0.6×), Delta (0.4×). No campaign-level restriction on which grades players can access.
+- **Toggle idea:** "Available Augmentation Grades" — GMs could restrict to Standard-only for street-level games, or unlock Delta for high-power campaigns.
+- **Implementation location:**
+  - `lib/rules/augmentations/grades.ts` — `getCyberwareGradeMultiplier()`, `getBiowareGradeMultiplier()`
+  - `lib/rules/augmentations/essence.ts` — essence cost calculations using grade multipliers
+- **Toggle exists today:** No
+
+### 17. Cyberlimb Attribute Bonus Cap
+
+- **What it controls:** Maximum attribute bonus from cyberlimbs (default: +4 per attribute).
+- **Current behavior:** Hardcoded in `DEFAULT_AUGMENTATION_RULES.maxAttributeBonus = 4`. Validated during augmentation installation.
+- **Toggle idea:** GMs could lower this for grittier games or raise it for cyber-heavy campaigns.
+- **Implementation location:**
+  - `lib/rules/augmentations/validation.ts:124` — `maxAttributeBonus` in default rules
+- **Toggle exists today:** No (value exists in rules data, not exposed to GM)
+
+### 18. Advancement Karma Multipliers
+
+- **What it controls:** Karma costs for improving attributes, skills, and learning spells during advancement.
+- **Current behavior:** Fully configurable per campaign via `CampaignAdvancementSettings`. Default multipliers: Attribute (×5), Active Skill (×2), Skill Group (×5), Knowledge Skill (×1). Fixed costs: Specialization (7), Spell (5), Complex Form (4).
+- **Toggle idea:** Already implemented. GMs can modify all multipliers and fixed costs.
+- **Implementation location:**
+  - `lib/types/campaign.ts:30-42` — `AdvancementRulesData` interface
+  - `app/campaigns/[id]/settings/components/AdvancementSettingsForm.tsx` — full editing UI
+  - `lib/rules/advancement/costs.ts` — karma cost calculations
+- **Toggle exists today:** Yes
+
+### 19. Advancement Rating Caps
+
+- **What it controls:** Maximum attribute rating (default: 10) and skill rating (default: 13) during advancement.
+- **Current behavior:** Required fields in `CampaignAdvancementSettings`. Enforced during validation in `campaign-validation.ts:71-98`.
+- **Toggle idea:** Already implemented. GMs set caps per campaign.
+- **Implementation location:**
+  - `lib/types/campaign.ts:49-52` — `attributeRatingCap`, `skillRatingCap`
+  - `lib/rules/campaign-validation.ts:71-98` — enforcement
+  - `app/campaigns/[id]/settings/components/AdvancementSettingsForm.tsx:150-196` — UI inputs
+- **Toggle exists today:** Yes
+
+### 20. Training Time Requirements
+
+- **What it controls:** Whether advancing attributes/skills requires in-game training time, and the time multiplier.
+- **Current behavior:** Configurable via `trainingTimeMultiplier` in advancement settings. `allowInstantAdvancement` boolean bypasses training entirely.
+- **Toggle idea:** Already implemented. GMs can set multiplier or enable instant advancement.
+- **Implementation location:**
+  - `lib/types/campaign.ts:31` — `trainingTimeMultiplier`
+  - `lib/types/campaign.ts:41` — `allowInstantAdvancement`
+  - `app/campaigns/[id]/settings/components/AdvancementSettingsForm.tsx:199-265` — UI toggles
+  - `lib/rules/advancement/training.ts` — training time calculation
+- **Toggle exists today:** Yes
+
+### 21. GM Approval for Character Finalization
+
+- **What it controls:** Whether newly created characters go through GM review before becoming active, or are auto-approved.
+- **Current behavior:** If campaign has `requireApproval: true`, finalized characters enter "pending-review" state. GM must explicitly approve or reject with feedback.
+- **Toggle idea:** Already implemented as `requireApproval` in advancement settings.
+- **Implementation location:**
+  - `lib/types/campaign.ts:54` — `requireApproval`
+  - `app/api/characters/[characterId]/finalize/route.ts:126-171` — approval workflow
+  - `app/api/campaigns/[id]/characters/[characterId]/approve/route.ts` — GM approval endpoint
+- **Toggle exists today:** Yes
+
+### 22. GM Approval for Advancements
+
+- **What it controls:** Whether character advancements (spending karma to improve attributes/skills) require GM approval or are auto-applied.
+- **Current behavior:** Tied to the same `requireApproval` flag. Advancement approval/rejection endpoints exist.
+- **Toggle idea:** Could be separated from character approval — some GMs want to review new characters but auto-approve karma spending.
+- **Implementation location:**
+  - `app/api/campaigns/[id]/advancements/[recordId]/approve/route.ts`
+  - `app/api/campaigns/[id]/advancements/[recordId]/reject/route.ts`
+- **Toggle exists today:** Yes (shared with character approval)
+
+### 23. Drain Minimum and Formula
+
+- **What it controls:** Minimum drain value (default: 2) and drain formula for spellcasting.
+- **Current behavior:** Minimum drain hardcoded to 2 in `lib/rules/magic/drain-calculator.ts:51`. Supports `customDrainFormula` parameter for house rules. Drain type (Stun vs Physical) determined by comparing drain value to Magic rating.
+- **Toggle idea:** "Custom Drain Rules" — allow GMs to set minimum drain value and override drain formulas per tradition.
+- **Implementation location:**
+  - `lib/rules/magic/drain-calculator.ts` — drain calculations, `customDrainFormula` parameter
+  - `lib/rules/magic/tradition-validator.ts` — tradition-specific drain attributes
+- **Toggle exists today:** Partial (code supports custom formulas, no campaign UI)
+
+### 24. Limit Enforcement (Physical/Mental/Social)
+
+- **What it controls:** Whether hits on tests are capped by the relevant limit (Physical, Mental, Social), or if limits are ignored.
+- **Current behavior:** Limits calculated in `pool-builder.ts` using `(Attr1 + Attr2 + Attr3) / 3, rounded up`. Applied via `calculateHitsWithLimit()` in the dice engine. Push the Limit edge action bypasses limits.
+- **Toggle idea:** "Limit Enforcement" — on (RAW), off (house rule that many tables use to simplify play), or advisory (show the limit but don't cap hits).
+- **Implementation location:**
+  - `lib/rules/action-resolution/pool-builder.ts` — limit calculation formulas
+  - `lib/rules/action-resolution/dice-engine.ts:176-196` — `calculateHitsWithLimit()`
+- **Toggle exists today:** No
+
+### 25. Sourcebook Availability Filtering
+
+- **What it controls:** Which sourcebooks' content (gear, qualities, metatypes, spells, creation methods) is available in the campaign.
+- **Current behavior:** Fully implemented via `enabledBookIds` on the Campaign type. Core and Errata books are required (cannot be disabled in UI). Optional sourcebooks (Run Faster) can be toggled. Character validation checks book availability.
+- **Toggle idea:** Already implemented. Core books locked, optional books toggleable.
+- **Implementation location:**
+  - `lib/types/campaign.ts:84` — `enabledBookIds`
+  - `app/campaigns/[id]/settings/page.tsx:470-536` — book selection UI with required/optional badges
+  - `lib/rules/campaign-validation.ts:38-54` — book compliance validation
+- **Toggle exists today:** Yes
+
+### 26. Optional Rules System
+
+- **What it controls:** Framework for enabling/disabling optional rules defined in sourcebooks. Rules can affect any module (combat, magic, matrix, etc.).
+- **Current behavior:** Full infrastructure in `lib/rules/optional-rules.ts` — extraction from book data, resolution with campaign overrides, validation. `disabledRuleIds` takes precedence. Campaign type has `optionalRules` field.
+- **Toggle idea:** Already implemented as an infrastructure. Currently no optional rules are defined in the book data, but the system is ready for them.
+- **Implementation location:**
+  - `lib/rules/optional-rules.ts` — full CRUD for optional rule state
+  - `lib/types/campaign.ts:101-106` — campaign storage
+  - `lib/rules/campaign-validation.ts:104-129` — compliance validation
+- **Toggle exists today:** Yes (infrastructure), but no rules are populated yet
+
+### 27. Edge Actions
+
+- **What it controls:** Which Edge actions are available (Push the Limit, Second Chance, Seize the Initiative, Blitz, Close Call, Dead Man's Trigger).
+- **Current behavior:** All six actions hardcoded in `DEFAULT_DICE_RULES.edgeActions`. Each has cost, timing (pre/post roll), and effects defined.
+- **Toggle idea:** GMs could disable specific Edge actions (e.g., no Blitz in a slower-paced campaign) or modify Edge costs.
+- **Implementation location:**
+  - `lib/rules/action-resolution/dice-engine.ts:24-71` — edge action definitions
+  - `lib/rules/action-resolution/edge-actions.ts` — edge action logic
+- **Toggle exists today:** No
+
+### 28. Lifestyle Options
+
+- **What it controls:** Available lifestyle tiers and their mechanical effects (Street, Squatter, Low, Middle, High, Luxury).
+- **Current behavior:** Six tiers with point budgets and component constraints (Comforts, Security, Neighborhood). Validated in `lib/rules/lifestyle/validation.ts`. Entertainment options have min-lifestyle requirements.
+- **Toggle idea:** GMs could restrict available lifestyle tiers (e.g., no Luxury in a street-level campaign) or modify point budgets.
+- **Implementation location:**
+  - `lib/rules/lifestyle/validation.ts` — lifestyle component validation
+  - `data/editions/sr5/core-rulebook.json` — lifestyle module data
+- **Toggle exists today:** No
+
+---
+
+## Run Faster (RF)
+
+### 29. Sum-to-Ten Budget
+
+- **What it controls:** Total priority points for Sum-to-Ten creation (default: exactly 10, using A=4, B=3, C=2, D=1, E=0).
+- **Current behavior:** Hardcoded in `lib/rules/sum-to-ten-validation.ts`. Point values per level and total budget (10) are constants.
+- **Toggle idea:** "Sum-to-X" — GMs could set a different total (e.g., Sum-to-8 for street-level, Sum-to-12 for prime runner). The point values per level could also be adjusted.
+- **Implementation location:**
+  - `lib/rules/sum-to-ten-validation.ts` — validation logic and constants
+- **Toggle exists today:** No
+
+### 30. Point Buy Karma Budget
+
+- **What it controls:** Starting karma for Point Buy creation (default: 800 Karma) and conversion rates (1 Karma = 2,000¥).
+- **Current behavior:** Constants in `lib/rules/point-buy-validation.ts` — `POINT_BUY_KARMA_BUDGET = 800`, `POINT_BUY_MAX_GEAR_KARMA = 200`, `POINT_BUY_NUYEN_PER_KARMA = 2000`, `POINT_BUY_MAX_LEFTOVER_NUYEN = 5000`.
+- **Toggle idea:** GMs could adjust the starting budget for different power levels, or modify the nuyen conversion rate.
+- **Implementation location:**
+  - `lib/rules/point-buy-validation.ts:19-28` — budget constants
+  - `lib/rules/point-buy-validation.ts:34-50+` — metatype costs table
+- **Toggle exists today:** No
+
+### 31. Point Buy Metatype Costs
+
+- **What it controls:** Karma cost to play each metatype in Point Buy creation (Human: 0, Elf: 40, Dwarf: 50, Ork: 50, Troll: 90, plus metavariants).
+- **Current behavior:** Hardcoded table `POINT_BUY_METATYPE_COSTS` with 20+ entries including metavariants from Run Faster.
+- **Toggle idea:** GMs could adjust metatype costs to encourage or discourage certain picks. Setting Human cost > 0 or Troll cost lower makes non-human characters more viable.
+- **Implementation location:**
+  - `lib/rules/point-buy-validation.ts:34-50+` — cost table
+- **Toggle exists today:** No
+
+### 32. Life Modules Budget and Caps
+
+- **What it controls:** Starting karma (750), max active skill rating (7), max knowledge skill rating (9), max gear karma (200), and max negative quality karma (25) for Life Modules creation.
+- **Current behavior:** Constants in `lib/rules/life-modules-validation.ts` and `lib/types/index.ts`.
+- **Toggle idea:** Similar to Point Buy, GMs could adjust the starting budget and caps for different campaign power levels.
+- **Implementation location:**
+  - `lib/rules/life-modules-validation.ts` — validation logic and constants
+  - `lib/types/index.ts` — `LIFE_MODULES_MAX_GEAR_KARMA`, `LIFE_MODULES_MAX_NEGATIVE_QUALITIES`
+- **Toggle exists today:** No
+
+### 33. Run Faster Metatype Availability
+
+- **What it controls:** Whether exotic metatypes from Run Faster (Gnome, Hanuman, Naga, Pixie, Sasquatch, etc.) are available for character creation.
+- **Current behavior:** Controlled by the sourcebook toggle (`enabledBookIds`). If Run Faster is disabled, its metatypes are unavailable. No per-metatype toggle within Run Faster.
+- **Toggle idea:** Allow GMs to enable Run Faster for qualities/creation methods but restrict specific exotic metatypes that don't fit their campaign setting.
+- **Implementation location:**
+  - `data/editions/sr5/run-faster.json` — metatypes module with `mergeStrategy: "append"`
+  - `lib/rules/campaign-validation.ts:38-54` — book-level filtering
+- **Toggle exists today:** Partial (book-level only, no per-metatype granularity)
+
+---
+
+## Cross-Book Systems
+
+### 34. House Rules Storage
+
+- **What it controls:** Freeform storage for GM house rules — text description or structured JSON.
+- **Current behavior:** Campaign type has `houseRules?: string | Record<string, unknown>` field. Stored and validated in `lib/storage/campaigns.ts` and `lib/storage/validation.ts`. Seed data shows example usage: `["No edge rerolls", "Threshold 5 for called shots"]`.
+- **Toggle idea:** The field exists but has no mechanical enforcement. This is the natural home for structured house rules that map to the toggle candidates above.
+- **Implementation location:**
+  - `lib/types/campaign.ts:108-109` — type definition
+  - `lib/storage/campaigns.ts:277` — persistence
+  - `lib/storage/validation.ts:497-500` — validation
+  - `scripts/seed-data.ts:430` — example seed data
+- **Toggle exists today:** Partial (storage exists, no enforcement or structured UI)
+
+### 35. Matrix Overwatch Score
+
+- **What it controls:** Overwatch Score accumulation from Matrix actions. A comment in `lib/rules/matrix/overwatch-calculator.ts:88` notes "Critical glitches add extra OS (GM discretion, +2d6 is common house rule)."
+- **Current behavior:** OS calculation implemented with explicit GM discretion noted in comments.
+- **Toggle idea:** "Overwatch Critical Glitch Rule" — off (RAW, no extra OS), or +2d6 OS on critical glitch (common house rule).
+- **Implementation location:**
+  - `lib/rules/matrix/overwatch-calculator.ts` — OS calculation with house rule comment
+- **Toggle exists today:** No
+
+---
+
+## Summary: Toggle Readiness
+
+### Already Fully Toggleable (8 systems)
+
+| #   | System                              | Location                           |
+| --- | ----------------------------------- | ---------------------------------- |
+| 5   | Creation Method Restrictions        | Campaign settings UI               |
+| 18  | Advancement Karma Multipliers       | AdvancementSettingsForm            |
+| 19  | Advancement Rating Caps             | AdvancementSettingsForm            |
+| 20  | Training Time / Instant Advancement | AdvancementSettingsForm            |
+| 21  | GM Approval for Characters          | AdvancementSettingsForm            |
+| 22  | GM Approval for Advancements        | Approval API routes                |
+| 25  | Sourcebook Filtering                | Campaign settings books UI         |
+| 26  | Optional Rules Framework            | optional-rules.ts (infrastructure) |
+
+### Partially Toggleable (8 systems — type/logic exists, no campaign UI)
+
+| #   | System                          | What's Missing                               |
+| --- | ------------------------------- | -------------------------------------------- |
+| 2   | Hit Threshold / Glitch Rules    | Campaign UI for EditionDiceRules overrides   |
+| 3   | Wound Modifiers                 | Campaign UI for boxesPerPenalty/maxPenalty   |
+| 4   | Gameplay Level (Custom)         | Custom values beyond 3 presets               |
+| 6   | Attribute One-at-Max Rule       | Campaign override for maxAtMax parameter     |
+| 7   | Skill Cap at Creation           | Campaign override for creation-phase max     |
+| 14  | Essence-Magic Reduction Formula | Campaign UI for magicReductionFormula        |
+| 15  | Essence Hole Tracking           | Campaign UI for trackEssenceHoles flag       |
+| 34  | House Rules                     | Structured schema for mechanical enforcement |
+
+### Not Yet Toggleable (19 systems — hardcoded, need new config)
+
+| #   | System                                | Priority                     |
+| --- | ------------------------------------- | ---------------------------- |
+| 1   | Dice Rolling Mode (App vs Physical)   | High                         |
+| 8   | Gear Availability / Restricted Access | High                         |
+| 9   | Quality Karma Caps (25/25)            | High                         |
+| 10  | Karma-to-Nuyen Conversion Cap         | Medium                       |
+| 11  | Nuyen/Karma Carryover Limits          | Medium                       |
+| 12  | Contact Rating Limits                 | Medium                       |
+| 13  | Contact Karma Budget Multiplier       | Low (tied to gameplay level) |
+| 16  | Augmentation Grade Availability       | Medium                       |
+| 17  | Cyberlimb Attribute Bonus Cap         | Low                          |
+| 23  | Drain Minimum/Formula                 | Medium                       |
+| 24  | Limit Enforcement (on/off/advisory)   | High                         |
+| 27  | Edge Actions (enable/disable)         | Low                          |
+| 28  | Lifestyle Tier Restrictions           | Low                          |
+| 29  | Sum-to-Ten Budget                     | Medium                       |
+| 30  | Point Buy Karma Budget                | Medium                       |
+| 31  | Point Buy Metatype Costs              | Low                          |
+| 32  | Life Modules Budget and Caps          | Low                          |
+| 33  | Run Faster Metatype Granularity       | Low                          |
+| 35  | Matrix Overwatch House Rule           | Low                          |
+
+---
+
+## Unimplemented Systems with Toggle Potential
+
+These systems are present in the data or referenced in rules but have no app-level implementation yet. When built, they would be natural toggle candidates.
+
+### 1. Initiative System
+
+- **Data:** Initiative rules defined in `diceRules` module (initiative dice, passes, Blitz edge action)
+- **Toggle potential:** Number of initiative dice, whether to use initiative passes or action economy, Blitz availability
+
+### 2. Called Shots
+
+- **Data:** Referenced in seed data house rules (`"Threshold 5 for called shots"`)
+- **Toggle potential:** Called shot threshold, available called shot types, damage modifiers
+
+### 3. Recoil and Firing Mode Rules
+
+- **Data:** Weapon modifications module includes recoil compensation. Actions module includes Fire Weapon types
+- **Toggle potential:** Recoil calculation mode, burst fire rules, suppressive fire area
+
+### 4. Armor Encumbrance
+
+- **Data:** Armor values in gear data, armor stacking rules referenced in modifications
+- **Toggle potential:** Armor stacking limits, encumbrance penalties, armor-as-DR variant rule
+
+### 5. Sprite/Spirit Service Limits
+
+- **Data:** Spirit types per tradition defined in tradition data
+- **Toggle potential:** Maximum number of bound spirits, spirit force caps, summoning drain modifiers
+
+### 6. Noise Calculation (Matrix)
+
+- **Data:** Noise modifiers referenced in RCC/Matrix rules
+- **Toggle potential:** Base noise values, noise reduction calculations, running silent penalties
+
+### 7. Background Count (Magic)
+
+- **Data:** Not yet in data, but a core SR5 mechanic
+- **Toggle potential:** Whether background count applies, aspected vs generic, severity levels
+
+### 8. Toxin/Pathogen Rules
+
+- **Data:** Not yet in data
+- **Toggle potential:** Contact vector rules, resistance test modifiers, onset time
+
+### 9. Vehicle Chase Rules
+
+- **Data:** Vehicle stats in data, rigging system partially implemented
+- **Toggle potential:** Chase scene abstraction level, crash damage, vehicle modification limits
+
+### 10. Reputation / Street Cred / Notoriety
+
+- **Data:** Notoriety tracking exists (`app/api/characters/[characterId]/reputation/`)
+- **Toggle potential:** How street cred is calculated, whether notoriety auto-accumulates, public awareness thresholds

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", ".next", "dist", "build", "e2e"]
+  "exclude": ["node_modules", ".next", "dist", "build", "e2e", "everything-claude-code"]
 }


### PR DESCRIPTION
## Summary
- Initial generation of token-lean architecture codemaps in `docs/CODEMAPS/` (architecture, backend, frontend, data, dependencies)
- Added `docs/CONTRIBUTING.md` with scripts table, git workflow, code style guide, and PR checklist
- Added `docs/ENV.md` documenting all environment variables from `.env.example` (30+ vars across 7 categories)
- Added `docs/RUNBOOK.md` with deployment procedures, health checks, common issues, and rollback steps
- Added `docs/gm-feature-toggle-candidates.md` for GM feature toggle planning
- Excluded `everything-claude-code/` from `tsconfig.json` to prevent ECC internal `.tsx` files from failing type-check
- Added `.reports/codemap-diff.txt` generation report with staleness warnings

## Test plan
- [x] `pnpm type-check` passes (verified by pre-commit hook)
- [x] `pnpm validate-docs` passes (verified by pre-push hook)
- [x] All new files are documentation only — no runtime changes
- [ ] Review codemaps for accuracy against current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)