### PR TITLE
feat: wire hit threshold and glitch rules into dice engine (#846)

### DIFF
--- a/app/api/characters/[characterId]/actions/[actionId]/reroll/route.ts
+++ b/app/api/characters/[characterId]/actions/[actionId]/reroll/route.ts
@@ -10,6 +10,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { getUserById } from "@/lib/storage/users";
 import { getCharacter, spendEdge } from "@/lib/storage/characters";
+import { getCampaignById } from "@/lib/storage/campaigns";
 import { getAction, updateActionResult } from "@/lib/storage/action-history";
 import {
   executeReroll,
@@ -18,6 +19,7 @@ import {
   getCurrentEdge,
   getMaxEdge,
   canSpendEdge,
+  resolveDiceRules,
 } from "@/lib/rules/action-resolution";
 import type { RerollActionRequest, EdgeActionType } from "@/lib/types";
 
@@ -90,12 +92,17 @@ export async function POST(
         );
       }
 
+      // Resolve campaign house rules for consistent thresholds
+      let diceRules = DEFAULT_DICE_RULES;
+      if (character.campaignId) {
+        const campaign = await getCampaignById(character.campaignId);
+        if (campaign?.houseRules) {
+          diceRules = resolveDiceRules(campaign.houseRules, DEFAULT_DICE_RULES);
+        }
+      }
+
       // Execute reroll
-      const rerollResult = executeReroll(
-        originalAction.dice,
-        DEFAULT_DICE_RULES,
-        originalAction.pool.limit
-      );
+      const rerollResult = executeReroll(originalAction.dice, diceRules, originalAction.pool.limit);
 
       // Spend Edge
       character = await spendEdge(userId, characterId, 1);

--- a/app/api/characters/[characterId]/actions/route.ts
+++ b/app/api/characters/[characterId]/actions/route.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from "uuid";
 import { getSession } from "@/lib/auth/session";
 import { getUserById } from "@/lib/storage/users";
 import { getCharacter, spendEdge } from "@/lib/storage/characters";
+import { getCampaignById } from "@/lib/storage/campaigns";
 import {
   getActionHistory,
   saveActionResult,
@@ -25,6 +26,7 @@ import {
   executePushTheLimit,
   getCurrentEdge,
   getMaxEdge,
+  resolveDiceRules,
 } from "@/lib/rules/action-resolution";
 import type {
   RollActionRequest,
@@ -151,6 +153,15 @@ export async function POST(
       );
     }
 
+    // Resolve campaign house rules (dice thresholds, etc.)
+    let diceRules = DEFAULT_DICE_RULES;
+    if (character.campaignId) {
+      const campaign = await getCampaignById(character.campaignId);
+      if (campaign?.houseRules) {
+        diceRules = resolveDiceRules(campaign.houseRules, DEFAULT_DICE_RULES);
+      }
+    }
+
     // Build or use provided pool
     let pool: ActionPool;
     if ("totalDice" in body.pool) {
@@ -158,7 +169,7 @@ export async function POST(
       pool = body.pool as ActionPool;
     } else {
       // Build from options
-      pool = buildActionPool(character, body.pool as PoolBuildOptions, DEFAULT_DICE_RULES);
+      pool = buildActionPool(character, body.pool as PoolBuildOptions, diceRules);
     }
 
     // Validate pool
@@ -182,7 +193,7 @@ export async function POST(
       }
 
       // Execute Push the Limit
-      const ptlResult = executePushTheLimit(character, pool, DEFAULT_DICE_RULES);
+      const ptlResult = executePushTheLimit(character, pool, diceRules);
       if (!ptlResult.success || !ptlResult.rollResult) {
         return NextResponse.json(
           { success: false, error: ptlResult.error || "Push the Limit failed" },
@@ -199,7 +210,7 @@ export async function POST(
       character = await spendEdge(userId, characterId, edgeSpent);
     } else {
       // Normal roll
-      rollResult = executeRoll(pool.totalDice, DEFAULT_DICE_RULES, {
+      rollResult = executeRoll(pool.totalDice, diceRules, {
         limit: pool.limit,
       });
     }

--- a/app/api/combat/[sessionId]/actions/route.ts
+++ b/app/api/combat/[sessionId]/actions/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { getUserById } from "@/lib/storage/users";
 import { getCharacterById, updateCharacter } from "@/lib/storage/characters";
+import { getCampaignById } from "@/lib/storage/campaigns";
 import {
   getCombatSession,
   getCurrentParticipant,
@@ -28,6 +29,8 @@ import {
   executeRoll,
   buildActionPool,
   calculateStateModifiers,
+  DEFAULT_DICE_RULES,
+  resolveDiceRules,
   type ValidationResult,
 } from "@/lib/rules/action-resolution";
 import { processDamageApplication } from "@/lib/rules/action-resolution/combat";
@@ -521,6 +524,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     // Execute roll if character and action has roll config
     if (character && action.rollConfig) {
+      // Resolve campaign house rules for dice thresholds (#846)
+      let diceRules = DEFAULT_DICE_RULES;
+      if (session.campaignId) {
+        const campaign = await getCampaignById(session.campaignId);
+        if (campaign?.houseRules) {
+          diceRules = resolveDiceRules(campaign.houseRules, DEFAULT_DICE_RULES);
+        }
+      }
+
       const stateModifiers = calculateStateModifiers(character, action, session);
       const pool = buildActionPool(character, {
         attribute: action.rollConfig.attribute,
@@ -530,7 +542,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
       // Execute the roll
       const limit = action.rollConfig.limitType === "none" ? undefined : pool.limit;
-      const rollResult = executeRoll(pool.totalDice, undefined, { limit });
+      const rollResult = executeRoll(pool.totalDice, diceRules, { limit });
 
       result.roll = {
         dice: rollResult.dice.map((d) => d.value),
@@ -563,7 +575,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
               skill: action.opposedBy.defaultDefenseSkill,
             });
 
-            const defenseRollResult = executeRoll(defensePool.totalDice);
+            const defenseRollResult = executeRoll(defensePool.totalDice, diceRules);
 
             result.defenseRoll = {
               dice: defenseRollResult.dice.map((d) => d.value),

--- a/lib/rules/action-resolution/__tests__/action-executor.test.ts
+++ b/lib/rules/action-resolution/__tests__/action-executor.test.ts
@@ -76,6 +76,7 @@ vi.mock("../dice-engine", () => ({
     explodingSixes: false,
     ruleOfSix: false,
   },
+  resolveDiceRules: vi.fn((_houseRules, base) => base),
 }));
 
 vi.mock("../action-validator", () => ({

--- a/lib/rules/action-resolution/__tests__/dice-engine.test.ts
+++ b/lib/rules/action-resolution/__tests__/dice-engine.test.ts
@@ -21,6 +21,7 @@ import {
   executeReroll,
   expectedHits,
   glitchProbability,
+  resolveDiceRules,
 } from "../dice-engine";
 
 // =============================================================================
@@ -903,5 +904,93 @@ describe("glitchProbability", () => {
     // P(at least 1 one) = 1/6 = ~16.67%
     const prob1 = glitchProbability(1);
     expect(prob1).toBeCloseTo(1 / 6, 2);
+  });
+});
+
+// =============================================================================
+// HOUSE RULE RESOLUTION (#846)
+// =============================================================================
+
+describe("resolveDiceRules", () => {
+  it("returns base unchanged when houseRules is undefined", () => {
+    const resolved = resolveDiceRules(undefined);
+    expect(resolved).toEqual(DEFAULT_DICE_RULES);
+  });
+
+  it("returns base unchanged when houseRules has no dice overrides", () => {
+    const resolved = resolveDiceRules({});
+    expect(resolved.hitThreshold).toBe(DEFAULT_DICE_RULES.hitThreshold);
+    expect(resolved.glitchThreshold).toBe(DEFAULT_DICE_RULES.glitchThreshold);
+  });
+
+  it("overrides hitThreshold when set", () => {
+    const resolved = resolveDiceRules({ hitThreshold: 4 });
+    expect(resolved.hitThreshold).toBe(4);
+    expect(resolved.glitchThreshold).toBe(DEFAULT_DICE_RULES.glitchThreshold);
+  });
+
+  it("overrides glitchThreshold when set", () => {
+    const resolved = resolveDiceRules({ glitchThreshold: 0.75 });
+    expect(resolved.glitchThreshold).toBe(0.75);
+    expect(resolved.hitThreshold).toBe(DEFAULT_DICE_RULES.hitThreshold);
+  });
+
+  it("overrides both thresholds together", () => {
+    const resolved = resolveDiceRules({ hitThreshold: 6, glitchThreshold: 0.3 });
+    expect(resolved.hitThreshold).toBe(6);
+    expect(resolved.glitchThreshold).toBe(0.3);
+  });
+
+  it("preserves other base rule fields (edgeActions, caps)", () => {
+    const resolved = resolveDiceRules({ hitThreshold: 4 });
+    expect(resolved.edgeActions).toEqual(DEFAULT_DICE_RULES.edgeActions);
+    expect(resolved.maxDicePool).toBe(DEFAULT_DICE_RULES.maxDicePool);
+    expect(resolved.criticalGlitchRequiresZeroHits).toBe(
+      DEFAULT_DICE_RULES.criticalGlitchRequiresZeroHits
+    );
+  });
+
+  it("overrides wound modifiers when set", () => {
+    const resolved = resolveDiceRules({ woundBoxesPerPenalty: 4, woundMaxPenalty: 6 });
+    expect(resolved.woundModifiers).toEqual({ boxesPerPenalty: 4, maxPenalty: -6 });
+  });
+
+  it("stores woundMaxPenalty as negative number regardless of input sign", () => {
+    const resolved = resolveDiceRules({ woundMaxPenalty: 8 });
+    expect(resolved.woundModifiers.maxPenalty).toBe(-8);
+  });
+
+  it("accepts a non-default base and overrides on top of it", () => {
+    const customBase: EditionDiceRules = {
+      ...DEFAULT_DICE_RULES,
+      hitThreshold: 5,
+      glitchThreshold: 0.5,
+      maxDicePool: 100,
+    };
+    const resolved = resolveDiceRules({ hitThreshold: 4 }, customBase);
+    expect(resolved.hitThreshold).toBe(4);
+    expect(resolved.maxDicePool).toBe(100);
+  });
+
+  it("does not mutate the input base", () => {
+    const base: EditionDiceRules = { ...DEFAULT_DICE_RULES };
+    resolveDiceRules({ hitThreshold: 4, glitchThreshold: 0.75 }, base);
+    expect(base.hitThreshold).toBe(DEFAULT_DICE_RULES.hitThreshold);
+    expect(base.glitchThreshold).toBe(DEFAULT_DICE_RULES.glitchThreshold);
+  });
+
+  it("affects hit counting when used in executeRoll", () => {
+    // With hitThreshold=4, a die showing 4 is a hit (normally only 5 and 6)
+    const rules = resolveDiceRules({ hitThreshold: 4 });
+    const dice = makeDice([4, 4, 4, 3, 2], rules.hitThreshold);
+    expect(calculateHits(dice, rules.hitThreshold)).toBe(3);
+  });
+
+  it("affects glitch threshold when used in calculateGlitch", () => {
+    // With glitchThreshold=0.25, 2 ones in a pool of 5 (2 > floor(5*0.25)=1) triggers glitch
+    const rules = resolveDiceRules({ glitchThreshold: 0.25 });
+    const dice = makeDice([1, 1, 5, 5, 5]);
+    const result = calculateGlitch(dice, 3, rules);
+    expect(result.isGlitch).toBe(true);
   });
 });

--- a/lib/rules/action-resolution/action-executor.ts
+++ b/lib/rules/action-resolution/action-executor.ts
@@ -29,8 +29,8 @@ import {
   ValidationError,
 } from "./action-validator";
 import { NotImplementedError } from "@/lib/rules/sync";
-import { executeRoll, executeReroll, DEFAULT_DICE_RULES } from "./dice-engine";
-import type { LimitEnforcement } from "@/lib/types/house-rules";
+import { executeRoll, executeReroll, DEFAULT_DICE_RULES, resolveDiceRules } from "./dice-engine";
+import type { HouseRules, LimitEnforcement } from "@/lib/types/house-rules";
 import { buildActionPool } from "./pool-builder";
 import * as actionHistoryStorage from "@/lib/storage/action-history";
 import * as combatStorage from "@/lib/storage/combat";
@@ -65,6 +65,8 @@ export interface ExecutionRequest {
   context?: ActionContext;
   /** Limit enforcement mode from campaign house rules */
   limitEnforcement?: LimitEnforcement;
+  /** Campaign house rules (applies dice threshold overrides when present) */
+  houseRules?: HouseRules;
 }
 
 /**
@@ -103,6 +105,8 @@ export interface RerollRequest {
   participantId?: ID;
   /** Limit enforcement mode from campaign house rules */
   limitEnforcement?: LimitEnforcement;
+  /** Campaign house rules (applies dice threshold overrides when present) */
+  houseRules?: HouseRules;
 }
 
 // =============================================================================
@@ -272,7 +276,8 @@ export async function executeAction(request: ExecutionRequest): Promise<Executio
   // Push the Limit bypasses limits per RAW, regardless of house rule setting
   const effectiveLimitEnforcement =
     request.edgeAction === "push-the-limit" ? "off" : (request.limitEnforcement ?? "on");
-  const rollResult = executeRoll(actionPool.totalDice, DEFAULT_DICE_RULES, {
+  const diceRules = resolveDiceRules(request.houseRules, DEFAULT_DICE_RULES);
+  const rollResult = executeRoll(actionPool.totalDice, diceRules, {
     limit: actionPool.limit,
     explodingSixes: request.edgeAction === "push-the-limit",
     limitEnforcement: effectiveLimitEnforcement,
@@ -437,9 +442,10 @@ export async function executeActionReroll(request: RerollRequest): Promise<Execu
   }
 
   // Second Chance - reroll non-hits
+  const diceRules = resolveDiceRules(request.houseRules, DEFAULT_DICE_RULES);
   const rerollResult = executeReroll(
     originalAction.dice,
-    DEFAULT_DICE_RULES,
+    diceRules,
     originalAction.pool.limit,
     request.limitEnforcement ?? "on"
   );

--- a/lib/rules/action-resolution/dice-engine.ts
+++ b/lib/rules/action-resolution/dice-engine.ts
@@ -6,7 +6,7 @@
  */
 
 import type { DiceResult, EditionDiceRules } from "@/lib/types";
-import type { LimitEnforcement } from "@/lib/types/house-rules";
+import type { HouseRules, LimitEnforcement } from "@/lib/types/house-rules";
 
 // =============================================================================
 // DEFAULT RULES (SR5)
@@ -75,6 +75,46 @@ export const DEFAULT_DICE_RULES: EditionDiceRules = {
     maxPenalty: -4,
   },
 };
+
+// =============================================================================
+// HOUSE RULE RESOLUTION
+// =============================================================================
+
+/**
+ * Merge house rule overrides into an EditionDiceRules base.
+ *
+ * Currently supports overrides for:
+ * - `hitThreshold` (#846): minimum die face that counts as a hit
+ * - `glitchThreshold` (#846): fraction of dice showing 1s that triggers a glitch
+ * - `woundBoxesPerPenalty` (#847): damage boxes per -1 penalty
+ * - `woundMaxPenalty` (#847): max wound penalty magnitude
+ *
+ * When `houseRules` is undefined or a given toggle is unset, the base rules
+ * value is preserved (no change vs. RAW).
+ */
+export function resolveDiceRules(
+  houseRules: HouseRules | undefined,
+  base: EditionDiceRules = DEFAULT_DICE_RULES
+): EditionDiceRules {
+  if (houseRules === undefined) {
+    return base;
+  }
+
+  const resolved: EditionDiceRules = {
+    ...base,
+    hitThreshold: houseRules.hitThreshold ?? base.hitThreshold,
+    glitchThreshold: houseRules.glitchThreshold ?? base.glitchThreshold,
+  };
+
+  if (houseRules.woundBoxesPerPenalty !== undefined || houseRules.woundMaxPenalty !== undefined) {
+    resolved.woundModifiers = {
+      boxesPerPenalty: houseRules.woundBoxesPerPenalty ?? base.woundModifiers.boxesPerPenalty,
+      maxPenalty: -Math.abs(houseRules.woundMaxPenalty ?? Math.abs(base.woundModifiers.maxPenalty)),
+    };
+  }
+
+  return resolved;
+}
 
 // =============================================================================
 // DICE ROLLING

--- a/lib/rules/action-resolution/index.ts
+++ b/lib/rules/action-resolution/index.ts
@@ -18,6 +18,7 @@ export {
   rerollNonHits,
   executeRoll,
   executeReroll,
+  resolveDiceRules,
   expectedHits,
   glitchProbability,
   type GlitchResult,


### PR DESCRIPTION
## Summary

Closes #846.

- Add `resolveDiceRules(houseRules, base)` in `lib/rules/action-resolution/dice-engine.ts` that merges `hitThreshold`, `glitchThreshold`, `woundBoxesPerPenalty`, and `woundMaxPenalty` overrides onto an `EditionDiceRules` base (other fields preserved).
- Thread `houseRules` through `ExecutionRequest`/`RerollRequest` so the action executor resolves campaign-specific dice rules before rolling.
- Wire campaign house rules into the three action API routes (`characters/[id]/actions`, its reroll endpoint, and `combat/[sessionId]/actions`) so the GM toggles already in the settings UI actually affect rolls. Campaign is looked up via `character.campaignId` / `session.campaignId`.

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm test` — 10536 passed
- [x] `pnpm eslint` on changed files — no new warnings
- [x] New unit tests for `resolveDiceRules` covering undefined/empty input, single + combined threshold overrides, wound modifier overrides (including sign normalization), base preservation, and integration with `calculateHits` / `calculateGlitch`.